### PR TITLE
Rename project from omakase to docket

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -24,8 +24,8 @@ body:
   - type: textarea
     id: report-output
     attributes:
-      label: omakase version
-      description: Please paste the output of the command `omakase version`
+      label: docket version
+      description: Please paste the output of the command `docket version`
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        While pull requests are always welcome, feel free to fill this out with an idea of what you would like to happen and we can discuss if and how it should be implemented in `omakase`.
+        While pull requests are always welcome, feel free to fill this out with an idea of what you would like to happen and we can discuss if and how it should be implemented in `docket`.
 
         Consider [sponsoring Dokku](https://github.com/sponsors/dokku). Sponsorship goes directly to supporting activities such as implementing new features and upgrading existing functionality.
   - type: textarea

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ validation/*
 # .env files
 .env*
 
-omakase
+docket

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -1,3 +1,3 @@
 FROM scratch
-COPY ./build/linux/omakase /omakase
-ENTRYPOINT ["/omakase"]
+COPY ./build/linux/docket /docket
+ENTRYPOINT ["/docket"]

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-NAME = omakase
-EMAIL = omakase@josediazgonzalez.com
+NAME = docket
+EMAIL = docket@josediazgonzalez.com
 MAINTAINER = dokku
 MAINTAINER_NAME = Jose Diaz-Gonzalez
-REPOSITORY = omakase
+REPOSITORY = docket
 HARDWARE = $(shell uname -m)
 SYSTEM_NAME  = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 BASE_VERSION ?= 0.1.0

--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
-# omakase
+# docket
 
 > Note: this is a heavy work in progress. YMMV.
-> Should we change the name? It's a "cute" name but doesn't really help end-users
-> and could be seen as fetishisation of Japanese culture. New name suggestions
-> welcome!
 
 A method to pre-package and ship applications on Dokku.
 
 ## Background
 
-While Ansible is all well and good, having something native to Dokku for shipping applications is awesome. The `omakase` package allows users to specify exactly what it means to be an app, while allowing for some minimal customization (which is against the `omakase` spirit but here we are).
+While Ansible is all well and good, having something native to Dokku for shipping applications is awesome. The `docket` package allows users to specify exactly what it means to be an app, while allowing for some minimal customization.
 
 This package provides the above functionality by exposing the modules from `ansible-dokku` within a single Golang binary. Users of `ansible-dokku` based task lists should be able to use their existing tasks with minimal changes, while organizations can decide to expose apps in easy to use methods for their users.
 
@@ -37,24 +34,24 @@ Run it:
 
 ```shell
 # from the same directory as the tasks.yml
-omakase
+docket
 ```
 
 A task file can also be specified via flag, and may be a file retrieved via http:
 
 ```shell
 # alternate path
-omakase --tasks path/to/task.yml
+docket --tasks path/to/task.yml
 
 # html file
-omakase --tasks http://dokku.com/omakase/example.yml
+docket --tasks http://dokku.com/docket/example.yml
 ```
 
 Some other ideas:
 
 - This could be automatically applied from within a repository if a `.dokku/task.yml` was found. In such a case, certain tasks would be added to a denylist and would be ignored during the run (such as dokku_app or dokku_sync).
-- Dokku may expose a command such as dokku app:install that would allow users to invoke omakase to install apps.
-- A web ui could expose a web ui to customize remote task files and then call `omakase` directly on the generated output.
+- Dokku may expose a command such as dokku app:install that would allow users to invoke docket to install apps.
+- A web ui could expose a web ui to customize remote task files and then call `docket` directly on the generated output.
 
 ### Inputs
 
@@ -79,7 +76,7 @@ With the above, the following method is used to override the `name` variable. Om
 
 ```shell
 # from the same directory as the tasks.yml
-omakase --name lollipop
+docket --name lollipop
 ```
 
 Any inputs for a given task file will also show up in the `--help` output.
@@ -109,7 +106,7 @@ Inputs can have the following properties:
     - `int`
     - `string`
 
-If all inputs are specified on the CLI, then they are injected as is. Otherwise, unless the `--no-interactive` flag is specified, `omakase` will ask for values for each input, with the cli-specified values merged onto the task file default values as defaults.
+If all inputs are specified on the CLI, then they are injected as is. Otherwise, unless the `--no-interactive` flag is specified, `docket` will ask for values for each input, with the cli-specified values merged onto the task file default values as defaults.
 
 Finally, the following input keys are reserved for internal usage:
 
@@ -120,7 +117,7 @@ Finally, the following input keys are reserved for internal usage:
 
 ### Tasks
 
-All implemented tasks should closely follow those available via the `ansible-dokku` library. Additionally, `omakase` will expose a few custom tasks that are specific to this package to ease migration from pure ansible.
+All implemented tasks should closely follow those available via the `ansible-dokku` library. Additionally, `docket` will expose a few custom tasks that are specific to this package to ease migration from pure ansible.
 
 Tasks will have both a `name` and an execution context, where the context maps to a single implemented modules. Tasks can be templated out via the variables from the `inputs` section, and may also use any functions exposed by `gliderlabs/sigil`.
 

--- a/arguments.go
+++ b/arguments.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
-	"omakase/tasks"
+	"docket/tasks"
 	"strconv"
 
 	sigil "github.com/gliderlabs/sigil"

--- a/arguments_test.go
+++ b/arguments_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"omakase/tasks"
+	"docket/tasks"
 	"strings"
 	"testing"
 )
@@ -57,27 +57,27 @@ func TestGetTaskYamlFilename(t *testing.T) {
 	}{
 		{
 			name:     "default when no --tasks flag",
-			args:     []string{"omakase"},
+			args:     []string{"docket"},
 			expected: "tasks.yml",
 		},
 		{
 			name:     "separate --tasks flag",
-			args:     []string{"omakase", "--tasks", "custom.yml"},
+			args:     []string{"docket", "--tasks", "custom.yml"},
 			expected: "custom.yml",
 		},
 		{
 			name:     "equals --tasks=flag",
-			args:     []string{"omakase", "--tasks=custom.yml"},
+			args:     []string{"docket", "--tasks=custom.yml"},
 			expected: "custom.yml",
 		},
 		{
 			name:     "--tasks at end with no value",
-			args:     []string{"omakase", "--tasks"},
+			args:     []string{"docket", "--tasks"},
 			expected: "tasks.yml",
 		},
 		{
 			name:     "--tasks with other flags before",
-			args:     []string{"omakase", "--app", "myapp", "--tasks", "other.yml"},
+			args:     []string{"docket", "--app", "myapp", "--tasks", "other.yml"},
 			expected: "other.yml",
 		},
 		{

--- a/generate/docs.go
+++ b/generate/docs.go
@@ -4,7 +4,7 @@ package main
 import (
 	"fmt"
 	"log"
-	"omakase/tasks"
+	"docket/tasks"
 	"os"
 	"path/filepath"
 	"strings"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module omakase
+module docket
 
 go 1.25.0
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"log"
-	"omakase/tasks"
+	"docket/tasks"
 	"os"
 	"strings"
 

--- a/subprocess/exec_test.go
+++ b/subprocess/exec_test.go
@@ -110,7 +110,7 @@ func TestCallExecCommandFailure(t *testing.T) {
 
 func TestCallExecCommandNotFound(t *testing.T) {
 	_, err := CallExecCommand(ExecCommandInput{
-		Command: "nonexistent-binary-omakase-test-12345",
+		Command: "nonexistent-binary-docket-test-12345",
 	})
 	if err == nil {
 		t.Fatal("expected error for nonexistent command")
@@ -120,13 +120,13 @@ func TestCallExecCommandNotFound(t *testing.T) {
 func TestCallExecCommandWithEnv(t *testing.T) {
 	resp, err := CallExecCommand(ExecCommandInput{
 		Command: "env",
-		Env:     map[string]string{"OMAKASE_TEST_VAR": "test123"},
+		Env:     map[string]string{"DOCKET_TEST_VAR": "test123"},
 	})
 	if err != nil {
 		t.Fatalf("CallExecCommand failed: %v", err)
 	}
-	if !strings.Contains(resp.StdoutContents(), "OMAKASE_TEST_VAR=test123") {
-		t.Errorf("stdout = %q, want it to contain 'OMAKASE_TEST_VAR=test123'", resp.StdoutContents())
+	if !strings.Contains(resp.StdoutContents(), "DOCKET_TEST_VAR=test123") {
+		t.Errorf("stdout = %q, want it to contain 'DOCKET_TEST_VAR=test123'", resp.StdoutContents())
 	}
 }
 

--- a/tasks/app_task.go
+++ b/tasks/app_task.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	"fmt"
-	"omakase/subprocess"
+	"docket/subprocess"
 
 	yaml "gopkg.in/yaml.v3"
 )

--- a/tasks/config_task.go
+++ b/tasks/config_task.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"omakase/subprocess"
+	"docket/subprocess"
 
 	yaml "gopkg.in/yaml.v3"
 )

--- a/tasks/domains_task.go
+++ b/tasks/domains_task.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	"fmt"
-	"omakase/subprocess"
+	"docket/subprocess"
 	"strings"
 
 	yaml "gopkg.in/yaml.v3"

--- a/tasks/git_from_image_task.go
+++ b/tasks/git_from_image_task.go
@@ -3,7 +3,7 @@ package tasks
 import (
 	"encoding/json"
 	"fmt"
-	"omakase/subprocess"
+	"docket/subprocess"
 
 	yaml "gopkg.in/yaml.v3"
 )

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -3,7 +3,7 @@ package tasks
 import (
 	"encoding/json"
 	"fmt"
-	"omakase/subprocess"
+	"docket/subprocess"
 
 	yaml "gopkg.in/yaml.v3"
 )

--- a/tasks/http_auth_task.go
+++ b/tasks/http_auth_task.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	"fmt"
-	"omakase/subprocess"
+	"docket/subprocess"
 	"strings"
 
 	yaml "gopkg.in/yaml.v3"

--- a/tasks/integration_test.go
+++ b/tasks/integration_test.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	"fmt"
-	"omakase/subprocess"
+	"docket/subprocess"
 	"os"
 	"strconv"
 	"strings"
@@ -83,24 +83,24 @@ func dockerLinkSupported() bool {
 	// if the link env vars are present.
 	subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "docker",
-		Args:    []string{"rm", "-f", "omakase-link-test-target", "omakase-link-test-client"},
+		Args:    []string{"rm", "-f", "docket-link-test-target", "docket-link-test-client"},
 	})
 
 	_, err = subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "docker",
-		Args:    []string{"run", "-d", "--name", "omakase-link-test-target", "alpine", "sleep", "30"},
+		Args:    []string{"run", "-d", "--name", "docket-link-test-target", "alpine", "sleep", "30"},
 	})
 	if err != nil {
 		return false
 	}
 	defer subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "docker",
-		Args:    []string{"rm", "-f", "omakase-link-test-target", "omakase-link-test-client"},
+		Args:    []string{"rm", "-f", "docket-link-test-target", "docket-link-test-client"},
 	})
 
 	result, err = subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "docker",
-		Args:    []string{"run", "--rm", "--name", "omakase-link-test-client", "--link", "omakase-link-test-target:target", "alpine", "env"},
+		Args:    []string{"run", "--rm", "--name", "docket-link-test-client", "--link", "docket-link-test-target:target", "alpine", "env"},
 	})
 	if err != nil {
 		return false
@@ -148,7 +148,7 @@ func getCurrentContainerIDs(appName, processType string) ([]string, error) {
 func TestIntegrationAppCreateAndDestroy(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-app"
+	appName := "docket-test-app"
 
 	// ensure clean state
 	destroyApp(appName)
@@ -218,7 +218,7 @@ func dockerNetworkExists(name string) bool {
 func TestIntegrationNetworkCreateAndDestroy(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	networkName := "omakase-test-network"
+	networkName := "docket-test-network"
 
 	// ensure clean state
 	destroyNetwork(networkName)
@@ -305,7 +305,7 @@ func TestIntegrationNetworkCreateAndDestroy(t *testing.T) {
 func TestIntegrationConfigSetAndUnset(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-config"
+	appName := "docket-test-config"
 
 	// ensure clean state
 	destroyApp(appName)
@@ -370,7 +370,7 @@ func TestIntegrationConfigSetAndUnset(t *testing.T) {
 func TestIntegrationBuilderProperty(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-builder"
+	appName := "docket-test-builder"
 
 	destroyApp(appName)
 	createApp(appName)
@@ -409,7 +409,7 @@ func TestIntegrationBuilderProperty(t *testing.T) {
 func TestIntegrationNetworkProperty(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-network"
+	appName := "docket-test-network"
 
 	destroyApp(appName)
 	createApp(appName)
@@ -448,7 +448,7 @@ func TestIntegrationNetworkProperty(t *testing.T) {
 func TestIntegrationStorageEnsure(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-storage"
+	appName := "docket-test-storage"
 
 	destroyApp(appName)
 	createApp(appName)
@@ -471,8 +471,8 @@ func TestIntegrationStorageEnsure(t *testing.T) {
 func TestIntegrationStorageMount(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-mount"
-	hostDir := "/var/lib/dokku/data/storage/omakase-test-mount"
+	appName := "docket-test-mount"
+	hostDir := "/var/lib/dokku/data/storage/docket-test-mount"
 	containerDir := "/app/storage"
 
 	destroyApp(appName)
@@ -543,7 +543,7 @@ func TestIntegrationStorageMount(t *testing.T) {
 func TestIntegrationGetTasksFullWorkflow(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-workflow"
+	appName := "docket-test-workflow"
 
 	// ensure clean state
 	destroyApp(appName)
@@ -577,7 +577,7 @@ func TestIntegrationGetTasksFullWorkflow(t *testing.T) {
 func TestIntegrationChecksToggle(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-checks"
+	appName := "docket-test-checks"
 
 	destroyApp(appName)
 	createApp(appName)
@@ -607,7 +607,7 @@ func TestIntegrationChecksToggle(t *testing.T) {
 func TestIntegrationDomainsToggle(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-domains"
+	appName := "docket-test-domains"
 
 	destroyApp(appName)
 	createApp(appName)
@@ -650,7 +650,7 @@ func getReportedDomains(appName string) []string {
 func TestIntegrationDomainsAddAndRemove(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-domains-task"
+	appName := "docket-test-domains-task"
 
 	destroyApp(appName)
 	createApp(appName)
@@ -786,7 +786,7 @@ func TestIntegrationDomainsAddAndRemove(t *testing.T) {
 func TestIntegrationProxyToggle(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-proxy"
+	appName := "docket-test-proxy"
 
 	destroyApp(appName)
 	createApp(appName)
@@ -816,7 +816,7 @@ func TestIntegrationProxyToggle(t *testing.T) {
 func TestIntegrationPortsAddAndRemove(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-ports"
+	appName := "docket-test-ports"
 
 	destroyApp(appName)
 	createApp(appName)
@@ -874,7 +874,7 @@ func TestIntegrationPortsAddAndRemove(t *testing.T) {
 func TestIntegrationConfigMultipleKeys(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-multiconfig"
+	appName := "docket-test-multiconfig"
 
 	destroyApp(appName)
 	createApp(appName)
@@ -941,7 +941,7 @@ func TestIntegrationConfigMultipleKeys(t *testing.T) {
 func TestIntegrationGitSync(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-gitsync"
+	appName := "docket-test-gitsync"
 
 	destroyApp(appName)
 	createApp(appName)
@@ -967,7 +967,7 @@ func TestIntegrationGitSync(t *testing.T) {
 func TestIntegrationGitFromImage(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-fromimage"
+	appName := "docket-test-fromimage"
 
 	destroyApp(appName)
 	createApp(appName)
@@ -1005,7 +1005,7 @@ func TestIntegrationGitFromImage(t *testing.T) {
 func TestIntegrationResourceLimit(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-reslimit"
+	appName := "docket-test-reslimit"
 
 	destroyApp(appName)
 	createApp(appName)
@@ -1066,7 +1066,7 @@ func TestIntegrationResourceLimit(t *testing.T) {
 func TestIntegrationResourceLimitProcessType(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-reslimit-pt"
+	appName := "docket-test-reslimit-pt"
 
 	destroyApp(appName)
 	createApp(appName)
@@ -1130,7 +1130,7 @@ func TestIntegrationResourceLimitProcessType(t *testing.T) {
 func TestIntegrationResourceReserve(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-resreserve"
+	appName := "docket-test-resreserve"
 
 	destroyApp(appName)
 	createApp(appName)
@@ -1191,7 +1191,7 @@ func TestIntegrationResourceReserve(t *testing.T) {
 func TestIntegrationResourceReserveProcessType(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-resreserve-pt"
+	appName := "docket-test-resreserve-pt"
 
 	destroyApp(appName)
 	createApp(appName)
@@ -1255,7 +1255,7 @@ func TestIntegrationResourceReserveProcessType(t *testing.T) {
 func TestIntegrationPsScale(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-psscale"
+	appName := "docket-test-psscale"
 
 	// ensure clean state
 	destroyApp(appName)
@@ -1382,7 +1382,7 @@ func TestIntegrationPsScale(t *testing.T) {
 func TestIntegrationPsScaleSkipDeploy(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-psscale-sd"
+	appName := "docket-test-psscale-sd"
 
 	destroyApp(appName)
 	createApp(appName)
@@ -1428,7 +1428,7 @@ func TestIntegrationPsScaleSkipDeploy(t *testing.T) {
 func TestIntegrationMultiTaskWorkflow(t *testing.T) {
 	skipIfNoDokkuT(t)
 
-	appName := "omakase-test-multi"
+	appName := "docket-test-multi"
 
 	destroyApp(appName)
 	defer destroyApp(appName)
@@ -1479,7 +1479,7 @@ func TestIntegrationServiceCreateAndDestroy(t *testing.T) {
 	skipIfNoDokkuT(t)
 	skipIfPluginMissingT(t, "redis")
 
-	serviceName := "omakase-test-service"
+	serviceName := "docket-test-service"
 	serviceType := "redis"
 
 	// ensure clean state
@@ -1541,8 +1541,8 @@ func TestIntegrationServiceLinkAndUnlink(t *testing.T) {
 	skipIfPluginMissingT(t, "redis")
 	skipIfDockerLinkUnsupportedT(t)
 
-	appName := "omakase-test-link-app"
-	serviceName := "omakase-test-link-svc"
+	appName := "docket-test-link-app"
+	serviceName := "docket-test-link-svc"
 	serviceType := "redis"
 
 	// ensure clean state
@@ -1722,7 +1722,7 @@ func TestIntegrationHttpAuth(t *testing.T) {
 	skipIfNoDokkuT(t)
 	skipIfPluginMissingT(t, "http-auth")
 
-	appName := "omakase-test-http-auth"
+	appName := "docket-test-http-auth"
 
 	destroyApp(appName)
 	createApp(appName)

--- a/tasks/network_task.go
+++ b/tasks/network_task.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	"fmt"
-	"omakase/subprocess"
+	"docket/subprocess"
 
 	yaml "gopkg.in/yaml.v3"
 )

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -3,7 +3,7 @@ package tasks
 import (
 	"errors"
 	"fmt"
-	"omakase/subprocess"
+	"docket/subprocess"
 	"strconv"
 	"strings"
 

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	"fmt"
-	"omakase/subprocess"
+	"docket/subprocess"
 )
 
 // PropertyContext represents the context for a property

--- a/tasks/ps_scale_task.go
+++ b/tasks/ps_scale_task.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	"fmt"
-	"omakase/subprocess"
+	"docket/subprocess"
 	"strconv"
 	"strings"
 

--- a/tasks/resources.go
+++ b/tasks/resources.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	"fmt"
-	"omakase/subprocess"
+	"docket/subprocess"
 	"strings"
 )
 

--- a/tasks/service_create_task.go
+++ b/tasks/service_create_task.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	"fmt"
-	"omakase/subprocess"
+	"docket/subprocess"
 
 	yaml "gopkg.in/yaml.v3"
 )

--- a/tasks/service_link_task.go
+++ b/tasks/service_link_task.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	"fmt"
-	"omakase/subprocess"
+	"docket/subprocess"
 
 	yaml "gopkg.in/yaml.v3"
 )

--- a/tasks/storage_ensure_task.go
+++ b/tasks/storage_ensure_task.go
@@ -3,7 +3,7 @@ package tasks
 import (
 	"errors"
 	"fmt"
-	"omakase/subprocess"
+	"docket/subprocess"
 
 	yaml "gopkg.in/yaml.v3"
 )

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -3,7 +3,7 @@ package tasks
 import (
 	"encoding/json"
 	"fmt"
-	"omakase/subprocess"
+	"docket/subprocess"
 
 	yaml "gopkg.in/yaml.v3"
 )

--- a/tasks/toggle.go
+++ b/tasks/toggle.go
@@ -2,7 +2,7 @@ package tasks
 
 import (
 	"fmt"
-	"omakase/subprocess"
+	"docket/subprocess"
 )
 
 // ToggleContext represents the context for a toggle operation


### PR DESCRIPTION
## Summary

- Renames the project from "omakase" to "docket" — a word meaning "an ordered list of items to be acted on", which directly describes what this tool does
- Updates Go module name, all imports, Makefile, Dockerfile, README, issue templates, .gitignore, and test fixtures