### PR TITLE
feat: add builder_nixpacks_property_task for managing builder-nixpacks:set property

### DIFF
--- a/docs/dokku_builder_nixpacks_property.md
+++ b/docs/dokku_builder_nixpacks_property.md
@@ -1,0 +1,30 @@
+# dokku_builder_nixpacks_property
+
+Manages the builder-nixpacks configuration for a given dokku application
+
+## Setting the nixpacks.toml path for an app
+
+```yaml
+dokku_builder_nixpacks_property:
+    app: node-js-app
+    property: nixpackstoml-path
+    value: config/nixpacks.toml
+```
+
+## Setting the nixpacks.toml path globally
+
+```yaml
+dokku_builder_nixpacks_property:
+    app: ""
+    global: true
+    property: nixpackstoml-path
+    value: nixpacks.toml
+```
+
+## Clearing the nixpacks.toml path for an app
+
+```yaml
+dokku_builder_nixpacks_property:
+    app: node-js-app
+    property: nixpackstoml-path
+```

--- a/tasks/builder_nixpacks_property_task.go
+++ b/tasks/builder_nixpacks_property_task.go
@@ -1,0 +1,77 @@
+package tasks
+
+// BuilderNixpacksPropertyTask manages the builder-nixpacks configuration for a given dokku application
+type BuilderNixpacksPropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the builder-nixpacks configuration should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Property is the name of the builder-nixpacks property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the builder-nixpacks property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the builder-nixpacks configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// BuilderNixpacksPropertyTaskExample contains an example of a BuilderNixpacksPropertyTask
+type BuilderNixpacksPropertyTaskExample struct {
+	// Name is the task name holding the BuilderNixpacksPropertyTask description
+	Name string `yaml:"-"`
+
+	// BuilderNixpacksPropertyTask is the BuilderNixpacksPropertyTask configuration
+	BuilderNixpacksPropertyTask BuilderNixpacksPropertyTask `yaml:"dokku_builder_nixpacks_property"`
+}
+
+// GetName returns the name of the example
+func (e BuilderNixpacksPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the builder-nixpacks property task
+func (t BuilderNixpacksPropertyTask) Doc() string {
+	return "Manages the builder-nixpacks configuration for a given dokku application"
+}
+
+// Examples returns the examples for the builder-nixpacks property task
+func (t BuilderNixpacksPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]BuilderNixpacksPropertyTaskExample{
+		{
+			Name: "Setting the nixpacks.toml path for an app",
+			BuilderNixpacksPropertyTask: BuilderNixpacksPropertyTask{
+				App:      "node-js-app",
+				Property: "nixpackstoml-path",
+				Value:    "config/nixpacks.toml",
+			},
+		},
+		{
+			Name: "Setting the nixpacks.toml path globally",
+			BuilderNixpacksPropertyTask: BuilderNixpacksPropertyTask{
+				Global:   true,
+				Property: "nixpackstoml-path",
+				Value:    "nixpacks.toml",
+			},
+		},
+		{
+			Name: "Clearing the nixpacks.toml path for an app",
+			BuilderNixpacksPropertyTask: BuilderNixpacksPropertyTask{
+				App:      "node-js-app",
+				Property: "nixpackstoml-path",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the builder-nixpacks property
+func (t BuilderNixpacksPropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-nixpacks:set")
+}
+
+// init registers the BuilderNixpacksPropertyTask with the task registry
+func init() {
+	RegisterTask(&BuilderNixpacksPropertyTask{})
+}

--- a/tasks/builder_nixpacks_property_task_integration_test.go
+++ b/tasks/builder_nixpacks_property_task_integration_test.go
@@ -1,0 +1,44 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationBuilderNixpacksProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-builder-nixpacks"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set builder-nixpacks property
+	setTask := BuilderNixpacksPropertyTask{
+		App:      appName,
+		Property: "nixpackstoml-path",
+		Value:    "config/nixpacks.toml",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set builder-nixpacks property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset builder-nixpacks property
+	unsetTask := BuilderNixpacksPropertyTask{
+		App:      appName,
+		Property: "nixpackstoml-path",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset builder-nixpacks property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}

--- a/tasks/builder_nixpacks_property_task_test.go
+++ b/tasks/builder_nixpacks_property_task_test.go
@@ -1,0 +1,71 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuilderNixpacksPropertyTaskInvalidState(t *testing.T) {
+	task := BuilderNixpacksPropertyTask{App: "test-app", Property: "nixpackstoml-path", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestBuilderNixpacksPropertyTaskMissingApp(t *testing.T) {
+	task := BuilderNixpacksPropertyTask{Property: "nixpackstoml-path", Value: "nixpacks.toml", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestBuilderNixpacksPropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := BuilderNixpacksPropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "nixpackstoml-path",
+		Value:    "nixpacks.toml",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestBuilderNixpacksPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := BuilderNixpacksPropertyTask{
+		App:      "test-app",
+		Property: "nixpackstoml-path",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestBuilderNixpacksPropertyTaskAbsentWithValue(t *testing.T) {
+	task := BuilderNixpacksPropertyTask{
+		App:      "test-app",
+		Property: "nixpackstoml-path",
+		Value:    "nixpacks.toml",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -161,6 +161,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_app_json_property",
 		"dokku_builder_dockerfile_property",
 		"dokku_builder_herokuish_property",
+		"dokku_builder_nixpacks_property",
 		"dokku_builder_pack_property",
 		"dokku_builder_property",
 		"dokku_caddy_property",
@@ -462,7 +463,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 38
+	expected := 39
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -477,6 +478,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&AppJsonPropertyTask{}, "Manages the app.json configuration for a given dokku application"},
 		{&BuilderDockerfilePropertyTask{}, "Manages the builder-dockerfile configuration for a given dokku application"},
 		{&BuilderHerokuishPropertyTask{}, "Manages the builder-herokuish configuration for a given dokku application"},
+		{&BuilderNixpacksPropertyTask{}, "Manages the builder-nixpacks configuration for a given dokku application"},
 		{&BuilderPackPropertyTask{}, "Manages the builder-pack configuration for a given dokku application"},
 		{&BuilderPropertyTask{}, "Manages the builder configuration for a given dokku application"},
 		{&BuildpacksPropertyTask{}, "Manages the buildpacks configuration for a given dokku application"},


### PR DESCRIPTION
## Summary

- Adds `BuilderNixpacksPropertyTask` (yaml `dokku_builder_nixpacks_property`) wrapping `dokku builder-nixpacks:set` with both per-app and global support
- Mirrors the existing property-task pattern; delegates to the shared `executeProperty` helper so idempotency work in #158 applies for free
- Stacked on top of #176

Closes #144