### PR TITLE
feat: add app_lock_task wrapping dokku apps:lock and apps:unlock

### DIFF
--- a/docs/dokku_app_lock.md
+++ b/docs/dokku_app_lock.md
@@ -1,0 +1,18 @@
+# dokku_app_lock
+
+Locks or unlocks a dokku application from deployment
+
+## Lock an app
+
+```yaml
+dokku_app_lock:
+    app: node-js-app
+```
+
+## Unlock an app
+
+```yaml
+dokku_app_lock:
+    app: node-js-app
+    state: absent
+```

--- a/tasks/app_lock_task.go
+++ b/tasks/app_lock_task.go
@@ -1,0 +1,139 @@
+package tasks
+
+import (
+	"fmt"
+
+	"docket/subprocess"
+)
+
+// AppLockTask locks or unlocks a dokku application from deployment
+type AppLockTask struct {
+	// App is the name of the app
+	App string `required:"true" yaml:"app"`
+
+	// State is the desired lock state
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// AppLockTaskExample contains an example of an AppLockTask
+type AppLockTaskExample struct {
+	// Name is the task name holding the AppLockTask description
+	Name string `yaml:"-"`
+
+	// AppLockTask is the AppLockTask configuration
+	AppLockTask AppLockTask `yaml:"dokku_app_lock"`
+}
+
+// GetName returns the name of the example
+func (e AppLockTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the app lock task
+func (t AppLockTask) Doc() string {
+	return "Locks or unlocks a dokku application from deployment"
+}
+
+// Examples returns the examples for the app lock task
+func (t AppLockTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]AppLockTaskExample{
+		{
+			Name: "Lock an app",
+			AppLockTask: AppLockTask{
+				App: "node-js-app",
+			},
+		},
+		{
+			Name: "Unlock an app",
+			AppLockTask: AppLockTask{
+				App:   "node-js-app",
+				State: StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute locks or unlocks the app
+func (t AppLockTask) Execute() TaskOutputState {
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		StatePresent: func() TaskOutputState { return lockApp(t.App) },
+		StateAbsent:  func() TaskOutputState { return unlockApp(t.App) },
+	})
+}
+
+// appLocked checks if a dokku app is locked
+func appLocked(app string) bool {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "apps:locked", app},
+	})
+	if err != nil {
+		return false
+	}
+	return result.ExitCode == 0
+}
+
+// lockApp locks a dokku app for deployment
+func lockApp(app string) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   StateAbsent,
+	}
+
+	if app == "" {
+		state.Error = fmt.Errorf("'app' is required")
+		return state
+	}
+
+	if appLocked(app) {
+		state.State = StatePresent
+		return state
+	}
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "apps:lock", app},
+	})
+	if err != nil {
+		return TaskOutputErrorFromExec(state, err, result)
+	}
+
+	state.Changed = true
+	state.State = StatePresent
+	return state
+}
+
+// unlockApp unlocks a dokku app for deployment
+func unlockApp(app string) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   StatePresent,
+	}
+
+	if app == "" {
+		state.Error = fmt.Errorf("'app' is required")
+		return state
+	}
+
+	if !appLocked(app) {
+		state.State = StateAbsent
+		return state
+	}
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "apps:unlock", app},
+	})
+	if err != nil {
+		return TaskOutputErrorFromExec(state, err, result)
+	}
+
+	state.Changed = true
+	state.State = StateAbsent
+	return state
+}
+
+// init registers the AppLockTask with the task registry
+func init() {
+	RegisterTask(&AppLockTask{})
+}

--- a/tasks/app_lock_task_integration_test.go
+++ b/tasks/app_lock_task_integration_test.go
@@ -1,0 +1,76 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationAppLock(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-app-lock"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// initial state - not locked
+	if appLocked(appName) {
+		t.Fatalf("expected newly-created app %q to be unlocked", appName)
+	}
+
+	// lock the app
+	lockTask := AppLockTask{App: appName, State: StatePresent}
+	result := lockTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to lock app: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first lock")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+	if !appLocked(appName) {
+		t.Errorf("expected app %q to be locked after lock task", appName)
+	}
+
+	// lock again - should be idempotent
+	result = lockTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second lock: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent lock")
+	}
+	if !appLocked(appName) {
+		t.Errorf("expected app %q to remain locked", appName)
+	}
+
+	// unlock the app
+	unlockTask := AppLockTask{App: appName, State: StateAbsent}
+	result = unlockTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unlock app: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first unlock")
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+	if appLocked(appName) {
+		t.Errorf("expected app %q to be unlocked after unlock task", appName)
+	}
+
+	// unlock again - should be idempotent
+	result = unlockTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second unlock: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent unlock")
+	}
+	if appLocked(appName) {
+		t.Errorf("expected app %q to remain unlocked", appName)
+	}
+}

--- a/tasks/app_lock_task_test.go
+++ b/tasks/app_lock_task_test.go
@@ -1,0 +1,68 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAppLockTaskInvalidState(t *testing.T) {
+	task := AppLockTask{App: "test-app", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestAppLockTaskPresentMissingApp(t *testing.T) {
+	task := AppLockTask{State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'app' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestAppLockTaskAbsentMissingApp(t *testing.T) {
+	task := AppLockTask{State: StateAbsent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'app' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestGetTasksAppLockTaskParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: lock app
+      dokku_app_lock:
+        app: test-app
+        state: present
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("lock app")
+	if task == nil {
+		t.Fatal("task 'lock app' not found")
+	}
+
+	lockTask, ok := task.(*AppLockTask)
+	if !ok {
+		t.Fatalf("task is not an AppLockTask (type is %T)", task)
+	}
+	if lockTask.App != "test-app" {
+		t.Errorf("App = %q, want %q", lockTask.App, "test-app")
+	}
+	if lockTask.State != StatePresent {
+		t.Errorf("State = %q, want %q", lockTask.State, StatePresent)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -160,6 +160,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_app",
 		"dokku_app_clone",
 		"dokku_app_json_property",
+		"dokku_app_lock",
 		"dokku_builder_dockerfile_property",
 		"dokku_builder_herokuish_property",
 		"dokku_builder_lambda_property",
@@ -468,7 +469,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 44
+	expected := 45
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -482,6 +483,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&AppTask{}, "Creates or destroys an app"},
 		{&AppCloneTask{}, "Clones an existing dokku app to a new app"},
 		{&AppJsonPropertyTask{}, "Manages the app.json configuration for a given dokku application"},
+		{&AppLockTask{}, "Locks or unlocks a dokku application from deployment"},
 		{&BuilderDockerfilePropertyTask{}, "Manages the builder-dockerfile configuration for a given dokku application"},
 		{&BuilderHerokuishPropertyTask{}, "Manages the builder-herokuish configuration for a given dokku application"},
 		{&BuilderLambdaPropertyTask{}, "Manages the builder-lambda configuration for a given dokku application"},


### PR DESCRIPTION
feat: add app_lock_task wrapping dokku apps:lock and apps:unlock with idempotency via apps:locked so re-running a task in the same desired state is a no-op

Closes #152