### PR TITLE
feat: add git_property_task for managing git:set properties

### DIFF
--- a/docs/dokku_git_property.md
+++ b/docs/dokku_git_property.md
@@ -1,0 +1,39 @@
+# dokku_git_property
+
+Manages the git configuration for a given dokku application
+
+## Setting the deploy branch for an app
+
+```yaml
+dokku_git_property:
+    app: node-js-app
+    property: deploy-branch
+    value: main
+```
+
+## Keeping the .git directory during builds
+
+```yaml
+dokku_git_property:
+    app: node-js-app
+    property: keep-git-dir
+    value: "true"
+```
+
+## Setting the rev env var globally
+
+```yaml
+dokku_git_property:
+    app: ""
+    global: true
+    property: rev-env-var
+    value: GIT_REV
+```
+
+## Clearing a git property
+
+```yaml
+dokku_git_property:
+    app: node-js-app
+    property: deploy-branch
+```

--- a/tasks/git_property_task.go
+++ b/tasks/git_property_task.go
@@ -1,0 +1,90 @@
+package tasks
+
+// GitPropertyTask manages the git configuration for a given dokku application
+type GitPropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the git configuration should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Property is the name of the git property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the git property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the git configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// GitPropertyTaskExample contains an example of a GitPropertyTask
+type GitPropertyTaskExample struct {
+	// Name is the task name holding the GitPropertyTask description
+	Name string `yaml:"-"`
+
+	// GitPropertyTask is the GitPropertyTask configuration
+	GitPropertyTask GitPropertyTask `yaml:"dokku_git_property"`
+}
+
+// GetName returns the name of the example
+func (e GitPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// DesiredState returns the desired state of the git configuration
+func (t GitPropertyTask) DesiredState() State {
+	return t.State
+}
+
+// Doc returns the docblock for the git property task
+func (t GitPropertyTask) Doc() string {
+	return "Manages the git configuration for a given dokku application"
+}
+
+// Examples returns the examples for the git property task
+func (t GitPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]GitPropertyTaskExample{
+		{
+			Name: "Setting the deploy branch for an app",
+			GitPropertyTask: GitPropertyTask{
+				App:      "node-js-app",
+				Property: "deploy-branch",
+				Value:    "main",
+			},
+		},
+		{
+			Name: "Keeping the .git directory during builds",
+			GitPropertyTask: GitPropertyTask{
+				App:      "node-js-app",
+				Property: "keep-git-dir",
+				Value:    "true",
+			},
+		},
+		{
+			Name: "Setting the rev env var globally",
+			GitPropertyTask: GitPropertyTask{
+				Global:   true,
+				Property: "rev-env-var",
+				Value:    "GIT_REV",
+			},
+		},
+		{
+			Name: "Clearing a git property",
+			GitPropertyTask: GitPropertyTask{
+				App:      "node-js-app",
+				Property: "deploy-branch",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the git property
+func (t GitPropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "git:set")
+}
+
+// init registers the GitPropertyTask with the task registry
+func init() {
+	RegisterTask(&GitPropertyTask{})
+}

--- a/tasks/integration_test.go
+++ b/tasks/integration_test.go
@@ -484,6 +484,45 @@ func TestIntegrationNginxProperty(t *testing.T) {
 	}
 }
 
+func TestIntegrationGitProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-git-prop"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set git property
+	setTask := GitPropertyTask{
+		App:      appName,
+		Property: "deploy-branch",
+		Value:    "main",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set git property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset git property
+	unsetTask := GitPropertyTask{
+		App:      appName,
+		Property: "deploy-branch",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset git property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}
+
 func TestIntegrationStorageEnsure(t *testing.T) {
 	skipIfNoDokkuT(t)
 

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -160,6 +160,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_domains",
 		"dokku_domains_toggle",
 		"dokku_git_from_image",
+		"dokku_git_property",
 		"dokku_git_sync",
 		"dokku_http_auth",
 		"dokku_network",

--- a/tasks/task_execute_test.go
+++ b/tasks/task_execute_test.go
@@ -273,6 +273,71 @@ func TestNginxPropertyTaskAbsentWithValue(t *testing.T) {
 	}
 }
 
+func TestGitPropertyTaskInvalidState(t *testing.T) {
+	task := GitPropertyTask{App: "test-app", Property: "deploy-branch", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestGitPropertyTaskMissingApp(t *testing.T) {
+	task := GitPropertyTask{Property: "deploy-branch", Value: "main", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestGitPropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := GitPropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "deploy-branch",
+		Value:    "main",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestGitPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := GitPropertyTask{
+		App:      "test-app",
+		Property: "deploy-branch",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestGitPropertyTaskAbsentWithValue(t *testing.T) {
+	task := GitPropertyTask{
+		App:      "test-app",
+		Property: "deploy-branch",
+		Value:    "main",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
 func TestNetworkPropertyTaskInvalidState(t *testing.T) {
 	task := NetworkPropertyTask{App: "test-app", Property: "attach-post-create", State: "invalid"}
 	result := task.Execute()
@@ -558,6 +623,8 @@ func TestAllTasksDesiredState(t *testing.T) {
 		{"DomainsToggleTask present", &DomainsToggleTask{App: "test", State: StatePresent}, StatePresent},
 		{"DomainsToggleTask absent", &DomainsToggleTask{App: "test", State: StateAbsent}, StateAbsent},
 		{"GitFromImageTask deployed", &GitFromImageTask{App: "test", Image: "nginx", State: StateDeployed}, StateDeployed},
+		{"GitPropertyTask present", &GitPropertyTask{App: "test", Property: "deploy-branch", State: StatePresent}, StatePresent},
+		{"GitPropertyTask absent", &GitPropertyTask{App: "test", Property: "deploy-branch", State: StateAbsent}, StateAbsent},
 		{"HttpAuthTask present", &HttpAuthTask{App: "test", Username: "admin", Password: "secret", State: StatePresent}, StatePresent},
 		{"HttpAuthTask absent", &HttpAuthTask{App: "test", State: StateAbsent}, StateAbsent},
 		{"GitSyncTask present", &GitSyncTask{App: "test", Remote: "https://example.com/repo", State: StatePresent}, StatePresent},
@@ -769,7 +836,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 21
+	expected := 22
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -787,6 +854,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&DomainsTask{}, "Manages the domains for a given dokku application or globally"},
 		{&DomainsToggleTask{}, "Enables or disables the domains plugin for a given dokku application"},
 		{&GitFromImageTask{}, "Deploys a git repository from a docker image"},
+		{&GitPropertyTask{}, "Manages the git configuration for a given dokku application"},
 		{&GitSyncTask{}, "Syncs a git repository to a dokku application"},
 		{&HttpAuthTask{}, "Manages HTTP authentication for a given dokku application"},
 		{&NetworkTask{}, "Creates or destroys a Docker network"},


### PR DESCRIPTION
## Summary

- Adds `dokku_git_property` task for managing git configuration via `dokku git:set`
- Supports properties: `deploy-branch`, `keep-git-dir`, `rev-env-var`
- Supports both app-specific and global scope
- Follows the established property task pattern (reuses `executeProperty()` shared helper)

Closes #126