### PR TITLE
feat: add certs_task

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,5 +48,7 @@ jobs:
         run: sudo dokku plugin:install https://github.com/dokku/dokku-redis.git redis
       - name: install dokku http-auth plugin
         run: sudo dokku plugin:install https://github.com/dokku/dokku-http-auth.git http-auth
+      - name: install dokku global-cert plugin
+        run: sudo dokku plugin:install https://github.com/dokku-community/dokku-global-cert.git global-cert
       - name: run integration tests
         run: sudo go test -v -count=1 -run TestIntegration ./tasks/

--- a/docs/dokku_certs.md
+++ b/docs/dokku_certs.md
@@ -1,0 +1,39 @@
+# dokku_certs
+
+Manages SSL certificates for a dokku app or globally
+
+## Add an SSL certificate to an app
+
+```yaml
+dokku_certs:
+    app: node-js-app
+    cert: /etc/nginx/ssl/node-js-app.crt
+    key: /etc/nginx/ssl/node-js-app.key
+```
+
+## Remove an SSL certificate from an app
+
+```yaml
+dokku_certs:
+    app: node-js-app
+    state: absent
+```
+
+## Add a global SSL certificate (requires the dokku-global-cert plugin)
+
+```yaml
+dokku_certs:
+    app: ""
+    global: true
+    cert: /etc/nginx/ssl/global.crt
+    key: /etc/nginx/ssl/global.key
+```
+
+## Remove the global SSL certificate
+
+```yaml
+dokku_certs:
+    app: ""
+    global: true
+    state: absent
+```

--- a/tasks/certs_task.go
+++ b/tasks/certs_task.go
@@ -1,0 +1,210 @@
+package tasks
+
+import (
+	"fmt"
+	"strings"
+
+	"docket/subprocess"
+)
+
+// CertsTask manages SSL certificates for a dokku app or globally
+type CertsTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the certificate should be applied globally
+	// via the dokku-global-cert plugin
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Cert is the path on the dokku server to the SSL certificate file
+	Cert string `required:"false" yaml:"cert,omitempty"`
+
+	// Key is the path on the dokku server to the SSL certificate key file
+	Key string `required:"false" yaml:"key,omitempty"`
+
+	// State is the desired state of the SSL configuration
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// CertsTaskExample contains an example of a CertsTask
+type CertsTaskExample struct {
+	// Name is the task name holding the CertsTask description
+	Name string `yaml:"-"`
+
+	// CertsTask is the CertsTask configuration
+	CertsTask CertsTask `yaml:"dokku_certs"`
+}
+
+// GetName returns the name of the example
+func (e CertsTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the certs task
+func (t CertsTask) Doc() string {
+	return "Manages SSL certificates for a dokku app or globally"
+}
+
+// Examples returns the examples for the certs task
+func (t CertsTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]CertsTaskExample{
+		{
+			Name: "Add an SSL certificate to an app",
+			CertsTask: CertsTask{
+				App:  "node-js-app",
+				Cert: "/etc/nginx/ssl/node-js-app.crt",
+				Key:  "/etc/nginx/ssl/node-js-app.key",
+			},
+		},
+		{
+			Name: "Remove an SSL certificate from an app",
+			CertsTask: CertsTask{
+				App:   "node-js-app",
+				State: StateAbsent,
+			},
+		},
+		{
+			Name: "Add a global SSL certificate (requires the dokku-global-cert plugin)",
+			CertsTask: CertsTask{
+				Global: true,
+				Cert:   "/etc/nginx/ssl/global.crt",
+				Key:    "/etc/nginx/ssl/global.key",
+			},
+		},
+		{
+			Name: "Remove the global SSL certificate",
+			CertsTask: CertsTask{
+				Global: true,
+				State:  StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute manages the SSL certificate
+func (t CertsTask) Execute() TaskOutputState {
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		StatePresent: func() TaskOutputState { return addCert(t) },
+		StateAbsent:  func() TaskOutputState { return removeCert(t) },
+	})
+}
+
+// validateCertsTask validates the certs task parameters
+func validateCertsTask(t CertsTask) error {
+	if t.Global && t.App != "" {
+		return fmt.Errorf("'app' must not be set when 'global' is set to true")
+	}
+	if !t.Global && t.App == "" {
+		return fmt.Errorf("'app' is required when 'global' is not set to true")
+	}
+	return nil
+}
+
+// certsEnabled checks if a certificate is currently configured for an app or globally
+func certsEnabled(t CertsTask) (bool, error) {
+	args := []string{"--quiet", "certs:report", t.App, "--ssl-enabled"}
+	if t.Global {
+		args = []string{"--quiet", "global-cert:report", "--global-cert-enabled"}
+	}
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return strings.TrimSpace(result.StdoutContents()) == "true", nil
+}
+
+// addCert installs an SSL certificate for an app or globally
+func addCert(t CertsTask) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   StateAbsent,
+	}
+
+	if err := validateCertsTask(t); err != nil {
+		state.Error = err
+		return state
+	}
+	if t.Cert == "" || t.Key == "" {
+		state.Error = fmt.Errorf("'cert' and 'key' are required when state is 'present'")
+		return state
+	}
+
+	enabled, err := certsEnabled(t)
+	if err != nil {
+		state.Error = err
+		state.Message = err.Error()
+		return state
+	}
+	if enabled {
+		state.State = StatePresent
+		return state
+	}
+
+	args := []string{"--quiet", "certs:add", t.App, t.Cert, t.Key}
+	if t.Global {
+		args = []string{"--quiet", "global-cert:set", t.Cert, t.Key}
+	}
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		return TaskOutputErrorFromExec(state, err, result)
+	}
+
+	state.Changed = true
+	state.State = StatePresent
+	return state
+}
+
+// removeCert removes the SSL certificate for an app or globally
+func removeCert(t CertsTask) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   StatePresent,
+	}
+
+	if err := validateCertsTask(t); err != nil {
+		state.Error = err
+		return state
+	}
+
+	enabled, err := certsEnabled(t)
+	if err != nil {
+		state.Error = err
+		state.Message = err.Error()
+		return state
+	}
+	if !enabled {
+		state.State = StateAbsent
+		return state
+	}
+
+	args := []string{"--quiet", "certs:remove", t.App}
+	if t.Global {
+		args = []string{"--quiet", "global-cert:remove"}
+	}
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		return TaskOutputErrorFromExec(state, err, result)
+	}
+
+	state.Changed = true
+	state.State = StateAbsent
+	return state
+}
+
+// init registers the CertsTask with the task registry
+func init() {
+	RegisterTask(&CertsTask{})
+}

--- a/tasks/certs_task_integration_test.go
+++ b/tasks/certs_task_integration_test.go
@@ -1,0 +1,220 @@
+package tasks
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// generateSelfSignedCert writes a self-signed cert+key pair into a fresh
+// directory under /tmp and returns their paths. The directory and files are
+// world-readable and the directory is registered for cleanup so the dokku
+// user (which various dokku plugins shell out to) can read the files even
+// when the test process runs as root.
+func generateSelfSignedCert(t *testing.T, commonName string) (certPath, keyPath string) {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("/tmp", "docket-certs-")
+	if err != nil {
+		t.Fatalf("failed to create cert dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatalf("failed to chmod cert dir: %v", err)
+	}
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		t.Fatalf("failed to generate serial: %v", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{commonName},
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	certPath = filepath.Join(dir, "test.crt")
+	if err := os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes}), 0o644); err != nil {
+		t.Fatalf("failed to write cert file: %v", err)
+	}
+
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("failed to marshal key: %v", err)
+	}
+	keyPath = filepath.Join(dir, "test.key")
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes}), 0o644); err != nil {
+		t.Fatalf("failed to write key file: %v", err)
+	}
+
+	return certPath, keyPath
+}
+
+func TestIntegrationCertsApp(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-certs"
+	certPath, keyPath := generateSelfSignedCert(t, appName+".example.com")
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// initial state - no cert
+	enabled, err := certsEnabled(CertsTask{App: appName})
+	if err != nil {
+		t.Fatalf("certsEnabled failed: %v", err)
+	}
+	if enabled {
+		t.Fatalf("expected newly-created app to have no cert")
+	}
+
+	// add cert
+	addTask := CertsTask{App: appName, Cert: certPath, Key: keyPath, State: StatePresent}
+	result := addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to add cert: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first add")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+	enabled, err = certsEnabled(CertsTask{App: appName})
+	if err != nil {
+		t.Fatalf("certsEnabled failed: %v", err)
+	}
+	if !enabled {
+		t.Errorf("expected cert to be enabled after add")
+	}
+
+	// add again - should be idempotent (does not update; matches ansible-dokku semantics)
+	result = addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second add: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent add")
+	}
+
+	// remove cert
+	removeTask := CertsTask{App: appName, State: StateAbsent}
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to remove cert: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first remove")
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+	enabled, err = certsEnabled(CertsTask{App: appName})
+	if err != nil {
+		t.Fatalf("certsEnabled failed: %v", err)
+	}
+	if enabled {
+		t.Errorf("expected cert to be disabled after remove")
+	}
+
+	// remove again - idempotent
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second remove: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent remove")
+	}
+}
+
+func TestIntegrationCertsGlobal(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "global-cert")
+
+	certPath, keyPath := generateSelfSignedCert(t, "global.example.com")
+
+	// best-effort cleanup before and after
+	cleanup := func() {
+		(CertsTask{Global: true, State: StateAbsent}).Execute()
+	}
+	cleanup()
+	defer cleanup()
+
+	// add global cert
+	addTask := CertsTask{Global: true, Cert: certPath, Key: keyPath, State: StatePresent}
+	result := addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to add global cert: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first global add")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+	enabled, err := certsEnabled(CertsTask{Global: true})
+	if err != nil {
+		t.Fatalf("certsEnabled failed: %v", err)
+	}
+	if !enabled {
+		t.Errorf("expected global cert to be enabled after add")
+	}
+
+	// add again - idempotent
+	result = addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second global add: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent global add")
+	}
+
+	// remove global cert
+	removeTask := CertsTask{Global: true, State: StateAbsent}
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to remove global cert: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first global remove")
+	}
+	enabled, err = certsEnabled(CertsTask{Global: true})
+	if err != nil {
+		t.Fatalf("certsEnabled failed: %v", err)
+	}
+	if enabled {
+		t.Errorf("expected global cert to be disabled after remove")
+	}
+
+	// remove again - idempotent
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second global remove: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent global remove")
+	}
+}

--- a/tasks/certs_task_test.go
+++ b/tasks/certs_task_test.go
@@ -1,0 +1,98 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCertsTaskInvalidState(t *testing.T) {
+	task := CertsTask{App: "test-app", Cert: "/tmp/cert", Key: "/tmp/key", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestCertsTaskMissingApp(t *testing.T) {
+	task := CertsTask{Cert: "/tmp/cert", Key: "/tmp/key", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'app' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestCertsTaskGlobalWithApp(t *testing.T) {
+	task := CertsTask{App: "test-app", Global: true, Cert: "/tmp/cert", Key: "/tmp/key", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestCertsTaskPresentMissingCert(t *testing.T) {
+	task := CertsTask{App: "test-app", Key: "/tmp/key", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without cert should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'cert' and 'key' are required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestCertsTaskPresentMissingKey(t *testing.T) {
+	task := CertsTask{App: "test-app", Cert: "/tmp/cert", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without key should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'cert' and 'key' are required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestGetTasksCertsTaskParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: install cert
+      dokku_certs:
+        app: test-app
+        cert: /etc/ssl/test-app.crt
+        key: /etc/ssl/test-app.key
+        state: present
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("install cert")
+	if task == nil {
+		t.Fatal("task 'install cert' not found")
+	}
+
+	certsTask, ok := task.(*CertsTask)
+	if !ok {
+		t.Fatalf("task is not a CertsTask (type is %T)", task)
+	}
+	if certsTask.App != "test-app" {
+		t.Errorf("App = %q, want %q", certsTask.App, "test-app")
+	}
+	if certsTask.Cert != "/etc/ssl/test-app.crt" {
+		t.Errorf("Cert = %q, want %q", certsTask.Cert, "/etc/ssl/test-app.crt")
+	}
+	if certsTask.Key != "/etc/ssl/test-app.key" {
+		t.Errorf("Key = %q, want %q", certsTask.Key, "/etc/ssl/test-app.key")
+	}
+	if certsTask.State != StatePresent {
+		t.Errorf("State = %q, want %q", certsTask.State, StatePresent)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -170,6 +170,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_builder_railpack_property",
 		"dokku_buildpacks",
 		"dokku_caddy_property",
+		"dokku_certs",
 		"dokku_checks_property",
 		"dokku_checks_toggle",
 		"dokku_config",
@@ -469,7 +470,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 45
+	expected := 46
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -494,6 +495,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&BuildpacksPropertyTask{}, "Manages the buildpacks configuration for a given dokku application"},
 		{&BuildpacksTask{}, "Manages the buildpacks for a given dokku application"},
 		{&CaddyPropertyTask{}, "Manages the caddy configuration for a given dokku application"},
+		{&CertsTask{}, "Manages SSL certificates for a dokku app or globally"},
 		{&ChecksPropertyTask{}, "Manages the checks configuration for a given dokku application"},
 		{&ChecksToggleTask{}, "Enables or disables the checks plugin for a given dokku application"},
 		{&ConfigTask{}, "Manages the configuration for a given dokku application"},


### PR DESCRIPTION
Wraps `dokku certs:add` and `certs:remove` for app SSL, and `global-cert:set` and `global-cert:remove` from the `dokku-community/dokku-global-cert` plugin when `global: true`. Idempotency reads `certs:report --ssl-enabled` and `global-cert:report --global-cert-enabled`, so re-runs are no-ops when the desired state already holds. CI installs the global-cert plugin, and the integration test writes self-signed certs to a fixed `/tmp/docket-certs-*` directory with world-readable permissions so the dokku user can read them when the test process runs as root.

Closes #5