### PR TITLE
feat: add unit and integration tests with CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+---
+name: test
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  unit-test:
+    name: unit-test
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: run unit tests
+        run: go test -v -count=1 . ./tasks/ ./subprocess/
+
+  integration-test:
+    name: integration-test
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: install dokku
+        run: |
+          sudo mkdir -p /etc/apt/keyrings
+          curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
+          echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
+          sudo apt-get update -qq
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku
+          sudo dokku plugin:install-dependencies --core
+      - name: run integration tests
+        run: sudo go test -v -count=1 -run TestIntegration ./tasks/

--- a/Makefile
+++ b/Makefile
@@ -202,3 +202,11 @@ prebuild:
 .PHONY: docs
 docs:
 	go generate generate/docs.go
+
+.PHONY: test
+test:
+	go test -v -count=1 . ./tasks/ ./subprocess/
+
+.PHONY: test-integration
+test-integration:
+	go test -v -count=1 -run TestIntegration ./tasks/

--- a/arguments_test.go
+++ b/arguments_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestIsTrueString(t *testing.T) {
+	trueValues := []string{"true", "yes", "on", "y", "Y"}
+	for _, v := range trueValues {
+		if !isTrueString(v) {
+			t.Errorf("isTrueString(%q) = false, want true", v)
+		}
+	}
+
+	falseValues := []string{"false", "no", "off", "n", "N", "", "maybe", "1", "0"}
+	for _, v := range falseValues {
+		if isTrueString(v) {
+			t.Errorf("isTrueString(%q) = true, want false", v)
+		}
+	}
+}
+
+func TestIsFalseString(t *testing.T) {
+	falseValues := []string{"false", "no", "off", "n", "N"}
+	for _, v := range falseValues {
+		if !isFalseString(v) {
+			t.Errorf("isFalseString(%q) = false, want true", v)
+		}
+	}
+
+	trueValues := []string{"true", "yes", "on", "y", "Y", "", "maybe", "1", "0"}
+	for _, v := range trueValues {
+		if isFalseString(v) {
+			t.Errorf("isFalseString(%q) = true, want false", v)
+		}
+	}
+}
+
+func TestIsTrueAndFalseAreMutuallyExclusive(t *testing.T) {
+	allValues := []string{"true", "false", "yes", "no", "on", "off", "y", "n", "Y", "N", "", "maybe"}
+	for _, v := range allValues {
+		isTrue := isTrueString(v)
+		isFalse := isFalseString(v)
+		if isTrue && isFalse {
+			t.Errorf("value %q is both true and false", v)
+		}
+	}
+}
+
+func TestGetTaskYamlFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{
+			name:     "default when no --tasks flag",
+			args:     []string{"omakase"},
+			expected: "tasks.yml",
+		},
+		{
+			name:     "separate --tasks flag",
+			args:     []string{"omakase", "--tasks", "custom.yml"},
+			expected: "custom.yml",
+		},
+		{
+			name:     "equals --tasks=flag",
+			args:     []string{"omakase", "--tasks=custom.yml"},
+			expected: "custom.yml",
+		},
+		{
+			name:     "--tasks at end with no value",
+			args:     []string{"omakase", "--tasks"},
+			expected: "tasks.yml",
+		},
+		{
+			name:     "--tasks with other flags before",
+			args:     []string{"omakase", "--app", "myapp", "--tasks", "other.yml"},
+			expected: "other.yml",
+		},
+		{
+			name:     "uses passed parameter not os.Args",
+			args:     []string{"anything", "--tasks", "from-param.yml"},
+			expected: "from-param.yml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getTaskYamlFilename(tt.args)
+			if result != tt.expected {
+				t.Errorf("getTaskYamlFilename(%v) = %q, want %q", tt.args, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestArgumentGetValue(t *testing.T) {
+	t.Run("bool value", func(t *testing.T) {
+		b := true
+		arg := Argument{}
+		arg.SetBoolValue(&b)
+		if arg.GetValue() == nil {
+			t.Error("GetValue() returned nil for bool argument")
+		}
+		if !arg.HasValue() {
+			t.Error("HasValue() returned false for bool argument")
+		}
+	})
+
+	t.Run("int value", func(t *testing.T) {
+		i := 42
+		arg := Argument{}
+		arg.SetIntValue(&i)
+		if arg.GetValue() == nil {
+			t.Error("GetValue() returned nil for int argument")
+		}
+		if !arg.HasValue() {
+			t.Error("HasValue() returned false for int argument")
+		}
+	})
+
+	t.Run("float value", func(t *testing.T) {
+		f := 3.14
+		arg := Argument{}
+		arg.SetFloatValue(&f)
+		if arg.GetValue() == nil {
+			t.Error("GetValue() returned nil for float argument")
+		}
+		if !arg.HasValue() {
+			t.Error("HasValue() returned false for float argument")
+		}
+	})
+
+	t.Run("string value non-empty", func(t *testing.T) {
+		s := "hello"
+		arg := Argument{}
+		arg.SetStringValue(&s)
+		if arg.GetValue() == nil {
+			t.Error("GetValue() returned nil for non-empty string argument")
+		}
+		if !arg.HasValue() {
+			t.Error("HasValue() returned false for non-empty string argument")
+		}
+	})
+
+	t.Run("string value empty", func(t *testing.T) {
+		s := ""
+		arg := Argument{}
+		arg.SetStringValue(&s)
+		if arg.GetValue() != nil {
+			t.Error("GetValue() returned non-nil for empty string argument")
+		}
+		if arg.HasValue() {
+			t.Error("HasValue() returned true for empty string argument")
+		}
+	})
+
+	t.Run("no value set", func(t *testing.T) {
+		arg := Argument{}
+		if arg.GetValue() != nil {
+			t.Error("GetValue() returned non-nil for unset argument")
+		}
+		if arg.HasValue() {
+			t.Error("HasValue() returned true for unset argument")
+		}
+	})
+}

--- a/tasks/integration_test.go
+++ b/tasks/integration_test.go
@@ -1,0 +1,357 @@
+package tasks
+
+import (
+	"omakase/subprocess"
+	"os"
+	"testing"
+)
+
+func dokkuAvailable() bool {
+	_, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"version"},
+	})
+	return err == nil
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}
+
+func skipIfNoDokkuT(t *testing.T) {
+	t.Helper()
+	if !dokkuAvailable() {
+		t.Skip("skipping integration test: dokku not available")
+	}
+}
+
+func TestIntegrationAppCreateAndDestroy(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "omakase-test-app"
+
+	// ensure clean state
+	destroyApp(appName)
+
+	// create the app
+	task := AppTask{App: appName, State: StatePresent}
+	result := task.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to create app: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for new app creation")
+	}
+
+	// creating again should be idempotent
+	result = task.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent create failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false for existing app")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// destroy the app
+	destroyTask := AppTask{App: appName, State: StateAbsent}
+	result = destroyTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to destroy app: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for app destruction")
+	}
+
+	// destroying again should be idempotent
+	result = destroyTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent destroy failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false for nonexistent app")
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}
+
+func TestIntegrationConfigSetAndUnset(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "omakase-test-config"
+
+	// ensure clean state
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set config
+	setTask := ConfigTask{
+		App:     appName,
+		Restart: false,
+		Config:  map[string]string{"TEST_KEY": "test_value"},
+		State:   StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set config: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for new config")
+	}
+
+	// setting same config again should be idempotent
+	result = setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent set failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false for unchanged config")
+	}
+
+	// unset config
+	unsetTask := ConfigTask{
+		App:     appName,
+		Restart: false,
+		Config:  map[string]string{"TEST_KEY": ""},
+		State:   StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset config: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for config removal")
+	}
+
+	// unset again should be idempotent
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent unset failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false for already-unset config")
+	}
+}
+
+func TestIntegrationBuilderProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "omakase-test-builder"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set builder property
+	setTask := BuilderPropertyTask{
+		App:      appName,
+		Property: "selected",
+		Value:    "dockerfile",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set builder property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset builder property
+	unsetTask := BuilderPropertyTask{
+		App:      appName,
+		Property: "selected",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset builder property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}
+
+func TestIntegrationNetworkProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "omakase-test-network"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set network property
+	setTask := NetworkPropertyTask{
+		App:      appName,
+		Property: "bind-all-interfaces",
+		Value:    "true",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set network property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset network property
+	unsetTask := NetworkPropertyTask{
+		App:      appName,
+		Property: "bind-all-interfaces",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset network property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}
+
+func TestIntegrationStorageEnsure(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "omakase-test-storage"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	task := StorageEnsureTask{
+		App:   appName,
+		Chown: "herokuish",
+		State: StatePresent,
+	}
+	result := task.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to ensure storage: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+}
+
+func TestIntegrationStorageMount(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "omakase-test-mount"
+	hostDir := "/var/lib/dokku/data/storage/omakase-test-mount"
+	containerDir := "/app/storage"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// ensure storage directory exists
+	subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "mkdir",
+		Args:    []string{"-p", hostDir},
+	})
+
+	// mount storage
+	mountTask := StorageMountTask{
+		App:          appName,
+		HostDir:      hostDir,
+		ContainerDir: containerDir,
+		State:        StatePresent,
+	}
+	result := mountTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to mount storage: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for new mount")
+	}
+
+	// mount again should be idempotent
+	result = mountTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent mount failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false for existing mount")
+	}
+
+	// unmount storage
+	unmountTask := StorageMountTask{
+		App:          appName,
+		HostDir:      hostDir,
+		ContainerDir: containerDir,
+		State:        StateAbsent,
+	}
+	result = unmountTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unmount storage: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for unmount")
+	}
+
+	// unmount again should be idempotent
+	result = unmountTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent unmount failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false for nonexistent mount")
+	}
+}
+
+func TestIntegrationGetTasksFullWorkflow(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "omakase-test-workflow"
+
+	// ensure clean state
+	destroyApp(appName)
+	defer destroyApp(appName)
+
+	data := []byte(`---
+- tasks:
+    - name: create app
+      dokku_app:
+        app: ` + appName + `
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	for _, name := range tasks.Keys() {
+		task := tasks.Get(name)
+		state := task.Execute()
+		if state.Error != nil {
+			t.Fatalf("task %q failed: %v", name, state.Error)
+		}
+		if state.State != task.DesiredState() {
+			t.Errorf("task %q: expected state %q, got %q", name, task.DesiredState(), state.State)
+		}
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -1,0 +1,173 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetTasksEmptyRecipe(t *testing.T) {
+	data := []byte("---\n")
+	context := map[string]interface{}{}
+
+	_, err := GetTasks(data, context)
+	if err == nil {
+		t.Fatal("GetTasks with empty recipe should return an error")
+	}
+
+	if !strings.Contains(err.Error(), "no recipe found") {
+		t.Errorf("expected 'no recipe found' error, got: %v", err)
+	}
+}
+
+func TestGetTasksEmptyList(t *testing.T) {
+	data := []byte("---\n- tasks: []\n")
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks with empty task list should not error, got: %v", err)
+	}
+
+	if len(tasks.Keys()) != 0 {
+		t.Errorf("expected 0 tasks, got %d", len(tasks.Keys()))
+	}
+}
+
+func TestGetTasksValidAppTask(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: create test app
+      dokku_app:
+        app: test-app
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks should not error for valid app task, got: %v", err)
+	}
+
+	if len(tasks.Keys()) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks.Keys()))
+	}
+
+	task := tasks.Get("create test app")
+	if task == nil {
+		t.Fatal("task 'create test app' not found")
+	}
+
+	if task.DesiredState() != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", task.DesiredState())
+	}
+}
+
+func TestGetTasksInvalidTaskType(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - dokku_nonexistent:
+        app: test-app
+`)
+	context := map[string]interface{}{}
+
+	_, err := GetTasks(data, context)
+	if err == nil {
+		t.Fatal("GetTasks with invalid task type should return an error")
+	}
+
+	if !strings.Contains(err.Error(), "not a valid task") {
+		t.Errorf("expected 'not a valid task' error, got: %v", err)
+	}
+}
+
+func TestGetTasksTooManyProperties(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: test
+      dokku_app:
+        app: test-app
+      dokku_config:
+        app: test-app
+`)
+	context := map[string]interface{}{}
+
+	_, err := GetTasks(data, context)
+	if err == nil {
+		t.Fatal("GetTasks with too many properties should return an error")
+	}
+
+	if !strings.Contains(err.Error(), "too many properties") {
+		t.Errorf("expected 'too many properties' error, got: %v", err)
+	}
+}
+
+func TestGetTasksAutoGeneratesName(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - dokku_app:
+        app: test-app
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks should not error for nameless task, got: %v", err)
+	}
+
+	keys := tasks.Keys()
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(keys))
+	}
+
+	if !strings.HasPrefix(keys[0], "task #1 ") {
+		t.Errorf("expected auto-generated name starting with 'task #1 ', got '%s'", keys[0])
+	}
+}
+
+func TestGetTasksWithTemplateContext(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: create {{ .app_name }}
+      dokku_app:
+        app: {{ .app_name }}
+`)
+	context := map[string]interface{}{
+		"app_name": "my-app",
+	}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks should not error with template context, got: %v", err)
+	}
+
+	if len(tasks.Keys()) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks.Keys()))
+	}
+
+	task := tasks.Get("create my-app")
+	if task == nil {
+		t.Fatal("task 'create my-app' not found")
+	}
+}
+
+func TestRegisteredTasksExist(t *testing.T) {
+	expectedTasks := []string{
+		"dokku_app",
+		"dokku_builder_property",
+		"dokku_checks_toggle",
+		"dokku_config",
+		"dokku_domains_toggle",
+		"dokku_git_from_image",
+		"dokku_git_sync",
+		"dokku_network_property",
+		"dokku_ports",
+		"dokku_proxy_toggle",
+		"dokku_storage_ensure",
+		"dokku_storage_mount",
+	}
+
+	for _, name := range expectedTasks {
+		if _, ok := RegisteredTasks[name]; !ok {
+			t.Errorf("expected task %q to be registered", name)
+		}
+	}
+}

--- a/tasks/ordered_map_test.go
+++ b/tasks/ordered_map_test.go
@@ -1,0 +1,76 @@
+package tasks
+
+import (
+	"testing"
+)
+
+type mockTask struct {
+	name  string
+	state State
+}
+
+func (m mockTask) DesiredState() State              { return m.state }
+func (m mockTask) Doc() string                      { return "" }
+func (m mockTask) Examples() ([]Doc, error)         { return nil, nil }
+func (m mockTask) Execute() TaskOutputState         { return TaskOutputState{State: m.state} }
+
+func TestOrderedStringTaskMapSetAndGet(t *testing.T) {
+	m := OrderedStringTaskMap{}
+
+	task := mockTask{name: "test", state: StatePresent}
+	m.Set("key1", task)
+
+	got := m.Get("key1")
+	if got == nil {
+		t.Fatal("Get returned nil for existing key")
+	}
+
+	if got.DesiredState() != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", got.DesiredState())
+	}
+}
+
+func TestOrderedStringTaskMapGetMissing(t *testing.T) {
+	m := OrderedStringTaskMap{}
+
+	got := m.Get("nonexistent")
+	if got != nil {
+		t.Error("Get returned non-nil for nonexistent key on empty map")
+	}
+
+	m.Set("key1", mockTask{name: "test", state: StatePresent})
+	got = m.Get("nonexistent")
+	if got != nil {
+		t.Error("Get returned non-nil for nonexistent key")
+	}
+}
+
+func TestOrderedStringTaskMapKeysPreservesOrder(t *testing.T) {
+	m := OrderedStringTaskMap{}
+
+	m.Set("third", mockTask{name: "3", state: StatePresent})
+	m.Set("first", mockTask{name: "1", state: StatePresent})
+	m.Set("second", mockTask{name: "2", state: StatePresent})
+
+	keys := m.Keys()
+	expected := []string{"third", "first", "second"}
+
+	if len(keys) != len(expected) {
+		t.Fatalf("expected %d keys, got %d", len(expected), len(keys))
+	}
+
+	for i, key := range keys {
+		if key != expected[i] {
+			t.Errorf("key[%d] = %q, want %q", i, key, expected[i])
+		}
+	}
+}
+
+func TestOrderedStringTaskMapEmptyKeys(t *testing.T) {
+	m := OrderedStringTaskMap{}
+
+	keys := m.Keys()
+	if keys != nil && len(keys) != 0 {
+		t.Errorf("expected nil or empty keys, got %v", keys)
+	}
+}

--- a/tasks/task_execute_test.go
+++ b/tasks/task_execute_test.go
@@ -1,0 +1,217 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestAppTaskInvalidState(t *testing.T) {
+	task := AppTask{App: "test-app", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestAppTaskDesiredState(t *testing.T) {
+	task := AppTask{App: "test-app", State: StatePresent}
+	if task.DesiredState() != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", task.DesiredState())
+	}
+
+	task = AppTask{App: "test-app", State: StateAbsent}
+	if task.DesiredState() != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", task.DesiredState())
+	}
+}
+
+func TestBuilderPropertyTaskInvalidState(t *testing.T) {
+	task := BuilderPropertyTask{App: "test-app", Property: "selected", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestBuilderPropertyTaskMissingApp(t *testing.T) {
+	task := BuilderPropertyTask{Property: "selected", Value: "dockerfile", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestChecksToggleTaskInvalidState(t *testing.T) {
+	task := ChecksToggleTask{App: "test-app", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestConfigTaskInvalidState(t *testing.T) {
+	task := ConfigTask{
+		App:    "test-app",
+		Config: map[string]string{"KEY": "VALUE"},
+		State:  "invalid",
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestDomainsToggleTaskInvalidState(t *testing.T) {
+	task := DomainsToggleTask{App: "test-app", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestGitFromImageTaskInvalidState(t *testing.T) {
+	task := GitFromImageTask{App: "test-app", Image: "nginx", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestNetworkPropertyTaskInvalidState(t *testing.T) {
+	task := NetworkPropertyTask{App: "test-app", Property: "attach-post-create", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestNetworkPropertyTaskMissingApp(t *testing.T) {
+	task := NetworkPropertyTask{Property: "attach-post-create", Value: "test-network", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestPortsTaskInvalidState(t *testing.T) {
+	task := PortsTask{
+		App:          "test-app",
+		PortMappings: []PortMapping{{Scheme: "http", Host: 80, Container: 5000}},
+		State:        "invalid",
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestPortsTaskEmptyPortMappings(t *testing.T) {
+	task := PortsTask{App: "test-app", PortMappings: []PortMapping{}, State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with empty port mappings should return an error")
+	}
+}
+
+func TestProxyToggleTaskInvalidState(t *testing.T) {
+	task := ProxyToggleTask{App: "test-app", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestStorageEnsureTaskInvalidState(t *testing.T) {
+	task := StorageEnsureTask{App: "test-app", Chown: "heroku", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestStorageMountTaskInvalidState(t *testing.T) {
+	task := StorageMountTask{
+		App:          "test-app",
+		HostDir:      "/host",
+		ContainerDir: "/container",
+		State:        "invalid",
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestPortMappingString(t *testing.T) {
+	pm := PortMapping{Scheme: "http", Host: 80, Container: 5000}
+	expected := "http:80:5000"
+	if pm.String() != expected {
+		t.Errorf("PortMapping.String() = %q, want %q", pm.String(), expected)
+	}
+}
+
+func TestStorageEnsureValidChownValues(t *testing.T) {
+	validValues := []string{"heroku", "herokuish", "paketo", "root", "false"}
+	for _, chown := range validValues {
+		task := StorageEnsureTask{App: "test-app", Chown: chown, State: StatePresent}
+		result := task.Execute()
+		// These will fail because dokku isn't running, but should NOT fail
+		// due to invalid chown value
+		if result.Error != nil && result.Error.Error() == "invalid chown value specified" {
+			t.Errorf("chown value %q should be valid but was rejected", chown)
+		}
+	}
+}
+
+func TestStorageEnsureInvalidChownValue(t *testing.T) {
+	task := StorageEnsureTask{App: "test-app", Chown: "packeto", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil || result.Error.Error() != "invalid chown value specified" {
+		t.Errorf("chown value 'packeto' (misspelled) should be rejected as invalid")
+	}
+}
+
+func TestStorageEnsureAbsentStateReturnsError(t *testing.T) {
+	task := StorageEnsureTask{App: "test-app", Chown: "heroku", State: StateAbsent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with absent state should return an error for storage ensure")
+	}
+}
+
+func TestGitSyncTaskDesiredState(t *testing.T) {
+	task := GitSyncTask{
+		App:        "test-app",
+		Repository: "https://github.com/example/repo",
+		State:      "synced",
+	}
+	if task.DesiredState() != "synced" {
+		t.Errorf("expected state 'synced', got '%s'", task.DesiredState())
+	}
+}
+
+func TestTaskDocStrings(t *testing.T) {
+	tests := []struct {
+		task Task
+		want string
+	}{
+		{&AppTask{}, "Creates or destroys an app"},
+		{&BuilderPropertyTask{}, "Manages the builder configuration for a given dokku application"},
+		{&ChecksToggleTask{}, "Enables or disables the checks plugin for a given dokku application"},
+		{&ConfigTask{}, "Manages the configuration for a given dokku application"},
+		{&DomainsToggleTask{}, "Enables or disables the domains plugin for a given dokku application"},
+		{&GitFromImageTask{}, "Deploys a git repository from a docker image"},
+		{&GitSyncTask{}, "Syncs a git repository to a dokku application"},
+		{&NetworkPropertyTask{}, "Manages the network property for a given dokku application"},
+		{&PortsTask{}, "Manages the ports for a given dokku application"},
+		{&ProxyToggleTask{}, "Enables or disables the proxy plugin for a given dokku application"},
+		{&StorageEnsureTask{}, "Ensures the storage for a given dokku application"},
+		{&StorageMountTask{}, "Mounts or unmounts the storage for a given dokku application"},
+	}
+
+	for _, tt := range tests {
+		doc := tt.task.Doc()
+		if doc != tt.want {
+			t.Errorf("Doc() = %q, want %q", doc, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add unit tests covering all bug fixes from #111 plus core data structures and task registration
- Add integration tests that run against a live dokku instance, covering app lifecycle, config management, builder/network properties, storage ensure/mount operations, and end-to-end GetTasks workflow
- Add a `test.yml` CI workflow with separate unit-test and integration-test jobs (integration tests install dokku on the runner)
- Add `make test` and `make test-integration` Makefile targets