### PR TITLE
feat: add builder_herokuish_property_task for managing builder-herokuish:set property

### DIFF
--- a/docs/dokku_builder_herokuish_property.md
+++ b/docs/dokku_builder_herokuish_property.md
@@ -1,0 +1,30 @@
+# dokku_builder_herokuish_property
+
+Manages the builder-herokuish configuration for a given dokku application
+
+## Allowing the herokuish builder for an app
+
+```yaml
+dokku_builder_herokuish_property:
+    app: node-js-app
+    property: allowed
+    value: "true"
+```
+
+## Allowing the herokuish builder globally
+
+```yaml
+dokku_builder_herokuish_property:
+    app: ""
+    global: true
+    property: allowed
+    value: "true"
+```
+
+## Clearing the allowed property for an app
+
+```yaml
+dokku_builder_herokuish_property:
+    app: node-js-app
+    property: allowed
+```

--- a/tasks/builder_herokuish_property_task.go
+++ b/tasks/builder_herokuish_property_task.go
@@ -1,0 +1,77 @@
+package tasks
+
+// BuilderHerokuishPropertyTask manages the builder-herokuish configuration for a given dokku application
+type BuilderHerokuishPropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the builder-herokuish configuration should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Property is the name of the builder-herokuish property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the builder-herokuish property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the builder-herokuish configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// BuilderHerokuishPropertyTaskExample contains an example of a BuilderHerokuishPropertyTask
+type BuilderHerokuishPropertyTaskExample struct {
+	// Name is the task name holding the BuilderHerokuishPropertyTask description
+	Name string `yaml:"-"`
+
+	// BuilderHerokuishPropertyTask is the BuilderHerokuishPropertyTask configuration
+	BuilderHerokuishPropertyTask BuilderHerokuishPropertyTask `yaml:"dokku_builder_herokuish_property"`
+}
+
+// GetName returns the name of the example
+func (e BuilderHerokuishPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the builder-herokuish property task
+func (t BuilderHerokuishPropertyTask) Doc() string {
+	return "Manages the builder-herokuish configuration for a given dokku application"
+}
+
+// Examples returns the examples for the builder-herokuish property task
+func (t BuilderHerokuishPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]BuilderHerokuishPropertyTaskExample{
+		{
+			Name: "Allowing the herokuish builder for an app",
+			BuilderHerokuishPropertyTask: BuilderHerokuishPropertyTask{
+				App:      "node-js-app",
+				Property: "allowed",
+				Value:    "true",
+			},
+		},
+		{
+			Name: "Allowing the herokuish builder globally",
+			BuilderHerokuishPropertyTask: BuilderHerokuishPropertyTask{
+				Global:   true,
+				Property: "allowed",
+				Value:    "true",
+			},
+		},
+		{
+			Name: "Clearing the allowed property for an app",
+			BuilderHerokuishPropertyTask: BuilderHerokuishPropertyTask{
+				App:      "node-js-app",
+				Property: "allowed",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the builder-herokuish property
+func (t BuilderHerokuishPropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-herokuish:set")
+}
+
+// init registers the BuilderHerokuishPropertyTask with the task registry
+func init() {
+	RegisterTask(&BuilderHerokuishPropertyTask{})
+}

--- a/tasks/builder_herokuish_property_task_integration_test.go
+++ b/tasks/builder_herokuish_property_task_integration_test.go
@@ -1,0 +1,44 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationBuilderHerokuishProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-builder-herokuish"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set builder-herokuish property
+	setTask := BuilderHerokuishPropertyTask{
+		App:      appName,
+		Property: "allowed",
+		Value:    "true",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set builder-herokuish property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset builder-herokuish property
+	unsetTask := BuilderHerokuishPropertyTask{
+		App:      appName,
+		Property: "allowed",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset builder-herokuish property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}

--- a/tasks/builder_herokuish_property_task_test.go
+++ b/tasks/builder_herokuish_property_task_test.go
@@ -1,0 +1,71 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuilderHerokuishPropertyTaskInvalidState(t *testing.T) {
+	task := BuilderHerokuishPropertyTask{App: "test-app", Property: "allowed", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestBuilderHerokuishPropertyTaskMissingApp(t *testing.T) {
+	task := BuilderHerokuishPropertyTask{Property: "allowed", Value: "true", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestBuilderHerokuishPropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := BuilderHerokuishPropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "allowed",
+		Value:    "true",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestBuilderHerokuishPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := BuilderHerokuishPropertyTask{
+		App:      "test-app",
+		Property: "allowed",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestBuilderHerokuishPropertyTaskAbsentWithValue(t *testing.T) {
+	task := BuilderHerokuishPropertyTask{
+		App:      "test-app",
+		Property: "allowed",
+		Value:    "true",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -160,6 +160,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_app",
 		"dokku_app_json_property",
 		"dokku_builder_dockerfile_property",
+		"dokku_builder_herokuish_property",
 		"dokku_builder_property",
 		"dokku_caddy_property",
 		"dokku_checks_property",
@@ -460,7 +461,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 36
+	expected := 37
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -474,6 +475,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&AppTask{}, "Creates or destroys an app"},
 		{&AppJsonPropertyTask{}, "Manages the app.json configuration for a given dokku application"},
 		{&BuilderDockerfilePropertyTask{}, "Manages the builder-dockerfile configuration for a given dokku application"},
+		{&BuilderHerokuishPropertyTask{}, "Manages the builder-herokuish configuration for a given dokku application"},
 		{&BuilderPropertyTask{}, "Manages the builder configuration for a given dokku application"},
 		{&BuildpacksPropertyTask{}, "Manages the buildpacks configuration for a given dokku application"},
 		{&CaddyPropertyTask{}, "Manages the caddy configuration for a given dokku application"},


### PR DESCRIPTION
## Summary

- Adds `BuilderHerokuishPropertyTask` (yaml `dokku_builder_herokuish_property`) wrapping `dokku builder-herokuish:set` with both per-app and global support
- Mirrors the existing property-task pattern; delegates to the shared `executeProperty` helper so idempotency work in #158 applies for free
- Stacked on top of #174

Closes #142