### PR TITLE
Implement resource limit task

### DIFF
--- a/docs/dokku_git_sync.md
+++ b/docs/dokku_git_sync.md
@@ -5,17 +5,25 @@ Syncs a git repository to a dokku application
 ## Sync a git repository to an app
 
 ```yaml
-dokku_git_sync:
+git_sync:
     app: hello-world
     remote: https://github.com/dokku/smoke-test-app.git
+    git_ref: ""
+    build: false
+    build_if_changes: false
+    skip_deploy_branch: false
+    state: ""
 ```
 
 ## Sync a git repository with a specific ref and build
 
 ```yaml
-dokku_git_sync:
+git_sync:
     app: hello-world
     remote: https://github.com/dokku/smoke-test-app.git
     git_ref: main
     build: true
+    build_if_changes: false
+    skip_deploy_branch: false
+    state: ""
 ```

--- a/docs/dokku_resource_limit.md
+++ b/docs/dokku_resource_limit.md
@@ -1,0 +1,35 @@
+# dokku_resource_limit
+
+Manages the resource limits for a given dokku application
+
+## Set CPU and memory limits
+
+```yaml
+resource_limit:
+    app: hello-world
+    resources:
+        cpu: "100"
+        memory: "256"
+    clear_before: false
+```
+
+## Set memory limit for web process type
+
+```yaml
+resource_limit:
+    app: hello-world
+    process_type: web
+    resources:
+        memory: "512"
+    clear_before: false
+```
+
+## Clear all resource limits
+
+```yaml
+resource_limit:
+    app: hello-world
+    resources: {}
+    clear_before: false
+    state: absent
+```

--- a/tasks/integration_test.go
+++ b/tasks/integration_test.go
@@ -635,6 +635,131 @@ func TestIntegrationGitFromImage(t *testing.T) {
 	}
 }
 
+func TestIntegrationResourceLimit(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "omakase-test-reslimit"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set resource limits
+	setTask := ResourceLimitTask{
+		App:       appName,
+		Resources: map[string]string{"cpu": "100", "memory": "256"},
+		State:     StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set resource limits: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for new resource limits")
+	}
+
+	// setting same limits again should be idempotent
+	result = setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent set failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false for unchanged resource limits")
+	}
+
+	// clear resource limits
+	clearTask := ResourceLimitTask{
+		App:   appName,
+		State: StateAbsent,
+	}
+	result = clearTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to clear resource limits: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for clearing resource limits")
+	}
+
+	// clear again should be idempotent
+	result = clearTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent clear failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false for already-cleared resource limits")
+	}
+}
+
+func TestIntegrationResourceLimitProcessType(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "omakase-test-reslimit-pt"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set resource limits for a specific process type
+	setTask := ResourceLimitTask{
+		App:         appName,
+		ProcessType: "web",
+		Resources:   map[string]string{"memory": "512"},
+		State:       StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set resource limits: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for new resource limits")
+	}
+
+	// idempotent
+	result = setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent set failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false for unchanged resource limits")
+	}
+
+	// clear before + set new values
+	clearBeforeTask := ResourceLimitTask{
+		App:         appName,
+		ProcessType: "web",
+		Resources:   map[string]string{"cpu": "200"},
+		ClearBefore: true,
+		State:       StatePresent,
+	}
+	result = clearBeforeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to clear_before and set: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for clear_before operation")
+	}
+
+	// clear process-type limits
+	clearTask := ResourceLimitTask{
+		App:         appName,
+		ProcessType: "web",
+		State:       StateAbsent,
+	}
+	result = clearTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to clear: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for clearing resource limits")
+	}
+}
+
 func TestIntegrationMultiTaskWorkflow(t *testing.T) {
 	skipIfNoDokkuT(t)
 

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -163,6 +163,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_network_property",
 		"dokku_ports",
 		"dokku_proxy_toggle",
+		"dokku_resource_limit",
 		"dokku_storage_ensure",
 		"dokku_storage_mount",
 	}
@@ -513,5 +514,61 @@ func TestGetTasksFromRealExample(t *testing.T) {
 	}
 	if gitTask.Image != "lscr.io/linuxserver/adguardhome-sync:latest" {
 		t.Errorf("Image = %q, want %q", gitTask.Image, "lscr.io/linuxserver/adguardhome-sync:latest")
+	}
+}
+
+func TestGetTasksResourceLimitTaskParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: set resource limits
+      dokku_resource_limit:
+        app: test-app
+        process_type: web
+        resources:
+          cpu: "100"
+          memory: "256"
+        clear_before: true
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("set resource limits")
+	if task == nil {
+		t.Fatal("task 'set resource limits' not found")
+	}
+
+	rlTask, ok := task.(*ResourceLimitTask)
+	if !ok {
+		rt, ok2 := task.(ResourceLimitTask)
+		if !ok2 {
+			t.Fatalf("task is not a ResourceLimitTask (type is %T)", task)
+		}
+		rlTask = &rt
+	}
+
+	if rlTask.App != "test-app" {
+		t.Errorf("App = %q, want %q", rlTask.App, "test-app")
+	}
+	if rlTask.ProcessType != "web" {
+		t.Errorf("ProcessType = %q, want %q", rlTask.ProcessType, "web")
+	}
+	if len(rlTask.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(rlTask.Resources))
+	}
+	if rlTask.Resources["cpu"] != "100" {
+		t.Errorf("Resources[cpu] = %q, want %q", rlTask.Resources["cpu"], "100")
+	}
+	if rlTask.Resources["memory"] != "256" {
+		t.Errorf("Resources[memory] = %q, want %q", rlTask.Resources["memory"], "256")
+	}
+	// Unlike ConfigTask.Restart (default:"true"), ClearBefore has default:"false" which
+	// is the zero value for bool. Since defaults.SetDefaults only overrides zero values,
+	// and true is non-zero, setting clear_before: true in YAML is preserved correctly.
+	if !rlTask.ClearBefore {
+		t.Error("ClearBefore = false, want true (YAML value should be preserved)")
 	}
 }

--- a/tasks/resource_limit_task.go
+++ b/tasks/resource_limit_task.go
@@ -1,0 +1,310 @@
+package tasks
+
+import (
+	"errors"
+	"fmt"
+	"omakase/subprocess"
+	"strings"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// ResourceLimitTask manages the resource limits for a given dokku application
+type ResourceLimitTask struct {
+	// App is the name of the app
+	App string `required:"true" yaml:"app"`
+
+	// ProcessType is the process type to set resource limits for
+	ProcessType string `required:"false" yaml:"process_type,omitempty"`
+
+	// Resources is a map of resource type to quantity
+	Resources map[string]string `yaml:"resources"`
+
+	// ClearBefore clears all resource limits before applying new ones
+	ClearBefore bool `yaml:"clear_before" default:"false"`
+
+	// State is the desired state of the resource limits
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// ResourceLimitTaskExample contains an example of a ResourceLimitTask
+type ResourceLimitTaskExample struct {
+	// Name is the task name holding the ResourceLimitTask description
+	Name string `yaml:"-"`
+
+	// ResourceLimitTask is the ResourceLimitTask configuration
+	ResourceLimitTask ResourceLimitTask `yaml:"resource_limit"`
+}
+
+// DesiredState returns the desired state of the resource limits
+func (t ResourceLimitTask) DesiredState() State {
+	return t.State
+}
+
+// Doc returns the docblock for the resource limit task
+func (t ResourceLimitTask) Doc() string {
+	return "Manages the resource limits for a given dokku application"
+}
+
+// Examples returns the examples for the resource limit task
+func (t ResourceLimitTask) Examples() ([]Doc, error) {
+	examples := []ResourceLimitTaskExample{
+		{
+			Name: "Set CPU and memory limits",
+			ResourceLimitTask: ResourceLimitTask{
+				App: "hello-world",
+				Resources: map[string]string{
+					"cpu":    "100",
+					"memory": "256",
+				},
+			},
+		},
+		{
+			Name: "Set memory limit for web process type",
+			ResourceLimitTask: ResourceLimitTask{
+				App:         "hello-world",
+				ProcessType: "web",
+				Resources: map[string]string{
+					"memory": "512",
+				},
+			},
+		},
+		{
+			Name: "Clear all resource limits",
+			ResourceLimitTask: ResourceLimitTask{
+				App:   "hello-world",
+				State: StateAbsent,
+			},
+		},
+	}
+
+	var output []Doc
+	for _, example := range examples {
+		b, err := yaml.Marshal(example)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, Doc{
+			Name:      example.Name,
+			Codeblock: string(b),
+		})
+	}
+
+	return output, nil
+}
+
+// Execute sets or clears the resource limits for a given dokku application
+func (t ResourceLimitTask) Execute() TaskOutputState {
+	funcMap := map[State]func(ResourceLimitTask) TaskOutputState{
+		"present": setResourceLimit,
+		"absent":  clearResourceLimit,
+	}
+
+	if t.State == StatePresent && len(t.Resources) == 0 {
+		return TaskOutputState{
+			Error:   errors.New("resources are required when state is present"),
+			Message: "resources are required when state is present",
+		}
+	}
+
+	fn, ok := funcMap[t.State]
+	if !ok {
+		return TaskOutputState{
+			Error: fmt.Errorf("invalid state: %s", t.State),
+		}
+	}
+	return fn(t)
+}
+
+// getResourceLimits retrieves the current resource limits for a given dokku application
+func getResourceLimits(t ResourceLimitTask) (map[string]string, error) {
+	args := []string{
+		"--quiet",
+		"resource:limit",
+	}
+
+	if t.ProcessType != "" {
+		args = append(args, "--process-type", t.ProcessType)
+	}
+
+	args = append(args, t.App)
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	limits := map[string]string{}
+	for _, line := range strings.Split(result.StdoutContents(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.Contains(line, ":") {
+			continue
+		}
+
+		parts := strings.SplitN(line, ":", 2)
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		if key != "" {
+			limits[key] = value
+		}
+	}
+
+	return limits, nil
+}
+
+// setResourceLimit sets the resource limits for a given dokku application
+func setResourceLimit(t ResourceLimitTask) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   "absent",
+	}
+
+	if t.ClearBefore {
+		err := execResourceLimitClear(t)
+		if err != nil {
+			state.Error = err
+			state.Message = err.Error()
+			return state
+		}
+		state.Changed = true
+	}
+
+	if !t.ClearBefore {
+		currentLimits, err := getResourceLimits(t)
+		if err != nil {
+			state.Error = err
+			state.Message = err.Error()
+			return state
+		}
+
+		// validate that all requested resources exist
+		for k := range t.Resources {
+			if _, ok := currentLimits[k]; !ok {
+				state.Error = fmt.Errorf("unknown resource %s, valid resources: %v", k, mapKeys(currentLimits))
+				state.Message = state.Error.Error()
+				return state
+			}
+		}
+
+		hasChanged := false
+		for k, v := range t.Resources {
+			if currentLimits[k] != v {
+				hasChanged = true
+				break
+			}
+		}
+
+		if !hasChanged {
+			state.State = "present"
+			return state
+		}
+	}
+
+	args := []string{
+		"resource:limit",
+	}
+
+	for key, value := range t.Resources {
+		args = append(args, fmt.Sprintf("--%s", key), value)
+	}
+
+	if t.ProcessType != "" {
+		args = append(args, "--process-type", t.ProcessType)
+	}
+
+	args = append(args, t.App)
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		state.Error = err
+		state.Message = result.StderrContents()
+		return state
+	}
+
+	state.Changed = true
+	state.State = "present"
+	return state
+}
+
+// clearResourceLimit clears the resource limits for a given dokku application
+func clearResourceLimit(t ResourceLimitTask) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   "present",
+	}
+
+	currentLimits, err := getResourceLimits(t)
+	if err != nil {
+		state.Error = err
+		state.Message = err.Error()
+		return state
+	}
+
+	hasLimits := false
+	for _, v := range currentLimits {
+		if v != "" && v != "0" {
+			hasLimits = true
+			break
+		}
+	}
+
+	if !hasLimits {
+		state.State = "absent"
+		return state
+	}
+
+	err = execResourceLimitClear(t)
+	if err != nil {
+		state.Error = err
+		state.Message = err.Error()
+		return state
+	}
+
+	state.Changed = true
+	state.State = "absent"
+	return state
+}
+
+// execResourceLimitClear executes the dokku resource:limit-clear command
+func execResourceLimitClear(t ResourceLimitTask) error {
+	args := []string{
+		"resource:limit-clear",
+	}
+
+	if t.ProcessType != "" {
+		args = append(args, "--process-type", t.ProcessType)
+	}
+
+	args = append(args, t.App)
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		return fmt.Errorf("%s", result.StderrContents())
+	}
+
+	return nil
+}
+
+// mapKeys returns the keys of a map as a sorted slice
+func mapKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// init registers the ResourceLimitTask with the task registry
+func init() {
+	RegisterTask(&ResourceLimitTask{})
+}

--- a/tasks/task_execute_test.go
+++ b/tasks/task_execute_test.go
@@ -179,6 +179,46 @@ func TestStorageEnsureAbsentStateReturnsError(t *testing.T) {
 	}
 }
 
+func TestResourceLimitTaskInvalidState(t *testing.T) {
+	task := ResourceLimitTask{
+		App:       "test-app",
+		Resources: map[string]string{"cpu": "100"},
+		State:     "invalid",
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestResourceLimitTaskDesiredState(t *testing.T) {
+	task := ResourceLimitTask{App: "test-app", State: StatePresent}
+	if task.DesiredState() != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", task.DesiredState())
+	}
+
+	task = ResourceLimitTask{App: "test-app", State: StateAbsent}
+	if task.DesiredState() != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", task.DesiredState())
+	}
+}
+
+func TestResourceLimitTaskEmptyResources(t *testing.T) {
+	task := ResourceLimitTask{App: "test-app", Resources: map[string]string{}, State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with empty resources and state=present should return an error")
+	}
+}
+
+func TestResourceLimitTaskNilResources(t *testing.T) {
+	task := ResourceLimitTask{App: "test-app", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with nil resources and state=present should return an error")
+	}
+}
+
 func TestGitSyncTaskDesiredState(t *testing.T) {
 	task := GitSyncTask{
 		App:    "test-app",
@@ -212,6 +252,8 @@ func TestAllTasksDesiredState(t *testing.T) {
 		{"NetworkPropertyTask absent", &NetworkPropertyTask{App: "test", Property: "bind-all-interfaces", State: StateAbsent}, StateAbsent},
 		{"PortsTask present", &PortsTask{App: "test", State: StatePresent}, StatePresent},
 		{"PortsTask absent", &PortsTask{App: "test", State: StateAbsent}, StateAbsent},
+		{"ResourceLimitTask present", &ResourceLimitTask{App: "test", Resources: map[string]string{"cpu": "100"}, State: StatePresent}, StatePresent},
+		{"ResourceLimitTask absent", &ResourceLimitTask{App: "test", State: StateAbsent}, StateAbsent},
 		{"ProxyToggleTask present", &ProxyToggleTask{App: "test", State: StatePresent}, StatePresent},
 		{"ProxyToggleTask absent", &ProxyToggleTask{App: "test", State: StateAbsent}, StateAbsent},
 		{"StorageEnsureTask present", &StorageEnsureTask{App: "test", Chown: "heroku", State: StatePresent}, StatePresent},
@@ -403,7 +445,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 12
+	expected := 13
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -423,6 +465,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&GitSyncTask{}, "Syncs a git repository to a dokku application"},
 		{&NetworkPropertyTask{}, "Manages the network property for a given dokku application"},
 		{&PortsTask{}, "Manages the ports for a given dokku application"},
+		{&ResourceLimitTask{}, "Manages the resource limits for a given dokku application"},
 		{&ProxyToggleTask{}, "Enables or disables the proxy plugin for a given dokku application"},
 		{&StorageEnsureTask{}, "Ensures the storage for a given dokku application"},
 		{&StorageMountTask{}, "Mounts or unmounts the storage for a given dokku application"},


### PR DESCRIPTION
## Summary

- Adds `dokku_resource_limit` task compatible with the upstream [ansible-dokku module](https://github.com/dokku/ansible-dokku/blob/master/library/dokku_resource_limit.py) interface
- Supports all upstream parameters: `app`, `process_type`, `resources`, `clear_before`, and `state` (present/absent)
- Implements full idempotency for both present and absent states (improvement over upstream which always clears on absent)
- Adds unit tests for validation, state handling, YAML parsing, and doc generation
- Adds integration tests for set/clear lifecycle, per-process-type limits, and `clear_before` behavior

Closes #17