### PR TITLE
feat: add buildpacks_property_task for managing buildpacks:set-property

### DIFF
--- a/docs/dokku_buildpacks_property.md
+++ b/docs/dokku_buildpacks_property.md
@@ -1,0 +1,30 @@
+# dokku_buildpacks_property
+
+Manages the buildpacks configuration for a given dokku application
+
+## Setting the stack value for an app
+
+```yaml
+dokku_buildpacks_property:
+    app: node-js-app
+    property: stack
+    value: gliderlabs/herokuish:latest
+```
+
+## Setting the stack value globally
+
+```yaml
+dokku_buildpacks_property:
+    app: ""
+    global: true
+    property: stack
+    value: gliderlabs/herokuish:latest
+```
+
+## Clearing the stack value for an app
+
+```yaml
+dokku_buildpacks_property:
+    app: node-js-app
+    property: stack
+```

--- a/tasks/buildpacks_property_task.go
+++ b/tasks/buildpacks_property_task.go
@@ -1,0 +1,77 @@
+package tasks
+
+// BuildpacksPropertyTask manages the buildpacks configuration for a given dokku application
+type BuildpacksPropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the buildpacks configuration should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Property is the name of the buildpacks property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the buildpacks property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the buildpacks configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// BuildpacksPropertyTaskExample contains an example of a BuildpacksPropertyTask
+type BuildpacksPropertyTaskExample struct {
+	// Name is the task name holding the BuildpacksPropertyTask description
+	Name string `yaml:"-"`
+
+	// BuildpacksPropertyTask is the BuildpacksPropertyTask configuration
+	BuildpacksPropertyTask BuildpacksPropertyTask `yaml:"dokku_buildpacks_property"`
+}
+
+// GetName returns the name of the example
+func (e BuildpacksPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the buildpacks property task
+func (t BuildpacksPropertyTask) Doc() string {
+	return "Manages the buildpacks configuration for a given dokku application"
+}
+
+// Examples returns the examples for the buildpacks property task
+func (t BuildpacksPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]BuildpacksPropertyTaskExample{
+		{
+			Name: "Setting the stack value for an app",
+			BuildpacksPropertyTask: BuildpacksPropertyTask{
+				App:      "node-js-app",
+				Property: "stack",
+				Value:    "gliderlabs/herokuish:latest",
+			},
+		},
+		{
+			Name: "Setting the stack value globally",
+			BuildpacksPropertyTask: BuildpacksPropertyTask{
+				Global:   true,
+				Property: "stack",
+				Value:    "gliderlabs/herokuish:latest",
+			},
+		},
+		{
+			Name: "Clearing the stack value for an app",
+			BuildpacksPropertyTask: BuildpacksPropertyTask{
+				App:      "node-js-app",
+				Property: "stack",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the buildpacks property
+func (t BuildpacksPropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "buildpacks:set-property")
+}
+
+// init registers the BuildpacksPropertyTask with the task registry
+func init() {
+	RegisterTask(&BuildpacksPropertyTask{})
+}

--- a/tasks/buildpacks_property_task_integration_test.go
+++ b/tasks/buildpacks_property_task_integration_test.go
@@ -1,0 +1,44 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationBuildpacksProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-buildpacks-prop"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set buildpacks property
+	setTask := BuildpacksPropertyTask{
+		App:      appName,
+		Property: "stack",
+		Value:    "gliderlabs/herokuish:latest",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set buildpacks property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset buildpacks property
+	unsetTask := BuildpacksPropertyTask{
+		App:      appName,
+		Property: "stack",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset buildpacks property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}

--- a/tasks/buildpacks_property_task_test.go
+++ b/tasks/buildpacks_property_task_test.go
@@ -1,0 +1,71 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildpacksPropertyTaskInvalidState(t *testing.T) {
+	task := BuildpacksPropertyTask{App: "test-app", Property: "stack", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestBuildpacksPropertyTaskMissingApp(t *testing.T) {
+	task := BuildpacksPropertyTask{Property: "stack", Value: "gliderlabs/herokuish:latest", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestBuildpacksPropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := BuildpacksPropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "stack",
+		Value:    "gliderlabs/herokuish:latest",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestBuildpacksPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := BuildpacksPropertyTask{
+		App:      "test-app",
+		Property: "stack",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestBuildpacksPropertyTaskAbsentWithValue(t *testing.T) {
+	task := BuildpacksPropertyTask{
+		App:      "test-app",
+		Property: "stack",
+		Value:    "gliderlabs/herokuish:latest",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -451,7 +451,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 26
+	expected := 27
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -464,6 +464,7 @@ func TestTaskDocStrings(t *testing.T) {
 	}{
 		{&AppTask{}, "Creates or destroys an app"},
 		{&BuilderPropertyTask{}, "Manages the builder configuration for a given dokku application"},
+		{&BuildpacksPropertyTask{}, "Manages the buildpacks configuration for a given dokku application"},
 		{&ChecksPropertyTask{}, "Manages the checks configuration for a given dokku application"},
 		{&ChecksToggleTask{}, "Enables or disables the checks plugin for a given dokku application"},
 		{&ConfigTask{}, "Manages the configuration for a given dokku application"},


### PR DESCRIPTION
## Summary

- Adds `BuildpacksPropertyTask` (registered as `dokku_buildpacks_property`) that wraps `dokku buildpacks:set-property` for per-app and global property management of the `stack` value.
- Delegates to the shared `executeProperty` helper in `tasks/properties.go`, mirroring the pattern used by `builder_property_task`, `ps_property_task`, and the other property tasks.
- Includes unit tests, an integration test, and generated docs at `docs/dokku_buildpacks_property.md`.

Closes #131.