### PR TITLE
feat: add checks_property_task for managing checks:set properties

### DIFF
--- a/docs/dokku_checks_property.md
+++ b/docs/dokku_checks_property.md
@@ -1,0 +1,30 @@
+# dokku_checks_property
+
+Manages the checks configuration for a given dokku application
+
+## Setting the wait-to-retire value for an app
+
+```yaml
+dokku_checks_property:
+    app: node-js-app
+    property: wait-to-retire
+    value: "60"
+```
+
+## Setting the wait-to-retire value globally
+
+```yaml
+dokku_checks_property:
+    app: ""
+    global: true
+    property: wait-to-retire
+    value: "60"
+```
+
+## Clearing the wait-to-retire value for an app
+
+```yaml
+dokku_checks_property:
+    app: node-js-app
+    property: wait-to-retire
+```

--- a/tasks/checks_property_task.go
+++ b/tasks/checks_property_task.go
@@ -1,0 +1,77 @@
+package tasks
+
+// ChecksPropertyTask manages the checks configuration for a given dokku application
+type ChecksPropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the checks configuration should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Property is the name of the checks property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the checks property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the checks configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// ChecksPropertyTaskExample contains an example of a ChecksPropertyTask
+type ChecksPropertyTaskExample struct {
+	// Name is the task name holding the ChecksPropertyTask description
+	Name string `yaml:"-"`
+
+	// ChecksPropertyTask is the ChecksPropertyTask configuration
+	ChecksPropertyTask ChecksPropertyTask `yaml:"dokku_checks_property"`
+}
+
+// GetName returns the name of the example
+func (e ChecksPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the checks property task
+func (t ChecksPropertyTask) Doc() string {
+	return "Manages the checks configuration for a given dokku application"
+}
+
+// Examples returns the examples for the checks property task
+func (t ChecksPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]ChecksPropertyTaskExample{
+		{
+			Name: "Setting the wait-to-retire value for an app",
+			ChecksPropertyTask: ChecksPropertyTask{
+				App:      "node-js-app",
+				Property: "wait-to-retire",
+				Value:    "60",
+			},
+		},
+		{
+			Name: "Setting the wait-to-retire value globally",
+			ChecksPropertyTask: ChecksPropertyTask{
+				Global:   true,
+				Property: "wait-to-retire",
+				Value:    "60",
+			},
+		},
+		{
+			Name: "Clearing the wait-to-retire value for an app",
+			ChecksPropertyTask: ChecksPropertyTask{
+				App:      "node-js-app",
+				Property: "wait-to-retire",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the checks property
+func (t ChecksPropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "checks:set")
+}
+
+// init registers the ChecksPropertyTask with the task registry
+func init() {
+	RegisterTask(&ChecksPropertyTask{})
+}

--- a/tasks/integration_test.go
+++ b/tasks/integration_test.go
@@ -484,6 +484,45 @@ func TestIntegrationNginxProperty(t *testing.T) {
 	}
 }
 
+func TestIntegrationChecksProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-checks-prop"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set checks property
+	setTask := ChecksPropertyTask{
+		App:      appName,
+		Property: "wait-to-retire",
+		Value:    "60",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set checks property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset checks property
+	unsetTask := ChecksPropertyTask{
+		App:      appName,
+		Property: "wait-to-retire",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset checks property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}
+
 func TestIntegrationSchedulerProperty(t *testing.T) {
 	skipIfNoDokkuT(t)
 

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -159,6 +159,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 	expectedTasks := []string{
 		"dokku_app",
 		"dokku_builder_property",
+		"dokku_checks_property",
 		"dokku_checks_toggle",
 		"dokku_config",
 		"dokku_domains",

--- a/tasks/task_execute_test.go
+++ b/tasks/task_execute_test.go
@@ -29,6 +29,71 @@ func TestBuilderPropertyTaskMissingApp(t *testing.T) {
 	}
 }
 
+func TestChecksPropertyTaskInvalidState(t *testing.T) {
+	task := ChecksPropertyTask{App: "test-app", Property: "wait-to-retire", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestChecksPropertyTaskMissingApp(t *testing.T) {
+	task := ChecksPropertyTask{Property: "wait-to-retire", Value: "60", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestChecksPropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := ChecksPropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "wait-to-retire",
+		Value:    "60",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestChecksPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := ChecksPropertyTask{
+		App:      "test-app",
+		Property: "wait-to-retire",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestChecksPropertyTaskAbsentWithValue(t *testing.T) {
+	task := ChecksPropertyTask{
+		App:      "test-app",
+		Property: "wait-to-retire",
+		Value:    "60",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
 func TestChecksToggleTaskInvalidState(t *testing.T) {
 	task := ChecksToggleTask{App: "test-app", State: "invalid"}
 	result := task.Execute()
@@ -717,7 +782,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 23
+	expected := 24
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -730,6 +795,7 @@ func TestTaskDocStrings(t *testing.T) {
 	}{
 		{&AppTask{}, "Creates or destroys an app"},
 		{&BuilderPropertyTask{}, "Manages the builder configuration for a given dokku application"},
+		{&ChecksPropertyTask{}, "Manages the checks configuration for a given dokku application"},
 		{&ChecksToggleTask{}, "Enables or disables the checks plugin for a given dokku application"},
 		{&ConfigTask{}, "Manages the configuration for a given dokku application"},
 		{&DomainsTask{}, "Manages the domains for a given dokku application or globally"},


### PR DESCRIPTION
## Summary

- Adds a new `dokku_checks_property` task that wraps `checks:set` (global-capable; e.g. the `wait-to-retire` property).
- Mirrors the existing property-task pattern by delegating to the shared `executeProperty` helper in `tasks/properties.go` - no per-task idempotency, since that is tracked in #158.
- Adds unit tests, an integration test, and the auto-generated documentation file.

Closes #129.