### PR TITLE
refactor: move DesiredState from Task interface to TaskOutputState

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,12 +133,11 @@ type LollipopTask struct {
   State State `required:"true" yaml:"state" default:"present"`
 }
 
-func (t LollipopTask) DesiredState() State {
-  return t.State
-}
-
-func (t LollipopTask) Execute() (string, error) {
-  return "", nil
+func (t LollipopTask) Execute() TaskOutputState {
+  return DispatchState(t.State, map[State]func() TaskOutputState{
+    "present": func() TaskOutputState { /* ... */ },
+    "absent":  func() TaskOutputState { /* ... */ },
+  })
 }
 
 func init() {
@@ -148,13 +147,6 @@ func init() {
 
 The `LollipopTask` struct contains the fields necessary for the task. The only necessary field is `State`, which holds the desired state of the task. All other fields are completely custom for the task at hand.
 
-The `DesiredState()` function must return `t.State`.
-
-The `Execute()` function should actually execute the task. The return values:
-
-- `string`: a string holding the current state
-- `error`: Whether an error occurred during processing
-
-> Todo: How do we expose stdout? Should the Status object actually be more structured? Should it serialize to json directly for use by ansible?
+The `Execute()` function should use `DispatchState()` to route to the appropriate handler based on the task's state. `DispatchState` automatically sets `DesiredState` on the returned `TaskOutputState`.
 
 The `init()` function registers the task for usage within a recipe.

--- a/main.go
+++ b/main.go
@@ -50,8 +50,8 @@ func main() {
 			log.Fatalf("execute error: %v", state.Error)
 		}
 
-		if state.State != task.DesiredState() {
-			log.Fatalf("error: Invalid state found, expected=%v actual=%v", task.DesiredState(), state.State)
+		if state.State != state.DesiredState {
+			log.Fatalf("error: Invalid state found, expected=%v actual=%v", state.DesiredState, state.State)
 		}
 	}
 }

--- a/tasks/app_task.go
+++ b/tasks/app_task.go
@@ -27,11 +27,6 @@ func (e AppTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the app
-func (t AppTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the app task
 func (t AppTask) Doc() string {
 	return "Creates or destroys an app"

--- a/tasks/builder_property_task.go
+++ b/tasks/builder_property_task.go
@@ -32,11 +32,6 @@ func (e BuilderPropertyTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the builder configuration
-func (t BuilderPropertyTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the builder property task
 func (t BuilderPropertyTask) Doc() string {
 	return "Manages the builder configuration for a given dokku application"

--- a/tasks/checks_toggle_task.go
+++ b/tasks/checks_toggle_task.go
@@ -26,11 +26,6 @@ func (e ChecksToggleTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the checks plugin
-func (t ChecksToggleTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the checks toggle task
 func (t ChecksToggleTask) Doc() string {
 	return "Enables or disables the checks plugin for a given dokku application"

--- a/tasks/config_task.go
+++ b/tasks/config_task.go
@@ -36,11 +36,6 @@ func (e ConfigTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the configuration
-func (t ConfigTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the config task
 func (t ConfigTask) Doc() string {
 	return "Manages the configuration for a given dokku application"

--- a/tasks/dispatch.go
+++ b/tasks/dispatch.go
@@ -12,5 +12,7 @@ func DispatchState(state State, funcMap map[State]func() TaskOutputState) TaskOu
 		}
 	}
 
-	return fn()
+	result := fn()
+	result.DesiredState = state
+	return result
 }

--- a/tasks/domains_task.go
+++ b/tasks/domains_task.go
@@ -35,11 +35,6 @@ func (e DomainsTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the domains
-func (t DomainsTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the domains task
 func (t DomainsTask) Doc() string {
 	return "Manages the domains for a given dokku application or globally"

--- a/tasks/domains_toggle_task.go
+++ b/tasks/domains_toggle_task.go
@@ -26,11 +26,6 @@ func (e DomainsToggleTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the domains plugin
-func (t DomainsToggleTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the domains toggle task
 func (t DomainsToggleTask) Doc() string {
 	return "Enables or disables the domains plugin for a given dokku application"

--- a/tasks/git_from_image_task.go
+++ b/tasks/git_from_image_task.go
@@ -41,11 +41,6 @@ func (e GitFromImageTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the git repository
-func (t GitFromImageTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the git from image task
 func (t GitFromImageTask) Doc() string {
 	return "Deploys a git repository from a docker image"

--- a/tasks/git_property_task.go
+++ b/tasks/git_property_task.go
@@ -32,11 +32,6 @@ func (e GitPropertyTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the git configuration
-func (t GitPropertyTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the git property task
 func (t GitPropertyTask) Doc() string {
 	return "Manages the git configuration for a given dokku application"

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -43,11 +43,6 @@ func (e GitSyncTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the git sync
-func (t GitSyncTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the git sync task
 func (t GitSyncTask) Doc() string {
 	return "Syncs a git repository to a dokku application"

--- a/tasks/http_auth_task.go
+++ b/tasks/http_auth_task.go
@@ -35,11 +35,6 @@ func (e HttpAuthTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the HTTP auth
-func (t HttpAuthTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the HTTP auth task
 func (t HttpAuthTask) Doc() string {
 	return "Manages HTTP authentication for a given dokku application"

--- a/tasks/integration_test.go
+++ b/tasks/integration_test.go
@@ -646,8 +646,8 @@ func TestIntegrationGetTasksFullWorkflow(t *testing.T) {
 		if state.Error != nil {
 			t.Fatalf("task %q failed: %v", name, state.Error)
 		}
-		if state.State != task.DesiredState() {
-			t.Errorf("task %q: expected state %q, got %q", name, task.DesiredState(), state.State)
+		if state.State != state.DesiredState {
+			t.Errorf("task %q: expected state %q, got %q", name, state.DesiredState, state.State)
 		}
 	}
 }
@@ -1544,8 +1544,8 @@ func TestIntegrationMultiTaskWorkflow(t *testing.T) {
 		if state.Error != nil {
 			t.Fatalf("task %q failed: %v", name, state.Error)
 		}
-		if state.State != task.DesiredState() {
-			t.Errorf("task %q: expected state %q, got %q", name, task.DesiredState(), state.State)
+		if state.State != state.DesiredState {
+			t.Errorf("task %q: expected state %q, got %q", name, state.DesiredState, state.State)
 		}
 		if !state.Changed {
 			t.Errorf("task %q: expected changed=true on first run", name)

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -65,6 +65,9 @@ type TaskOutputState struct {
 	// Changed is a flag indicating if the task was changed
 	Changed bool
 
+	// DesiredState is the desired state of the task
+	DesiredState State
+
 	// Error is the error of the task
 	Error error
 
@@ -80,9 +83,6 @@ type TaskOutputState struct {
 
 // Task represents a task
 type Task interface {
-	// DesiredState returns the desired state of the task
-	DesiredState() State
-
 	// Doc returns the docblock for the task
 	Doc() string
 

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -58,8 +58,12 @@ func TestGetTasksValidAppTask(t *testing.T) {
 		t.Fatal("task 'create test app' not found")
 	}
 
-	if task.DesiredState() != StatePresent {
-		t.Errorf("expected state 'present', got '%s'", task.DesiredState())
+	appTask, ok := task.(*AppTask)
+	if !ok {
+		t.Fatalf("task is not an AppTask (type is %T)", task)
+	}
+	if appTask.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", appTask.State)
 	}
 }
 
@@ -243,8 +247,12 @@ func TestGetTasksTaskWithDefaultState(t *testing.T) {
 		t.Fatal("task not found")
 	}
 
-	if task.DesiredState() != StatePresent {
-		t.Errorf("expected default state 'present', got %q", task.DesiredState())
+	appTask, ok := task.(*AppTask)
+	if !ok {
+		t.Fatalf("task is not an AppTask (type is %T)", task)
+	}
+	if appTask.State != StatePresent {
+		t.Errorf("expected default state 'present', got %q", appTask.State)
 	}
 }
 
@@ -670,8 +678,8 @@ func TestGetTasksServiceCreateTaskParsedCorrectly(t *testing.T) {
 	if scTask.Name != "my-redis" {
 		t.Errorf("Name = %q, want %q", scTask.Name, "my-redis")
 	}
-	if scTask.DesiredState() != StatePresent {
-		t.Errorf("expected default state 'present', got %q", scTask.DesiredState())
+	if scTask.State != StatePresent {
+		t.Errorf("expected default state 'present', got %q", scTask.State)
 	}
 }
 
@@ -754,8 +762,8 @@ func TestGetTasksServiceLinkTaskParsedCorrectly(t *testing.T) {
 	if slTask.Name != "my-redis" {
 		t.Errorf("Name = %q, want %q", slTask.Name, "my-redis")
 	}
-	if slTask.DesiredState() != StatePresent {
-		t.Errorf("expected default state 'present', got %q", slTask.DesiredState())
+	if slTask.State != StatePresent {
+		t.Errorf("expected default state 'present', got %q", slTask.State)
 	}
 }
 
@@ -884,8 +892,8 @@ func TestGetTasksNetworkTaskParsedCorrectly(t *testing.T) {
 	if netTask.Name != "test-network" {
 		t.Errorf("Name = %q, want %q", netTask.Name, "test-network")
 	}
-	if netTask.DesiredState() != StatePresent {
-		t.Errorf("expected default state 'present', got %q", netTask.DesiredState())
+	if netTask.State != StatePresent {
+		t.Errorf("expected default state 'present', got %q", netTask.State)
 	}
 }
 
@@ -933,8 +941,8 @@ func TestGetTasksDomainsTaskParsedCorrectly(t *testing.T) {
 	if dTask.Domains[1] != "www.example.com" {
 		t.Errorf("Domains[1] = %q, want %q", dTask.Domains[1], "www.example.com")
 	}
-	if dTask.DesiredState() != StatePresent {
-		t.Errorf("expected state 'present', got %q", dTask.DesiredState())
+	if dTask.State != StatePresent {
+		t.Errorf("expected state 'present', got %q", dTask.State)
 	}
 }
 
@@ -978,8 +986,8 @@ func TestGetTasksDomainsTaskGlobalParsedCorrectly(t *testing.T) {
 	if dTask.Domains[0] != "global.example.com" {
 		t.Errorf("Domains[0] = %q, want %q", dTask.Domains[0], "global.example.com")
 	}
-	if dTask.DesiredState() != StateSet {
-		t.Errorf("expected state 'set', got %q", dTask.DesiredState())
+	if dTask.State != StateSet {
+		t.Errorf("expected state 'set', got %q", dTask.State)
 	}
 }
 
@@ -1022,7 +1030,7 @@ func TestGetTasksHttpAuthTaskParsedCorrectly(t *testing.T) {
 	if haTask.Password != "secret" {
 		t.Errorf("Password = %q, want %q", haTask.Password, "secret")
 	}
-	if haTask.DesiredState() != StatePresent {
-		t.Errorf("expected default state 'present', got %q", haTask.DesiredState())
+	if haTask.State != StatePresent {
+		t.Errorf("expected default state 'present', got %q", haTask.State)
 	}
 }

--- a/tasks/network_property_task.go
+++ b/tasks/network_property_task.go
@@ -32,11 +32,6 @@ func (e NetworkPropertyTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the network property
-func (t NetworkPropertyTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the network property task
 func (t NetworkPropertyTask) Doc() string {
 	return "Manages the network property for a given dokku application"

--- a/tasks/network_task.go
+++ b/tasks/network_task.go
@@ -27,11 +27,6 @@ func (e NetworkTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the network
-func (t NetworkTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the network task
 func (t NetworkTask) Doc() string {
 	return "Creates or destroys a Docker network"

--- a/tasks/nginx_property_task.go
+++ b/tasks/nginx_property_task.go
@@ -32,11 +32,6 @@ func (e NginxPropertyTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the nginx configuration
-func (t NginxPropertyTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the nginx property task
 func (t NginxPropertyTask) Doc() string {
 	return "Manages the nginx configuration for a given dokku application"

--- a/tasks/ordered_map_test.go
+++ b/tasks/ordered_map_test.go
@@ -10,10 +10,9 @@ type mockTask struct {
 	state State
 }
 
-func (m mockTask) DesiredState() State              { return m.state }
-func (m mockTask) Doc() string                      { return "" }
-func (m mockTask) Examples() ([]Doc, error)         { return nil, nil }
-func (m mockTask) Execute() TaskOutputState         { return TaskOutputState{State: m.state} }
+func (m mockTask) Doc() string              { return "" }
+func (m mockTask) Examples() ([]Doc, error) { return nil, nil }
+func (m mockTask) Execute() TaskOutputState { return TaskOutputState{State: m.state} }
 
 func TestOrderedStringTaskMapSetAndGet(t *testing.T) {
 	m := OrderedStringTaskMap{}
@@ -26,8 +25,8 @@ func TestOrderedStringTaskMapSetAndGet(t *testing.T) {
 		t.Fatal("Get returned nil for existing key")
 	}
 
-	if got.DesiredState() != StatePresent {
-		t.Errorf("expected state 'present', got '%s'", got.DesiredState())
+	if got.Execute().State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", got.Execute().State)
 	}
 }
 
@@ -90,8 +89,8 @@ func TestOrderedStringTaskMapOverwriteValue(t *testing.T) {
 	if got == nil {
 		t.Fatal("Get returned nil for overwritten key")
 	}
-	if got.DesiredState() != StateAbsent {
-		t.Errorf("expected overwritten state 'absent', got '%s'", got.DesiredState())
+	if got.Execute().State != StateAbsent {
+		t.Errorf("expected overwritten state 'absent', got '%s'", got.Execute().State)
 	}
 
 	// Keys will contain the key twice (current implementation appends without dedup)

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -51,11 +51,6 @@ func (p PortMapping) String() string {
 	return fmt.Sprintf("%s:%d:%d", p.Scheme, p.Host, p.Container)
 }
 
-// DesiredState returns the desired state of the ports
-func (t PortsTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the ports task
 func (t PortsTask) Doc() string {
 	return "Manages the ports for a given dokku application"

--- a/tasks/proxy_toggle_task.go
+++ b/tasks/proxy_toggle_task.go
@@ -26,11 +26,6 @@ func (e ProxyToggleTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the proxy
-func (t ProxyToggleTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the proxy toggle task
 func (t ProxyToggleTask) Doc() string {
 	return "Enables or disables the proxy plugin for a given dokku application"

--- a/tasks/ps_scale_task.go
+++ b/tasks/ps_scale_task.go
@@ -36,11 +36,6 @@ func (e PsScaleTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the process scale
-func (t PsScaleTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the ps scale task
 func (t PsScaleTask) Doc() string {
 	return "Manages the process scale for a given dokku application"

--- a/tasks/resource_limit_task.go
+++ b/tasks/resource_limit_task.go
@@ -32,11 +32,6 @@ func (e ResourceLimitTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the resource limits
-func (t ResourceLimitTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the resource limit task
 func (t ResourceLimitTask) Doc() string {
 	return "Manages the resource limits for a given dokku application"

--- a/tasks/resource_reserve_task.go
+++ b/tasks/resource_reserve_task.go
@@ -32,11 +32,6 @@ func (e ResourceReserveTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the resource reservations
-func (t ResourceReserveTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the resource reserve task
 func (t ResourceReserveTask) Doc() string {
 	return "Manages the resource reservations for a given dokku application"

--- a/tasks/service_create_task.go
+++ b/tasks/service_create_task.go
@@ -31,11 +31,6 @@ func (e ServiceCreateTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the service
-func (t ServiceCreateTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the service create task
 func (t ServiceCreateTask) Doc() string {
 	return "Creates or destroys a dokku service"

--- a/tasks/service_link_task.go
+++ b/tasks/service_link_task.go
@@ -34,11 +34,6 @@ func (e ServiceLinkTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the service link
-func (t ServiceLinkTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the service link task
 func (t ServiceLinkTask) Doc() string {
 	return "Links or unlinks a dokku service to an app"

--- a/tasks/storage_ensure_task.go
+++ b/tasks/storage_ensure_task.go
@@ -31,11 +31,6 @@ func (e StorageEnsureTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the storage
-func (t StorageEnsureTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the storage ensure task
 func (t StorageEnsureTask) Doc() string {
 	return "Ensures the storage for a given dokku application"

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -35,11 +35,6 @@ func (e StorageMountTaskExample) GetName() string {
 	return e.Name
 }
 
-// DesiredState returns the desired state of the storage
-func (t StorageMountTask) DesiredState() State {
-	return t.State
-}
-
 // Doc returns the docblock for the storage mount task
 func (t StorageMountTask) Doc() string {
 	return "Mounts or unmounts the storage for a given dokku application"

--- a/tasks/task_execute_test.go
+++ b/tasks/task_execute_test.go
@@ -13,18 +13,6 @@ func TestAppTaskInvalidState(t *testing.T) {
 	}
 }
 
-func TestAppTaskDesiredState(t *testing.T) {
-	task := AppTask{App: "test-app", State: StatePresent}
-	if task.DesiredState() != StatePresent {
-		t.Errorf("expected state 'present', got '%s'", task.DesiredState())
-	}
-
-	task = AppTask{App: "test-app", State: StateAbsent}
-	if task.DesiredState() != StateAbsent {
-		t.Errorf("expected state 'absent', got '%s'", task.DesiredState())
-	}
-}
-
 func TestBuilderPropertyTaskInvalidState(t *testing.T) {
 	task := BuilderPropertyTask{App: "test-app", Property: "selected", State: "invalid"}
 	result := task.Execute()
@@ -66,28 +54,6 @@ func TestDomainsTaskInvalidState(t *testing.T) {
 	result := task.Execute()
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
-	}
-}
-
-func TestDomainsTaskDesiredState(t *testing.T) {
-	task := DomainsTask{App: "test-app", Domains: []string{"example.com"}, State: StatePresent}
-	if task.DesiredState() != StatePresent {
-		t.Errorf("expected state 'present', got '%s'", task.DesiredState())
-	}
-
-	task = DomainsTask{App: "test-app", Domains: []string{"example.com"}, State: StateAbsent}
-	if task.DesiredState() != StateAbsent {
-		t.Errorf("expected state 'absent', got '%s'", task.DesiredState())
-	}
-
-	task = DomainsTask{App: "test-app", Domains: []string{"example.com"}, State: StateSet}
-	if task.DesiredState() != StateSet {
-		t.Errorf("expected state 'set', got '%s'", task.DesiredState())
-	}
-
-	task = DomainsTask{App: "test-app", State: StateClear}
-	if task.DesiredState() != StateClear {
-		t.Errorf("expected state 'clear', got '%s'", task.DesiredState())
 	}
 }
 
@@ -146,18 +112,6 @@ func TestHttpAuthTaskInvalidState(t *testing.T) {
 	}
 }
 
-func TestHttpAuthTaskDesiredState(t *testing.T) {
-	task := HttpAuthTask{App: "test-app", State: StatePresent}
-	if task.DesiredState() != StatePresent {
-		t.Errorf("expected state 'present', got '%s'", task.DesiredState())
-	}
-
-	task = HttpAuthTask{App: "test-app", State: StateAbsent}
-	if task.DesiredState() != StateAbsent {
-		t.Errorf("expected state 'absent', got '%s'", task.DesiredState())
-	}
-}
-
 func TestHttpAuthTaskPresentWithoutUsername(t *testing.T) {
 	task := HttpAuthTask{App: "test-app", Password: "secret", State: StatePresent}
 	result := task.Execute()
@@ -193,18 +147,6 @@ func TestNetworkTaskInvalidState(t *testing.T) {
 	result := task.Execute()
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
-	}
-}
-
-func TestNetworkTaskDesiredState(t *testing.T) {
-	task := NetworkTask{Name: "test-network", State: StatePresent}
-	if task.DesiredState() != StatePresent {
-		t.Errorf("expected state 'present', got '%s'", task.DesiredState())
-	}
-
-	task = NetworkTask{Name: "test-network", State: StateAbsent}
-	if task.DesiredState() != StateAbsent {
-		t.Errorf("expected state 'absent', got '%s'", task.DesiredState())
 	}
 }
 
@@ -448,13 +390,6 @@ func TestPsScaleTaskInvalidState(t *testing.T) {
 	}
 }
 
-func TestPsScaleTaskDesiredState(t *testing.T) {
-	task := PsScaleTask{App: "test-app", Scale: map[string]int{"web": 1}, State: StatePresent}
-	if task.DesiredState() != StatePresent {
-		t.Errorf("expected state 'present', got '%s'", task.DesiredState())
-	}
-}
-
 func TestPsScaleTaskEmptyScale(t *testing.T) {
 	task := PsScaleTask{App: "test-app", Scale: map[string]int{}, State: StatePresent}
 	result := task.Execute()
@@ -483,18 +418,6 @@ func TestResourceLimitTaskInvalidState(t *testing.T) {
 	}
 }
 
-func TestResourceLimitTaskDesiredState(t *testing.T) {
-	task := ResourceLimitTask{App: "test-app", State: StatePresent}
-	if task.DesiredState() != StatePresent {
-		t.Errorf("expected state 'present', got '%s'", task.DesiredState())
-	}
-
-	task = ResourceLimitTask{App: "test-app", State: StateAbsent}
-	if task.DesiredState() != StateAbsent {
-		t.Errorf("expected state 'absent', got '%s'", task.DesiredState())
-	}
-}
-
 func TestResourceLimitTaskEmptyResources(t *testing.T) {
 	task := ResourceLimitTask{App: "test-app", Resources: map[string]string{}, State: StatePresent}
 	result := task.Execute()
@@ -519,35 +442,11 @@ func TestServiceCreateTaskInvalidState(t *testing.T) {
 	}
 }
 
-func TestServiceCreateTaskDesiredState(t *testing.T) {
-	task := ServiceCreateTask{Service: "redis", Name: "test-service", State: StatePresent}
-	if task.DesiredState() != StatePresent {
-		t.Errorf("expected state 'present', got '%s'", task.DesiredState())
-	}
-
-	task = ServiceCreateTask{Service: "redis", Name: "test-service", State: StateAbsent}
-	if task.DesiredState() != StateAbsent {
-		t.Errorf("expected state 'absent', got '%s'", task.DesiredState())
-	}
-}
-
 func TestServiceLinkTaskInvalidState(t *testing.T) {
 	task := ServiceLinkTask{App: "test-app", Service: "redis", Name: "test-service", State: "invalid"}
 	result := task.Execute()
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
-	}
-}
-
-func TestServiceLinkTaskDesiredState(t *testing.T) {
-	task := ServiceLinkTask{App: "test-app", Service: "redis", Name: "test-service", State: StatePresent}
-	if task.DesiredState() != StatePresent {
-		t.Errorf("expected state 'present', got '%s'", task.DesiredState())
-	}
-
-	task = ServiceLinkTask{App: "test-app", Service: "redis", Name: "test-service", State: StateAbsent}
-	if task.DesiredState() != StateAbsent {
-		t.Errorf("expected state 'absent', got '%s'", task.DesiredState())
 	}
 }
 
@@ -560,18 +459,6 @@ func TestResourceReserveTaskInvalidState(t *testing.T) {
 	result := task.Execute()
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
-	}
-}
-
-func TestResourceReserveTaskDesiredState(t *testing.T) {
-	task := ResourceReserveTask{App: "test-app", State: StatePresent}
-	if task.DesiredState() != StatePresent {
-		t.Errorf("expected state 'present', got '%s'", task.DesiredState())
-	}
-
-	task = ResourceReserveTask{App: "test-app", State: StateAbsent}
-	if task.DesiredState() != StateAbsent {
-		t.Errorf("expected state 'absent', got '%s'", task.DesiredState())
 	}
 }
 
@@ -588,77 +475,6 @@ func TestResourceReserveTaskNilResources(t *testing.T) {
 	result := task.Execute()
 	if result.Error == nil {
 		t.Fatal("Execute with nil resources and state=present should return an error")
-	}
-}
-
-func TestGitSyncTaskDesiredState(t *testing.T) {
-	task := GitSyncTask{
-		App:    "test-app",
-		Remote: "https://github.com/example/repo",
-		State:  StatePresent,
-	}
-	if task.DesiredState() != StatePresent {
-		t.Errorf("expected state 'present', got '%s'", task.DesiredState())
-	}
-}
-
-func TestAllTasksDesiredState(t *testing.T) {
-	tests := []struct {
-		name  string
-		task  Task
-		state State
-	}{
-		{"AppTask present", &AppTask{App: "test", State: StatePresent}, StatePresent},
-		{"AppTask absent", &AppTask{App: "test", State: StateAbsent}, StateAbsent},
-		{"BuilderPropertyTask present", &BuilderPropertyTask{App: "test", Property: "selected", State: StatePresent}, StatePresent},
-		{"BuilderPropertyTask absent", &BuilderPropertyTask{App: "test", Property: "selected", State: StateAbsent}, StateAbsent},
-		{"ChecksToggleTask present", &ChecksToggleTask{App: "test", State: StatePresent}, StatePresent},
-		{"ChecksToggleTask absent", &ChecksToggleTask{App: "test", State: StateAbsent}, StateAbsent},
-		{"ConfigTask present", &ConfigTask{App: "test", State: StatePresent}, StatePresent},
-		{"ConfigTask absent", &ConfigTask{App: "test", State: StateAbsent}, StateAbsent},
-		{"DomainsTask present", &DomainsTask{App: "test", Domains: []string{"example.com"}, State: StatePresent}, StatePresent},
-		{"DomainsTask absent", &DomainsTask{App: "test", Domains: []string{"example.com"}, State: StateAbsent}, StateAbsent},
-		{"DomainsTask set", &DomainsTask{App: "test", Domains: []string{"example.com"}, State: StateSet}, StateSet},
-		{"DomainsTask clear", &DomainsTask{App: "test", State: StateClear}, StateClear},
-		{"DomainsToggleTask present", &DomainsToggleTask{App: "test", State: StatePresent}, StatePresent},
-		{"DomainsToggleTask absent", &DomainsToggleTask{App: "test", State: StateAbsent}, StateAbsent},
-		{"GitFromImageTask deployed", &GitFromImageTask{App: "test", Image: "nginx", State: StateDeployed}, StateDeployed},
-		{"GitPropertyTask present", &GitPropertyTask{App: "test", Property: "deploy-branch", State: StatePresent}, StatePresent},
-		{"GitPropertyTask absent", &GitPropertyTask{App: "test", Property: "deploy-branch", State: StateAbsent}, StateAbsent},
-		{"HttpAuthTask present", &HttpAuthTask{App: "test", Username: "admin", Password: "secret", State: StatePresent}, StatePresent},
-		{"HttpAuthTask absent", &HttpAuthTask{App: "test", State: StateAbsent}, StateAbsent},
-		{"GitSyncTask present", &GitSyncTask{App: "test", Remote: "https://example.com/repo", State: StatePresent}, StatePresent},
-		{"NetworkTask present", &NetworkTask{Name: "test", State: StatePresent}, StatePresent},
-		{"NetworkTask absent", &NetworkTask{Name: "test", State: StateAbsent}, StateAbsent},
-		{"NetworkPropertyTask present", &NetworkPropertyTask{App: "test", Property: "bind-all-interfaces", State: StatePresent}, StatePresent},
-		{"NetworkPropertyTask absent", &NetworkPropertyTask{App: "test", Property: "bind-all-interfaces", State: StateAbsent}, StateAbsent},
-		{"NginxPropertyTask present", &NginxPropertyTask{App: "test", Property: "proxy-read-timeout", State: StatePresent}, StatePresent},
-		{"NginxPropertyTask absent", &NginxPropertyTask{App: "test", Property: "proxy-read-timeout", State: StateAbsent}, StateAbsent},
-		{"PortsTask present", &PortsTask{App: "test", State: StatePresent}, StatePresent},
-		{"PortsTask absent", &PortsTask{App: "test", State: StateAbsent}, StateAbsent},
-		{"PsScaleTask present", &PsScaleTask{App: "test", Scale: map[string]int{"web": 1}, State: StatePresent}, StatePresent},
-		{"ResourceLimitTask present", &ResourceLimitTask{App: "test", Resources: map[string]string{"cpu": "100"}, State: StatePresent}, StatePresent},
-		{"ResourceLimitTask absent", &ResourceLimitTask{App: "test", State: StateAbsent}, StateAbsent},
-		{"ResourceReserveTask present", &ResourceReserveTask{App: "test", Resources: map[string]string{"cpu": "100"}, State: StatePresent}, StatePresent},
-		{"ResourceReserveTask absent", &ResourceReserveTask{App: "test", State: StateAbsent}, StateAbsent},
-		{"ServiceCreateTask present", &ServiceCreateTask{Service: "redis", Name: "test", State: StatePresent}, StatePresent},
-		{"ServiceCreateTask absent", &ServiceCreateTask{Service: "redis", Name: "test", State: StateAbsent}, StateAbsent},
-		{"ServiceLinkTask present", &ServiceLinkTask{App: "test", Service: "redis", Name: "test", State: StatePresent}, StatePresent},
-		{"ServiceLinkTask absent", &ServiceLinkTask{App: "test", Service: "redis", Name: "test", State: StateAbsent}, StateAbsent},
-		{"ProxyToggleTask present", &ProxyToggleTask{App: "test", State: StatePresent}, StatePresent},
-		{"ProxyToggleTask absent", &ProxyToggleTask{App: "test", State: StateAbsent}, StateAbsent},
-		{"StorageEnsureTask present", &StorageEnsureTask{App: "test", Chown: "heroku", State: StatePresent}, StatePresent},
-		{"StorageEnsureTask absent", &StorageEnsureTask{App: "test", Chown: "heroku", State: StateAbsent}, StateAbsent},
-		{"StorageMountTask present", &StorageMountTask{App: "test", HostDir: "/host", ContainerDir: "/container", State: StatePresent}, StatePresent},
-		{"StorageMountTask absent", &StorageMountTask{App: "test", HostDir: "/host", ContainerDir: "/container", State: StateAbsent}, StateAbsent},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.task.DesiredState(); got != tt.state {
-				t.Errorf("DesiredState() = %q, want %q", got, tt.state)
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Removes `DesiredState()` from the `Task` interface and deletes all 22 identical method implementations that just returned `t.State`
- Adds a `DesiredState` field to `TaskOutputState`, set centrally in `DispatchState()` which all tasks already route through
- Eliminates boilerplate while preserving the post-execution state validation in `main.go`