### PR TITLE
feat: add cron_property_task for managing cron:set property

### DIFF
--- a/docs/dokku_cron_property.md
+++ b/docs/dokku_cron_property.md
@@ -1,0 +1,30 @@
+# dokku_cron_property
+
+Manages the cron configuration for a given dokku application
+
+## Setting the mailto address for an app
+
+```yaml
+dokku_cron_property:
+    app: node-js-app
+    property: mailto
+    value: ops@example.com
+```
+
+## Setting the mailto address globally
+
+```yaml
+dokku_cron_property:
+    app: ""
+    global: true
+    property: mailto
+    value: ops@example.com
+```
+
+## Clearing the mailto address for an app
+
+```yaml
+dokku_cron_property:
+    app: node-js-app
+    property: mailto
+```

--- a/docs/dokku_cron_property.md
+++ b/docs/dokku_cron_property.md
@@ -2,13 +2,13 @@
 
 Manages the cron configuration for a given dokku application
 
-## Setting the mailto address for an app
+## Enabling maintenance mode for an app
 
 ```yaml
 dokku_cron_property:
     app: node-js-app
-    property: mailto
-    value: ops@example.com
+    property: maintenance
+    value: "true"
 ```
 
 ## Setting the mailto address globally
@@ -21,10 +21,10 @@ dokku_cron_property:
     value: ops@example.com
 ```
 
-## Clearing the mailto address for an app
+## Clearing the maintenance mode for an app
 
 ```yaml
 dokku_cron_property:
     app: node-js-app
-    property: mailto
+    property: maintenance
 ```

--- a/tasks/cron_property_task.go
+++ b/tasks/cron_property_task.go
@@ -41,11 +41,11 @@ func (t CronPropertyTask) Doc() string {
 func (t CronPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]CronPropertyTaskExample{
 		{
-			Name: "Setting the mailto address for an app",
+			Name: "Enabling maintenance mode for an app",
 			CronPropertyTask: CronPropertyTask{
 				App:      "node-js-app",
-				Property: "mailto",
-				Value:    "ops@example.com",
+				Property: "maintenance",
+				Value:    "true",
 			},
 		},
 		{
@@ -57,10 +57,10 @@ func (t CronPropertyTask) Examples() ([]Doc, error) {
 			},
 		},
 		{
-			Name: "Clearing the mailto address for an app",
+			Name: "Clearing the maintenance mode for an app",
 			CronPropertyTask: CronPropertyTask{
 				App:      "node-js-app",
-				Property: "mailto",
+				Property: "maintenance",
 			},
 		},
 	})

--- a/tasks/cron_property_task.go
+++ b/tasks/cron_property_task.go
@@ -1,0 +1,77 @@
+package tasks
+
+// CronPropertyTask manages the cron configuration for a given dokku application
+type CronPropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the cron configuration should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Property is the name of the cron property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the cron property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the cron configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// CronPropertyTaskExample contains an example of a CronPropertyTask
+type CronPropertyTaskExample struct {
+	// Name is the task name holding the CronPropertyTask description
+	Name string `yaml:"-"`
+
+	// CronPropertyTask is the CronPropertyTask configuration
+	CronPropertyTask CronPropertyTask `yaml:"dokku_cron_property"`
+}
+
+// GetName returns the name of the example
+func (e CronPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the cron property task
+func (t CronPropertyTask) Doc() string {
+	return "Manages the cron configuration for a given dokku application"
+}
+
+// Examples returns the examples for the cron property task
+func (t CronPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]CronPropertyTaskExample{
+		{
+			Name: "Setting the mailto address for an app",
+			CronPropertyTask: CronPropertyTask{
+				App:      "node-js-app",
+				Property: "mailto",
+				Value:    "ops@example.com",
+			},
+		},
+		{
+			Name: "Setting the mailto address globally",
+			CronPropertyTask: CronPropertyTask{
+				Global:   true,
+				Property: "mailto",
+				Value:    "ops@example.com",
+			},
+		},
+		{
+			Name: "Clearing the mailto address for an app",
+			CronPropertyTask: CronPropertyTask{
+				App:      "node-js-app",
+				Property: "mailto",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the cron property
+func (t CronPropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "cron:set")
+}
+
+// init registers the CronPropertyTask with the task registry
+func init() {
+	RegisterTask(&CronPropertyTask{})
+}

--- a/tasks/cron_property_task_integration_test.go
+++ b/tasks/cron_property_task_integration_test.go
@@ -16,8 +16,8 @@ func TestIntegrationCronProperty(t *testing.T) {
 	// set cron property
 	setTask := CronPropertyTask{
 		App:      appName,
-		Property: "mailto",
-		Value:    "ops@example.com",
+		Property: "maintenance",
+		Value:    "true",
 		State:    StatePresent,
 	}
 	result := setTask.Execute()
@@ -31,7 +31,7 @@ func TestIntegrationCronProperty(t *testing.T) {
 	// unset cron property
 	unsetTask := CronPropertyTask{
 		App:      appName,
-		Property: "mailto",
+		Property: "maintenance",
 		State:    StateAbsent,
 	}
 	result = unsetTask.Execute()

--- a/tasks/cron_property_task_integration_test.go
+++ b/tasks/cron_property_task_integration_test.go
@@ -1,0 +1,44 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationCronProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-cron"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set cron property
+	setTask := CronPropertyTask{
+		App:      appName,
+		Property: "mailto",
+		Value:    "ops@example.com",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set cron property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset cron property
+	unsetTask := CronPropertyTask{
+		App:      appName,
+		Property: "mailto",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset cron property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}

--- a/tasks/cron_property_task_test.go
+++ b/tasks/cron_property_task_test.go
@@ -1,0 +1,71 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCronPropertyTaskInvalidState(t *testing.T) {
+	task := CronPropertyTask{App: "test-app", Property: "mailto", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestCronPropertyTaskMissingApp(t *testing.T) {
+	task := CronPropertyTask{Property: "mailto", Value: "ops@example.com", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestCronPropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := CronPropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "mailto",
+		Value:    "ops@example.com",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestCronPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := CronPropertyTask{
+		App:      "test-app",
+		Property: "mailto",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestCronPropertyTaskAbsentWithValue(t *testing.T) {
+	task := CronPropertyTask{
+		App:      "test-app",
+		Property: "mailto",
+		Value:    "ops@example.com",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -163,6 +163,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_checks_property",
 		"dokku_checks_toggle",
 		"dokku_config",
+		"dokku_cron_property",
 		"dokku_domains",
 		"dokku_domains_toggle",
 		"dokku_git_from_image",
@@ -452,7 +453,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 28
+	expected := 29
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -470,6 +471,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&ChecksPropertyTask{}, "Manages the checks configuration for a given dokku application"},
 		{&ChecksToggleTask{}, "Enables or disables the checks plugin for a given dokku application"},
 		{&ConfigTask{}, "Manages the configuration for a given dokku application"},
+		{&CronPropertyTask{}, "Manages the cron configuration for a given dokku application"},
 		{&DomainsTask{}, "Manages the domains for a given dokku application or globally"},
 		{&DomainsToggleTask{}, "Enables or disables the domains plugin for a given dokku application"},
 		{&GitFromImageTask{}, "Deploys a git repository from a docker image"},


### PR DESCRIPTION
## Summary

- Adds `CronPropertyTask` (registered as `dokku_cron_property`) that wraps `dokku cron:set` for per-app and global management of the `mailfrom`, `mailto`, and `maintenance` properties.
- Delegates to the shared `executeProperty` helper in `tasks/properties.go`, mirroring the pattern used by `app_json_property_task`, `scheduler_property_task`, and the other property tasks.
- Includes unit tests, an integration test, and generated docs at `docs/dokku_cron_property.md`.

Closes #133.