### PR TITLE
feat: add builder_pack_property_task for managing builder-pack:set property

### DIFF
--- a/docs/dokku_builder_pack_property.md
+++ b/docs/dokku_builder_pack_property.md
@@ -1,0 +1,30 @@
+# dokku_builder_pack_property
+
+Manages the builder-pack configuration for a given dokku application
+
+## Setting the project.toml path for an app
+
+```yaml
+dokku_builder_pack_property:
+    app: node-js-app
+    property: projecttoml-path
+    value: config/project.toml
+```
+
+## Setting the project.toml path globally
+
+```yaml
+dokku_builder_pack_property:
+    app: ""
+    global: true
+    property: projecttoml-path
+    value: project.toml
+```
+
+## Clearing the project.toml path for an app
+
+```yaml
+dokku_builder_pack_property:
+    app: node-js-app
+    property: projecttoml-path
+```

--- a/tasks/builder_pack_property_task.go
+++ b/tasks/builder_pack_property_task.go
@@ -1,0 +1,77 @@
+package tasks
+
+// BuilderPackPropertyTask manages the builder-pack configuration for a given dokku application
+type BuilderPackPropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the builder-pack configuration should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Property is the name of the builder-pack property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the builder-pack property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the builder-pack configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// BuilderPackPropertyTaskExample contains an example of a BuilderPackPropertyTask
+type BuilderPackPropertyTaskExample struct {
+	// Name is the task name holding the BuilderPackPropertyTask description
+	Name string `yaml:"-"`
+
+	// BuilderPackPropertyTask is the BuilderPackPropertyTask configuration
+	BuilderPackPropertyTask BuilderPackPropertyTask `yaml:"dokku_builder_pack_property"`
+}
+
+// GetName returns the name of the example
+func (e BuilderPackPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the builder-pack property task
+func (t BuilderPackPropertyTask) Doc() string {
+	return "Manages the builder-pack configuration for a given dokku application"
+}
+
+// Examples returns the examples for the builder-pack property task
+func (t BuilderPackPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]BuilderPackPropertyTaskExample{
+		{
+			Name: "Setting the project.toml path for an app",
+			BuilderPackPropertyTask: BuilderPackPropertyTask{
+				App:      "node-js-app",
+				Property: "projecttoml-path",
+				Value:    "config/project.toml",
+			},
+		},
+		{
+			Name: "Setting the project.toml path globally",
+			BuilderPackPropertyTask: BuilderPackPropertyTask{
+				Global:   true,
+				Property: "projecttoml-path",
+				Value:    "project.toml",
+			},
+		},
+		{
+			Name: "Clearing the project.toml path for an app",
+			BuilderPackPropertyTask: BuilderPackPropertyTask{
+				App:      "node-js-app",
+				Property: "projecttoml-path",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the builder-pack property
+func (t BuilderPackPropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-pack:set")
+}
+
+// init registers the BuilderPackPropertyTask with the task registry
+func init() {
+	RegisterTask(&BuilderPackPropertyTask{})
+}

--- a/tasks/builder_pack_property_task_integration_test.go
+++ b/tasks/builder_pack_property_task_integration_test.go
@@ -1,0 +1,44 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationBuilderPackProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-builder-pack"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set builder-pack property
+	setTask := BuilderPackPropertyTask{
+		App:      appName,
+		Property: "projecttoml-path",
+		Value:    "config/project.toml",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set builder-pack property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset builder-pack property
+	unsetTask := BuilderPackPropertyTask{
+		App:      appName,
+		Property: "projecttoml-path",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset builder-pack property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}

--- a/tasks/builder_pack_property_task_test.go
+++ b/tasks/builder_pack_property_task_test.go
@@ -1,0 +1,71 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuilderPackPropertyTaskInvalidState(t *testing.T) {
+	task := BuilderPackPropertyTask{App: "test-app", Property: "projecttoml-path", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestBuilderPackPropertyTaskMissingApp(t *testing.T) {
+	task := BuilderPackPropertyTask{Property: "projecttoml-path", Value: "project.toml", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestBuilderPackPropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := BuilderPackPropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "projecttoml-path",
+		Value:    "project.toml",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestBuilderPackPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := BuilderPackPropertyTask{
+		App:      "test-app",
+		Property: "projecttoml-path",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestBuilderPackPropertyTaskAbsentWithValue(t *testing.T) {
+	task := BuilderPackPropertyTask{
+		App:      "test-app",
+		Property: "projecttoml-path",
+		Value:    "project.toml",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -161,6 +161,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_app_json_property",
 		"dokku_builder_dockerfile_property",
 		"dokku_builder_herokuish_property",
+		"dokku_builder_pack_property",
 		"dokku_builder_property",
 		"dokku_caddy_property",
 		"dokku_checks_property",
@@ -461,7 +462,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 37
+	expected := 38
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -476,6 +477,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&AppJsonPropertyTask{}, "Manages the app.json configuration for a given dokku application"},
 		{&BuilderDockerfilePropertyTask{}, "Manages the builder-dockerfile configuration for a given dokku application"},
 		{&BuilderHerokuishPropertyTask{}, "Manages the builder-herokuish configuration for a given dokku application"},
+		{&BuilderPackPropertyTask{}, "Manages the builder-pack configuration for a given dokku application"},
 		{&BuilderPropertyTask{}, "Manages the builder configuration for a given dokku application"},
 		{&BuildpacksPropertyTask{}, "Manages the buildpacks configuration for a given dokku application"},
 		{&CaddyPropertyTask{}, "Manages the caddy configuration for a given dokku application"},


### PR DESCRIPTION
## Summary

- Adds `BuilderPackPropertyTask` (yaml `dokku_builder_pack_property`) wrapping `dokku builder-pack:set` with both per-app and global support
- Mirrors the existing property-task pattern; delegates to the shared `executeProperty` helper so idempotency work in #158 applies for free
- Stacked on top of #175

Closes #143