### PR TITLE
feat: implement resource reserve task

### DIFF
--- a/docs/dokku_resource_reserve.md
+++ b/docs/dokku_resource_reserve.md
@@ -1,0 +1,35 @@
+# dokku_resource_reserve
+
+Manages the resource reservations for a given dokku application
+
+## Set CPU and memory reservations
+
+```yaml
+dokku_resource_reserve:
+    app: hello-world
+    resources:
+        cpu: "100"
+        memory: "256"
+    clear_before: false
+```
+
+## Set memory reservation for web process type
+
+```yaml
+dokku_resource_reserve:
+    app: hello-world
+    process_type: web
+    resources:
+        memory: "512"
+    clear_before: false
+```
+
+## Clear all resource reservations
+
+```yaml
+dokku_resource_reserve:
+    app: hello-world
+    resources: {}
+    clear_before: false
+    state: absent
+```

--- a/tasks/integration_test.go
+++ b/tasks/integration_test.go
@@ -760,6 +760,131 @@ func TestIntegrationResourceLimitProcessType(t *testing.T) {
 	}
 }
 
+func TestIntegrationResourceReserve(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "omakase-test-resreserve"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set resource reservations
+	setTask := ResourceReserveTask{
+		App:       appName,
+		Resources: map[string]string{"cpu": "100", "memory": "256"},
+		State:     StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set resource reservations: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for new resource reservations")
+	}
+
+	// setting same reservations again should be idempotent
+	result = setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent set failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false for unchanged resource reservations")
+	}
+
+	// clear resource reservations
+	clearTask := ResourceReserveTask{
+		App:   appName,
+		State: StateAbsent,
+	}
+	result = clearTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to clear resource reservations: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for clearing resource reservations")
+	}
+
+	// clear again should be idempotent
+	result = clearTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent clear failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false for already-cleared resource reservations")
+	}
+}
+
+func TestIntegrationResourceReserveProcessType(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "omakase-test-resreserve-pt"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set resource reservations for a specific process type
+	setTask := ResourceReserveTask{
+		App:         appName,
+		ProcessType: "web",
+		Resources:   map[string]string{"memory": "512"},
+		State:       StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set resource reservations: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for new resource reservations")
+	}
+
+	// idempotent
+	result = setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent set failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false for unchanged resource reservations")
+	}
+
+	// clear before + set new values
+	clearBeforeTask := ResourceReserveTask{
+		App:         appName,
+		ProcessType: "web",
+		Resources:   map[string]string{"cpu": "200"},
+		ClearBefore: true,
+		State:       StatePresent,
+	}
+	result = clearBeforeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to clear_before and set: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for clear_before operation")
+	}
+
+	// clear process-type reservations
+	clearTask := ResourceReserveTask{
+		App:         appName,
+		ProcessType: "web",
+		State:       StateAbsent,
+	}
+	result = clearTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to clear: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for clearing resource reservations")
+	}
+}
+
 func TestIntegrationMultiTaskWorkflow(t *testing.T) {
 	skipIfNoDokkuT(t)
 

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -164,6 +164,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_ports",
 		"dokku_proxy_toggle",
 		"dokku_resource_limit",
+		"dokku_resource_reserve",
 		"dokku_storage_ensure",
 		"dokku_storage_mount",
 	}
@@ -569,6 +570,59 @@ func TestGetTasksResourceLimitTaskParsedCorrectly(t *testing.T) {
 	// is the zero value for bool. Since defaults.SetDefaults only overrides zero values,
 	// and true is non-zero, setting clear_before: true in YAML is preserved correctly.
 	if !rlTask.ClearBefore {
+		t.Error("ClearBefore = false, want true (YAML value should be preserved)")
+	}
+}
+
+func TestGetTasksResourceReserveTaskParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: set resource reservations
+      dokku_resource_reserve:
+        app: test-app
+        process_type: web
+        resources:
+          cpu: "100"
+          memory: "256"
+        clear_before: true
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("set resource reservations")
+	if task == nil {
+		t.Fatal("task 'set resource reservations' not found")
+	}
+
+	rrTask, ok := task.(*ResourceReserveTask)
+	if !ok {
+		rt, ok2 := task.(ResourceReserveTask)
+		if !ok2 {
+			t.Fatalf("task is not a ResourceReserveTask (type is %T)", task)
+		}
+		rrTask = &rt
+	}
+
+	if rrTask.App != "test-app" {
+		t.Errorf("App = %q, want %q", rrTask.App, "test-app")
+	}
+	if rrTask.ProcessType != "web" {
+		t.Errorf("ProcessType = %q, want %q", rrTask.ProcessType, "web")
+	}
+	if len(rrTask.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(rrTask.Resources))
+	}
+	if rrTask.Resources["cpu"] != "100" {
+		t.Errorf("Resources[cpu] = %q, want %q", rrTask.Resources["cpu"], "100")
+	}
+	if rrTask.Resources["memory"] != "256" {
+		t.Errorf("Resources[memory] = %q, want %q", rrTask.Resources["memory"], "256")
+	}
+	if !rrTask.ClearBefore {
 		t.Error("ClearBefore = false, want true (YAML value should be preserved)")
 	}
 }

--- a/tasks/resource_reserve_task.go
+++ b/tasks/resource_reserve_task.go
@@ -7,49 +7,49 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
-// ResourceLimitTask manages the resource limits for a given dokku application
-type ResourceLimitTask struct {
+// ResourceReserveTask manages the resource reservations for a given dokku application
+type ResourceReserveTask struct {
 	// App is the name of the app
 	App string `required:"true" yaml:"app"`
 
-	// ProcessType is the process type to set resource limits for
+	// ProcessType is the process type to set resource reservations for
 	ProcessType string `required:"false" yaml:"process_type,omitempty"`
 
 	// Resources is a map of resource type to quantity
 	Resources map[string]string `yaml:"resources"`
 
-	// ClearBefore clears all resource limits before applying new ones
+	// ClearBefore clears all resource reservations before applying new ones
 	ClearBefore bool `yaml:"clear_before" default:"false"`
 
-	// State is the desired state of the resource limits
+	// State is the desired state of the resource reservations
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
 }
 
-// ResourceLimitTaskExample contains an example of a ResourceLimitTask
-type ResourceLimitTaskExample struct {
-	// Name is the task name holding the ResourceLimitTask description
+// ResourceReserveTaskExample contains an example of a ResourceReserveTask
+type ResourceReserveTaskExample struct {
+	// Name is the task name holding the ResourceReserveTask description
 	Name string `yaml:"-"`
 
-	// ResourceLimitTask is the ResourceLimitTask configuration
-	ResourceLimitTask ResourceLimitTask `yaml:"dokku_resource_limit"`
+	// ResourceReserveTask is the ResourceReserveTask configuration
+	ResourceReserveTask ResourceReserveTask `yaml:"dokku_resource_reserve"`
 }
 
-// DesiredState returns the desired state of the resource limits
-func (t ResourceLimitTask) DesiredState() State {
+// DesiredState returns the desired state of the resource reservations
+func (t ResourceReserveTask) DesiredState() State {
 	return t.State
 }
 
-// Doc returns the docblock for the resource limit task
-func (t ResourceLimitTask) Doc() string {
-	return "Manages the resource limits for a given dokku application"
+// Doc returns the docblock for the resource reserve task
+func (t ResourceReserveTask) Doc() string {
+	return "Manages the resource reservations for a given dokku application"
 }
 
-// Examples returns the examples for the resource limit task
-func (t ResourceLimitTask) Examples() ([]Doc, error) {
-	examples := []ResourceLimitTaskExample{
+// Examples returns the examples for the resource reserve task
+func (t ResourceReserveTask) Examples() ([]Doc, error) {
+	examples := []ResourceReserveTaskExample{
 		{
-			Name: "Set CPU and memory limits",
-			ResourceLimitTask: ResourceLimitTask{
+			Name: "Set CPU and memory reservations",
+			ResourceReserveTask: ResourceReserveTask{
 				App: "hello-world",
 				Resources: map[string]string{
 					"cpu":    "100",
@@ -58,8 +58,8 @@ func (t ResourceLimitTask) Examples() ([]Doc, error) {
 			},
 		},
 		{
-			Name: "Set memory limit for web process type",
-			ResourceLimitTask: ResourceLimitTask{
+			Name: "Set memory reservation for web process type",
+			ResourceReserveTask: ResourceReserveTask{
 				App:         "hello-world",
 				ProcessType: "web",
 				Resources: map[string]string{
@@ -68,8 +68,8 @@ func (t ResourceLimitTask) Examples() ([]Doc, error) {
 			},
 		},
 		{
-			Name: "Clear all resource limits",
-			ResourceLimitTask: ResourceLimitTask{
+			Name: "Clear all resource reservations",
+			ResourceReserveTask: ResourceReserveTask{
 				App:   "hello-world",
 				State: StateAbsent,
 			},
@@ -92,8 +92,8 @@ func (t ResourceLimitTask) Examples() ([]Doc, error) {
 	return output, nil
 }
 
-// Execute sets or clears the resource limits for a given dokku application
-func (t ResourceLimitTask) Execute() TaskOutputState {
+// Execute sets or clears the resource reservations for a given dokku application
+func (t ResourceReserveTask) Execute() TaskOutputState {
 	funcMap := map[State]func(string, ResourceContext) TaskOutputState{
 		"present": setResource,
 		"absent":  clearResource,
@@ -120,10 +120,10 @@ func (t ResourceLimitTask) Execute() TaskOutputState {
 		ClearBefore: t.ClearBefore,
 	}
 
-	return fn("resource:limit", rctx)
+	return fn("resource:reserve", rctx)
 }
 
-// init registers the ResourceLimitTask with the task registry
+// init registers the ResourceReserveTask with the task registry
 func init() {
-	RegisterTask(&ResourceLimitTask{})
+	RegisterTask(&ResourceReserveTask{})
 }

--- a/tasks/resources.go
+++ b/tasks/resources.go
@@ -1,0 +1,209 @@
+package tasks
+
+import (
+	"fmt"
+	"omakase/subprocess"
+	"strings"
+)
+
+// ResourceContext represents the context for a resource operation
+type ResourceContext struct {
+	// App is the name of the app
+	App string
+
+	// ProcessType is the process type to filter resources for
+	ProcessType string
+
+	// Resources is a map of resource type to quantity
+	Resources map[string]string
+
+	// ClearBefore clears all resources before applying new ones
+	ClearBefore bool
+}
+
+// getResources retrieves the current resources for a given dokku application
+func getResources(subcommand string, rctx ResourceContext) (map[string]string, error) {
+	args := []string{
+		"--quiet",
+		subcommand,
+	}
+
+	if rctx.ProcessType != "" {
+		args = append(args, "--process-type", rctx.ProcessType)
+	}
+
+	args = append(args, rctx.App)
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	resources := map[string]string{}
+	for _, line := range strings.Split(result.StdoutContents(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.Contains(line, ":") {
+			continue
+		}
+
+		parts := strings.SplitN(line, ":", 2)
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		if key != "" {
+			resources[key] = value
+		}
+	}
+
+	return resources, nil
+}
+
+// setResource sets the resources for a given dokku application
+func setResource(subcommand string, rctx ResourceContext) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   "absent",
+	}
+
+	if rctx.ClearBefore {
+		err := execResourceClear(subcommand, rctx)
+		if err != nil {
+			state.Error = err
+			state.Message = err.Error()
+			return state
+		}
+		state.Changed = true
+	}
+
+	if !rctx.ClearBefore {
+		currentResources, err := getResources(subcommand, rctx)
+		if err != nil {
+			state.Error = err
+			state.Message = err.Error()
+			return state
+		}
+
+		// validate that all requested resources exist
+		for k := range rctx.Resources {
+			if _, ok := currentResources[k]; !ok {
+				state.Error = fmt.Errorf("unknown resource %s, valid resources: %v", k, mapKeys(currentResources))
+				state.Message = state.Error.Error()
+				return state
+			}
+		}
+
+		hasChanged := false
+		for k, v := range rctx.Resources {
+			if currentResources[k] != v {
+				hasChanged = true
+				break
+			}
+		}
+
+		if !hasChanged {
+			state.State = "present"
+			return state
+		}
+	}
+
+	args := []string{
+		subcommand,
+	}
+
+	for key, value := range rctx.Resources {
+		args = append(args, fmt.Sprintf("--%s", key), value)
+	}
+
+	if rctx.ProcessType != "" {
+		args = append(args, "--process-type", rctx.ProcessType)
+	}
+
+	args = append(args, rctx.App)
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		state.Error = err
+		state.Message = result.StderrContents()
+		return state
+	}
+
+	state.Changed = true
+	state.State = "present"
+	return state
+}
+
+// clearResource clears the resources for a given dokku application
+func clearResource(subcommand string, rctx ResourceContext) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   "present",
+	}
+
+	currentResources, err := getResources(subcommand, rctx)
+	if err != nil {
+		state.Error = err
+		state.Message = err.Error()
+		return state
+	}
+
+	hasResources := false
+	for _, v := range currentResources {
+		if v != "" && v != "0" {
+			hasResources = true
+			break
+		}
+	}
+
+	if !hasResources {
+		state.State = "absent"
+		return state
+	}
+
+	err = execResourceClear(subcommand, rctx)
+	if err != nil {
+		state.Error = err
+		state.Message = err.Error()
+		return state
+	}
+
+	state.Changed = true
+	state.State = "absent"
+	return state
+}
+
+// execResourceClear executes the dokku resource clear command
+func execResourceClear(subcommand string, rctx ResourceContext) error {
+	args := []string{
+		subcommand + "-clear",
+	}
+
+	if rctx.ProcessType != "" {
+		args = append(args, "--process-type", rctx.ProcessType)
+	}
+
+	args = append(args, rctx.App)
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		return fmt.Errorf("%s", result.StderrContents())
+	}
+
+	return nil
+}
+
+// mapKeys returns the keys of a map as a slice
+func mapKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/tasks/task_execute_test.go
+++ b/tasks/task_execute_test.go
@@ -219,6 +219,46 @@ func TestResourceLimitTaskNilResources(t *testing.T) {
 	}
 }
 
+func TestResourceReserveTaskInvalidState(t *testing.T) {
+	task := ResourceReserveTask{
+		App:       "test-app",
+		Resources: map[string]string{"cpu": "100"},
+		State:     "invalid",
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestResourceReserveTaskDesiredState(t *testing.T) {
+	task := ResourceReserveTask{App: "test-app", State: StatePresent}
+	if task.DesiredState() != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", task.DesiredState())
+	}
+
+	task = ResourceReserveTask{App: "test-app", State: StateAbsent}
+	if task.DesiredState() != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", task.DesiredState())
+	}
+}
+
+func TestResourceReserveTaskEmptyResources(t *testing.T) {
+	task := ResourceReserveTask{App: "test-app", Resources: map[string]string{}, State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with empty resources and state=present should return an error")
+	}
+}
+
+func TestResourceReserveTaskNilResources(t *testing.T) {
+	task := ResourceReserveTask{App: "test-app", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with nil resources and state=present should return an error")
+	}
+}
+
 func TestGitSyncTaskDesiredState(t *testing.T) {
 	task := GitSyncTask{
 		App:    "test-app",
@@ -254,6 +294,8 @@ func TestAllTasksDesiredState(t *testing.T) {
 		{"PortsTask absent", &PortsTask{App: "test", State: StateAbsent}, StateAbsent},
 		{"ResourceLimitTask present", &ResourceLimitTask{App: "test", Resources: map[string]string{"cpu": "100"}, State: StatePresent}, StatePresent},
 		{"ResourceLimitTask absent", &ResourceLimitTask{App: "test", State: StateAbsent}, StateAbsent},
+		{"ResourceReserveTask present", &ResourceReserveTask{App: "test", Resources: map[string]string{"cpu": "100"}, State: StatePresent}, StatePresent},
+		{"ResourceReserveTask absent", &ResourceReserveTask{App: "test", State: StateAbsent}, StateAbsent},
 		{"ProxyToggleTask present", &ProxyToggleTask{App: "test", State: StatePresent}, StatePresent},
 		{"ProxyToggleTask absent", &ProxyToggleTask{App: "test", State: StateAbsent}, StateAbsent},
 		{"StorageEnsureTask present", &StorageEnsureTask{App: "test", Chown: "heroku", State: StatePresent}, StatePresent},
@@ -445,7 +487,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 13
+	expected := 14
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -466,6 +508,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&NetworkPropertyTask{}, "Manages the network property for a given dokku application"},
 		{&PortsTask{}, "Manages the ports for a given dokku application"},
 		{&ResourceLimitTask{}, "Manages the resource limits for a given dokku application"},
+		{&ResourceReserveTask{}, "Manages the resource reservations for a given dokku application"},
 		{&ProxyToggleTask{}, "Enables or disables the proxy plugin for a given dokku application"},
 		{&StorageEnsureTask{}, "Ensures the storage for a given dokku application"},
 		{&StorageMountTask{}, "Mounts or unmounts the storage for a given dokku application"},


### PR DESCRIPTION
## Summary

- Extracts shared resource management logic from `ResourceLimitTask` into a new `ResourceContext` pattern in `resources.go`, following the existing `PropertyContext`/`ToggleContext` conventions
- Implements `ResourceReserveTask` for managing dokku app resource reservations (`resource:reserve` / `resource:reserve-clear`), compatible with the upstream ansible-dokku implementation
- Both `ResourceLimitTask` and `ResourceReserveTask` are now thin wrappers delegating to shared `getResources`, `setResource`, `clearResource`, and `execResourceClear` functions parameterized by subcommand string

Closes #16