### PR TITLE
feat: add builder_dockerfile_property_task for managing builder-dockerfile:set property

### DIFF
--- a/docs/dokku_builder_dockerfile_property.md
+++ b/docs/dokku_builder_dockerfile_property.md
@@ -1,0 +1,30 @@
+# dokku_builder_dockerfile_property
+
+Manages the builder-dockerfile configuration for a given dokku application
+
+## Setting the dockerfile path for an app
+
+```yaml
+dokku_builder_dockerfile_property:
+    app: node-js-app
+    property: dockerfile-path
+    value: Dockerfile.production
+```
+
+## Setting the dockerfile path globally
+
+```yaml
+dokku_builder_dockerfile_property:
+    app: ""
+    global: true
+    property: dockerfile-path
+    value: Dockerfile
+```
+
+## Clearing the dockerfile path for an app
+
+```yaml
+dokku_builder_dockerfile_property:
+    app: node-js-app
+    property: dockerfile-path
+```

--- a/tasks/builder_dockerfile_property_task.go
+++ b/tasks/builder_dockerfile_property_task.go
@@ -1,0 +1,77 @@
+package tasks
+
+// BuilderDockerfilePropertyTask manages the builder-dockerfile configuration for a given dokku application
+type BuilderDockerfilePropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the builder-dockerfile configuration should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Property is the name of the builder-dockerfile property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the builder-dockerfile property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the builder-dockerfile configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// BuilderDockerfilePropertyTaskExample contains an example of a BuilderDockerfilePropertyTask
+type BuilderDockerfilePropertyTaskExample struct {
+	// Name is the task name holding the BuilderDockerfilePropertyTask description
+	Name string `yaml:"-"`
+
+	// BuilderDockerfilePropertyTask is the BuilderDockerfilePropertyTask configuration
+	BuilderDockerfilePropertyTask BuilderDockerfilePropertyTask `yaml:"dokku_builder_dockerfile_property"`
+}
+
+// GetName returns the name of the example
+func (e BuilderDockerfilePropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the builder-dockerfile property task
+func (t BuilderDockerfilePropertyTask) Doc() string {
+	return "Manages the builder-dockerfile configuration for a given dokku application"
+}
+
+// Examples returns the examples for the builder-dockerfile property task
+func (t BuilderDockerfilePropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]BuilderDockerfilePropertyTaskExample{
+		{
+			Name: "Setting the dockerfile path for an app",
+			BuilderDockerfilePropertyTask: BuilderDockerfilePropertyTask{
+				App:      "node-js-app",
+				Property: "dockerfile-path",
+				Value:    "Dockerfile.production",
+			},
+		},
+		{
+			Name: "Setting the dockerfile path globally",
+			BuilderDockerfilePropertyTask: BuilderDockerfilePropertyTask{
+				Global:   true,
+				Property: "dockerfile-path",
+				Value:    "Dockerfile",
+			},
+		},
+		{
+			Name: "Clearing the dockerfile path for an app",
+			BuilderDockerfilePropertyTask: BuilderDockerfilePropertyTask{
+				App:      "node-js-app",
+				Property: "dockerfile-path",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the builder-dockerfile property
+func (t BuilderDockerfilePropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-dockerfile:set")
+}
+
+// init registers the BuilderDockerfilePropertyTask with the task registry
+func init() {
+	RegisterTask(&BuilderDockerfilePropertyTask{})
+}

--- a/tasks/builder_dockerfile_property_task_integration_test.go
+++ b/tasks/builder_dockerfile_property_task_integration_test.go
@@ -1,0 +1,44 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationBuilderDockerfileProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-builder-dockerfile"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set builder-dockerfile property
+	setTask := BuilderDockerfilePropertyTask{
+		App:      appName,
+		Property: "dockerfile-path",
+		Value:    "Dockerfile.production",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set builder-dockerfile property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset builder-dockerfile property
+	unsetTask := BuilderDockerfilePropertyTask{
+		App:      appName,
+		Property: "dockerfile-path",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset builder-dockerfile property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}

--- a/tasks/builder_dockerfile_property_task_test.go
+++ b/tasks/builder_dockerfile_property_task_test.go
@@ -1,0 +1,71 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuilderDockerfilePropertyTaskInvalidState(t *testing.T) {
+	task := BuilderDockerfilePropertyTask{App: "test-app", Property: "dockerfile-path", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestBuilderDockerfilePropertyTaskMissingApp(t *testing.T) {
+	task := BuilderDockerfilePropertyTask{Property: "dockerfile-path", Value: "Dockerfile", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestBuilderDockerfilePropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := BuilderDockerfilePropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "dockerfile-path",
+		Value:    "Dockerfile",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestBuilderDockerfilePropertyTaskPresentWithoutValue(t *testing.T) {
+	task := BuilderDockerfilePropertyTask{
+		App:      "test-app",
+		Property: "dockerfile-path",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestBuilderDockerfilePropertyTaskAbsentWithValue(t *testing.T) {
+	task := BuilderDockerfilePropertyTask{
+		App:      "test-app",
+		Property: "dockerfile-path",
+		Value:    "Dockerfile",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -159,6 +159,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 	expectedTasks := []string{
 		"dokku_app",
 		"dokku_app_json_property",
+		"dokku_builder_dockerfile_property",
 		"dokku_builder_property",
 		"dokku_caddy_property",
 		"dokku_checks_property",
@@ -458,7 +459,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 34
+	expected := 35
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -471,6 +472,7 @@ func TestTaskDocStrings(t *testing.T) {
 	}{
 		{&AppTask{}, "Creates or destroys an app"},
 		{&AppJsonPropertyTask{}, "Manages the app.json configuration for a given dokku application"},
+		{&BuilderDockerfilePropertyTask{}, "Manages the builder-dockerfile configuration for a given dokku application"},
 		{&BuilderPropertyTask{}, "Manages the builder configuration for a given dokku application"},
 		{&BuildpacksPropertyTask{}, "Manages the buildpacks configuration for a given dokku application"},
 		{&CaddyPropertyTask{}, "Manages the caddy configuration for a given dokku application"},


### PR DESCRIPTION
## Summary

- Adds `BuilderDockerfilePropertyTask` (yaml `dokku_builder_dockerfile_property`) wrapping `dokku builder-dockerfile:set` with both per-app and global support
- Mirrors the existing property-task pattern; delegates to the shared `executeProperty` helper so idempotency work in #158 applies for free

Closes #141