### PR TITLE
feat: add registry_property_task for managing registry:set property

### DIFF
--- a/docs/dokku_registry_property.md
+++ b/docs/dokku_registry_property.md
@@ -1,0 +1,39 @@
+# dokku_registry_property
+
+Manages the registry configuration for a given dokku application
+
+## Setting the image repo for an app
+
+```yaml
+dokku_registry_property:
+    app: node-js-app
+    property: image-repo
+    value: registry.example.com/node-js-app
+```
+
+## Enabling push-on-release for an app
+
+```yaml
+dokku_registry_property:
+    app: node-js-app
+    property: push-on-release
+    value: "true"
+```
+
+## Setting the registry server globally
+
+```yaml
+dokku_registry_property:
+    app: ""
+    global: true
+    property: server
+    value: registry.example.com
+```
+
+## Clearing the image repo for an app
+
+```yaml
+dokku_registry_property:
+    app: node-js-app
+    property: image-repo
+```

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -186,6 +186,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_proxy_toggle",
 		"dokku_ps_property",
 		"dokku_ps_scale",
+		"dokku_registry_property",
 		"dokku_resource_limit",
 		"dokku_resource_reserve",
 		"dokku_scheduler_docker_local_property",
@@ -464,7 +465,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 40
+	expected := 41
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -503,6 +504,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&OpenrestyPropertyTask{}, "Manages the openresty configuration for a given dokku application"},
 		{&PortsTask{}, "Manages the ports for a given dokku application"},
 		{&PsScaleTask{}, "Manages the process scale for a given dokku application"},
+		{&RegistryPropertyTask{}, "Manages the registry configuration for a given dokku application"},
 		{&ResourceLimitTask{}, "Manages the resource limits for a given dokku application"},
 		{&ResourceReserveTask{}, "Manages the resource reservations for a given dokku application"},
 		{&SchedulerDockerLocalPropertyTask{}, "Manages the scheduler-docker-local configuration for a given dokku application"},

--- a/tasks/registry_property_task.go
+++ b/tasks/registry_property_task.go
@@ -1,0 +1,85 @@
+package tasks
+
+// RegistryPropertyTask manages the registry configuration for a given dokku application
+type RegistryPropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the registry configuration should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Property is the name of the registry property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the registry property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the registry configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// RegistryPropertyTaskExample contains an example of a RegistryPropertyTask
+type RegistryPropertyTaskExample struct {
+	// Name is the task name holding the RegistryPropertyTask description
+	Name string `yaml:"-"`
+
+	// RegistryPropertyTask is the RegistryPropertyTask configuration
+	RegistryPropertyTask RegistryPropertyTask `yaml:"dokku_registry_property"`
+}
+
+// GetName returns the name of the example
+func (e RegistryPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the registry property task
+func (t RegistryPropertyTask) Doc() string {
+	return "Manages the registry configuration for a given dokku application"
+}
+
+// Examples returns the examples for the registry property task
+func (t RegistryPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]RegistryPropertyTaskExample{
+		{
+			Name: "Setting the image repo for an app",
+			RegistryPropertyTask: RegistryPropertyTask{
+				App:      "node-js-app",
+				Property: "image-repo",
+				Value:    "registry.example.com/node-js-app",
+			},
+		},
+		{
+			Name: "Enabling push-on-release for an app",
+			RegistryPropertyTask: RegistryPropertyTask{
+				App:      "node-js-app",
+				Property: "push-on-release",
+				Value:    "true",
+			},
+		},
+		{
+			Name: "Setting the registry server globally",
+			RegistryPropertyTask: RegistryPropertyTask{
+				Global:   true,
+				Property: "server",
+				Value:    "registry.example.com",
+			},
+		},
+		{
+			Name: "Clearing the image repo for an app",
+			RegistryPropertyTask: RegistryPropertyTask{
+				App:      "node-js-app",
+				Property: "image-repo",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the registry property
+func (t RegistryPropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "registry:set")
+}
+
+// init registers the RegistryPropertyTask with the task registry
+func init() {
+	RegisterTask(&RegistryPropertyTask{})
+}

--- a/tasks/registry_property_task_integration_test.go
+++ b/tasks/registry_property_task_integration_test.go
@@ -1,0 +1,44 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationRegistryProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-registry"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set registry property
+	setTask := RegistryPropertyTask{
+		App:      appName,
+		Property: "image-repo",
+		Value:    "registry.example.com/" + appName,
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set registry property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset registry property
+	unsetTask := RegistryPropertyTask{
+		App:      appName,
+		Property: "image-repo",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset registry property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}

--- a/tasks/registry_property_task_test.go
+++ b/tasks/registry_property_task_test.go
@@ -1,0 +1,71 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRegistryPropertyTaskInvalidState(t *testing.T) {
+	task := RegistryPropertyTask{App: "test-app", Property: "image-repo", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestRegistryPropertyTaskMissingApp(t *testing.T) {
+	task := RegistryPropertyTask{Property: "image-repo", Value: "registry.example.com/app", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestRegistryPropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := RegistryPropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "server",
+		Value:    "registry.example.com",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestRegistryPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := RegistryPropertyTask{
+		App:      "test-app",
+		Property: "image-repo",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestRegistryPropertyTaskAbsentWithValue(t *testing.T) {
+	task := RegistryPropertyTask{
+		App:      "test-app",
+		Property: "image-repo",
+		Value:    "registry.example.com/app",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `RegistryPropertyTask` (yaml `dokku_registry_property`) wrapping `dokku registry:set` with both per-app and global support
- Mirrors the existing property-task pattern; delegates to the shared `executeProperty` helper so idempotency work in #158 applies for free
- Split from #12, which retains the action aspects (login/push)
- Stacked on top of #178

Closes #147