### PR TITLE
feat: add nginx_property_task for managing nginx:set properties

### DIFF
--- a/docs/dokku_nginx_property.md
+++ b/docs/dokku_nginx_property.md
@@ -1,0 +1,39 @@
+# dokku_nginx_property
+
+Manages the nginx configuration for a given dokku application
+
+## Setting the proxy read timeout for an app
+
+```yaml
+dokku_nginx_property:
+    app: node-js-app
+    property: proxy-read-timeout
+    value: 120s
+```
+
+## Setting the client max body size for an app
+
+```yaml
+dokku_nginx_property:
+    app: node-js-app
+    property: client-max-body-size
+    value: 50m
+```
+
+## Setting a global nginx property
+
+```yaml
+dokku_nginx_property:
+    app: ""
+    global: true
+    property: bind-address-ipv4
+    value: 0.0.0.0
+```
+
+## Clearing an nginx property
+
+```yaml
+dokku_nginx_property:
+    app: node-js-app
+    property: proxy-read-timeout
+```

--- a/tasks/integration_test.go
+++ b/tasks/integration_test.go
@@ -445,6 +445,45 @@ func TestIntegrationNetworkProperty(t *testing.T) {
 	}
 }
 
+func TestIntegrationNginxProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-nginx"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set nginx property
+	setTask := NginxPropertyTask{
+		App:      appName,
+		Property: "proxy-read-timeout",
+		Value:    "120s",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set nginx property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset nginx property
+	unsetTask := NginxPropertyTask{
+		App:      appName,
+		Property: "proxy-read-timeout",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset nginx property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}
+
 func TestIntegrationStorageEnsure(t *testing.T) {
 	skipIfNoDokkuT(t)
 

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -164,6 +164,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_http_auth",
 		"dokku_network",
 		"dokku_network_property",
+		"dokku_nginx_property",
 		"dokku_ports",
 		"dokku_proxy_toggle",
 		"dokku_ps_scale",

--- a/tasks/nginx_property_task.go
+++ b/tasks/nginx_property_task.go
@@ -1,0 +1,90 @@
+package tasks
+
+// NginxPropertyTask manages the nginx configuration for a given dokku application
+type NginxPropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the nginx configuration should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Property is the name of the nginx property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the nginx property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the nginx configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// NginxPropertyTaskExample contains an example of a NginxPropertyTask
+type NginxPropertyTaskExample struct {
+	// Name is the task name holding the NginxPropertyTask description
+	Name string `yaml:"-"`
+
+	// NginxPropertyTask is the NginxPropertyTask configuration
+	NginxPropertyTask NginxPropertyTask `yaml:"dokku_nginx_property"`
+}
+
+// GetName returns the name of the example
+func (e NginxPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// DesiredState returns the desired state of the nginx configuration
+func (t NginxPropertyTask) DesiredState() State {
+	return t.State
+}
+
+// Doc returns the docblock for the nginx property task
+func (t NginxPropertyTask) Doc() string {
+	return "Manages the nginx configuration for a given dokku application"
+}
+
+// Examples returns the examples for the nginx property task
+func (t NginxPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]NginxPropertyTaskExample{
+		{
+			Name: "Setting the proxy read timeout for an app",
+			NginxPropertyTask: NginxPropertyTask{
+				App:      "node-js-app",
+				Property: "proxy-read-timeout",
+				Value:    "120s",
+			},
+		},
+		{
+			Name: "Setting the client max body size for an app",
+			NginxPropertyTask: NginxPropertyTask{
+				App:      "node-js-app",
+				Property: "client-max-body-size",
+				Value:    "50m",
+			},
+		},
+		{
+			Name: "Setting a global nginx property",
+			NginxPropertyTask: NginxPropertyTask{
+				Global:   true,
+				Property: "bind-address-ipv4",
+				Value:    "0.0.0.0",
+			},
+		},
+		{
+			Name: "Clearing an nginx property",
+			NginxPropertyTask: NginxPropertyTask{
+				App:      "node-js-app",
+				Property: "proxy-read-timeout",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the nginx property
+func (t NginxPropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "nginx:set")
+}
+
+// init registers the NginxPropertyTask with the task registry
+func init() {
+	RegisterTask(&NginxPropertyTask{})
+}

--- a/tasks/task_execute_test.go
+++ b/tasks/task_execute_test.go
@@ -208,6 +208,71 @@ func TestNetworkTaskDesiredState(t *testing.T) {
 	}
 }
 
+func TestNginxPropertyTaskInvalidState(t *testing.T) {
+	task := NginxPropertyTask{App: "test-app", Property: "proxy-read-timeout", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestNginxPropertyTaskMissingApp(t *testing.T) {
+	task := NginxPropertyTask{Property: "proxy-read-timeout", Value: "120s", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestNginxPropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := NginxPropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "proxy-read-timeout",
+		Value:    "120s",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestNginxPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := NginxPropertyTask{
+		App:      "test-app",
+		Property: "proxy-read-timeout",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestNginxPropertyTaskAbsentWithValue(t *testing.T) {
+	task := NginxPropertyTask{
+		App:      "test-app",
+		Property: "proxy-read-timeout",
+		Value:    "120s",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
 func TestNetworkPropertyTaskInvalidState(t *testing.T) {
 	task := NetworkPropertyTask{App: "test-app", Property: "attach-post-create", State: "invalid"}
 	result := task.Execute()
@@ -500,6 +565,8 @@ func TestAllTasksDesiredState(t *testing.T) {
 		{"NetworkTask absent", &NetworkTask{Name: "test", State: StateAbsent}, StateAbsent},
 		{"NetworkPropertyTask present", &NetworkPropertyTask{App: "test", Property: "bind-all-interfaces", State: StatePresent}, StatePresent},
 		{"NetworkPropertyTask absent", &NetworkPropertyTask{App: "test", Property: "bind-all-interfaces", State: StateAbsent}, StateAbsent},
+		{"NginxPropertyTask present", &NginxPropertyTask{App: "test", Property: "proxy-read-timeout", State: StatePresent}, StatePresent},
+		{"NginxPropertyTask absent", &NginxPropertyTask{App: "test", Property: "proxy-read-timeout", State: StateAbsent}, StateAbsent},
 		{"PortsTask present", &PortsTask{App: "test", State: StatePresent}, StatePresent},
 		{"PortsTask absent", &PortsTask{App: "test", State: StateAbsent}, StateAbsent},
 		{"PsScaleTask present", &PsScaleTask{App: "test", Scale: map[string]int{"web": 1}, State: StatePresent}, StatePresent},
@@ -702,7 +769,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 20
+	expected := 21
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -724,6 +791,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&HttpAuthTask{}, "Manages HTTP authentication for a given dokku application"},
 		{&NetworkTask{}, "Creates or destroys a Docker network"},
 		{&NetworkPropertyTask{}, "Manages the network property for a given dokku application"},
+		{&NginxPropertyTask{}, "Manages the nginx configuration for a given dokku application"},
 		{&PortsTask{}, "Manages the ports for a given dokku application"},
 		{&PsScaleTask{}, "Manages the process scale for a given dokku application"},
 		{&ResourceLimitTask{}, "Manages the resource limits for a given dokku application"},


### PR DESCRIPTION
## Summary

- Adds `dokku_nginx_property` task wrapping the `nginx:set` subcommand
- Supports both app-level and global (`--global`) property management
- Reuses the shared `executeProperty()` helper for set/unset operations
- Includes documentation with examples for `proxy-read-timeout`, `client-max-body-size`, and `bind-address-ipv4`

Closes #125