### PR TITLE
feat: add caddy_property_task for managing caddy:set property

### DIFF
--- a/docs/dokku_caddy_property.md
+++ b/docs/dokku_caddy_property.md
@@ -1,0 +1,30 @@
+# dokku_caddy_property
+
+Manages the caddy configuration for a given dokku application
+
+## Enabling internal TLS for an app
+
+```yaml
+dokku_caddy_property:
+    app: node-js-app
+    property: tls-internal
+    value: "true"
+```
+
+## Setting the letsencrypt email globally
+
+```yaml
+dokku_caddy_property:
+    app: ""
+    global: true
+    property: letsencrypt-email
+    value: admin@example.com
+```
+
+## Clearing internal TLS for an app
+
+```yaml
+dokku_caddy_property:
+    app: node-js-app
+    property: tls-internal
+```

--- a/tasks/caddy_property_task.go
+++ b/tasks/caddy_property_task.go
@@ -1,0 +1,77 @@
+package tasks
+
+// CaddyPropertyTask manages the caddy configuration for a given dokku application
+type CaddyPropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the caddy configuration should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Property is the name of the caddy property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the caddy property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the caddy configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// CaddyPropertyTaskExample contains an example of a CaddyPropertyTask
+type CaddyPropertyTaskExample struct {
+	// Name is the task name holding the CaddyPropertyTask description
+	Name string `yaml:"-"`
+
+	// CaddyPropertyTask is the CaddyPropertyTask configuration
+	CaddyPropertyTask CaddyPropertyTask `yaml:"dokku_caddy_property"`
+}
+
+// GetName returns the name of the example
+func (e CaddyPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the caddy property task
+func (t CaddyPropertyTask) Doc() string {
+	return "Manages the caddy configuration for a given dokku application"
+}
+
+// Examples returns the examples for the caddy property task
+func (t CaddyPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]CaddyPropertyTaskExample{
+		{
+			Name: "Enabling internal TLS for an app",
+			CaddyPropertyTask: CaddyPropertyTask{
+				App:      "node-js-app",
+				Property: "tls-internal",
+				Value:    "true",
+			},
+		},
+		{
+			Name: "Setting the letsencrypt email globally",
+			CaddyPropertyTask: CaddyPropertyTask{
+				Global:   true,
+				Property: "letsencrypt-email",
+				Value:    "admin@example.com",
+			},
+		},
+		{
+			Name: "Clearing internal TLS for an app",
+			CaddyPropertyTask: CaddyPropertyTask{
+				App:      "node-js-app",
+				Property: "tls-internal",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the caddy property
+func (t CaddyPropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "caddy:set")
+}
+
+// init registers the CaddyPropertyTask with the task registry
+func init() {
+	RegisterTask(&CaddyPropertyTask{})
+}

--- a/tasks/caddy_property_task_integration_test.go
+++ b/tasks/caddy_property_task_integration_test.go
@@ -1,0 +1,44 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationCaddyProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-caddy"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set caddy property
+	setTask := CaddyPropertyTask{
+		App:      appName,
+		Property: "tls-internal",
+		Value:    "true",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set caddy property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset caddy property
+	unsetTask := CaddyPropertyTask{
+		App:      appName,
+		Property: "tls-internal",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset caddy property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}

--- a/tasks/caddy_property_task_test.go
+++ b/tasks/caddy_property_task_test.go
@@ -1,0 +1,71 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCaddyPropertyTaskInvalidState(t *testing.T) {
+	task := CaddyPropertyTask{App: "test-app", Property: "tls-internal", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestCaddyPropertyTaskMissingApp(t *testing.T) {
+	task := CaddyPropertyTask{Property: "tls-internal", Value: "true", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestCaddyPropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := CaddyPropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "tls-internal",
+		Value:    "true",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestCaddyPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := CaddyPropertyTask{
+		App:      "test-app",
+		Property: "tls-internal",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestCaddyPropertyTaskAbsentWithValue(t *testing.T) {
+	task := CaddyPropertyTask{
+		App:      "test-app",
+		Property: "tls-internal",
+		Value:    "true",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -160,6 +160,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_app",
 		"dokku_app_json_property",
 		"dokku_builder_property",
+		"dokku_caddy_property",
 		"dokku_checks_property",
 		"dokku_checks_toggle",
 		"dokku_config",
@@ -453,7 +454,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 29
+	expected := 30
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -468,6 +469,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&AppJsonPropertyTask{}, "Manages the app.json configuration for a given dokku application"},
 		{&BuilderPropertyTask{}, "Manages the builder configuration for a given dokku application"},
 		{&BuildpacksPropertyTask{}, "Manages the buildpacks configuration for a given dokku application"},
+		{&CaddyPropertyTask{}, "Manages the caddy configuration for a given dokku application"},
 		{&ChecksPropertyTask{}, "Manages the checks configuration for a given dokku application"},
 		{&ChecksToggleTask{}, "Enables or disables the checks plugin for a given dokku application"},
 		{&ConfigTask{}, "Manages the configuration for a given dokku application"},


### PR DESCRIPTION
## Summary

- Adds `CaddyPropertyTask` that wraps `dokku caddy:set` for app-level and global properties
- Mirrors the existing property-task pattern (`Doc`/`Examples`/`Execute` delegating to `executeProperty`)
- Generated `docs/dokku_caddy_property.md` from `Examples()` via `make docs`
- Closes #135