### PR TITLE
feat: add scheduler_k3s_property_task for managing scheduler-k3s:set property

### DIFF
--- a/docs/dokku_scheduler_k3s_property.md
+++ b/docs/dokku_scheduler_k3s_property.md
@@ -1,0 +1,39 @@
+# dokku_scheduler_k3s_property
+
+Manages the scheduler-k3s configuration for a given dokku application
+
+## Setting the deploy timeout for an app
+
+```yaml
+dokku_scheduler_k3s_property:
+    app: node-js-app
+    property: deploy-timeout
+    value: 300s
+```
+
+## Setting the namespace for an app
+
+```yaml
+dokku_scheduler_k3s_property:
+    app: node-js-app
+    property: namespace
+    value: production
+```
+
+## Setting the letsencrypt prod email globally
+
+```yaml
+dokku_scheduler_k3s_property:
+    app: ""
+    global: true
+    property: letsencrypt-email-prod
+    value: admin@example.com
+```
+
+## Clearing the namespace for an app
+
+```yaml
+dokku_scheduler_k3s_property:
+    app: node-js-app
+    property: namespace
+```

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -183,6 +183,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_ps_scale",
 		"dokku_resource_limit",
 		"dokku_resource_reserve",
+		"dokku_scheduler_k3s_property",
 		"dokku_scheduler_property",
 		"dokku_service_create",
 		"dokku_service_link",
@@ -457,7 +458,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 33
+	expected := 34
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -493,6 +494,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&PsScaleTask{}, "Manages the process scale for a given dokku application"},
 		{&ResourceLimitTask{}, "Manages the resource limits for a given dokku application"},
 		{&ResourceReserveTask{}, "Manages the resource reservations for a given dokku application"},
+		{&SchedulerK3sPropertyTask{}, "Manages the scheduler-k3s configuration for a given dokku application"},
 		{&SchedulerPropertyTask{}, "Manages the scheduler configuration for a given dokku application"},
 		{&ServiceCreateTask{}, "Creates or destroys a dokku service"},
 		{&ServiceLinkTask{}, "Links or unlinks a dokku service to an app"},

--- a/tasks/scheduler_k3s_property_task.go
+++ b/tasks/scheduler_k3s_property_task.go
@@ -1,0 +1,85 @@
+package tasks
+
+// SchedulerK3sPropertyTask manages the scheduler-k3s configuration for a given dokku application
+type SchedulerK3sPropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the scheduler-k3s configuration should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Property is the name of the scheduler-k3s property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the scheduler-k3s property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the scheduler-k3s configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// SchedulerK3sPropertyTaskExample contains an example of a SchedulerK3sPropertyTask
+type SchedulerK3sPropertyTaskExample struct {
+	// Name is the task name holding the SchedulerK3sPropertyTask description
+	Name string `yaml:"-"`
+
+	// SchedulerK3sPropertyTask is the SchedulerK3sPropertyTask configuration
+	SchedulerK3sPropertyTask SchedulerK3sPropertyTask `yaml:"dokku_scheduler_k3s_property"`
+}
+
+// GetName returns the name of the example
+func (e SchedulerK3sPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the scheduler-k3s property task
+func (t SchedulerK3sPropertyTask) Doc() string {
+	return "Manages the scheduler-k3s configuration for a given dokku application"
+}
+
+// Examples returns the examples for the scheduler-k3s property task
+func (t SchedulerK3sPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]SchedulerK3sPropertyTaskExample{
+		{
+			Name: "Setting the deploy timeout for an app",
+			SchedulerK3sPropertyTask: SchedulerK3sPropertyTask{
+				App:      "node-js-app",
+				Property: "deploy-timeout",
+				Value:    "300s",
+			},
+		},
+		{
+			Name: "Setting the namespace for an app",
+			SchedulerK3sPropertyTask: SchedulerK3sPropertyTask{
+				App:      "node-js-app",
+				Property: "namespace",
+				Value:    "production",
+			},
+		},
+		{
+			Name: "Setting the letsencrypt prod email globally",
+			SchedulerK3sPropertyTask: SchedulerK3sPropertyTask{
+				Global:   true,
+				Property: "letsencrypt-email-prod",
+				Value:    "admin@example.com",
+			},
+		},
+		{
+			Name: "Clearing the namespace for an app",
+			SchedulerK3sPropertyTask: SchedulerK3sPropertyTask{
+				App:      "node-js-app",
+				Property: "namespace",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the scheduler-k3s property
+func (t SchedulerK3sPropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "scheduler-k3s:set")
+}
+
+// init registers the SchedulerK3sPropertyTask with the task registry
+func init() {
+	RegisterTask(&SchedulerK3sPropertyTask{})
+}

--- a/tasks/scheduler_k3s_property_task_integration_test.go
+++ b/tasks/scheduler_k3s_property_task_integration_test.go
@@ -1,0 +1,44 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationSchedulerK3sProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-scheduler-k3s"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set scheduler-k3s property
+	setTask := SchedulerK3sPropertyTask{
+		App:      appName,
+		Property: "deploy-timeout",
+		Value:    "300s",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set scheduler-k3s property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset scheduler-k3s property
+	unsetTask := SchedulerK3sPropertyTask{
+		App:      appName,
+		Property: "deploy-timeout",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset scheduler-k3s property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}

--- a/tasks/scheduler_k3s_property_task_test.go
+++ b/tasks/scheduler_k3s_property_task_test.go
@@ -1,0 +1,71 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSchedulerK3sPropertyTaskInvalidState(t *testing.T) {
+	task := SchedulerK3sPropertyTask{App: "test-app", Property: "deploy-timeout", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestSchedulerK3sPropertyTaskMissingApp(t *testing.T) {
+	task := SchedulerK3sPropertyTask{Property: "deploy-timeout", Value: "300s", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestSchedulerK3sPropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := SchedulerK3sPropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "letsencrypt-email-prod",
+		Value:    "admin@example.com",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerK3sPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := SchedulerK3sPropertyTask{
+		App:      "test-app",
+		Property: "deploy-timeout",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerK3sPropertyTaskAbsentWithValue(t *testing.T) {
+	task := SchedulerK3sPropertyTask{
+		App:      "test-app",
+		Property: "deploy-timeout",
+		Value:    "300s",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `SchedulerK3sPropertyTask` (yaml `dokku_scheduler_k3s_property`) wrapping `dokku scheduler-k3s:set` with both per-app and global support
- Mirrors the existing property-task pattern; delegates to the shared `executeProperty` helper so idempotency work in #158 applies for free

Closes #139