### PR TITLE
feat: add builder_lambda_property_task for managing builder-lambda:set property

### DIFF
--- a/docs/dokku_builder_lambda_property.md
+++ b/docs/dokku_builder_lambda_property.md
@@ -1,0 +1,30 @@
+# dokku_builder_lambda_property
+
+Manages the builder-lambda configuration for a given dokku application
+
+## Setting the lambda.yml path for an app
+
+```yaml
+dokku_builder_lambda_property:
+    app: node-js-app
+    property: lambdayml-path
+    value: config/lambda.yml
+```
+
+## Setting the lambda.yml path globally
+
+```yaml
+dokku_builder_lambda_property:
+    app: ""
+    global: true
+    property: lambdayml-path
+    value: lambda.yml
+```
+
+## Clearing the lambda.yml path for an app
+
+```yaml
+dokku_builder_lambda_property:
+    app: node-js-app
+    property: lambdayml-path
+```

--- a/tasks/builder_lambda_property_task.go
+++ b/tasks/builder_lambda_property_task.go
@@ -1,0 +1,77 @@
+package tasks
+
+// BuilderLambdaPropertyTask manages the builder-lambda configuration for a given dokku application
+type BuilderLambdaPropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the builder-lambda configuration should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Property is the name of the builder-lambda property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the builder-lambda property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the builder-lambda configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// BuilderLambdaPropertyTaskExample contains an example of a BuilderLambdaPropertyTask
+type BuilderLambdaPropertyTaskExample struct {
+	// Name is the task name holding the BuilderLambdaPropertyTask description
+	Name string `yaml:"-"`
+
+	// BuilderLambdaPropertyTask is the BuilderLambdaPropertyTask configuration
+	BuilderLambdaPropertyTask BuilderLambdaPropertyTask `yaml:"dokku_builder_lambda_property"`
+}
+
+// GetName returns the name of the example
+func (e BuilderLambdaPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the builder-lambda property task
+func (t BuilderLambdaPropertyTask) Doc() string {
+	return "Manages the builder-lambda configuration for a given dokku application"
+}
+
+// Examples returns the examples for the builder-lambda property task
+func (t BuilderLambdaPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]BuilderLambdaPropertyTaskExample{
+		{
+			Name: "Setting the lambda.yml path for an app",
+			BuilderLambdaPropertyTask: BuilderLambdaPropertyTask{
+				App:      "node-js-app",
+				Property: "lambdayml-path",
+				Value:    "config/lambda.yml",
+			},
+		},
+		{
+			Name: "Setting the lambda.yml path globally",
+			BuilderLambdaPropertyTask: BuilderLambdaPropertyTask{
+				Global:   true,
+				Property: "lambdayml-path",
+				Value:    "lambda.yml",
+			},
+		},
+		{
+			Name: "Clearing the lambda.yml path for an app",
+			BuilderLambdaPropertyTask: BuilderLambdaPropertyTask{
+				App:      "node-js-app",
+				Property: "lambdayml-path",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the builder-lambda property
+func (t BuilderLambdaPropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-lambda:set")
+}
+
+// init registers the BuilderLambdaPropertyTask with the task registry
+func init() {
+	RegisterTask(&BuilderLambdaPropertyTask{})
+}

--- a/tasks/builder_lambda_property_task_integration_test.go
+++ b/tasks/builder_lambda_property_task_integration_test.go
@@ -1,0 +1,44 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationBuilderLambdaProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-builder-lambda"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set builder-lambda property
+	setTask := BuilderLambdaPropertyTask{
+		App:      appName,
+		Property: "lambdayml-path",
+		Value:    "config/lambda.yml",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set builder-lambda property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset builder-lambda property
+	unsetTask := BuilderLambdaPropertyTask{
+		App:      appName,
+		Property: "lambdayml-path",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset builder-lambda property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}

--- a/tasks/builder_lambda_property_task_test.go
+++ b/tasks/builder_lambda_property_task_test.go
@@ -1,0 +1,71 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuilderLambdaPropertyTaskInvalidState(t *testing.T) {
+	task := BuilderLambdaPropertyTask{App: "test-app", Property: "lambdayml-path", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestBuilderLambdaPropertyTaskMissingApp(t *testing.T) {
+	task := BuilderLambdaPropertyTask{Property: "lambdayml-path", Value: "lambda.yml", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestBuilderLambdaPropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := BuilderLambdaPropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "lambdayml-path",
+		Value:    "lambda.yml",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestBuilderLambdaPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := BuilderLambdaPropertyTask{
+		App:      "test-app",
+		Property: "lambdayml-path",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestBuilderLambdaPropertyTaskAbsentWithValue(t *testing.T) {
+	task := BuilderLambdaPropertyTask{
+		App:      "test-app",
+		Property: "lambdayml-path",
+		Value:    "lambda.yml",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -161,6 +161,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_app_json_property",
 		"dokku_builder_dockerfile_property",
 		"dokku_builder_herokuish_property",
+		"dokku_builder_lambda_property",
 		"dokku_builder_nixpacks_property",
 		"dokku_builder_pack_property",
 		"dokku_builder_property",
@@ -463,7 +464,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 39
+	expected := 40
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -478,6 +479,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&AppJsonPropertyTask{}, "Manages the app.json configuration for a given dokku application"},
 		{&BuilderDockerfilePropertyTask{}, "Manages the builder-dockerfile configuration for a given dokku application"},
 		{&BuilderHerokuishPropertyTask{}, "Manages the builder-herokuish configuration for a given dokku application"},
+		{&BuilderLambdaPropertyTask{}, "Manages the builder-lambda configuration for a given dokku application"},
 		{&BuilderNixpacksPropertyTask{}, "Manages the builder-nixpacks configuration for a given dokku application"},
 		{&BuilderPackPropertyTask{}, "Manages the builder-pack configuration for a given dokku application"},
 		{&BuilderPropertyTask{}, "Manages the builder configuration for a given dokku application"},


### PR DESCRIPTION
## Summary

- Adds `BuilderLambdaPropertyTask` (yaml `dokku_builder_lambda_property`) wrapping `dokku builder-lambda:set` with both per-app and global support
- Mirrors the existing property-task pattern; delegates to the shared `executeProperty` helper so idempotency work in #158 applies for free
- Stacked on top of #177

Closes #145