### PR TITLE
feat: add logs_property_task for managing logs:set properties

### DIFF
--- a/docs/dokku_logs_property.md
+++ b/docs/dokku_logs_property.md
@@ -1,0 +1,30 @@
+# dokku_logs_property
+
+Manages the logs configuration for a given dokku application
+
+## Setting the max-size value for an app
+
+```yaml
+dokku_logs_property:
+    app: node-js-app
+    property: max-size
+    value: 100m
+```
+
+## Setting the max-size value globally
+
+```yaml
+dokku_logs_property:
+    app: ""
+    global: true
+    property: max-size
+    value: 100m
+```
+
+## Clearing the max-size value for an app
+
+```yaml
+dokku_logs_property:
+    app: node-js-app
+    property: max-size
+```

--- a/tasks/integration_test.go
+++ b/tasks/integration_test.go
@@ -523,6 +523,45 @@ func TestIntegrationChecksProperty(t *testing.T) {
 	}
 }
 
+func TestIntegrationLogsProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-logs-prop"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set logs property
+	setTask := LogsPropertyTask{
+		App:      appName,
+		Property: "max-size",
+		Value:    "100m",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set logs property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset logs property
+	unsetTask := LogsPropertyTask{
+		App:      appName,
+		Property: "max-size",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset logs property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}
+
 func TestIntegrationSchedulerProperty(t *testing.T) {
 	skipIfNoDokkuT(t)
 

--- a/tasks/logs_property_task.go
+++ b/tasks/logs_property_task.go
@@ -1,0 +1,77 @@
+package tasks
+
+// LogsPropertyTask manages the logs configuration for a given dokku application
+type LogsPropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the logs configuration should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Property is the name of the logs property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the logs property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the logs configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// LogsPropertyTaskExample contains an example of a LogsPropertyTask
+type LogsPropertyTaskExample struct {
+	// Name is the task name holding the LogsPropertyTask description
+	Name string `yaml:"-"`
+
+	// LogsPropertyTask is the LogsPropertyTask configuration
+	LogsPropertyTask LogsPropertyTask `yaml:"dokku_logs_property"`
+}
+
+// GetName returns the name of the example
+func (e LogsPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the logs property task
+func (t LogsPropertyTask) Doc() string {
+	return "Manages the logs configuration for a given dokku application"
+}
+
+// Examples returns the examples for the logs property task
+func (t LogsPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]LogsPropertyTaskExample{
+		{
+			Name: "Setting the max-size value for an app",
+			LogsPropertyTask: LogsPropertyTask{
+				App:      "node-js-app",
+				Property: "max-size",
+				Value:    "100m",
+			},
+		},
+		{
+			Name: "Setting the max-size value globally",
+			LogsPropertyTask: LogsPropertyTask{
+				Global:   true,
+				Property: "max-size",
+				Value:    "100m",
+			},
+		},
+		{
+			Name: "Clearing the max-size value for an app",
+			LogsPropertyTask: LogsPropertyTask{
+				App:      "node-js-app",
+				Property: "max-size",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the logs property
+func (t LogsPropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "logs:set")
+}
+
+// init registers the LogsPropertyTask with the task registry
+func init() {
+	RegisterTask(&LogsPropertyTask{})
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -168,6 +168,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_git_property",
 		"dokku_git_sync",
 		"dokku_http_auth",
+		"dokku_logs_property",
 		"dokku_network",
 		"dokku_network_property",
 		"dokku_nginx_property",

--- a/tasks/task_execute_test.go
+++ b/tasks/task_execute_test.go
@@ -353,6 +353,71 @@ func TestNetworkPropertyTaskInvalidState(t *testing.T) {
 	}
 }
 
+func TestLogsPropertyTaskInvalidState(t *testing.T) {
+	task := LogsPropertyTask{App: "test-app", Property: "max-size", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestLogsPropertyTaskMissingApp(t *testing.T) {
+	task := LogsPropertyTask{Property: "max-size", Value: "100m", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestLogsPropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := LogsPropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "max-size",
+		Value:    "100m",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestLogsPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := LogsPropertyTask{
+		App:      "test-app",
+		Property: "max-size",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestLogsPropertyTaskAbsentWithValue(t *testing.T) {
+	task := LogsPropertyTask{
+		App:      "test-app",
+		Property: "max-size",
+		Value:    "100m",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
 func TestSchedulerPropertyTaskInvalidState(t *testing.T) {
 	task := SchedulerPropertyTask{App: "test-app", Property: "selected", State: "invalid"}
 	result := task.Execute()
@@ -782,7 +847,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 24
+	expected := 25
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -804,6 +869,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&GitPropertyTask{}, "Manages the git configuration for a given dokku application"},
 		{&GitSyncTask{}, "Syncs a git repository to a dokku application"},
 		{&HttpAuthTask{}, "Manages HTTP authentication for a given dokku application"},
+		{&LogsPropertyTask{}, "Manages the logs configuration for a given dokku application"},
 		{&NetworkTask{}, "Creates or destroys a Docker network"},
 		{&NetworkPropertyTask{}, "Manages the network property for a given dokku application"},
 		{&NginxPropertyTask{}, "Manages the nginx configuration for a given dokku application"},


### PR DESCRIPTION
## Summary

- Adds a new `dokku_logs_property` task that wraps `logs:set` (global-capable; supports the `app-label-alias`, `max-size`, and `vector-sink` properties).
- Mirrors the existing property-task pattern by delegating to the shared `executeProperty` helper in `tasks/properties.go` - no per-task idempotency, since that is tracked in #158.
- Adds unit tests, an integration test, and the auto-generated documentation file.

Closes #130.