### PR TITLE
feat: add openresty_property_task for managing openresty:set property

### DIFF
--- a/docs/dokku_openresty_property.md
+++ b/docs/dokku_openresty_property.md
@@ -1,0 +1,39 @@
+# dokku_openresty_property
+
+Manages the openresty configuration for a given dokku application
+
+## Setting the proxy read timeout for an app
+
+```yaml
+dokku_openresty_property:
+    app: node-js-app
+    property: proxy-read-timeout
+    value: 120s
+```
+
+## Setting the client max body size for an app
+
+```yaml
+dokku_openresty_property:
+    app: node-js-app
+    property: client-max-body-size
+    value: 50m
+```
+
+## Setting a global openresty property
+
+```yaml
+dokku_openresty_property:
+    app: ""
+    global: true
+    property: bind-address-ipv4
+    value: 0.0.0.0
+```
+
+## Clearing an openresty property
+
+```yaml
+dokku_openresty_property:
+    app: node-js-app
+    property: proxy-read-timeout
+```

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -176,6 +176,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_network",
 		"dokku_network_property",
 		"dokku_nginx_property",
+		"dokku_openresty_property",
 		"dokku_ports",
 		"dokku_proxy_toggle",
 		"dokku_ps_property",
@@ -455,7 +456,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 31
+	expected := 32
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -486,6 +487,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&NetworkTask{}, "Creates or destroys a Docker network"},
 		{&NetworkPropertyTask{}, "Manages the network property for a given dokku application"},
 		{&NginxPropertyTask{}, "Manages the nginx configuration for a given dokku application"},
+		{&OpenrestyPropertyTask{}, "Manages the openresty configuration for a given dokku application"},
 		{&PortsTask{}, "Manages the ports for a given dokku application"},
 		{&PsScaleTask{}, "Manages the process scale for a given dokku application"},
 		{&ResourceLimitTask{}, "Manages the resource limits for a given dokku application"},

--- a/tasks/openresty_property_task.go
+++ b/tasks/openresty_property_task.go
@@ -1,0 +1,85 @@
+package tasks
+
+// OpenrestyPropertyTask manages the openresty configuration for a given dokku application
+type OpenrestyPropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the openresty configuration should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Property is the name of the openresty property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the openresty property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the openresty configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// OpenrestyPropertyTaskExample contains an example of an OpenrestyPropertyTask
+type OpenrestyPropertyTaskExample struct {
+	// Name is the task name holding the OpenrestyPropertyTask description
+	Name string `yaml:"-"`
+
+	// OpenrestyPropertyTask is the OpenrestyPropertyTask configuration
+	OpenrestyPropertyTask OpenrestyPropertyTask `yaml:"dokku_openresty_property"`
+}
+
+// GetName returns the name of the example
+func (e OpenrestyPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the openresty property task
+func (t OpenrestyPropertyTask) Doc() string {
+	return "Manages the openresty configuration for a given dokku application"
+}
+
+// Examples returns the examples for the openresty property task
+func (t OpenrestyPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]OpenrestyPropertyTaskExample{
+		{
+			Name: "Setting the proxy read timeout for an app",
+			OpenrestyPropertyTask: OpenrestyPropertyTask{
+				App:      "node-js-app",
+				Property: "proxy-read-timeout",
+				Value:    "120s",
+			},
+		},
+		{
+			Name: "Setting the client max body size for an app",
+			OpenrestyPropertyTask: OpenrestyPropertyTask{
+				App:      "node-js-app",
+				Property: "client-max-body-size",
+				Value:    "50m",
+			},
+		},
+		{
+			Name: "Setting a global openresty property",
+			OpenrestyPropertyTask: OpenrestyPropertyTask{
+				Global:   true,
+				Property: "bind-address-ipv4",
+				Value:    "0.0.0.0",
+			},
+		},
+		{
+			Name: "Clearing an openresty property",
+			OpenrestyPropertyTask: OpenrestyPropertyTask{
+				App:      "node-js-app",
+				Property: "proxy-read-timeout",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the openresty property
+func (t OpenrestyPropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "openresty:set")
+}
+
+// init registers the OpenrestyPropertyTask with the task registry
+func init() {
+	RegisterTask(&OpenrestyPropertyTask{})
+}

--- a/tasks/openresty_property_task_integration_test.go
+++ b/tasks/openresty_property_task_integration_test.go
@@ -1,0 +1,44 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationOpenrestyProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-openresty"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set openresty property
+	setTask := OpenrestyPropertyTask{
+		App:      appName,
+		Property: "proxy-read-timeout",
+		Value:    "120s",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set openresty property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset openresty property
+	unsetTask := OpenrestyPropertyTask{
+		App:      appName,
+		Property: "proxy-read-timeout",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset openresty property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}

--- a/tasks/openresty_property_task_test.go
+++ b/tasks/openresty_property_task_test.go
@@ -1,0 +1,71 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOpenrestyPropertyTaskInvalidState(t *testing.T) {
+	task := OpenrestyPropertyTask{App: "test-app", Property: "proxy-read-timeout", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestOpenrestyPropertyTaskMissingApp(t *testing.T) {
+	task := OpenrestyPropertyTask{Property: "proxy-read-timeout", Value: "120s", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestOpenrestyPropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := OpenrestyPropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "bind-address-ipv4",
+		Value:    "0.0.0.0",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestOpenrestyPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := OpenrestyPropertyTask{
+		App:      "test-app",
+		Property: "proxy-read-timeout",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestOpenrestyPropertyTaskAbsentWithValue(t *testing.T) {
+	task := OpenrestyPropertyTask{
+		App:      "test-app",
+		Property: "proxy-read-timeout",
+		Value:    "120s",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `OpenrestyPropertyTask` (yaml `dokku_openresty_property`) wrapping `dokku openresty:set` with both per-app and global support
- Mirrors the existing property-task pattern; delegates to the shared `executeProperty` helper so idempotency work in #158 applies for free

Closes #138