### PR TITLE
feat: add scheduler_docker_local_property_task for managing scheduler-docker-local:set property

### DIFF
--- a/docs/dokku_scheduler_docker_local_property.md
+++ b/docs/dokku_scheduler_docker_local_property.md
@@ -1,0 +1,29 @@
+# dokku_scheduler_docker_local_property
+
+Manages the scheduler-docker-local configuration for a given dokku application
+
+## Enabling the init process for an app
+
+```yaml
+dokku_scheduler_docker_local_property:
+    app: node-js-app
+    property: init-process
+    value: "true"
+```
+
+## Setting the parallel schedule count for an app
+
+```yaml
+dokku_scheduler_docker_local_property:
+    app: node-js-app
+    property: parallel-schedule-count
+    value: "4"
+```
+
+## Clearing the init process for an app
+
+```yaml
+dokku_scheduler_docker_local_property:
+    app: node-js-app
+    property: init-process
+```

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -184,6 +184,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_ps_scale",
 		"dokku_resource_limit",
 		"dokku_resource_reserve",
+		"dokku_scheduler_docker_local_property",
 		"dokku_scheduler_k3s_property",
 		"dokku_scheduler_property",
 		"dokku_service_create",
@@ -459,7 +460,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 35
+	expected := 36
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -496,6 +497,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&PsScaleTask{}, "Manages the process scale for a given dokku application"},
 		{&ResourceLimitTask{}, "Manages the resource limits for a given dokku application"},
 		{&ResourceReserveTask{}, "Manages the resource reservations for a given dokku application"},
+		{&SchedulerDockerLocalPropertyTask{}, "Manages the scheduler-docker-local configuration for a given dokku application"},
 		{&SchedulerK3sPropertyTask{}, "Manages the scheduler-k3s configuration for a given dokku application"},
 		{&SchedulerPropertyTask{}, "Manages the scheduler configuration for a given dokku application"},
 		{&ServiceCreateTask{}, "Creates or destroys a dokku service"},

--- a/tasks/scheduler_docker_local_property_task.go
+++ b/tasks/scheduler_docker_local_property_task.go
@@ -1,0 +1,74 @@
+package tasks
+
+// SchedulerDockerLocalPropertyTask manages the scheduler-docker-local configuration for a given dokku application
+type SchedulerDockerLocalPropertyTask struct {
+	// App is the name of the app
+	App string `required:"true" yaml:"app"`
+
+	// Property is the name of the scheduler-docker-local property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the scheduler-docker-local property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the scheduler-docker-local configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// SchedulerDockerLocalPropertyTaskExample contains an example of a SchedulerDockerLocalPropertyTask
+type SchedulerDockerLocalPropertyTaskExample struct {
+	// Name is the task name holding the SchedulerDockerLocalPropertyTask description
+	Name string `yaml:"-"`
+
+	// SchedulerDockerLocalPropertyTask is the SchedulerDockerLocalPropertyTask configuration
+	SchedulerDockerLocalPropertyTask SchedulerDockerLocalPropertyTask `yaml:"dokku_scheduler_docker_local_property"`
+}
+
+// GetName returns the name of the example
+func (e SchedulerDockerLocalPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the scheduler-docker-local property task
+func (t SchedulerDockerLocalPropertyTask) Doc() string {
+	return "Manages the scheduler-docker-local configuration for a given dokku application"
+}
+
+// Examples returns the examples for the scheduler-docker-local property task
+func (t SchedulerDockerLocalPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]SchedulerDockerLocalPropertyTaskExample{
+		{
+			Name: "Enabling the init process for an app",
+			SchedulerDockerLocalPropertyTask: SchedulerDockerLocalPropertyTask{
+				App:      "node-js-app",
+				Property: "init-process",
+				Value:    "true",
+			},
+		},
+		{
+			Name: "Setting the parallel schedule count for an app",
+			SchedulerDockerLocalPropertyTask: SchedulerDockerLocalPropertyTask{
+				App:      "node-js-app",
+				Property: "parallel-schedule-count",
+				Value:    "4",
+			},
+		},
+		{
+			Name: "Clearing the init process for an app",
+			SchedulerDockerLocalPropertyTask: SchedulerDockerLocalPropertyTask{
+				App:      "node-js-app",
+				Property: "init-process",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the scheduler-docker-local property
+func (t SchedulerDockerLocalPropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, false, t.Property, t.Value, "scheduler-docker-local:set")
+}
+
+// init registers the SchedulerDockerLocalPropertyTask with the task registry
+func init() {
+	RegisterTask(&SchedulerDockerLocalPropertyTask{})
+}

--- a/tasks/scheduler_docker_local_property_task_integration_test.go
+++ b/tasks/scheduler_docker_local_property_task_integration_test.go
@@ -1,0 +1,44 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationSchedulerDockerLocalProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-scheduler-docker-local"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set scheduler-docker-local property
+	setTask := SchedulerDockerLocalPropertyTask{
+		App:      appName,
+		Property: "init-process",
+		Value:    "true",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set scheduler-docker-local property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset scheduler-docker-local property
+	unsetTask := SchedulerDockerLocalPropertyTask{
+		App:      appName,
+		Property: "init-process",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset scheduler-docker-local property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}

--- a/tasks/scheduler_docker_local_property_task_test.go
+++ b/tasks/scheduler_docker_local_property_task_test.go
@@ -1,0 +1,57 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSchedulerDockerLocalPropertyTaskInvalidState(t *testing.T) {
+	task := SchedulerDockerLocalPropertyTask{App: "test-app", Property: "init-process", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestSchedulerDockerLocalPropertyTaskMissingApp(t *testing.T) {
+	task := SchedulerDockerLocalPropertyTask{Property: "init-process", Value: "true", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "app is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerDockerLocalPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := SchedulerDockerLocalPropertyTask{
+		App:      "test-app",
+		Property: "init-process",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerDockerLocalPropertyTaskAbsentWithValue(t *testing.T) {
+	task := SchedulerDockerLocalPropertyTask{
+		App:      "test-app",
+		Property: "init-process",
+		Value:    "true",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `SchedulerDockerLocalPropertyTask` (yaml `dokku_scheduler_docker_local_property`) wrapping `dokku scheduler-docker-local:set`
- App-only per the issue (no `Global` field); delegates to the shared `executeProperty` helper so idempotency work in #158 applies for free
- Stacked on top of #173

Closes #140