### PR TITLE
feat: add traefik_property_task for managing traefik:set property

### DIFF
--- a/docs/dokku_traefik_property.md
+++ b/docs/dokku_traefik_property.md
@@ -1,0 +1,30 @@
+# dokku_traefik_property
+
+Manages the traefik configuration for a given dokku application
+
+## Setting the letsencrypt email for an app
+
+```yaml
+dokku_traefik_property:
+    app: node-js-app
+    property: letsencrypt-email
+    value: admin@example.com
+```
+
+## Setting the log level globally
+
+```yaml
+dokku_traefik_property:
+    app: ""
+    global: true
+    property: log-level
+    value: INFO
+```
+
+## Clearing the letsencrypt email for an app
+
+```yaml
+dokku_traefik_property:
+    app: node-js-app
+    property: letsencrypt-email
+```

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -188,6 +188,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_service_link",
 		"dokku_storage_ensure",
 		"dokku_storage_mount",
+		"dokku_traefik_property",
 	}
 
 	for _, name := range expectedTasks {
@@ -456,7 +457,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 32
+	expected := 33
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -498,6 +499,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&ProxyToggleTask{}, "Enables or disables the proxy plugin for a given dokku application"},
 		{&StorageEnsureTask{}, "Ensures the storage for a given dokku application"},
 		{&StorageMountTask{}, "Mounts or unmounts the storage for a given dokku application"},
+		{&TraefikPropertyTask{}, "Manages the traefik configuration for a given dokku application"},
 	}
 
 	for _, tt := range tests {

--- a/tasks/traefik_property_task.go
+++ b/tasks/traefik_property_task.go
@@ -1,0 +1,77 @@
+package tasks
+
+// TraefikPropertyTask manages the traefik configuration for a given dokku application
+type TraefikPropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the traefik configuration should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Property is the name of the traefik property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the traefik property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the traefik configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// TraefikPropertyTaskExample contains an example of a TraefikPropertyTask
+type TraefikPropertyTaskExample struct {
+	// Name is the task name holding the TraefikPropertyTask description
+	Name string `yaml:"-"`
+
+	// TraefikPropertyTask is the TraefikPropertyTask configuration
+	TraefikPropertyTask TraefikPropertyTask `yaml:"dokku_traefik_property"`
+}
+
+// GetName returns the name of the example
+func (e TraefikPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the traefik property task
+func (t TraefikPropertyTask) Doc() string {
+	return "Manages the traefik configuration for a given dokku application"
+}
+
+// Examples returns the examples for the traefik property task
+func (t TraefikPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]TraefikPropertyTaskExample{
+		{
+			Name: "Setting the letsencrypt email for an app",
+			TraefikPropertyTask: TraefikPropertyTask{
+				App:      "node-js-app",
+				Property: "letsencrypt-email",
+				Value:    "admin@example.com",
+			},
+		},
+		{
+			Name: "Setting the log level globally",
+			TraefikPropertyTask: TraefikPropertyTask{
+				Global:   true,
+				Property: "log-level",
+				Value:    "INFO",
+			},
+		},
+		{
+			Name: "Clearing the letsencrypt email for an app",
+			TraefikPropertyTask: TraefikPropertyTask{
+				App:      "node-js-app",
+				Property: "letsencrypt-email",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the traefik property
+func (t TraefikPropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "traefik:set")
+}
+
+// init registers the TraefikPropertyTask with the task registry
+func init() {
+	RegisterTask(&TraefikPropertyTask{})
+}

--- a/tasks/traefik_property_task_integration_test.go
+++ b/tasks/traefik_property_task_integration_test.go
@@ -1,0 +1,44 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationTraefikProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-traefik"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set traefik property
+	setTask := TraefikPropertyTask{
+		App:      appName,
+		Property: "letsencrypt-email",
+		Value:    "admin@example.com",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set traefik property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset traefik property
+	unsetTask := TraefikPropertyTask{
+		App:      appName,
+		Property: "letsencrypt-email",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset traefik property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}

--- a/tasks/traefik_property_task_test.go
+++ b/tasks/traefik_property_task_test.go
@@ -1,0 +1,71 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTraefikPropertyTaskInvalidState(t *testing.T) {
+	task := TraefikPropertyTask{App: "test-app", Property: "letsencrypt-email", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestTraefikPropertyTaskMissingApp(t *testing.T) {
+	task := TraefikPropertyTask{Property: "letsencrypt-email", Value: "admin@example.com", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestTraefikPropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := TraefikPropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "letsencrypt-email",
+		Value:    "admin@example.com",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestTraefikPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := TraefikPropertyTask{
+		App:      "test-app",
+		Property: "letsencrypt-email",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestTraefikPropertyTaskAbsentWithValue(t *testing.T) {
+	task := TraefikPropertyTask{
+		App:      "test-app",
+		Property: "letsencrypt-email",
+		Value:    "admin@example.com",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `TraefikPropertyTask` (yaml `dokku_traefik_property`) wrapping `dokku traefik:set` with both per-app and global support
- Mirrors the existing property-task pattern; delegates to the shared `executeProperty` helper so idempotency work in #158 applies for free

Closes #137