### PR TITLE
feat: add docker_options_task

### DIFF
--- a/docs/dokku_docker_options.md
+++ b/docs/dokku_docker_options.md
@@ -1,0 +1,22 @@
+# dokku_docker_options
+
+Manages docker-options for a given dokku application
+
+## Mount the docker socket at deploy
+
+```yaml
+dokku_docker_options:
+    app: node-js-app
+    phase: deploy
+    option: -v /var/run/docker.sock:/var/run/docker.sock
+```
+
+## Remove a docker option from the deploy phase
+
+```yaml
+dokku_docker_options:
+    app: node-js-app
+    phase: deploy
+    option: -v /var/run/docker.sock:/var/run/docker.sock
+    state: absent
+```

--- a/tasks/docker_options_task.go
+++ b/tasks/docker_options_task.go
@@ -1,0 +1,212 @@
+package tasks
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"docket/subprocess"
+)
+
+// DockerOptionsTask manages docker-options for a given dokku application
+type DockerOptionsTask struct {
+	// App is the name of the app
+	App string `required:"true" yaml:"app"`
+
+	// Phase is the deployment phase the option applies to
+	Phase string `required:"true" yaml:"phase" options:"build,deploy,run"`
+
+	// Option is the docker option string (e.g. "-v /var/run/docker.sock:/var/run/docker.sock")
+	Option string `required:"true" yaml:"option"`
+
+	// State is the desired state of the docker option
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// DockerOptionsTaskExample contains an example of a DockerOptionsTask
+type DockerOptionsTaskExample struct {
+	// Name is the task name holding the DockerOptionsTask description
+	Name string `yaml:"-"`
+
+	// DockerOptionsTask is the DockerOptionsTask configuration
+	DockerOptionsTask DockerOptionsTask `yaml:"dokku_docker_options"`
+}
+
+// GetName returns the name of the example
+func (e DockerOptionsTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the docker options task
+func (t DockerOptionsTask) Doc() string {
+	return "Manages docker-options for a given dokku application"
+}
+
+// Examples returns the examples for the docker options task
+func (t DockerOptionsTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]DockerOptionsTaskExample{
+		{
+			Name: "Mount the docker socket at deploy",
+			DockerOptionsTask: DockerOptionsTask{
+				App:    "node-js-app",
+				Phase:  "deploy",
+				Option: "-v /var/run/docker.sock:/var/run/docker.sock",
+			},
+		},
+		{
+			Name: "Remove a docker option from the deploy phase",
+			DockerOptionsTask: DockerOptionsTask{
+				App:    "node-js-app",
+				Phase:  "deploy",
+				Option: "-v /var/run/docker.sock:/var/run/docker.sock",
+				State:  StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute manages the docker option
+func (t DockerOptionsTask) Execute() TaskOutputState {
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		StatePresent: func() TaskOutputState { return addDockerOption(t) },
+		StateAbsent:  func() TaskOutputState { return removeDockerOption(t) },
+	})
+}
+
+var dockerOptionPhases = map[string]bool{"build": true, "deploy": true, "run": true}
+
+// validateDockerOptionsTask validates the docker options task parameters
+func validateDockerOptionsTask(t DockerOptionsTask) error {
+	if t.App == "" {
+		return fmt.Errorf("'app' is required")
+	}
+	if !dockerOptionPhases[t.Phase] {
+		return fmt.Errorf("'phase' must be one of build, deploy, run")
+	}
+	if strings.TrimSpace(t.Option) == "" {
+		return fmt.Errorf("'option' is required")
+	}
+	return nil
+}
+
+var dockerOptionsReportRe = regexp.MustCompile(`^Docker options (build|deploy|run):\s*(.*)$`)
+
+// getDockerOptions returns the current docker options for each phase of an app
+func getDockerOptions(app string) (map[string]string, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "docker-options:report", app},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	options := map[string]string{"build": "", "deploy": "", "run": ""}
+	for _, line := range strings.Split(result.StdoutContents(), "\n") {
+		match := dockerOptionsReportRe.FindStringSubmatch(strings.TrimSpace(line))
+		if match == nil {
+			continue
+		}
+		options[match[1]] = strings.TrimSpace(match[2])
+	}
+	return options, nil
+}
+
+// optionPresent returns true if option appears as a contiguous token sequence in existing
+func optionPresent(existing, option string) bool {
+	optionTokens := strings.Fields(option)
+	if len(optionTokens) == 0 {
+		return false
+	}
+	existingTokens := strings.Fields(existing)
+	for i := 0; i+len(optionTokens) <= len(existingTokens); i++ {
+		match := true
+		for j, tok := range optionTokens {
+			if existingTokens[i+j] != tok {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// addDockerOption adds a docker option to the specified phase
+func addDockerOption(t DockerOptionsTask) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   StateAbsent,
+	}
+
+	if err := validateDockerOptionsTask(t); err != nil {
+		state.Error = err
+		return state
+	}
+
+	current, err := getDockerOptions(t.App)
+	if err != nil {
+		state.Error = err
+		state.Message = err.Error()
+		return state
+	}
+	if optionPresent(current[t.Phase], t.Option) {
+		state.State = StatePresent
+		return state
+	}
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "docker-options:add", t.App, t.Phase, t.Option},
+	})
+	if err != nil {
+		return TaskOutputErrorFromExec(state, err, result)
+	}
+
+	state.Changed = true
+	state.State = StatePresent
+	return state
+}
+
+// removeDockerOption removes a docker option from the specified phase
+func removeDockerOption(t DockerOptionsTask) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   StatePresent,
+	}
+
+	if err := validateDockerOptionsTask(t); err != nil {
+		state.Error = err
+		return state
+	}
+
+	current, err := getDockerOptions(t.App)
+	if err != nil {
+		state.Error = err
+		state.Message = err.Error()
+		return state
+	}
+	if !optionPresent(current[t.Phase], t.Option) {
+		state.State = StateAbsent
+		return state
+	}
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "docker-options:remove", t.App, t.Phase, t.Option},
+	})
+	if err != nil {
+		return TaskOutputErrorFromExec(state, err, result)
+	}
+
+	state.Changed = true
+	state.State = StateAbsent
+	return state
+}
+
+// init registers the DockerOptionsTask with the task registry
+func init() {
+	RegisterTask(&DockerOptionsTask{})
+}

--- a/tasks/docker_options_task_integration_test.go
+++ b/tasks/docker_options_task_integration_test.go
@@ -1,0 +1,85 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationDockerOptions(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-docker-options"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	option := "-v /tmp/docket-test:/tmp/docket-test"
+	phase := "deploy"
+
+	// initial state - option not present
+	current, err := getDockerOptions(appName)
+	if err != nil {
+		t.Fatalf("getDockerOptions failed: %v", err)
+	}
+	if optionPresent(current[phase], option) {
+		t.Fatalf("expected option not to be present initially")
+	}
+
+	// add option
+	addTask := DockerOptionsTask{App: appName, Phase: phase, Option: option, State: StatePresent}
+	result := addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to add option: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first add")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+	current, err = getDockerOptions(appName)
+	if err != nil {
+		t.Fatalf("getDockerOptions failed: %v", err)
+	}
+	if !optionPresent(current[phase], option) {
+		t.Errorf("expected option to be present after add (got %q for phase %s)", current[phase], phase)
+	}
+
+	// add same option - idempotent
+	result = addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second add: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent add")
+	}
+
+	// remove option
+	removeTask := DockerOptionsTask{App: appName, Phase: phase, Option: option, State: StateAbsent}
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to remove option: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first remove")
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+	current, err = getDockerOptions(appName)
+	if err != nil {
+		t.Fatalf("getDockerOptions failed: %v", err)
+	}
+	if optionPresent(current[phase], option) {
+		t.Errorf("expected option not to be present after remove (got %q for phase %s)", current[phase], phase)
+	}
+
+	// remove again - idempotent
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second remove: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent remove")
+	}
+}

--- a/tasks/docker_options_task_test.go
+++ b/tasks/docker_options_task_test.go
@@ -1,0 +1,112 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDockerOptionsTaskInvalidState(t *testing.T) {
+	task := DockerOptionsTask{App: "test-app", Phase: "deploy", Option: "-v /a:/a", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestDockerOptionsTaskMissingApp(t *testing.T) {
+	task := DockerOptionsTask{Phase: "deploy", Option: "-v /a:/a", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'app' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestDockerOptionsTaskInvalidPhase(t *testing.T) {
+	for _, phase := range []string{"", "start", "any"} {
+		task := DockerOptionsTask{App: "test-app", Phase: phase, Option: "-v /a:/a", State: StatePresent}
+		result := task.Execute()
+		if result.Error == nil {
+			t.Fatalf("Execute with invalid phase %q should return an error", phase)
+		}
+		if !strings.Contains(result.Error.Error(), "'phase' must be one of") {
+			t.Errorf("phase=%q: unexpected error: %v", phase, result.Error)
+		}
+	}
+}
+
+func TestDockerOptionsTaskMissingOption(t *testing.T) {
+	task := DockerOptionsTask{App: "test-app", Phase: "deploy", Option: "  ", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without option should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'option' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestOptionPresent(t *testing.T) {
+	tests := []struct {
+		existing string
+		option   string
+		want     bool
+	}{
+		{"", "-v /a:/a", false},
+		{"-v /a:/a", "-v /a:/a", true},
+		{"-v /a:/a -p 80:80", "-p 80:80", true},
+		{"-v /a:/a -p 80:80", "-v /a:/a", true},
+		{"-v /a:/aa", "-v /a:/a", false},      // exact token match, not substring
+		{"-v /a:/a", "-v /a:/aa", false},      // exact token match
+		{"-p 80:80 -v /a:/a", "-v /a:/a", true},
+		{"-p 8080:80", "-p 80:80", false},     // distinct tokens
+	}
+	for _, tt := range tests {
+		got := optionPresent(tt.existing, tt.option)
+		if got != tt.want {
+			t.Errorf("optionPresent(%q, %q) = %v, want %v", tt.existing, tt.option, got, tt.want)
+		}
+	}
+}
+
+func TestGetTasksDockerOptionsTaskParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: add docker option
+      dokku_docker_options:
+        app: test-app
+        phase: deploy
+        option: "-v /var/run/docker.sock:/var/run/docker.sock"
+        state: present
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("add docker option")
+	if task == nil {
+		t.Fatal("task 'add docker option' not found")
+	}
+
+	doTask, ok := task.(*DockerOptionsTask)
+	if !ok {
+		t.Fatalf("task is not a DockerOptionsTask (type is %T)", task)
+	}
+	if doTask.App != "test-app" {
+		t.Errorf("App = %q, want %q", doTask.App, "test-app")
+	}
+	if doTask.Phase != "deploy" {
+		t.Errorf("Phase = %q, want %q", doTask.Phase, "deploy")
+	}
+	if doTask.Option != "-v /var/run/docker.sock:/var/run/docker.sock" {
+		t.Errorf("Option = %q, want %q", doTask.Option, "-v /var/run/docker.sock:/var/run/docker.sock")
+	}
+	if doTask.State != StatePresent {
+		t.Errorf("State = %q, want %q", doTask.State, StatePresent)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -175,6 +175,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_checks_toggle",
 		"dokku_config",
 		"dokku_cron_property",
+		"dokku_docker_options",
 		"dokku_domains",
 		"dokku_domains_toggle",
 		"dokku_git_from_image",
@@ -470,7 +471,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 46
+	expected := 47
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -500,6 +501,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&ChecksToggleTask{}, "Enables or disables the checks plugin for a given dokku application"},
 		{&ConfigTask{}, "Manages the configuration for a given dokku application"},
 		{&CronPropertyTask{}, "Manages the cron configuration for a given dokku application"},
+		{&DockerOptionsTask{}, "Manages docker-options for a given dokku application"},
 		{&DomainsTask{}, "Manages the domains for a given dokku application or globally"},
 		{&DomainsToggleTask{}, "Enables or disables the domains plugin for a given dokku application"},
 		{&GitFromImageTask{}, "Deploys a git repository from a docker image"},


### PR DESCRIPTION
Wraps `dokku docker-options:add` and `docker-options:remove` for the `build`, `deploy`, and `run` phases. Idempotency reads `docker-options:report` and matches on whitespace-delimited token sequences so `-v /a:/a` does not falsely match `-v /a:/aa`.

Closes #7