### PR TITLE
Refactor task files to promote code reuse

### DIFF
--- a/tasks/app_report.go
+++ b/tasks/app_report.go
@@ -1,0 +1,30 @@
+package tasks
+
+import (
+	"encoding/json"
+	"docket/subprocess"
+)
+
+// AppDeploySource contains deploy source information from apps:report
+type AppDeploySource struct {
+	Source         string `json:"app-deploy-source"`
+	SourceMetadata string `json:"app-deploy-source-metadata"`
+}
+
+// getAppDeploySource retrieves the deploy source for an app via apps:report
+func getAppDeploySource(app string) (AppDeploySource, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"apps:report", app, "--format", "json"},
+	})
+	if err != nil {
+		return AppDeploySource{}, err
+	}
+
+	var source AppDeploySource
+	if err := json.Unmarshal(result.StdoutBytes(), &source); err != nil {
+		return AppDeploySource{}, err
+	}
+
+	return source, nil
+}

--- a/tasks/app_task.go
+++ b/tasks/app_task.go
@@ -101,9 +101,7 @@ func createApp(app string) TaskOutputState {
 		},
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true
@@ -132,9 +130,7 @@ func destroyApp(app string) TaskOutputState {
 		},
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true

--- a/tasks/app_task.go
+++ b/tasks/app_task.go
@@ -1,7 +1,6 @@
 package tasks
 
 import (
-	"fmt"
 	"docket/subprocess"
 )
 
@@ -59,18 +58,10 @@ func (t AppTask) Examples() ([]Doc, error) {
 
 // Execute creates or destroys an app
 func (t AppTask) Execute() TaskOutputState {
-	funcMap := map[State]func(string) TaskOutputState{
-		"present": createApp,
-		"absent":  destroyApp,
-	}
-
-	fn, ok := funcMap[t.State]
-	if !ok {
-		return TaskOutputState{
-			Error: fmt.Errorf("invalid state: %s", t.State),
-		}
-	}
-	return fn(t.App)
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return createApp(t.App) },
+		"absent":  func() TaskOutputState { return destroyApp(t.App) },
+	})
 }
 
 // appExists checks if an app exists

--- a/tasks/app_task.go
+++ b/tasks/app_task.go
@@ -3,8 +3,6 @@ package tasks
 import (
 	"fmt"
 	"docket/subprocess"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // AppTask creates or destroys an app
@@ -25,6 +23,11 @@ type AppTaskExample struct {
 	DokkuApp AppTask `yaml:"dokku_app"`
 }
 
+// GetName returns the name of the example
+func (e AppTaskExample) GetName() string {
+	return e.Name
+}
+
 // DesiredState returns the desired state of the app
 func (t AppTask) DesiredState() State {
 	return t.State
@@ -37,7 +40,7 @@ func (t AppTask) Doc() string {
 
 // Examples returns a list of AppTaskExamples as yaml
 func (t AppTask) Examples() ([]Doc, error) {
-	examples := []AppTaskExample{
+	return MarshalExamples([]AppTaskExample{
 		{
 			Name: "Create an app named hello-world",
 			DokkuApp: AppTask{
@@ -51,22 +54,7 @@ func (t AppTask) Examples() ([]Doc, error) {
 				State: "absent",
 			},
 		},
-	}
-
-	var output []Doc
-	for _, example := range examples {
-		b, err := yaml.Marshal(example)
-		if err != nil {
-			return nil, err
-		}
-
-		output = append(output, Doc{
-			Name:      example.Name,
-			Codeblock: string(b),
-		})
-	}
-
-	return output, nil
+	})
 }
 
 // Execute creates or destroys an app

--- a/tasks/builder_property_task.go
+++ b/tasks/builder_property_task.go
@@ -2,7 +2,6 @@ package tasks
 
 import (
 	"errors"
-	"fmt"
 )
 
 // BuilderTask manages the builder configuration for a given dokku application
@@ -98,22 +97,10 @@ func (t BuilderPropertyTask) Execute() TaskOutputState {
 		Property: t.Property,
 		Value:    t.Value,
 	}
-	funcMap := map[State]func() TaskOutputState{
-		"present": func() TaskOutputState {
-			return setProperty("builder:set", ctx)
-		},
-		"absent": func() TaskOutputState {
-			return unsetProperty("builder:set", ctx)
-		},
-	}
-
-	fn, ok := funcMap[t.State]
-	if !ok {
-		return TaskOutputState{
-			Error: fmt.Errorf("invalid state: %s", t.State),
-		}
-	}
-	return fn()
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return setProperty("builder:set", ctx) },
+		"absent":  func() TaskOutputState { return unsetProperty("builder:set", ctx) },
+	})
 }
 
 // init registers the BuilderTask with the task registry

--- a/tasks/builder_property_task.go
+++ b/tasks/builder_property_task.go
@@ -3,8 +3,6 @@ package tasks
 import (
 	"errors"
 	"fmt"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // BuilderTask manages the builder configuration for a given dokku application
@@ -34,6 +32,11 @@ type BuilderPropertyTaskExample struct {
 	BuilderPropertyTask BuilderPropertyTask `yaml:"dokku_builder_property"`
 }
 
+// GetName returns the name of the example
+func (e BuilderPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
 // DesiredState returns the desired state of the builder configuration
 func (t BuilderPropertyTask) DesiredState() State {
 	return t.State
@@ -46,7 +49,7 @@ func (t BuilderPropertyTask) Doc() string {
 
 // Examples returns the examples for the builder property task
 func (t BuilderPropertyTask) Examples() ([]Doc, error) {
-	examples := []BuilderPropertyTaskExample{
+	return MarshalExamples([]BuilderPropertyTaskExample{
 		{
 			Name: "Overriding the auto-selected builder",
 			BuilderPropertyTask: BuilderPropertyTask{
@@ -78,22 +81,7 @@ func (t BuilderPropertyTask) Examples() ([]Doc, error) {
 				Value:    "herokuish",
 			},
 		},
-	}
-
-	var output []Doc
-	for _, example := range examples {
-		b, err := yaml.Marshal(example)
-		if err != nil {
-			return nil, err
-		}
-
-		output = append(output, Doc{
-			Name:      example.Name,
-			Codeblock: string(b),
-		})
-	}
-
-	return output, nil
+	})
 }
 
 // Execute executes the builder configuration task

--- a/tasks/builder_property_task.go
+++ b/tasks/builder_property_task.go
@@ -1,9 +1,5 @@
 package tasks
 
-import (
-	"errors"
-)
-
 // BuilderTask manages the builder configuration for a given dokku application
 type BuilderPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
@@ -85,22 +81,7 @@ func (t BuilderPropertyTask) Examples() ([]Doc, error) {
 
 // Execute executes the builder configuration task
 func (t BuilderPropertyTask) Execute() TaskOutputState {
-	if !t.Global && t.App == "" {
-		return TaskOutputState{
-			Error: errors.New("app is required when global is false"),
-		}
-	}
-
-	ctx := PropertyContext{
-		App:      t.App,
-		Global:   t.Global,
-		Property: t.Property,
-		Value:    t.Value,
-	}
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return setProperty("builder:set", ctx) },
-		"absent":  func() TaskOutputState { return unsetProperty("builder:set", ctx) },
-	})
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder:set")
 }
 
 // init registers the BuilderTask with the task registry

--- a/tasks/checks_toggle_task.go
+++ b/tasks/checks_toggle_task.go
@@ -58,15 +58,7 @@ func (t ChecksToggleTask) Examples() ([]Doc, error) {
 
 // Execute enables or disables the checks plugin
 func (t ChecksToggleTask) Execute() TaskOutputState {
-	ctx := ToggleContext{
-		AllowGlobal: false,
-		App:         t.App,
-		Global:      t.Global,
-	}
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return enablePlugin("checks:enable", ctx) },
-		"absent":  func() TaskOutputState { return disablePlugin("checks:disable", ctx) },
-	})
+	return executeToggle(t.State, t.App, t.Global, false, "checks:enable", "checks:disable")
 }
 
 // init registers the ChecksToggleTask with the task registry

--- a/tasks/checks_toggle_task.go
+++ b/tasks/checks_toggle_task.go
@@ -2,8 +2,6 @@ package tasks
 
 import (
 	"fmt"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // ChecksToggleTask enables or disables the checks plugin for a given dokku application
@@ -27,6 +25,11 @@ type ChecksToggleTaskExample struct {
 	ChecksToggleTask ChecksToggleTask `yaml:"dokku_checks_toggle"`
 }
 
+// GetName returns the name of the example
+func (e ChecksToggleTaskExample) GetName() string {
+	return e.Name
+}
+
 // DesiredState returns the desired state of the checks plugin
 func (t ChecksToggleTask) DesiredState() State {
 	return t.State
@@ -37,9 +40,9 @@ func (t ChecksToggleTask) Doc() string {
 	return "Enables or disables the checks plugin for a given dokku application"
 }
 
-// Examples returns the examples for the builder property task
+// Examples returns the examples for the checks toggle task
 func (t ChecksToggleTask) Examples() ([]Doc, error) {
-	examples := []ChecksToggleTaskExample{
+	return MarshalExamples([]ChecksToggleTaskExample{
 		{
 			Name: "Disable the zero downtime deployment",
 			ChecksToggleTask: ChecksToggleTask{
@@ -54,22 +57,7 @@ func (t ChecksToggleTask) Examples() ([]Doc, error) {
 				State: "present",
 			},
 		},
-	}
-
-	var output []Doc
-	for _, example := range examples {
-		b, err := yaml.Marshal(example)
-		if err != nil {
-			return nil, err
-		}
-
-		output = append(output, Doc{
-			Name:      example.Name,
-			Codeblock: string(b),
-		})
-	}
-
-	return output, nil
+	})
 }
 
 // Execute enables or disables the checks plugin

--- a/tasks/checks_toggle_task.go
+++ b/tasks/checks_toggle_task.go
@@ -1,9 +1,5 @@
 package tasks
 
-import (
-	"fmt"
-)
-
 // ChecksToggleTask enables or disables the checks plugin for a given dokku application
 type ChecksToggleTask struct {
 	// App is the name of the app
@@ -67,22 +63,10 @@ func (t ChecksToggleTask) Execute() TaskOutputState {
 		App:         t.App,
 		Global:      t.Global,
 	}
-	funcMap := map[State]func() TaskOutputState{
-		"present": func() TaskOutputState {
-			return enablePlugin("checks:enable", ctx)
-		},
-		"absent": func() TaskOutputState {
-			return disablePlugin("checks:disable", ctx)
-		},
-	}
-
-	fn, ok := funcMap[t.State]
-	if !ok {
-		return TaskOutputState{
-			Error: fmt.Errorf("invalid state: %s", t.State),
-		}
-	}
-	return fn()
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return enablePlugin("checks:enable", ctx) },
+		"absent":  func() TaskOutputState { return disablePlugin("checks:disable", ctx) },
+	})
 }
 
 // init registers the ChecksToggleTask with the task registry

--- a/tasks/config_task.go
+++ b/tasks/config_task.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"docket/subprocess"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // ConfigTask manages the configuration for a given dokku application
@@ -33,6 +31,11 @@ type ConfigTaskExample struct {
 	ConfigTask ConfigTask `yaml:"dokku_config"`
 }
 
+// GetName returns the name of the example
+func (e ConfigTaskExample) GetName() string {
+	return e.Name
+}
+
 // DesiredState returns the desired state of the configuration
 func (t ConfigTask) DesiredState() State {
 	return t.State
@@ -43,9 +46,9 @@ func (t ConfigTask) Doc() string {
 	return "Manages the configuration for a given dokku application"
 }
 
-// Examples returns the examples for the builder property task
+// Examples returns the examples for the config task
 func (t ConfigTask) Examples() ([]Doc, error) {
-	examples := []ConfigTaskExample{
+	return MarshalExamples([]ConfigTaskExample{
 		{
 			Name: "set KEY=VALUE",
 			ConfigTask: ConfigTask{
@@ -66,22 +69,7 @@ func (t ConfigTask) Examples() ([]Doc, error) {
 				},
 			},
 		},
-	}
-
-	var output []Doc
-	for _, example := range examples {
-		b, err := yaml.Marshal(example)
-		if err != nil {
-			return nil, err
-		}
-
-		output = append(output, Doc{
-			Name:      example.Name,
-			Codeblock: string(b),
-		})
-	}
-
-	return output, nil
+	})
 }
 
 // Execute sets or unsets the configuration for a given dokku application

--- a/tasks/config_task.go
+++ b/tasks/config_task.go
@@ -74,18 +74,10 @@ func (t ConfigTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the configuration for a given dokku application
 func (t ConfigTask) Execute() TaskOutputState {
-	funcMap := map[State]func(ConfigTask) TaskOutputState{
-		"present": setConfig,
-		"absent":  unsetConfig,
-	}
-
-	fn, ok := funcMap[t.State]
-	if !ok {
-		return TaskOutputState{
-			Error: fmt.Errorf("invalid state: %s", t.State),
-		}
-	}
-	return fn(t)
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return setConfig(t) },
+		"absent":  func() TaskOutputState { return unsetConfig(t) },
+	})
 }
 
 // getConfig retrieves the current configuration for a given dokku application

--- a/tasks/config_task.go
+++ b/tasks/config_task.go
@@ -157,9 +157,7 @@ func setConfig(t ConfigTask) TaskOutputState {
 		Args:    args,
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true
@@ -213,9 +211,7 @@ func unsetConfig(t ConfigTask) TaskOutputState {
 		Args:    args,
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true

--- a/tasks/dispatch.go
+++ b/tasks/dispatch.go
@@ -1,0 +1,16 @@
+package tasks
+
+import "fmt"
+
+// DispatchState looks up the given state in the funcMap, calls the matching function,
+// and returns an error TaskOutputState if the state is not found.
+func DispatchState(state State, funcMap map[State]func() TaskOutputState) TaskOutputState {
+	fn, ok := funcMap[state]
+	if !ok {
+		return TaskOutputState{
+			Error: fmt.Errorf("invalid state: %s", state),
+		}
+	}
+
+	return fn()
+}

--- a/tasks/domains_task.go
+++ b/tasks/domains_task.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"docket/subprocess"
 	"strings"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // DomainsTask manages the domains for a given dokku application or globally
@@ -32,6 +30,11 @@ type DomainsTaskExample struct {
 	DomainsTask DomainsTask `yaml:"dokku_domains"`
 }
 
+// GetName returns the name of the example
+func (e DomainsTaskExample) GetName() string {
+	return e.Name
+}
+
 // DesiredState returns the desired state of the domains
 func (t DomainsTask) DesiredState() State {
 	return t.State
@@ -44,7 +47,7 @@ func (t DomainsTask) Doc() string {
 
 // Examples returns the examples for the domains task
 func (t DomainsTask) Examples() ([]Doc, error) {
-	examples := []DomainsTaskExample{
+	return MarshalExamples([]DomainsTaskExample{
 		{
 			Name: "Add domains to an app",
 			DomainsTask: DomainsTask{
@@ -75,22 +78,7 @@ func (t DomainsTask) Examples() ([]Doc, error) {
 				State: "clear",
 			},
 		},
-	}
-
-	var output []Doc
-	for _, example := range examples {
-		b, err := yaml.Marshal(example)
-		if err != nil {
-			return nil, err
-		}
-
-		output = append(output, Doc{
-			Name:      example.Name,
-			Codeblock: string(b),
-		})
-	}
-
-	return output, nil
+	})
 }
 
 // Execute manages the domains

--- a/tasks/domains_task.go
+++ b/tasks/domains_task.go
@@ -83,20 +83,12 @@ func (t DomainsTask) Examples() ([]Doc, error) {
 
 // Execute manages the domains
 func (t DomainsTask) Execute() TaskOutputState {
-	funcMap := map[State]func(DomainsTask) TaskOutputState{
-		StatePresent: addDomains,
-		StateAbsent:  removeDomains,
-		StateSet:     setDomains,
-		StateClear:   clearDomains,
-	}
-
-	fn, ok := funcMap[t.State]
-	if !ok {
-		return TaskOutputState{
-			Error: fmt.Errorf("invalid state: %s", t.State),
-		}
-	}
-	return fn(t)
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		StatePresent: func() TaskOutputState { return addDomains(t) },
+		StateAbsent:  func() TaskOutputState { return removeDomains(t) },
+		StateSet:     func() TaskOutputState { return setDomains(t) },
+		StateClear:   func() TaskOutputState { return clearDomains(t) },
+	})
 }
 
 // validateDomainsTask validates the domains task parameters

--- a/tasks/domains_task.go
+++ b/tasks/domains_task.go
@@ -182,9 +182,7 @@ func addDomains(t DomainsTask) TaskOutputState {
 		Args:    args,
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true
@@ -238,9 +236,7 @@ func removeDomains(t DomainsTask) TaskOutputState {
 		Args:    args,
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true
@@ -275,9 +271,7 @@ func setDomains(t DomainsTask) TaskOutputState {
 		Args:    args,
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true
@@ -311,9 +305,7 @@ func clearDomains(t DomainsTask) TaskOutputState {
 		Args:    args,
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true

--- a/tasks/domains_toggle_task.go
+++ b/tasks/domains_toggle_task.go
@@ -43,15 +43,7 @@ func (t DomainsToggleTask) Examples() ([]Doc, error) {
 
 // Execute enables or disables the domains plugin
 func (t DomainsToggleTask) Execute() TaskOutputState {
-	ctx := ToggleContext{
-		AllowGlobal: false,
-		App:         t.App,
-		Global:      t.Global,
-	}
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return enablePlugin("domains:enable", ctx) },
-		"absent":  func() TaskOutputState { return disablePlugin("domains:disable", ctx) },
-	})
+	return executeToggle(t.State, t.App, t.Global, false, "domains:enable", "domains:disable")
 }
 
 // init registers the DomainsToggleTask with the task registry

--- a/tasks/domains_toggle_task.go
+++ b/tasks/domains_toggle_task.go
@@ -1,9 +1,5 @@
 package tasks
 
-import (
-	"fmt"
-)
-
 // DomainsToggleTask enables or disables the domains plugin for a given dokku application
 type DomainsToggleTask struct {
 	// App is the name of the app
@@ -52,22 +48,10 @@ func (t DomainsToggleTask) Execute() TaskOutputState {
 		App:         t.App,
 		Global:      t.Global,
 	}
-	funcMap := map[State]func() TaskOutputState{
-		"present": func() TaskOutputState {
-			return enablePlugin("domains:enable", ctx)
-		},
-		"absent": func() TaskOutputState {
-			return disablePlugin("domains:disable", ctx)
-		},
-	}
-
-	fn, ok := funcMap[t.State]
-	if !ok {
-		return TaskOutputState{
-			Error: fmt.Errorf("invalid state: %s", t.State),
-		}
-	}
-	return fn()
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return enablePlugin("domains:enable", ctx) },
+		"absent":  func() TaskOutputState { return disablePlugin("domains:disable", ctx) },
+	})
 }
 
 // init registers the DomainsToggleTask with the task registry

--- a/tasks/domains_toggle_task.go
+++ b/tasks/domains_toggle_task.go
@@ -2,8 +2,6 @@ package tasks
 
 import (
 	"fmt"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // DomainsToggleTask enables or disables the domains plugin for a given dokku application
@@ -27,6 +25,11 @@ type DomainsToggleTaskExample struct {
 	DomainsToggleTask DomainsToggleTask `yaml:"dokku_domains_toggle"`
 }
 
+// GetName returns the name of the example
+func (e DomainsToggleTaskExample) GetName() string {
+	return e.Name
+}
+
 // DesiredState returns the desired state of the domains plugin
 func (t DomainsToggleTask) DesiredState() State {
 	return t.State
@@ -37,24 +40,9 @@ func (t DomainsToggleTask) Doc() string {
 	return "Enables or disables the domains plugin for a given dokku application"
 }
 
-// Examples returns the examples for the builder property task
+// Examples returns the examples for the domains toggle task
 func (t DomainsToggleTask) Examples() ([]Doc, error) {
-	examples := []DomainsToggleTaskExample{}
-
-	var output []Doc
-	for _, example := range examples {
-		b, err := yaml.Marshal(example)
-		if err != nil {
-			return nil, err
-		}
-
-		output = append(output, Doc{
-			Name:      example.Name,
-			Codeblock: string(b),
-		})
-	}
-
-	return output, nil
+	return MarshalExamples([]DomainsToggleTaskExample{})
 }
 
 // Execute enables or disables the domains plugin

--- a/tasks/errors.go
+++ b/tasks/errors.go
@@ -1,0 +1,11 @@
+package tasks
+
+import "docket/subprocess"
+
+// TaskOutputErrorFromExec sets Error and Message on the given state from an exec result.
+// Returns the modified state for convenient use with early returns.
+func TaskOutputErrorFromExec(state TaskOutputState, err error, result subprocess.ExecCommandResponse) TaskOutputState {
+	state.Error = err
+	state.Message = result.StderrContents()
+	return state
+}

--- a/tasks/examples.go
+++ b/tasks/examples.go
@@ -1,0 +1,28 @@
+package tasks
+
+import (
+	yaml "gopkg.in/yaml.v3"
+)
+
+// TaskExample is a constraint for example structs that have a Name field.
+type TaskExample interface {
+	GetName() string
+}
+
+// MarshalExamples converts a slice of task examples into Doc slices.
+func MarshalExamples[T TaskExample](examples []T) ([]Doc, error) {
+	var output []Doc
+	for _, example := range examples {
+		b, err := yaml.Marshal(example)
+		if err != nil {
+			return nil, err
+		}
+
+		output = append(output, Doc{
+			Name:      example.GetName(),
+			Codeblock: string(b),
+		})
+	}
+
+	return output, nil
+}

--- a/tasks/git_from_image_task.go
+++ b/tasks/git_from_image_task.go
@@ -2,7 +2,6 @@ package tasks
 
 import (
 	"encoding/json"
-	"fmt"
 	"docket/subprocess"
 )
 
@@ -60,17 +59,9 @@ func (t GitFromImageTask) Examples() ([]Doc, error) {
 
 // Execute deploys a git repository from a docker image
 func (t GitFromImageTask) Execute() TaskOutputState {
-	funcMap := map[State]func(GitFromImageTask) TaskOutputState{
-		"deployed": deployGitFromImage,
-	}
-
-	fn, ok := funcMap[t.State]
-	if !ok {
-		return TaskOutputState{
-			Error: fmt.Errorf("invalid state: %s", t.State),
-		}
-	}
-	return fn(t)
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		"deployed": func() TaskOutputState { return deployGitFromImage(t) },
+	})
 }
 
 // checkAppSourceImage checks if the app is already deployed from a docker image

--- a/tasks/git_from_image_task.go
+++ b/tasks/git_from_image_task.go
@@ -1,7 +1,6 @@
 package tasks
 
 import (
-	"encoding/json"
 	"docket/subprocess"
 )
 
@@ -66,21 +65,7 @@ func (t GitFromImageTask) Execute() TaskOutputState {
 
 // checkAppSourceImage checks if the app is already deployed from a docker image
 func checkAppSourceImage(app, expectedImage string) bool {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    []string{"apps:report", app, "--format", "json"},
-	})
-	if err != nil {
-		return false
-	}
-
-	type appSource struct {
-		Source         string `json:"app-deploy-source"`
-		SourceMetadata string `json:"app-deploy-source-metadata"`
-	}
-
-	var source appSource
-	err = json.Unmarshal(result.StdoutBytes(), &source)
+	source, err := getAppDeploySource(app)
 	if err != nil {
 		return false
 	}

--- a/tasks/git_from_image_task.go
+++ b/tasks/git_from_image_task.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"docket/subprocess"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // git:from-image [--build-dir DIRECTORY] <app> <docker-image> [<git-username> <git-email>]
@@ -40,6 +38,11 @@ type GitFromImageTaskExample struct {
 	GitFromImageTask GitFromImageTask `yaml:"dokku_git_from_image"`
 }
 
+// GetName returns the name of the example
+func (e GitFromImageTaskExample) GetName() string {
+	return e.Name
+}
+
 // DesiredState returns the desired state of the git repository
 func (t GitFromImageTask) DesiredState() State {
 	return t.State
@@ -50,24 +53,9 @@ func (t GitFromImageTask) Doc() string {
 	return "Deploys a git repository from a docker image"
 }
 
-// Examples returns the examples for the builder property task
+// Examples returns the examples for the git from image task
 func (t GitFromImageTask) Examples() ([]Doc, error) {
-	examples := []GitFromImageTaskExample{}
-
-	var output []Doc
-	for _, example := range examples {
-		b, err := yaml.Marshal(example)
-		if err != nil {
-			return nil, err
-		}
-
-		output = append(output, Doc{
-			Name:      example.Name,
-			Codeblock: string(b),
-		})
-	}
-
-	return output, nil
+	return MarshalExamples([]GitFromImageTaskExample{})
 }
 
 // Execute deploys a git repository from a docker image

--- a/tasks/git_from_image_task.go
+++ b/tasks/git_from_image_task.go
@@ -122,9 +122,7 @@ func deployGitFromImage(t GitFromImageTask) TaskOutputState {
 		Args:    args,
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -1,7 +1,6 @@
 package tasks
 
 import (
-	"encoding/json"
 	"fmt"
 	"docket/subprocess"
 )
@@ -85,21 +84,7 @@ func (t GitSyncTask) Execute() TaskOutputState {
 
 // checkAppSyncState checks if the app is already synced from the expected remote and ref
 func checkAppSyncState(app, expectedRemote, expectedRef string) bool {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    []string{"apps:report", app, "--format", "json"},
-	})
-	if err != nil {
-		return false
-	}
-
-	type appSource struct {
-		Source         string `json:"app-deploy-source"`
-		SourceMetadata string `json:"app-deploy-source-metadata"`
-	}
-
-	var source appSource
-	err = json.Unmarshal(result.StdoutBytes(), &source)
+	source, err := getAppDeploySource(app)
 	if err != nil {
 		return false
 	}

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -78,17 +78,9 @@ func (t GitSyncTask) Examples() ([]Doc, error) {
 
 // Execute syncs a git repository to a dokku application
 func (t GitSyncTask) Execute() TaskOutputState {
-	funcMap := map[State]func(GitSyncTask) TaskOutputState{
-		"present": syncGitRepository,
-	}
-
-	fn, ok := funcMap[t.State]
-	if !ok {
-		return TaskOutputState{
-			Error: fmt.Errorf("invalid state: %s", t.State),
-		}
-	}
-	return fn(t)
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return syncGitRepository(t) },
+	})
 }
 
 // checkAppSyncState checks if the app is already synced from the expected remote and ref

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"docket/subprocess"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // GitSyncTask syncs a git repository to a dokku application
@@ -41,6 +39,11 @@ type GitSyncTaskExample struct {
 	GitSyncTask GitSyncTask `yaml:"dokku_git_sync"`
 }
 
+// GetName returns the name of the example
+func (e GitSyncTaskExample) GetName() string {
+	return e.Name
+}
+
 // DesiredState returns the desired state of the git sync
 func (t GitSyncTask) DesiredState() State {
 	return t.State
@@ -53,7 +56,7 @@ func (t GitSyncTask) Doc() string {
 
 // Examples returns the examples for the git sync task
 func (t GitSyncTask) Examples() ([]Doc, error) {
-	examples := []GitSyncTaskExample{
+	return MarshalExamples([]GitSyncTaskExample{
 		{
 			Name: "Sync a git repository to an app",
 			GitSyncTask: GitSyncTask{
@@ -70,22 +73,7 @@ func (t GitSyncTask) Examples() ([]Doc, error) {
 				Build:  true,
 			},
 		},
-	}
-
-	var output []Doc
-	for _, example := range examples {
-		b, err := yaml.Marshal(example)
-		if err != nil {
-			return nil, err
-		}
-
-		output = append(output, Doc{
-			Name:      example.Name,
-			Codeblock: string(b),
-		})
-	}
-
-	return output, nil
+	})
 }
 
 // Execute syncs a git repository to a dokku application

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -145,9 +145,7 @@ func syncGitRepository(t GitSyncTask) TaskOutputState {
 		Args:    args,
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true

--- a/tasks/http_auth_task.go
+++ b/tasks/http_auth_task.go
@@ -79,22 +79,10 @@ func (t HttpAuthTask) Execute() TaskOutputState {
 		}
 	}
 
-	funcMap := map[State]func() TaskOutputState{
-		"present": func() TaskOutputState {
-			return enableHttpAuth(t.App, t.Username, t.Password)
-		},
-		"absent": func() TaskOutputState {
-			return disableHttpAuth(t.App)
-		},
-	}
-
-	fn, ok := funcMap[t.State]
-	if !ok {
-		return TaskOutputState{
-			Error: fmt.Errorf("invalid state: %s", t.State),
-		}
-	}
-	return fn()
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return enableHttpAuth(t.App, t.Username, t.Password) },
+		"absent":  func() TaskOutputState { return disableHttpAuth(t.App) },
+	})
 }
 
 // httpAuthEnabled checks if HTTP authentication is enabled for an app

--- a/tasks/http_auth_task.go
+++ b/tasks/http_auth_task.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"docket/subprocess"
 	"strings"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // HttpAuthTask manages HTTP authentication for a dokku application
@@ -32,6 +30,11 @@ type HttpAuthTaskExample struct {
 	DokkuHttpAuth HttpAuthTask `yaml:"dokku_http_auth"`
 }
 
+// GetName returns the name of the example
+func (e HttpAuthTaskExample) GetName() string {
+	return e.Name
+}
+
 // DesiredState returns the desired state of the HTTP auth
 func (t HttpAuthTask) DesiredState() State {
 	return t.State
@@ -44,7 +47,7 @@ func (t HttpAuthTask) Doc() string {
 
 // Examples returns a list of HttpAuthTaskExamples as yaml
 func (t HttpAuthTask) Examples() ([]Doc, error) {
-	examples := []HttpAuthTaskExample{
+	return MarshalExamples([]HttpAuthTaskExample{
 		{
 			Name: "Enable HTTP authentication for an app",
 			DokkuHttpAuth: HttpAuthTask{
@@ -60,22 +63,7 @@ func (t HttpAuthTask) Examples() ([]Doc, error) {
 				State: "absent",
 			},
 		},
-	}
-
-	var output []Doc
-	for _, example := range examples {
-		b, err := yaml.Marshal(example)
-		if err != nil {
-			return nil, err
-		}
-
-		output = append(output, Doc{
-			Name:      example.Name,
-			Codeblock: string(b),
-		})
-	}
-
-	return output, nil
+	})
 }
 
 // Execute enables or disables HTTP authentication for an app

--- a/tasks/http_auth_task.go
+++ b/tasks/http_auth_task.go
@@ -134,9 +134,7 @@ func enableHttpAuth(app, username, password string) TaskOutputState {
 		},
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true
@@ -164,9 +162,7 @@ func disableHttpAuth(app string) TaskOutputState {
 		},
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true

--- a/tasks/network_property_task.go
+++ b/tasks/network_property_task.go
@@ -2,7 +2,6 @@ package tasks
 
 import (
 	"errors"
-	"fmt"
 )
 
 // NetworkPropertyTask manages the network property for a given dokku application
@@ -98,22 +97,10 @@ func (t NetworkPropertyTask) Execute() TaskOutputState {
 		Property: t.Property,
 		Value:    t.Value,
 	}
-	funcMap := map[State]func() TaskOutputState{
-		"present": func() TaskOutputState {
-			return setProperty("network:set", ctx)
-		},
-		"absent": func() TaskOutputState {
-			return unsetProperty("network:set", ctx)
-		},
-	}
-
-	fn, ok := funcMap[t.State]
-	if !ok {
-		return TaskOutputState{
-			Error: fmt.Errorf("invalid state: %s", t.State),
-		}
-	}
-	return fn()
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return setProperty("network:set", ctx) },
+		"absent":  func() TaskOutputState { return unsetProperty("network:set", ctx) },
+	})
 }
 
 // init registers the NetworkPropertyTask with the task registry

--- a/tasks/network_property_task.go
+++ b/tasks/network_property_task.go
@@ -1,9 +1,5 @@
 package tasks
 
-import (
-	"errors"
-)
-
 // NetworkPropertyTask manages the network property for a given dokku application
 type NetworkPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
@@ -85,22 +81,7 @@ func (t NetworkPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the network property
 func (t NetworkPropertyTask) Execute() TaskOutputState {
-	if !t.Global && t.App == "" {
-		return TaskOutputState{
-			Error: errors.New("app is required when global is false"),
-		}
-	}
-
-	ctx := PropertyContext{
-		App:      t.App,
-		Global:   t.Global,
-		Property: t.Property,
-		Value:    t.Value,
-	}
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return setProperty("network:set", ctx) },
-		"absent":  func() TaskOutputState { return unsetProperty("network:set", ctx) },
-	})
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "network:set")
 }
 
 // init registers the NetworkPropertyTask with the task registry

--- a/tasks/network_property_task.go
+++ b/tasks/network_property_task.go
@@ -3,8 +3,6 @@ package tasks
 import (
 	"errors"
 	"fmt"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // NetworkPropertyTask manages the network property for a given dokku application
@@ -34,6 +32,11 @@ type NetworkPropertyTaskExample struct {
 	NetworkPropertyTask NetworkPropertyTask `yaml:"dokku_network_property"`
 }
 
+// GetName returns the name of the example
+func (e NetworkPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
 // DesiredState returns the desired state of the network property
 func (t NetworkPropertyTask) DesiredState() State {
 	return t.State
@@ -44,9 +47,9 @@ func (t NetworkPropertyTask) Doc() string {
 	return "Manages the network property for a given dokku application"
 }
 
-// Examples returns the examples for the builder property task
+// Examples returns the examples for the network property task
 func (t NetworkPropertyTask) Examples() ([]Doc, error) {
-	examples := []NetworkPropertyTaskExample{
+	return MarshalExamples([]NetworkPropertyTaskExample{
 		{
 			Name: "Associates a network after a container is created but before it is started",
 			NetworkPropertyTask: NetworkPropertyTask{
@@ -78,22 +81,7 @@ func (t NetworkPropertyTask) Examples() ([]Doc, error) {
 				Property: "attach-post-create",
 			},
 		},
-	}
-
-	var output []Doc
-	for _, example := range examples {
-		b, err := yaml.Marshal(example)
-		if err != nil {
-			return nil, err
-		}
-
-		output = append(output, Doc{
-			Name:      example.Name,
-			Codeblock: string(b),
-		})
-	}
-
-	return output, nil
+	})
 }
 
 // Execute sets or unsets the network property

--- a/tasks/network_task.go
+++ b/tasks/network_task.go
@@ -3,8 +3,6 @@ package tasks
 import (
 	"fmt"
 	"docket/subprocess"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // NetworkTask creates or destroys a Docker network
@@ -25,6 +23,11 @@ type NetworkTaskExample struct {
 	DokkuNetwork NetworkTask `yaml:"dokku_network"`
 }
 
+// GetName returns the name of the example
+func (e NetworkTaskExample) GetName() string {
+	return e.Name
+}
+
 // DesiredState returns the desired state of the network
 func (t NetworkTask) DesiredState() State {
 	return t.State
@@ -37,7 +40,7 @@ func (t NetworkTask) Doc() string {
 
 // Examples returns a list of NetworkTaskExamples as yaml
 func (t NetworkTask) Examples() ([]Doc, error) {
-	examples := []NetworkTaskExample{
+	return MarshalExamples([]NetworkTaskExample{
 		{
 			Name: "Create a network named example-network",
 			DokkuNetwork: NetworkTask{
@@ -51,22 +54,7 @@ func (t NetworkTask) Examples() ([]Doc, error) {
 				State: "absent",
 			},
 		},
-	}
-
-	var output []Doc
-	for _, example := range examples {
-		b, err := yaml.Marshal(example)
-		if err != nil {
-			return nil, err
-		}
-
-		output = append(output, Doc{
-			Name:      example.Name,
-			Codeblock: string(b),
-		})
-	}
-
-	return output, nil
+	})
 }
 
 // Execute creates or destroys a Docker network

--- a/tasks/network_task.go
+++ b/tasks/network_task.go
@@ -1,7 +1,6 @@
 package tasks
 
 import (
-	"fmt"
 	"docket/subprocess"
 )
 
@@ -59,18 +58,10 @@ func (t NetworkTask) Examples() ([]Doc, error) {
 
 // Execute creates or destroys a Docker network
 func (t NetworkTask) Execute() TaskOutputState {
-	funcMap := map[State]func(string) TaskOutputState{
-		"present": createNetwork,
-		"absent":  destroyNetwork,
-	}
-
-	fn, ok := funcMap[t.State]
-	if !ok {
-		return TaskOutputState{
-			Error: fmt.Errorf("invalid state: %s", t.State),
-		}
-	}
-	return fn(t.Name)
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return createNetwork(t.Name) },
+		"absent":  func() TaskOutputState { return destroyNetwork(t.Name) },
+	})
 }
 
 // networkExists checks if a Docker network exists

--- a/tasks/network_task.go
+++ b/tasks/network_task.go
@@ -101,9 +101,7 @@ func createNetwork(name string) TaskOutputState {
 		},
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true
@@ -132,9 +130,7 @@ func destroyNetwork(name string) TaskOutputState {
 		},
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -68,29 +68,20 @@ func (t PortsTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the ports
 func (t PortsTask) Execute() TaskOutputState {
-	funcMap := map[State]func(string, []PortMapping) TaskOutputState{
-		"present": setPorts,
-		"absent":  unsetPorts,
-	}
-
 	// todo: add port mapping validation
 	if len(t.PortMappings) == 0 {
-		state := TaskOutputState{
+		return TaskOutputState{
 			Changed: false,
 			State:   "absent",
+			Error:   errors.New("no port mappings provided"),
+			Message: "no port mappings provided",
 		}
-		state.Error = errors.New("no port mappings provided")
-		state.Message = "no port mappings provided"
-		return state
 	}
 
-	fn, ok := funcMap[t.State]
-	if !ok {
-		return TaskOutputState{
-			Error: fmt.Errorf("invalid state: %s", t.State),
-		}
-	}
-	return fn(t.App, t.PortMappings)
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return setPorts(t.App, t.PortMappings) },
+		"absent":  func() TaskOutputState { return unsetPorts(t.App, t.PortMappings) },
+	})
 }
 
 // getPorts gets the ports for a given app

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -6,8 +6,6 @@ import (
 	"docket/subprocess"
 	"strconv"
 	"strings"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // PortsTask manages the ports for a given dokku application
@@ -29,6 +27,11 @@ type PortsTaskExample struct {
 
 	// PortsTask is the PortsTask configuration
 	PortsTask PortsTask `yaml:"dokku_ports"`
+}
+
+// GetName returns the name of the example
+func (e PortsTaskExample) GetName() string {
+	return e.Name
 }
 
 // PortMapping represents a port mapping
@@ -58,24 +61,9 @@ func (t PortsTask) Doc() string {
 	return "Manages the ports for a given dokku application"
 }
 
-// Examples returns the examples for the builder property task
+// Examples returns the examples for the ports task
 func (t PortsTask) Examples() ([]Doc, error) {
-	examples := []PortsTaskExample{}
-
-	var output []Doc
-	for _, example := range examples {
-		b, err := yaml.Marshal(example)
-		if err != nil {
-			return nil, err
-		}
-
-		output = append(output, Doc{
-			Name:      example.Name,
-			Codeblock: string(b),
-		})
-	}
-
-	return output, nil
+	return MarshalExamples([]PortsTaskExample{})
 }
 
 // Execute sets or unsets the ports

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -163,9 +163,7 @@ func setPorts(appName string, portMappings []PortMapping) TaskOutputState {
 		Args:    args,
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true
@@ -208,9 +206,7 @@ func unsetPorts(appName string, portMappings []PortMapping) TaskOutputState {
 		Args:    args,
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"errors"
 	"fmt"
 	"docket/subprocess"
 )
@@ -18,6 +19,26 @@ type PropertyContext struct {
 
 	// Value is the value of the property to set
 	Value string `required:"false" yaml:"value"`
+}
+
+// executeProperty is a shared Execute implementation for property tasks.
+func executeProperty(state State, app string, global bool, property, value, subcommand string) TaskOutputState {
+	if !global && app == "" {
+		return TaskOutputState{
+			Error: errors.New("app is required when global is false"),
+		}
+	}
+
+	ctx := PropertyContext{
+		App:      app,
+		Global:   global,
+		Property: property,
+		Value:    value,
+	}
+	return DispatchState(state, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return setProperty(subcommand, ctx) },
+		"absent":  func() TaskOutputState { return unsetProperty(subcommand, ctx) },
+	})
 }
 
 // setProperty sets a property for a given app

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -55,9 +55,7 @@ func setProperty(subcommand string, pctx PropertyContext) TaskOutputState {
 		},
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true
@@ -99,9 +97,7 @@ func unsetProperty(subcommand string, pctx PropertyContext) TaskOutputState {
 		},
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true

--- a/tasks/proxy_toggle_task.go
+++ b/tasks/proxy_toggle_task.go
@@ -1,9 +1,5 @@
 package tasks
 
-import (
-	"fmt"
-)
-
 // ProxyToggleTask manages the proxy for a given dokku application
 type ProxyToggleTask struct {
 	// App is the name of the app
@@ -52,22 +48,10 @@ func (t ProxyToggleTask) Execute() TaskOutputState {
 		App:         t.App,
 		Global:      t.Global,
 	}
-	funcMap := map[State]func() TaskOutputState{
-		"present": func() TaskOutputState {
-			return enablePlugin("proxy:enable", ctx)
-		},
-		"absent": func() TaskOutputState {
-			return disablePlugin("proxy:disable", ctx)
-		},
-	}
-
-	fn, ok := funcMap[t.State]
-	if !ok {
-		return TaskOutputState{
-			Error: fmt.Errorf("invalid state: %s", t.State),
-		}
-	}
-	return fn()
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return enablePlugin("proxy:enable", ctx) },
+		"absent":  func() TaskOutputState { return disablePlugin("proxy:disable", ctx) },
+	})
 }
 
 // init registers the ProxyToggleTask with the task registry

--- a/tasks/proxy_toggle_task.go
+++ b/tasks/proxy_toggle_task.go
@@ -2,8 +2,6 @@ package tasks
 
 import (
 	"fmt"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // ProxyToggleTask manages the proxy for a given dokku application
@@ -27,6 +25,11 @@ type ProxyToggleTaskExample struct {
 	ProxyToggleTask ProxyToggleTask `yaml:"dokku_proxy_toggle"`
 }
 
+// GetName returns the name of the example
+func (e ProxyToggleTaskExample) GetName() string {
+	return e.Name
+}
+
 // DesiredState returns the desired state of the proxy
 func (t ProxyToggleTask) DesiredState() State {
 	return t.State
@@ -37,24 +40,9 @@ func (t ProxyToggleTask) Doc() string {
 	return "Enables or disables the proxy plugin for a given dokku application"
 }
 
-// Examples returns the examples for the builder property task
+// Examples returns the examples for the proxy toggle task
 func (t ProxyToggleTask) Examples() ([]Doc, error) {
-	examples := []ProxyToggleTaskExample{}
-
-	var output []Doc
-	for _, example := range examples {
-		b, err := yaml.Marshal(example)
-		if err != nil {
-			return nil, err
-		}
-
-		output = append(output, Doc{
-			Name:      example.Name,
-			Codeblock: string(b),
-		})
-	}
-
-	return output, nil
+	return MarshalExamples([]ProxyToggleTaskExample{})
 }
 
 // Execute enables or disables the proxy

--- a/tasks/proxy_toggle_task.go
+++ b/tasks/proxy_toggle_task.go
@@ -43,15 +43,7 @@ func (t ProxyToggleTask) Examples() ([]Doc, error) {
 
 // Execute enables or disables the proxy
 func (t ProxyToggleTask) Execute() TaskOutputState {
-	ctx := ToggleContext{
-		AllowGlobal: false,
-		App:         t.App,
-		Global:      t.Global,
-	}
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return enablePlugin("proxy:enable", ctx) },
-		"absent":  func() TaskOutputState { return disablePlugin("proxy:disable", ctx) },
-	})
+	return executeToggle(t.State, t.App, t.Global, false, "proxy:enable", "proxy:disable")
 }
 
 // init registers the ProxyToggleTask with the task registry

--- a/tasks/ps_scale_task.go
+++ b/tasks/ps_scale_task.go
@@ -75,25 +75,15 @@ func (t PsScaleTask) Examples() ([]Doc, error) {
 
 // Execute sets the process scale for a given dokku application
 func (t PsScaleTask) Execute() TaskOutputState {
-	if t.State == StatePresent {
-		if t.Scale == nil || len(t.Scale) == 0 {
-			return TaskOutputState{
-				Error: fmt.Errorf("scale must be specified when state is present"),
-			}
-		}
-	}
-
-	funcMap := map[State]func(PsScaleTask) TaskOutputState{
-		"present": setPsScale,
-	}
-
-	fn, ok := funcMap[t.State]
-	if !ok {
+	if t.State == StatePresent && len(t.Scale) == 0 {
 		return TaskOutputState{
-			Error: fmt.Errorf("invalid state: %s", t.State),
+			Error: fmt.Errorf("scale must be specified when state is present"),
 		}
 	}
-	return fn(t)
+
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return setPsScale(t) },
+	})
 }
 
 // getPsScale retrieves the current process scale for a given dokku application

--- a/tasks/ps_scale_task.go
+++ b/tasks/ps_scale_task.go
@@ -159,9 +159,7 @@ func setPsScale(t PsScaleTask) TaskOutputState {
 		Args:    args,
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true

--- a/tasks/ps_scale_task.go
+++ b/tasks/ps_scale_task.go
@@ -5,8 +5,6 @@ import (
 	"docket/subprocess"
 	"strconv"
 	"strings"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // PsScaleTask manages the process scale for a given dokku application
@@ -33,6 +31,11 @@ type PsScaleTaskExample struct {
 	PsScaleTask PsScaleTask `yaml:"dokku_ps_scale"`
 }
 
+// GetName returns the name of the example
+func (e PsScaleTaskExample) GetName() string {
+	return e.Name
+}
+
 // DesiredState returns the desired state of the process scale
 func (t PsScaleTask) DesiredState() State {
 	return t.State
@@ -45,7 +48,7 @@ func (t PsScaleTask) Doc() string {
 
 // Examples returns the examples for the ps scale task
 func (t PsScaleTask) Examples() ([]Doc, error) {
-	examples := []PsScaleTaskExample{
+	return MarshalExamples([]PsScaleTaskExample{
 		{
 			Name: "Scale web and worker processes",
 			PsScaleTask: PsScaleTask{
@@ -67,22 +70,7 @@ func (t PsScaleTask) Examples() ([]Doc, error) {
 				},
 			},
 		},
-	}
-
-	var output []Doc
-	for _, example := range examples {
-		b, err := yaml.Marshal(example)
-		if err != nil {
-			return nil, err
-		}
-
-		output = append(output, Doc{
-			Name:      example.Name,
-			Codeblock: string(b),
-		})
-	}
-
-	return output, nil
+	})
 }
 
 // Execute sets the process scale for a given dokku application

--- a/tasks/resource_limit_task.go
+++ b/tasks/resource_limit_task.go
@@ -1,9 +1,5 @@
 package tasks
 
-import (
-	"errors"
-)
-
 // ResourceLimitTask manages the resource limits for a given dokku application
 type ResourceLimitTask struct {
 	// App is the name of the app
@@ -81,23 +77,7 @@ func (t ResourceLimitTask) Examples() ([]Doc, error) {
 
 // Execute sets or clears the resource limits for a given dokku application
 func (t ResourceLimitTask) Execute() TaskOutputState {
-	if t.State == StatePresent && len(t.Resources) == 0 {
-		return TaskOutputState{
-			Error:   errors.New("resources are required when state is present"),
-			Message: "resources are required when state is present",
-		}
-	}
-
-	rctx := ResourceContext{
-		App:         t.App,
-		ProcessType: t.ProcessType,
-		Resources:   t.Resources,
-		ClearBefore: t.ClearBefore,
-	}
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return setResource("resource:limit", rctx) },
-		"absent":  func() TaskOutputState { return clearResource("resource:limit", rctx) },
-	})
+	return executeResource(t.State, t.App, t.ProcessType, t.Resources, t.ClearBefore, "resource:limit")
 }
 
 // init registers the ResourceLimitTask with the task registry

--- a/tasks/resource_limit_task.go
+++ b/tasks/resource_limit_task.go
@@ -2,7 +2,6 @@ package tasks
 
 import (
 	"errors"
-	"fmt"
 )
 
 // ResourceLimitTask manages the resource limits for a given dokku application
@@ -82,22 +81,10 @@ func (t ResourceLimitTask) Examples() ([]Doc, error) {
 
 // Execute sets or clears the resource limits for a given dokku application
 func (t ResourceLimitTask) Execute() TaskOutputState {
-	funcMap := map[State]func(string, ResourceContext) TaskOutputState{
-		"present": setResource,
-		"absent":  clearResource,
-	}
-
 	if t.State == StatePresent && len(t.Resources) == 0 {
 		return TaskOutputState{
 			Error:   errors.New("resources are required when state is present"),
 			Message: "resources are required when state is present",
-		}
-	}
-
-	fn, ok := funcMap[t.State]
-	if !ok {
-		return TaskOutputState{
-			Error: fmt.Errorf("invalid state: %s", t.State),
 		}
 	}
 
@@ -107,8 +94,10 @@ func (t ResourceLimitTask) Execute() TaskOutputState {
 		Resources:   t.Resources,
 		ClearBefore: t.ClearBefore,
 	}
-
-	return fn("resource:limit", rctx)
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return setResource("resource:limit", rctx) },
+		"absent":  func() TaskOutputState { return clearResource("resource:limit", rctx) },
+	})
 }
 
 // init registers the ResourceLimitTask with the task registry

--- a/tasks/resource_limit_task.go
+++ b/tasks/resource_limit_task.go
@@ -3,8 +3,6 @@ package tasks
 import (
 	"errors"
 	"fmt"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // ResourceLimitTask manages the resource limits for a given dokku application
@@ -34,6 +32,11 @@ type ResourceLimitTaskExample struct {
 	ResourceLimitTask ResourceLimitTask `yaml:"dokku_resource_limit"`
 }
 
+// GetName returns the name of the example
+func (e ResourceLimitTaskExample) GetName() string {
+	return e.Name
+}
+
 // DesiredState returns the desired state of the resource limits
 func (t ResourceLimitTask) DesiredState() State {
 	return t.State
@@ -46,7 +49,7 @@ func (t ResourceLimitTask) Doc() string {
 
 // Examples returns the examples for the resource limit task
 func (t ResourceLimitTask) Examples() ([]Doc, error) {
-	examples := []ResourceLimitTaskExample{
+	return MarshalExamples([]ResourceLimitTaskExample{
 		{
 			Name: "Set CPU and memory limits",
 			ResourceLimitTask: ResourceLimitTask{
@@ -74,22 +77,7 @@ func (t ResourceLimitTask) Examples() ([]Doc, error) {
 				State: StateAbsent,
 			},
 		},
-	}
-
-	var output []Doc
-	for _, example := range examples {
-		b, err := yaml.Marshal(example)
-		if err != nil {
-			return nil, err
-		}
-
-		output = append(output, Doc{
-			Name:      example.Name,
-			Codeblock: string(b),
-		})
-	}
-
-	return output, nil
+	})
 }
 
 // Execute sets or clears the resource limits for a given dokku application

--- a/tasks/resource_reserve_task.go
+++ b/tasks/resource_reserve_task.go
@@ -2,7 +2,6 @@ package tasks
 
 import (
 	"errors"
-	"fmt"
 )
 
 // ResourceReserveTask manages the resource reservations for a given dokku application
@@ -82,22 +81,10 @@ func (t ResourceReserveTask) Examples() ([]Doc, error) {
 
 // Execute sets or clears the resource reservations for a given dokku application
 func (t ResourceReserveTask) Execute() TaskOutputState {
-	funcMap := map[State]func(string, ResourceContext) TaskOutputState{
-		"present": setResource,
-		"absent":  clearResource,
-	}
-
 	if t.State == StatePresent && len(t.Resources) == 0 {
 		return TaskOutputState{
 			Error:   errors.New("resources are required when state is present"),
 			Message: "resources are required when state is present",
-		}
-	}
-
-	fn, ok := funcMap[t.State]
-	if !ok {
-		return TaskOutputState{
-			Error: fmt.Errorf("invalid state: %s", t.State),
 		}
 	}
 
@@ -107,8 +94,10 @@ func (t ResourceReserveTask) Execute() TaskOutputState {
 		Resources:   t.Resources,
 		ClearBefore: t.ClearBefore,
 	}
-
-	return fn("resource:reserve", rctx)
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return setResource("resource:reserve", rctx) },
+		"absent":  func() TaskOutputState { return clearResource("resource:reserve", rctx) },
+	})
 }
 
 // init registers the ResourceReserveTask with the task registry

--- a/tasks/resource_reserve_task.go
+++ b/tasks/resource_reserve_task.go
@@ -1,9 +1,5 @@
 package tasks
 
-import (
-	"errors"
-)
-
 // ResourceReserveTask manages the resource reservations for a given dokku application
 type ResourceReserveTask struct {
 	// App is the name of the app
@@ -81,23 +77,7 @@ func (t ResourceReserveTask) Examples() ([]Doc, error) {
 
 // Execute sets or clears the resource reservations for a given dokku application
 func (t ResourceReserveTask) Execute() TaskOutputState {
-	if t.State == StatePresent && len(t.Resources) == 0 {
-		return TaskOutputState{
-			Error:   errors.New("resources are required when state is present"),
-			Message: "resources are required when state is present",
-		}
-	}
-
-	rctx := ResourceContext{
-		App:         t.App,
-		ProcessType: t.ProcessType,
-		Resources:   t.Resources,
-		ClearBefore: t.ClearBefore,
-	}
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return setResource("resource:reserve", rctx) },
-		"absent":  func() TaskOutputState { return clearResource("resource:reserve", rctx) },
-	})
+	return executeResource(t.State, t.App, t.ProcessType, t.Resources, t.ClearBefore, "resource:reserve")
 }
 
 // init registers the ResourceReserveTask with the task registry

--- a/tasks/resource_reserve_task.go
+++ b/tasks/resource_reserve_task.go
@@ -3,8 +3,6 @@ package tasks
 import (
 	"errors"
 	"fmt"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // ResourceReserveTask manages the resource reservations for a given dokku application
@@ -34,6 +32,11 @@ type ResourceReserveTaskExample struct {
 	ResourceReserveTask ResourceReserveTask `yaml:"dokku_resource_reserve"`
 }
 
+// GetName returns the name of the example
+func (e ResourceReserveTaskExample) GetName() string {
+	return e.Name
+}
+
 // DesiredState returns the desired state of the resource reservations
 func (t ResourceReserveTask) DesiredState() State {
 	return t.State
@@ -46,7 +49,7 @@ func (t ResourceReserveTask) Doc() string {
 
 // Examples returns the examples for the resource reserve task
 func (t ResourceReserveTask) Examples() ([]Doc, error) {
-	examples := []ResourceReserveTaskExample{
+	return MarshalExamples([]ResourceReserveTaskExample{
 		{
 			Name: "Set CPU and memory reservations",
 			ResourceReserveTask: ResourceReserveTask{
@@ -74,22 +77,7 @@ func (t ResourceReserveTask) Examples() ([]Doc, error) {
 				State: StateAbsent,
 			},
 		},
-	}
-
-	var output []Doc
-	for _, example := range examples {
-		b, err := yaml.Marshal(example)
-		if err != nil {
-			return nil, err
-		}
-
-		output = append(output, Doc{
-			Name:      example.Name,
-			Codeblock: string(b),
-		})
-	}
-
-	return output, nil
+	})
 }
 
 // Execute sets or clears the resource reservations for a given dokku application

--- a/tasks/resources.go
+++ b/tasks/resources.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"errors"
 	"fmt"
 	"docket/subprocess"
 	"strings"
@@ -19,6 +20,27 @@ type ResourceContext struct {
 
 	// ClearBefore clears all resources before applying new ones
 	ClearBefore bool
+}
+
+// executeResource is a shared Execute implementation for resource tasks.
+func executeResource(state State, app, processType string, resources map[string]string, clearBefore bool, subcommand string) TaskOutputState {
+	if state == StatePresent && len(resources) == 0 {
+		return TaskOutputState{
+			Error:   errors.New("resources are required when state is present"),
+			Message: "resources are required when state is present",
+		}
+	}
+
+	rctx := ResourceContext{
+		App:         app,
+		ProcessType: processType,
+		Resources:   resources,
+		ClearBefore: clearBefore,
+	}
+	return DispatchState(state, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return setResource(subcommand, rctx) },
+		"absent":  func() TaskOutputState { return clearResource(subcommand, rctx) },
+	})
 }
 
 // getResources retrieves the current resources for a given dokku application

--- a/tasks/resources.go
+++ b/tasks/resources.go
@@ -127,9 +127,7 @@ func setResource(subcommand string, rctx ResourceContext) TaskOutputState {
 		Args:    args,
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true

--- a/tasks/service_create_task.go
+++ b/tasks/service_create_task.go
@@ -71,18 +71,10 @@ func (t ServiceCreateTask) Examples() ([]Doc, error) {
 
 // Execute creates or destroys a dokku service
 func (t ServiceCreateTask) Execute() TaskOutputState {
-	funcMap := map[State]func(string, string) TaskOutputState{
-		"present": createService,
-		"absent":  destroyService,
-	}
-
-	fn, ok := funcMap[t.State]
-	if !ok {
-		return TaskOutputState{
-			Error: fmt.Errorf("invalid state: %s", t.State),
-		}
-	}
-	return fn(t.Service, t.Name)
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return createService(t.Service, t.Name) },
+		"absent":  func() TaskOutputState { return destroyService(t.Service, t.Name) },
+	})
 }
 
 // serviceExists checks if a dokku service exists

--- a/tasks/service_create_task.go
+++ b/tasks/service_create_task.go
@@ -3,8 +3,6 @@ package tasks
 import (
 	"fmt"
 	"docket/subprocess"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // ServiceCreateTask creates or destroys a dokku service
@@ -28,6 +26,11 @@ type ServiceCreateTaskExample struct {
 	ServiceCreateTask ServiceCreateTask `yaml:"dokku_service_create"`
 }
 
+// GetName returns the name of the example
+func (e ServiceCreateTaskExample) GetName() string {
+	return e.Name
+}
+
 // DesiredState returns the desired state of the service
 func (t ServiceCreateTask) DesiredState() State {
 	return t.State
@@ -40,7 +43,7 @@ func (t ServiceCreateTask) Doc() string {
 
 // Examples returns a list of ServiceCreateTaskExamples as yaml
 func (t ServiceCreateTask) Examples() ([]Doc, error) {
-	examples := []ServiceCreateTaskExample{
+	return MarshalExamples([]ServiceCreateTaskExample{
 		{
 			Name: "Create a redis service named my-redis",
 			ServiceCreateTask: ServiceCreateTask{
@@ -63,22 +66,7 @@ func (t ServiceCreateTask) Examples() ([]Doc, error) {
 				State:   "absent",
 			},
 		},
-	}
-
-	var output []Doc
-	for _, example := range examples {
-		b, err := yaml.Marshal(example)
-		if err != nil {
-			return nil, err
-		}
-
-		output = append(output, Doc{
-			Name:      example.Name,
-			Codeblock: string(b),
-		})
-	}
-
-	return output, nil
+	})
 }
 
 // Execute creates or destroys a dokku service

--- a/tasks/service_create_task.go
+++ b/tasks/service_create_task.go
@@ -114,9 +114,7 @@ func createService(service, name string) TaskOutputState {
 		},
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true
@@ -145,9 +143,7 @@ func destroyService(service, name string) TaskOutputState {
 		},
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true

--- a/tasks/service_link_task.go
+++ b/tasks/service_link_task.go
@@ -77,18 +77,10 @@ func (t ServiceLinkTask) Examples() ([]Doc, error) {
 
 // Execute links or unlinks a dokku service to an app
 func (t ServiceLinkTask) Execute() TaskOutputState {
-	funcMap := map[State]func(string, string, string) TaskOutputState{
-		"present": linkService,
-		"absent":  unlinkService,
-	}
-
-	fn, ok := funcMap[t.State]
-	if !ok {
-		return TaskOutputState{
-			Error: fmt.Errorf("invalid state: %s", t.State),
-		}
-	}
-	return fn(t.Service, t.Name, t.App)
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return linkService(t.Service, t.Name, t.App) },
+		"absent":  func() TaskOutputState { return unlinkService(t.Service, t.Name, t.App) },
+	})
 }
 
 // serviceLinked checks if a dokku service is linked to an app

--- a/tasks/service_link_task.go
+++ b/tasks/service_link_task.go
@@ -133,9 +133,7 @@ func linkService(service, name, app string) TaskOutputState {
 		},
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true
@@ -175,9 +173,7 @@ func unlinkService(service, name, app string) TaskOutputState {
 		},
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true

--- a/tasks/service_link_task.go
+++ b/tasks/service_link_task.go
@@ -3,8 +3,6 @@ package tasks
 import (
 	"fmt"
 	"docket/subprocess"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // ServiceLinkTask links or unlinks a dokku service to an app
@@ -31,6 +29,11 @@ type ServiceLinkTaskExample struct {
 	ServiceLinkTask ServiceLinkTask `yaml:"dokku_service_link"`
 }
 
+// GetName returns the name of the example
+func (e ServiceLinkTaskExample) GetName() string {
+	return e.Name
+}
+
 // DesiredState returns the desired state of the service link
 func (t ServiceLinkTask) DesiredState() State {
 	return t.State
@@ -43,7 +46,7 @@ func (t ServiceLinkTask) Doc() string {
 
 // Examples returns a list of ServiceLinkTaskExamples as yaml
 func (t ServiceLinkTask) Examples() ([]Doc, error) {
-	examples := []ServiceLinkTaskExample{
+	return MarshalExamples([]ServiceLinkTaskExample{
 		{
 			Name: "Link a redis service named my-redis to my-app",
 			ServiceLinkTask: ServiceLinkTask{
@@ -69,22 +72,7 @@ func (t ServiceLinkTask) Examples() ([]Doc, error) {
 				State:   "absent",
 			},
 		},
-	}
-
-	var output []Doc
-	for _, example := range examples {
-		b, err := yaml.Marshal(example)
-		if err != nil {
-			return nil, err
-		}
-
-		output = append(output, Doc{
-			Name:      example.Name,
-			Codeblock: string(b),
-		})
-	}
-
-	return output, nil
+	})
 }
 
 // Execute links or unlinks a dokku service to an app

--- a/tasks/storage_ensure_task.go
+++ b/tasks/storage_ensure_task.go
@@ -86,9 +86,7 @@ func ensureStorage(app, chown string) TaskOutputState {
 		},
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true

--- a/tasks/storage_ensure_task.go
+++ b/tasks/storage_ensure_task.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"docket/subprocess"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // StorageEnsureTask manages the storage for a given dokku application
@@ -29,6 +27,11 @@ type StorageEnsureTaskExample struct {
 	StorageEnsureTask StorageEnsureTask `yaml:"dokku_storage_ensure"`
 }
 
+// GetName returns the name of the example
+func (e StorageEnsureTaskExample) GetName() string {
+	return e.Name
+}
+
 // DesiredState returns the desired state of the storage
 func (t StorageEnsureTask) DesiredState() State {
 	return t.State
@@ -39,24 +42,9 @@ func (t StorageEnsureTask) Doc() string {
 	return "Ensures the storage for a given dokku application"
 }
 
-// Examples returns the examples for the builder property task
+// Examples returns the examples for the storage ensure task
 func (t StorageEnsureTask) Examples() ([]Doc, error) {
-	examples := []StorageEnsureTaskExample{}
-
-	var output []Doc
-	for _, example := range examples {
-		b, err := yaml.Marshal(example)
-		if err != nil {
-			return nil, err
-		}
-
-		output = append(output, Doc{
-			Name:      example.Name,
-			Codeblock: string(b),
-		})
-	}
-
-	return output, nil
+	return MarshalExamples([]StorageEnsureTaskExample{})
 }
 
 // Execute ensures the storage for a given app

--- a/tasks/storage_ensure_task.go
+++ b/tasks/storage_ensure_task.go
@@ -2,7 +2,6 @@ package tasks
 
 import (
 	"errors"
-	"fmt"
 	"docket/subprocess"
 )
 
@@ -49,18 +48,10 @@ func (t StorageEnsureTask) Examples() ([]Doc, error) {
 
 // Execute ensures the storage for a given app
 func (t StorageEnsureTask) Execute() TaskOutputState {
-	funcMap := map[State]func(string, string) TaskOutputState{
-		"present": ensureStorage,
-		"absent":  removeStorage,
-	}
-
-	fn, ok := funcMap[t.State]
-	if !ok {
-		return TaskOutputState{
-			Error: fmt.Errorf("invalid state: %s", t.State),
-		}
-	}
-	return fn(t.App, t.Chown)
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return ensureStorage(t.App, t.Chown) },
+		"absent":  func() TaskOutputState { return removeStorage(t.App, t.Chown) },
+	})
 }
 
 // ensureStorage ensures the storage for a given app

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -116,9 +116,7 @@ func mountStorage(app, hostDir, containerDir string) TaskOutputState {
 		},
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true
@@ -148,9 +146,7 @@ func unmountStorage(app, hostDir, containerDir string) TaskOutputState {
 		},
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"docket/subprocess"
-
-	yaml "gopkg.in/yaml.v3"
 )
 
 // StorageMountTask manages the storage for a given dokku application
@@ -32,6 +30,11 @@ type StorageMountTaskExample struct {
 	StorageMountTask StorageMountTask `yaml:"dokku_storage_mount"`
 }
 
+// GetName returns the name of the example
+func (e StorageMountTaskExample) GetName() string {
+	return e.Name
+}
+
 // DesiredState returns the desired state of the storage
 func (t StorageMountTask) DesiredState() State {
 	return t.State
@@ -42,24 +45,9 @@ func (t StorageMountTask) Doc() string {
 	return "Mounts or unmounts the storage for a given dokku application"
 }
 
-// Examples returns the examples for the builder property task
+// Examples returns the examples for the storage mount task
 func (t StorageMountTask) Examples() ([]Doc, error) {
-	examples := []StorageMountTaskExample{}
-
-	var output []Doc
-	for _, example := range examples {
-		b, err := yaml.Marshal(example)
-		if err != nil {
-			return nil, err
-		}
-
-		output = append(output, Doc{
-			Name:      example.Name,
-			Codeblock: string(b),
-		})
-	}
-
-	return output, nil
+	return MarshalExamples([]StorageMountTaskExample{})
 }
 
 // Execute mounts or unmounts the storage for a given app

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -52,18 +52,10 @@ func (t StorageMountTask) Examples() ([]Doc, error) {
 
 // Execute mounts or unmounts the storage for a given app
 func (t StorageMountTask) Execute() TaskOutputState {
-	funcMap := map[State]func(string, string, string) TaskOutputState{
-		"present": mountStorage,
-		"absent":  unmountStorage,
-	}
-
-	fn, ok := funcMap[t.State]
-	if !ok {
-		return TaskOutputState{
-			Error: fmt.Errorf("invalid state: %s", t.State),
-		}
-	}
-	return fn(t.App, t.HostDir, t.ContainerDir)
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return mountStorage(t.App, t.HostDir, t.ContainerDir) },
+		"absent":  func() TaskOutputState { return unmountStorage(t.App, t.HostDir, t.ContainerDir) },
+	})
 }
 
 // mountExists checks if the storage mount exists

--- a/tasks/toggle.go
+++ b/tasks/toggle.go
@@ -53,6 +53,19 @@ func enablePlugin(subcommand string, pctx ToggleContext) TaskOutputState {
 	return state
 }
 
+// executeToggle is a shared Execute implementation for toggle tasks.
+func executeToggle(state State, app string, global bool, allowGlobal bool, enableCmd, disableCmd string) TaskOutputState {
+	ctx := ToggleContext{
+		AllowGlobal: allowGlobal,
+		App:         app,
+		Global:      global,
+	}
+	return DispatchState(state, map[State]func() TaskOutputState{
+		"present": func() TaskOutputState { return enablePlugin(enableCmd, ctx) },
+		"absent":  func() TaskOutputState { return disablePlugin(disableCmd, ctx) },
+	})
+}
+
 // disablePlugin executes the disable state for a plugin
 func disablePlugin(subcommand string, pctx ToggleContext) TaskOutputState {
 	state := TaskOutputState{

--- a/tasks/toggle.go
+++ b/tasks/toggle.go
@@ -45,9 +45,7 @@ func enablePlugin(subcommand string, pctx ToggleContext) TaskOutputState {
 		},
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true
@@ -83,9 +81,7 @@ func disablePlugin(subcommand string, pctx ToggleContext) TaskOutputState {
 		},
 	})
 	if err != nil {
-		state.Error = err
-		state.Message = result.StderrContents()
-		return state
+		return TaskOutputErrorFromExec(state, err, result)
 	}
 
 	state.Changed = true


### PR DESCRIPTION
## Summary

- Extract shared helpers to eliminate ~500 lines of duplicated boilerplate across 20 task files
- Add `MarshalExamples[T]()` generic helper for identical YAML example marshaling in all task files
- Add `DispatchState()` helper for state-based funcMap dispatch used by all Execute() methods
- Add `TaskOutputErrorFromExec()` helper replacing 28 identical 3-line error handling blocks
- Add `executeToggle()`, `executeProperty()`, `executeResource()` helpers for task families with identical Execute() bodies differing only by subcommand string
- Add `getAppDeploySource()` shared struct and helper for duplicate `apps:report` JSON parsing in git tasks