### PR TITLE
Add dokku_ prefix to example struct yaml tags

### DIFF
--- a/docs/dokku_builder_property.md
+++ b/docs/dokku_builder_property.md
@@ -5,7 +5,7 @@ Manages the builder configuration for a given dokku application
 ## Overriding the auto-selected builder
 
 ```yaml
-builder_property:
+dokku_builder_property:
     app: node-js-app
     property: selected
     value: dockerfile
@@ -14,7 +14,7 @@ builder_property:
 ## Setting the builder to the default value
 
 ```yaml
-builder_property:
+dokku_builder_property:
     app: node-js-app
     property: selected
 ```
@@ -22,7 +22,7 @@ builder_property:
 ## Changing the build build directory
 
 ```yaml
-builder_property:
+dokku_builder_property:
     app: monorepo
     property: build-dir
     value: backend
@@ -31,7 +31,7 @@ builder_property:
 ## Overriding the auto-selected builder globally
 
 ```yaml
-builder_property:
+dokku_builder_property:
     app: ""
     global: true
     property: selected

--- a/docs/dokku_checks_toggle.md
+++ b/docs/dokku_checks_toggle.md
@@ -5,7 +5,7 @@ Enables or disables the checks plugin for a given dokku application
 ## Disable the zero downtime deployment
 
 ```yaml
-checks_toggle:
+dokku_checks_toggle:
     app: hello-world
     state: absent
 ```
@@ -13,7 +13,7 @@ checks_toggle:
 ## Re-enable the zero downtime deployment (enabled by default)
 
 ```yaml
-checks_toggle:
+dokku_checks_toggle:
     app: hello-world
     state: present
 ```

--- a/docs/dokku_config.md
+++ b/docs/dokku_config.md
@@ -5,7 +5,7 @@ Manages the configuration for a given dokku application
 ## set KEY=VALUE
 
 ```yaml
-config:
+dokku_config:
     app: hello-world
     restart: true
     config:
@@ -15,7 +15,7 @@ config:
 ## set KEY=VALUE without restart
 
 ```yaml
-config:
+dokku_config:
     app: hello-world
     restart: false
     config:

--- a/docs/dokku_git_sync.md
+++ b/docs/dokku_git_sync.md
@@ -5,7 +5,7 @@ Syncs a git repository to a dokku application
 ## Sync a git repository to an app
 
 ```yaml
-git_sync:
+dokku_git_sync:
     app: hello-world
     remote: https://github.com/dokku/smoke-test-app.git
     git_ref: ""
@@ -18,7 +18,7 @@ git_sync:
 ## Sync a git repository with a specific ref and build
 
 ```yaml
-git_sync:
+dokku_git_sync:
     app: hello-world
     remote: https://github.com/dokku/smoke-test-app.git
     git_ref: main

--- a/docs/dokku_network_property.md
+++ b/docs/dokku_network_property.md
@@ -5,7 +5,7 @@ Manages the network property for a given dokku application
 ## Associates a network after a container is created but before it is started
 
 ```yaml
-network_property:
+dokku_network_property:
     app: hello-world
     property: attach-post-create
     value: example-network
@@ -14,7 +14,7 @@ network_property:
 ## Associates the network at container creation
 
 ```yaml
-network_property:
+dokku_network_property:
     app: hello-world
     property: initial-network
     value: example-network
@@ -23,7 +23,7 @@ network_property:
 ## Setting a global network property
 
 ```yaml
-network_property:
+dokku_network_property:
     app: ""
     global: true
     property: attach-post-create
@@ -33,7 +33,7 @@ network_property:
 ## Clearing a network property
 
 ```yaml
-network_property:
+dokku_network_property:
     app: hello-world
     property: attach-post-create
 ```

--- a/docs/dokku_resource_limit.md
+++ b/docs/dokku_resource_limit.md
@@ -5,7 +5,7 @@ Manages the resource limits for a given dokku application
 ## Set CPU and memory limits
 
 ```yaml
-resource_limit:
+dokku_resource_limit:
     app: hello-world
     resources:
         cpu: "100"
@@ -16,7 +16,7 @@ resource_limit:
 ## Set memory limit for web process type
 
 ```yaml
-resource_limit:
+dokku_resource_limit:
     app: hello-world
     process_type: web
     resources:
@@ -27,7 +27,7 @@ resource_limit:
 ## Clear all resource limits
 
 ```yaml
-resource_limit:
+dokku_resource_limit:
     app: hello-world
     resources: {}
     clear_before: false

--- a/tasks/builder_property_task.go
+++ b/tasks/builder_property_task.go
@@ -31,7 +31,7 @@ type BuilderPropertyTaskExample struct {
 	Name string `yaml:"-"`
 
 	// BuilderPropertyTask is the BuilderPropertyTask configuration
-	BuilderPropertyTask BuilderPropertyTask `yaml:"builder_property"`
+	BuilderPropertyTask BuilderPropertyTask `yaml:"dokku_builder_property"`
 }
 
 // DesiredState returns the desired state of the builder configuration

--- a/tasks/checks_toggle_task.go
+++ b/tasks/checks_toggle_task.go
@@ -24,7 +24,7 @@ type ChecksToggleTaskExample struct {
 	Name string `yaml:"-"`
 
 	// ChecksToggleTask is the ChecksToggleTask configuration
-	ChecksToggleTask ChecksToggleTask `yaml:"checks_toggle"`
+	ChecksToggleTask ChecksToggleTask `yaml:"dokku_checks_toggle"`
 }
 
 // DesiredState returns the desired state of the checks plugin

--- a/tasks/config_task.go
+++ b/tasks/config_task.go
@@ -30,7 +30,7 @@ type ConfigTaskExample struct {
 	Name string `yaml:"-"`
 
 	// ConfigTask is the ConfigTask configuration
-	ConfigTask ConfigTask `yaml:"config"`
+	ConfigTask ConfigTask `yaml:"dokku_config"`
 }
 
 // DesiredState returns the desired state of the configuration

--- a/tasks/domains_toggle_task.go
+++ b/tasks/domains_toggle_task.go
@@ -24,7 +24,7 @@ type DomainsToggleTaskExample struct {
 	Name string `yaml:"-"`
 
 	// DomainsToggleTask is the DomainsToggleTask configuration
-	DomainsToggleTask DomainsToggleTask `yaml:"domains_toggle"`
+	DomainsToggleTask DomainsToggleTask `yaml:"dokku_domains_toggle"`
 }
 
 // DesiredState returns the desired state of the domains plugin

--- a/tasks/git_from_image_task.go
+++ b/tasks/git_from_image_task.go
@@ -37,7 +37,7 @@ type GitFromImageTaskExample struct {
 	Name string `yaml:"-"`
 
 	// GitFromImageTask is the GitFromImageTask configuration
-	GitFromImageTask GitFromImageTask `yaml:"git_from_image"`
+	GitFromImageTask GitFromImageTask `yaml:"dokku_git_from_image"`
 }
 
 // DesiredState returns the desired state of the git repository

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -38,7 +38,7 @@ type GitSyncTaskExample struct {
 	Name string `yaml:"-"`
 
 	// GitSyncTask is the GitSyncTask configuration
-	GitSyncTask GitSyncTask `yaml:"git_sync"`
+	GitSyncTask GitSyncTask `yaml:"dokku_git_sync"`
 }
 
 // DesiredState returns the desired state of the git sync

--- a/tasks/network_property_task.go
+++ b/tasks/network_property_task.go
@@ -31,7 +31,7 @@ type NetworkPropertyTaskExample struct {
 	Name string `yaml:"-"`
 
 	// NetworkPropertyTask is the NetworkPropertyTask configuration
-	NetworkPropertyTask NetworkPropertyTask `yaml:"network_property"`
+	NetworkPropertyTask NetworkPropertyTask `yaml:"dokku_network_property"`
 }
 
 // DesiredState returns the desired state of the network property

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -28,7 +28,7 @@ type PortsTaskExample struct {
 	Name string `yaml:"-"`
 
 	// PortsTask is the PortsTask configuration
-	PortsTask PortsTask `yaml:"ports"`
+	PortsTask PortsTask `yaml:"dokku_ports"`
 }
 
 // PortMapping represents a port mapping

--- a/tasks/proxy_toggle_task.go
+++ b/tasks/proxy_toggle_task.go
@@ -24,7 +24,7 @@ type ProxyToggleTaskExample struct {
 	Name string `yaml:"-"`
 
 	// ProxyToggleTask is the ProxyToggleTask configuration
-	ProxyToggleTask ProxyToggleTask `yaml:"proxy_toggle"`
+	ProxyToggleTask ProxyToggleTask `yaml:"dokku_proxy_toggle"`
 }
 
 // DesiredState returns the desired state of the proxy

--- a/tasks/resource_limit_task.go
+++ b/tasks/resource_limit_task.go
@@ -33,7 +33,7 @@ type ResourceLimitTaskExample struct {
 	Name string `yaml:"-"`
 
 	// ResourceLimitTask is the ResourceLimitTask configuration
-	ResourceLimitTask ResourceLimitTask `yaml:"resource_limit"`
+	ResourceLimitTask ResourceLimitTask `yaml:"dokku_resource_limit"`
 }
 
 // DesiredState returns the desired state of the resource limits

--- a/tasks/storage_ensure_task.go
+++ b/tasks/storage_ensure_task.go
@@ -26,7 +26,7 @@ type StorageEnsureTaskExample struct {
 	Name string `yaml:"-"`
 
 	// StorageEnsureTask is the StorageEnsureTask configuration
-	StorageEnsureTask StorageEnsureTask `yaml:"storage_ensure"`
+	StorageEnsureTask StorageEnsureTask `yaml:"dokku_storage_ensure"`
 }
 
 // DesiredState returns the desired state of the storage

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -29,7 +29,7 @@ type StorageMountTaskExample struct {
 	Name string `yaml:"-"`
 
 	// StorageMountTask is the StorageMountTask configuration
-	StorageMountTask StorageMountTask `yaml:"storage_mount"`
+	StorageMountTask StorageMountTask `yaml:"dokku_storage_mount"`
 }
 
 // DesiredState returns the desired state of the storage


### PR DESCRIPTION
## Summary

- Add `dokku_` prefix to yaml tags on all task example structs to match registered task names
- 12 example structs were missing the prefix; only `AppTaskExample` already had it