### PR TITLE
feat: add haproxy_property_task for managing haproxy:set property

### DIFF
--- a/docs/dokku_haproxy_property.md
+++ b/docs/dokku_haproxy_property.md
@@ -1,0 +1,30 @@
+# dokku_haproxy_property
+
+Manages the haproxy configuration for a given dokku application
+
+## Setting the letsencrypt email for an app
+
+```yaml
+dokku_haproxy_property:
+    app: node-js-app
+    property: letsencrypt-email
+    value: admin@example.com
+```
+
+## Setting the log level globally
+
+```yaml
+dokku_haproxy_property:
+    app: ""
+    global: true
+    property: log-level
+    value: INFO
+```
+
+## Clearing the letsencrypt email for an app
+
+```yaml
+dokku_haproxy_property:
+    app: node-js-app
+    property: letsencrypt-email
+```

--- a/tasks/haproxy_property_task.go
+++ b/tasks/haproxy_property_task.go
@@ -1,0 +1,77 @@
+package tasks
+
+// HaproxyPropertyTask manages the haproxy configuration for a given dokku application
+type HaproxyPropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the haproxy configuration should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Property is the name of the haproxy property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the haproxy property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the haproxy configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// HaproxyPropertyTaskExample contains an example of a HaproxyPropertyTask
+type HaproxyPropertyTaskExample struct {
+	// Name is the task name holding the HaproxyPropertyTask description
+	Name string `yaml:"-"`
+
+	// HaproxyPropertyTask is the HaproxyPropertyTask configuration
+	HaproxyPropertyTask HaproxyPropertyTask `yaml:"dokku_haproxy_property"`
+}
+
+// GetName returns the name of the example
+func (e HaproxyPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the haproxy property task
+func (t HaproxyPropertyTask) Doc() string {
+	return "Manages the haproxy configuration for a given dokku application"
+}
+
+// Examples returns the examples for the haproxy property task
+func (t HaproxyPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]HaproxyPropertyTaskExample{
+		{
+			Name: "Setting the letsencrypt email for an app",
+			HaproxyPropertyTask: HaproxyPropertyTask{
+				App:      "node-js-app",
+				Property: "letsencrypt-email",
+				Value:    "admin@example.com",
+			},
+		},
+		{
+			Name: "Setting the log level globally",
+			HaproxyPropertyTask: HaproxyPropertyTask{
+				Global:   true,
+				Property: "log-level",
+				Value:    "INFO",
+			},
+		},
+		{
+			Name: "Clearing the letsencrypt email for an app",
+			HaproxyPropertyTask: HaproxyPropertyTask{
+				App:      "node-js-app",
+				Property: "letsencrypt-email",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the haproxy property
+func (t HaproxyPropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "haproxy:set")
+}
+
+// init registers the HaproxyPropertyTask with the task registry
+func init() {
+	RegisterTask(&HaproxyPropertyTask{})
+}

--- a/tasks/haproxy_property_task_integration_test.go
+++ b/tasks/haproxy_property_task_integration_test.go
@@ -1,0 +1,44 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationHaproxyProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-haproxy"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set haproxy property
+	setTask := HaproxyPropertyTask{
+		App:      appName,
+		Property: "letsencrypt-email",
+		Value:    "admin@example.com",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set haproxy property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset haproxy property
+	unsetTask := HaproxyPropertyTask{
+		App:      appName,
+		Property: "letsencrypt-email",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset haproxy property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}

--- a/tasks/haproxy_property_task_test.go
+++ b/tasks/haproxy_property_task_test.go
@@ -1,0 +1,71 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHaproxyPropertyTaskInvalidState(t *testing.T) {
+	task := HaproxyPropertyTask{App: "test-app", Property: "letsencrypt-email", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestHaproxyPropertyTaskMissingApp(t *testing.T) {
+	task := HaproxyPropertyTask{Property: "letsencrypt-email", Value: "admin@example.com", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestHaproxyPropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := HaproxyPropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "letsencrypt-email",
+		Value:    "admin@example.com",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestHaproxyPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := HaproxyPropertyTask{
+		App:      "test-app",
+		Property: "letsencrypt-email",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestHaproxyPropertyTaskAbsentWithValue(t *testing.T) {
+	task := HaproxyPropertyTask{
+		App:      "test-app",
+		Property: "letsencrypt-email",
+		Value:    "admin@example.com",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -170,6 +170,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_git_from_image",
 		"dokku_git_property",
 		"dokku_git_sync",
+		"dokku_haproxy_property",
 		"dokku_http_auth",
 		"dokku_logs_property",
 		"dokku_network",
@@ -454,7 +455,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 30
+	expected := 31
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -479,6 +480,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&GitFromImageTask{}, "Deploys a git repository from a docker image"},
 		{&GitPropertyTask{}, "Manages the git configuration for a given dokku application"},
 		{&GitSyncTask{}, "Syncs a git repository to a dokku application"},
+		{&HaproxyPropertyTask{}, "Manages the haproxy configuration for a given dokku application"},
 		{&HttpAuthTask{}, "Manages HTTP authentication for a given dokku application"},
 		{&LogsPropertyTask{}, "Manages the logs configuration for a given dokku application"},
 		{&NetworkTask{}, "Creates or destroys a Docker network"},


### PR DESCRIPTION
## Summary

- Adds `dokku_haproxy_property` task wrapping `haproxy:set`, mirroring the existing property-task pattern (`caddy_property_task`, `nginx_property_task`, etc.)
- Supports per-app and global properties; delegates validation to the shared `executeProperty` helper
- Per issue #136, no per-task idempotency is added - that lands centrally via #158

Closes #136