### PR TITLE
feat: add app_json_property_task for managing app-json:set-property

### DIFF
--- a/docs/dokku_app_json_property.md
+++ b/docs/dokku_app_json_property.md
@@ -1,0 +1,30 @@
+# dokku_app_json_property
+
+Manages the app.json configuration for a given dokku application
+
+## Setting the appjson-path for an app
+
+```yaml
+dokku_app_json_property:
+    app: node-js-app
+    property: appjson-path
+    value: app.json
+```
+
+## Setting the appjson-path globally
+
+```yaml
+dokku_app_json_property:
+    app: ""
+    global: true
+    property: appjson-path
+    value: app.json
+```
+
+## Clearing the appjson-path for an app
+
+```yaml
+dokku_app_json_property:
+    app: node-js-app
+    property: appjson-path
+```

--- a/tasks/app_json_property_task.go
+++ b/tasks/app_json_property_task.go
@@ -1,0 +1,77 @@
+package tasks
+
+// AppJsonPropertyTask manages the app.json configuration for a given dokku application
+type AppJsonPropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the app.json configuration should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Property is the name of the app.json property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the app.json property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the app.json configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// AppJsonPropertyTaskExample contains an example of an AppJsonPropertyTask
+type AppJsonPropertyTaskExample struct {
+	// Name is the task name holding the AppJsonPropertyTask description
+	Name string `yaml:"-"`
+
+	// AppJsonPropertyTask is the AppJsonPropertyTask configuration
+	AppJsonPropertyTask AppJsonPropertyTask `yaml:"dokku_app_json_property"`
+}
+
+// GetName returns the name of the example
+func (e AppJsonPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the app.json property task
+func (t AppJsonPropertyTask) Doc() string {
+	return "Manages the app.json configuration for a given dokku application"
+}
+
+// Examples returns the examples for the app.json property task
+func (t AppJsonPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]AppJsonPropertyTaskExample{
+		{
+			Name: "Setting the appjson-path for an app",
+			AppJsonPropertyTask: AppJsonPropertyTask{
+				App:      "node-js-app",
+				Property: "appjson-path",
+				Value:    "app.json",
+			},
+		},
+		{
+			Name: "Setting the appjson-path globally",
+			AppJsonPropertyTask: AppJsonPropertyTask{
+				Global:   true,
+				Property: "appjson-path",
+				Value:    "app.json",
+			},
+		},
+		{
+			Name: "Clearing the appjson-path for an app",
+			AppJsonPropertyTask: AppJsonPropertyTask{
+				App:      "node-js-app",
+				Property: "appjson-path",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the app.json property
+func (t AppJsonPropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "app-json:set")
+}
+
+// init registers the AppJsonPropertyTask with the task registry
+func init() {
+	RegisterTask(&AppJsonPropertyTask{})
+}

--- a/tasks/app_json_property_task_integration_test.go
+++ b/tasks/app_json_property_task_integration_test.go
@@ -1,0 +1,44 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationAppJsonProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-app-json-prop"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set app.json property
+	setTask := AppJsonPropertyTask{
+		App:      appName,
+		Property: "appjson-path",
+		Value:    "app.json",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set app.json property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset app.json property
+	unsetTask := AppJsonPropertyTask{
+		App:      appName,
+		Property: "appjson-path",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset app.json property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}

--- a/tasks/app_json_property_task_test.go
+++ b/tasks/app_json_property_task_test.go
@@ -1,0 +1,71 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAppJsonPropertyTaskInvalidState(t *testing.T) {
+	task := AppJsonPropertyTask{App: "test-app", Property: "appjson-path", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestAppJsonPropertyTaskMissingApp(t *testing.T) {
+	task := AppJsonPropertyTask{Property: "appjson-path", Value: "app.json", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestAppJsonPropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := AppJsonPropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "appjson-path",
+		Value:    "app.json",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestAppJsonPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := AppJsonPropertyTask{
+		App:      "test-app",
+		Property: "appjson-path",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestAppJsonPropertyTaskAbsentWithValue(t *testing.T) {
+	task := AppJsonPropertyTask{
+		App:      "test-app",
+		Property: "appjson-path",
+		Value:    "app.json",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -158,6 +158,7 @@ func TestGetTasksWithTemplateContext(t *testing.T) {
 func TestRegisteredTasksExist(t *testing.T) {
 	expectedTasks := []string{
 		"dokku_app",
+		"dokku_app_json_property",
 		"dokku_builder_property",
 		"dokku_checks_property",
 		"dokku_checks_toggle",
@@ -451,7 +452,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 27
+	expected := 28
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -463,6 +464,7 @@ func TestTaskDocStrings(t *testing.T) {
 		want string
 	}{
 		{&AppTask{}, "Creates or destroys an app"},
+		{&AppJsonPropertyTask{}, "Manages the app.json configuration for a given dokku application"},
 		{&BuilderPropertyTask{}, "Manages the builder configuration for a given dokku application"},
 		{&BuildpacksPropertyTask{}, "Manages the buildpacks configuration for a given dokku application"},
 		{&ChecksPropertyTask{}, "Manages the checks configuration for a given dokku application"},


### PR DESCRIPTION
## Summary

- Adds `AppJsonPropertyTask` (registered as `dokku_app_json_property`) that wraps `dokku app-json:set` for per-app and global property management of the `appjson-path` value.
- Delegates to the shared `executeProperty` helper in `tasks/properties.go`, mirroring the pattern used by `builder_property_task`, `buildpacks_property_task`, `ps_property_task`, and the other property tasks.
- Includes unit tests, an integration test, and generated docs at `docs/dokku_app_json_property.md`.

Closes #132.