### PR TITLE
feat: add scheduler_property_task for managing scheduler:set properties

### DIFF
--- a/docs/dokku_scheduler_property.md
+++ b/docs/dokku_scheduler_property.md
@@ -1,0 +1,30 @@
+# dokku_scheduler_property
+
+Manages the scheduler configuration for a given dokku application
+
+## Selecting the scheduler for an app
+
+```yaml
+dokku_scheduler_property:
+    app: node-js-app
+    property: selected
+    value: docker-local
+```
+
+## Selecting the scheduler globally
+
+```yaml
+dokku_scheduler_property:
+    app: ""
+    global: true
+    property: selected
+    value: docker-local
+```
+
+## Clearing the scheduler property for an app
+
+```yaml
+dokku_scheduler_property:
+    app: node-js-app
+    property: selected
+```

--- a/tasks/integration_test.go
+++ b/tasks/integration_test.go
@@ -484,6 +484,45 @@ func TestIntegrationNginxProperty(t *testing.T) {
 	}
 }
 
+func TestIntegrationSchedulerProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-scheduler"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set scheduler property
+	setTask := SchedulerPropertyTask{
+		App:      appName,
+		Property: "selected",
+		Value:    "docker-local",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set scheduler property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset scheduler property
+	unsetTask := SchedulerPropertyTask{
+		App:      appName,
+		Property: "selected",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset scheduler property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}
+
 func TestIntegrationGitProperty(t *testing.T) {
 	skipIfNoDokkuT(t)
 

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -175,6 +175,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_ps_scale",
 		"dokku_resource_limit",
 		"dokku_resource_reserve",
+		"dokku_scheduler_property",
 		"dokku_service_create",
 		"dokku_service_link",
 		"dokku_storage_ensure",

--- a/tasks/scheduler_property_task.go
+++ b/tasks/scheduler_property_task.go
@@ -1,0 +1,77 @@
+package tasks
+
+// SchedulerPropertyTask manages the scheduler configuration for a given dokku application
+type SchedulerPropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the scheduler configuration should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Property is the name of the scheduler property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the scheduler property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the scheduler configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// SchedulerPropertyTaskExample contains an example of a SchedulerPropertyTask
+type SchedulerPropertyTaskExample struct {
+	// Name is the task name holding the SchedulerPropertyTask description
+	Name string `yaml:"-"`
+
+	// SchedulerPropertyTask is the SchedulerPropertyTask configuration
+	SchedulerPropertyTask SchedulerPropertyTask `yaml:"dokku_scheduler_property"`
+}
+
+// GetName returns the name of the example
+func (e SchedulerPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the scheduler property task
+func (t SchedulerPropertyTask) Doc() string {
+	return "Manages the scheduler configuration for a given dokku application"
+}
+
+// Examples returns the examples for the scheduler property task
+func (t SchedulerPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]SchedulerPropertyTaskExample{
+		{
+			Name: "Selecting the scheduler for an app",
+			SchedulerPropertyTask: SchedulerPropertyTask{
+				App:      "node-js-app",
+				Property: "selected",
+				Value:    "docker-local",
+			},
+		},
+		{
+			Name: "Selecting the scheduler globally",
+			SchedulerPropertyTask: SchedulerPropertyTask{
+				Global:   true,
+				Property: "selected",
+				Value:    "docker-local",
+			},
+		},
+		{
+			Name: "Clearing the scheduler property for an app",
+			SchedulerPropertyTask: SchedulerPropertyTask{
+				App:      "node-js-app",
+				Property: "selected",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the scheduler property
+func (t SchedulerPropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "scheduler:set")
+}
+
+// init registers the SchedulerPropertyTask with the task registry
+func init() {
+	RegisterTask(&SchedulerPropertyTask{})
+}

--- a/tasks/task_execute_test.go
+++ b/tasks/task_execute_test.go
@@ -288,6 +288,71 @@ func TestNetworkPropertyTaskInvalidState(t *testing.T) {
 	}
 }
 
+func TestSchedulerPropertyTaskInvalidState(t *testing.T) {
+	task := SchedulerPropertyTask{App: "test-app", Property: "selected", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestSchedulerPropertyTaskMissingApp(t *testing.T) {
+	task := SchedulerPropertyTask{Property: "selected", Value: "docker-local", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestSchedulerPropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := SchedulerPropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "selected",
+		Value:    "docker-local",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := SchedulerPropertyTask{
+		App:      "test-app",
+		Property: "selected",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerPropertyTaskAbsentWithValue(t *testing.T) {
+	task := SchedulerPropertyTask{
+		App:      "test-app",
+		Property: "selected",
+		Value:    "docker-local",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
 func TestNetworkPropertyTaskMissingApp(t *testing.T) {
 	task := NetworkPropertyTask{Property: "attach-post-create", Value: "test-network", State: StatePresent}
 	result := task.Execute()
@@ -652,7 +717,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 22
+	expected := 23
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -680,6 +745,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&PsScaleTask{}, "Manages the process scale for a given dokku application"},
 		{&ResourceLimitTask{}, "Manages the resource limits for a given dokku application"},
 		{&ResourceReserveTask{}, "Manages the resource reservations for a given dokku application"},
+		{&SchedulerPropertyTask{}, "Manages the scheduler configuration for a given dokku application"},
 		{&ServiceCreateTask{}, "Creates or destroys a dokku service"},
 		{&ServiceLinkTask{}, "Links or unlinks a dokku service to an app"},
 		{&ProxyToggleTask{}, "Enables or disables the proxy plugin for a given dokku application"},


### PR DESCRIPTION
## Summary

- Adds `dokku_scheduler_property` task, mirroring the existing `git_property_task`, `builder_property_task`, `network_property_task`, and `nginx_property_task` wrappers around `dokku <plugin>:set`.
- Supports per-app and global modes via the shared `executeProperty` helper.
- Adds the standard validation suite (invalid state, missing app, global+app, present-without-value, absent-with-value), an integration test that exercises real `scheduler:set` set+unset against dokku, and the corresponding doc page.

Resolves #128 (the issue's idempotency requirement is split out into #158 because correctly fixing it across all five property tasks requires a shared-helper refactor and depends on dokku/dokku#8499 / dokku/dokku#8500).