### PR TITLE
feat: align git sync task with upstream ansible module

### DIFF
--- a/docs/dokku_git_sync.md
+++ b/docs/dokku_git_sync.md
@@ -1,3 +1,21 @@
 # dokku_git_sync
 
 Syncs a git repository to a dokku application
+
+## Sync a git repository to an app
+
+```yaml
+dokku_git_sync:
+    app: hello-world
+    remote: https://github.com/dokku/smoke-test-app.git
+```
+
+## Sync a git repository with a specific ref and build
+
+```yaml
+dokku_git_sync:
+    app: hello-world
+    remote: https://github.com/dokku/smoke-test-app.git
+    git_ref: main
+    build: true
+```

--- a/tasks.yml
+++ b/tasks.yml
@@ -4,9 +4,9 @@
       description: "Name of app to be created"
       type: string
       required: true
-    - name: repository
+    - name: remote
       default: "http://github.com/cakephp/inflector.cakephp.org"
-      description: "Repository to be synced"
+      description: "Remote git repository to be synced"
   tasks:
     - name: dokku apps:create {{ .app | default "" }}
       dokku_app:
@@ -15,4 +15,4 @@
     - name: dokku git:sync {{ .app | default "" }}
       dokku_git_sync:
         app: {{.app | default ""}}
-        repository: {{.repository | default ""}}
+        remote: {{.remote | default ""}}

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"encoding/json"
 	"fmt"
 	"omakase/subprocess"
 
@@ -102,11 +103,41 @@ func (t GitSyncTask) Execute() TaskOutputState {
 	return fn(t)
 }
 
+// checkAppSyncState checks if the app is already synced from the expected remote and ref
+func checkAppSyncState(app, expectedRemote, expectedRef string) bool {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"apps:report", app, "--format", "json"},
+	})
+	if err != nil {
+		return false
+	}
+
+	type appSource struct {
+		Source         string `json:"app-deploy-source"`
+		SourceMetadata string `json:"app-deploy-source-metadata"`
+	}
+
+	var source appSource
+	err = json.Unmarshal(result.StdoutBytes(), &source)
+	if err != nil {
+		return false
+	}
+
+	expectedMetadata := fmt.Sprintf("%s#%s", expectedRemote, expectedRef)
+	return source.Source == "git-sync" && source.SourceMetadata == expectedMetadata
+}
+
 // syncGitRepository syncs a git repository to a dokku application
 func syncGitRepository(t GitSyncTask) TaskOutputState {
 	state := TaskOutputState{
 		Changed: false,
 		State:   "absent",
+	}
+
+	if checkAppSyncState(t.App, t.Remote, t.GitRef) {
+		state.State = "present"
+		return state
 	}
 
 	args := []string{

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"fmt"
 	"omakase/subprocess"
 
 	yaml "gopkg.in/yaml.v3"
@@ -11,14 +12,23 @@ type GitSyncTask struct {
 	// App is the name of the app
 	App string `required:"true" yaml:"app"`
 
-	// Repository is the git repository to sync
-	Repository string `required:"true" yaml:"repository"`
+	// Remote is the git remote url to sync
+	Remote string `required:"true" yaml:"remote"`
 
 	// GitRef is the git reference to sync
 	GitRef string `required:"false" yaml:"git_ref"`
 
+	// Build triggers an application build after syncing
+	Build bool `required:"false" yaml:"build"`
+
+	// BuildIfChanges triggers a build only if changes are detected
+	BuildIfChanges bool `required:"false" yaml:"build_if_changes"`
+
+	// SkipDeployBranch skips automatically setting the deploy-branch property
+	SkipDeployBranch bool `required:"false" yaml:"skip_deploy_branch"`
+
 	// State is the desired state of the git sync
-	State State `required:"false" yaml:"state" default:"synced" options:"synced"`
+	State State `required:"false" yaml:"state" default:"present" options:"present"`
 }
 
 // GitSyncTaskExample contains an example of a GitSyncTask
@@ -40,9 +50,26 @@ func (t GitSyncTask) Doc() string {
 	return "Syncs a git repository to a dokku application"
 }
 
-// Examples returns the examples for the builder property task
+// Examples returns the examples for the git sync task
 func (t GitSyncTask) Examples() ([]Doc, error) {
-	examples := []GitSyncTaskExample{}
+	examples := []GitSyncTaskExample{
+		{
+			Name: "Sync a git repository to an app",
+			GitSyncTask: GitSyncTask{
+				App:    "hello-world",
+				Remote: "https://github.com/dokku/smoke-test-app.git",
+			},
+		},
+		{
+			Name: "Sync a git repository with a specific ref and build",
+			GitSyncTask: GitSyncTask{
+				App:    "hello-world",
+				Remote: "https://github.com/dokku/smoke-test-app.git",
+				GitRef: "main",
+				Build:  true,
+			},
+		},
+	}
 
 	var output []Doc
 	for _, example := range examples {
@@ -62,16 +89,41 @@ func (t GitSyncTask) Examples() ([]Doc, error) {
 
 // Execute syncs a git repository to a dokku application
 func (t GitSyncTask) Execute() TaskOutputState {
+	funcMap := map[State]func(GitSyncTask) TaskOutputState{
+		"present": syncGitRepository,
+	}
+
+	fn, ok := funcMap[t.State]
+	if !ok {
+		return TaskOutputState{
+			Error: fmt.Errorf("invalid state: %s", t.State),
+		}
+	}
+	return fn(t)
+}
+
+// syncGitRepository syncs a git repository to a dokku application
+func syncGitRepository(t GitSyncTask) TaskOutputState {
 	state := TaskOutputState{
 		Changed: false,
-		State:   "unsynced",
+		State:   "absent",
 	}
 
 	args := []string{
 		"git:sync",
 	}
 
-	args = append(args, t.App, t.Repository)
+	if t.Build {
+		args = append(args, "--build")
+	}
+	if t.BuildIfChanges {
+		args = append(args, "--build-if-changes")
+	}
+	if t.SkipDeployBranch {
+		args = append(args, "--skip-deploy-branch")
+	}
+
+	args = append(args, t.App, t.Remote)
 
 	if t.GitRef != "" {
 		args = append(args, t.GitRef)
@@ -88,7 +140,7 @@ func (t GitSyncTask) Execute() TaskOutputState {
 	}
 
 	state.Changed = true
-	state.State = "synced"
+	state.State = "present"
 	return state
 }
 

--- a/tasks/integration_test.go
+++ b/tasks/integration_test.go
@@ -581,16 +581,16 @@ func TestIntegrationGitSync(t *testing.T) {
 	defer destroyApp(appName)
 
 	task := GitSyncTask{
-		App:        appName,
-		Repository: "https://github.com/dokku/smoke-test-app",
-		State:      "synced",
+		App:    appName,
+		Remote: "https://github.com/dokku/smoke-test-app",
+		State:  StatePresent,
 	}
 	result := task.Execute()
 	if result.Error != nil {
 		t.Fatalf("failed to sync git: %v", result.Error)
 	}
-	if result.State != "synced" {
-		t.Errorf("expected state 'synced', got '%s'", result.State)
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
 	}
 	if !result.Changed {
 		t.Error("expected changed=true for git sync")

--- a/tasks/task_execute_test.go
+++ b/tasks/task_execute_test.go
@@ -181,12 +181,12 @@ func TestStorageEnsureAbsentStateReturnsError(t *testing.T) {
 
 func TestGitSyncTaskDesiredState(t *testing.T) {
 	task := GitSyncTask{
-		App:        "test-app",
-		Repository: "https://github.com/example/repo",
-		State:      "synced",
+		App:    "test-app",
+		Remote: "https://github.com/example/repo",
+		State:  StatePresent,
 	}
-	if task.DesiredState() != "synced" {
-		t.Errorf("expected state 'synced', got '%s'", task.DesiredState())
+	if task.DesiredState() != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", task.DesiredState())
 	}
 }
 
@@ -207,7 +207,7 @@ func TestAllTasksDesiredState(t *testing.T) {
 		{"DomainsToggleTask present", &DomainsToggleTask{App: "test", State: StatePresent}, StatePresent},
 		{"DomainsToggleTask absent", &DomainsToggleTask{App: "test", State: StateAbsent}, StateAbsent},
 		{"GitFromImageTask deployed", &GitFromImageTask{App: "test", Image: "nginx", State: StateDeployed}, StateDeployed},
-		{"GitSyncTask synced", &GitSyncTask{App: "test", Repository: "https://example.com/repo", State: "synced"}, "synced"},
+		{"GitSyncTask present", &GitSyncTask{App: "test", Remote: "https://example.com/repo", State: StatePresent}, StatePresent},
 		{"NetworkPropertyTask present", &NetworkPropertyTask{App: "test", Property: "bind-all-interfaces", State: StatePresent}, StatePresent},
 		{"NetworkPropertyTask absent", &NetworkPropertyTask{App: "test", Property: "bind-all-interfaces", State: StateAbsent}, StateAbsent},
 		{"PortsTask present", &PortsTask{App: "test", State: StatePresent}, StatePresent},
@@ -350,20 +350,15 @@ func TestGitFromImageTaskNonDeployedStates(t *testing.T) {
 	}
 }
 
-func TestGitSyncTaskNoStateValidation(t *testing.T) {
+func TestGitSyncTaskInvalidState(t *testing.T) {
 	task := GitSyncTask{
-		App:        "test-app",
-		Repository: "https://example.com/repo",
-		State:      "invalid",
+		App:    "test-app",
+		Remote: "https://example.com/repo",
+		State:  "invalid",
 	}
 	result := task.Execute()
-	// GitSyncTask has no funcMap-based state validation; it always tries to run
-	// the dokku command. The error should be from subprocess, not state validation.
 	if result.Error == nil {
-		t.Fatal("expected error from subprocess (dokku not available)")
-	}
-	if strings.Contains(result.Error.Error(), "invalid state") {
-		t.Error("GitSyncTask should not have state validation, but got 'invalid state' error")
+		t.Fatal("Execute with invalid state should return an error")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Renames `repository` field to `remote` to match the upstream [ansible dokku_git_sync module](https://github.com/dokku/ansible-dokku/blob/master/library/dokku_git_sync.py)
- Changes state from `synced` to `present` to align with codebase conventions and the upstream module's state interface
- Adds funcMap-based state dispatch for proper state validation (invalid states now return errors)
- Adds support for `--build`, `--build-if-changes`, and `--skip-deploy-branch` flags from the `dokku git:sync` command
- Adds task examples and expands documentation

Closes #20