### PR TITLE
feat: add registry_auth_task

### DIFF
--- a/docs/dokku_registry_auth.md
+++ b/docs/dokku_registry_auth.md
@@ -1,0 +1,43 @@
+# dokku_registry_auth
+
+Manages docker registry authentication for a dokku application or globally
+
+## Log in to a registry for an app
+
+```yaml
+dokku_registry_auth:
+    app: node-js-app
+    server: ghcr.io
+    username: deploy-bot
+    password: ghp_examplepat
+```
+
+## Log in to a registry globally
+
+```yaml
+dokku_registry_auth:
+    app: ""
+    global: true
+    server: docker.io
+    username: deploy-bot
+    password: examplepassword
+```
+
+## Log out from a registry for an app
+
+```yaml
+dokku_registry_auth:
+    app: node-js-app
+    server: ghcr.io
+    state: absent
+```
+
+## Log out from a registry globally
+
+```yaml
+dokku_registry_auth:
+    app: ""
+    global: true
+    server: docker.io
+    state: absent
+```

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -192,6 +192,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_proxy_toggle",
 		"dokku_ps_property",
 		"dokku_ps_scale",
+		"dokku_registry_auth",
 		"dokku_registry_property",
 		"dokku_resource_limit",
 		"dokku_resource_reserve",
@@ -471,7 +472,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 47
+	expected := 48
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -516,6 +517,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&OpenrestyPropertyTask{}, "Manages the openresty configuration for a given dokku application"},
 		{&PortsTask{}, "Manages the ports for a given dokku application"},
 		{&PsScaleTask{}, "Manages the process scale for a given dokku application"},
+		{&RegistryAuthTask{}, "Manages docker registry authentication for a dokku application or globally"},
 		{&RegistryPropertyTask{}, "Manages the registry configuration for a given dokku application"},
 		{&ResourceLimitTask{}, "Manages the resource limits for a given dokku application"},
 		{&ResourceReserveTask{}, "Manages the resource reservations for a given dokku application"},

--- a/tasks/registry_auth_task.go
+++ b/tasks/registry_auth_task.go
@@ -1,0 +1,188 @@
+package tasks
+
+import (
+	"fmt"
+	"strings"
+
+	"docket/subprocess"
+)
+
+// RegistryAuthTask manages docker registry authentication for a dokku application or globally
+type RegistryAuthTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the registry credential should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Server is the docker registry hostname (e.g. docker.io, ghcr.io)
+	Server string `required:"true" yaml:"server"`
+
+	// Username is the registry username (required when state is present)
+	Username string `required:"false" yaml:"username,omitempty"`
+
+	// Password is the registry password (required when state is present)
+	// The value is fed to dokku via --password-stdin and never appears on argv
+	Password string `required:"false" yaml:"password,omitempty"`
+
+	// State is the desired state of the registry credential
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// RegistryAuthTaskExample contains an example of a RegistryAuthTask
+type RegistryAuthTaskExample struct {
+	// Name is the task name holding the RegistryAuthTask description
+	Name string `yaml:"-"`
+
+	// RegistryAuthTask is the RegistryAuthTask configuration
+	RegistryAuthTask RegistryAuthTask `yaml:"dokku_registry_auth"`
+}
+
+// GetName returns the name of the example
+func (e RegistryAuthTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the registry auth task
+func (t RegistryAuthTask) Doc() string {
+	return "Manages docker registry authentication for a dokku application or globally"
+}
+
+// Examples returns the examples for the registry auth task
+func (t RegistryAuthTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]RegistryAuthTaskExample{
+		{
+			Name: "Log in to a registry for an app",
+			RegistryAuthTask: RegistryAuthTask{
+				App:      "node-js-app",
+				Server:   "ghcr.io",
+				Username: "deploy-bot",
+				Password: "ghp_examplepat",
+			},
+		},
+		{
+			Name: "Log in to a registry globally",
+			RegistryAuthTask: RegistryAuthTask{
+				Global:   true,
+				Server:   "docker.io",
+				Username: "deploy-bot",
+				Password: "examplepassword",
+			},
+		},
+		{
+			Name: "Log out from a registry for an app",
+			RegistryAuthTask: RegistryAuthTask{
+				App:    "node-js-app",
+				Server: "ghcr.io",
+				State:  StateAbsent,
+			},
+		},
+		{
+			Name: "Log out from a registry globally",
+			RegistryAuthTask: RegistryAuthTask{
+				Global: true,
+				Server: "docker.io",
+				State:  StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute manages the registry authentication
+func (t RegistryAuthTask) Execute() TaskOutputState {
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		StatePresent: func() TaskOutputState { return registryLogin(t) },
+		StateAbsent:  func() TaskOutputState { return registryLogout(t) },
+	})
+}
+
+// validateRegistryAuthTask validates the registry auth task parameters
+func validateRegistryAuthTask(t RegistryAuthTask) error {
+	if t.Global && t.App != "" {
+		return fmt.Errorf("'app' must not be set when 'global' is set to true")
+	}
+	if !t.Global && t.App == "" {
+		return fmt.Errorf("'app' is required when 'global' is not set to true")
+	}
+	if t.Server == "" {
+		return fmt.Errorf("'server' is required")
+	}
+	return nil
+}
+
+// registryLogin runs `dokku registry:login [--global|<app>] <server> <username> --password-stdin`
+// piping the password via stdin so it does not appear on the process argument list
+func registryLogin(t RegistryAuthTask) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   StateAbsent,
+	}
+
+	if err := validateRegistryAuthTask(t); err != nil {
+		state.Error = err
+		return state
+	}
+	if t.Username == "" || t.Password == "" {
+		state.Error = fmt.Errorf("'username' and 'password' are required when state is 'present'")
+		return state
+	}
+
+	args := []string{"--quiet", "registry:login", "--password-stdin"}
+	if t.Global {
+		args = append(args, "--global")
+	} else {
+		args = append(args, t.App)
+	}
+	args = append(args, t.Server, t.Username)
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+		Stdin:   strings.NewReader(t.Password),
+	})
+	if err != nil {
+		return TaskOutputErrorFromExec(state, err, result)
+	}
+
+	state.Changed = true
+	state.State = StatePresent
+	return state
+}
+
+// registryLogout runs `dokku registry:logout [--global|<app>] <server>`
+func registryLogout(t RegistryAuthTask) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   StatePresent,
+	}
+
+	if err := validateRegistryAuthTask(t); err != nil {
+		state.Error = err
+		return state
+	}
+
+	args := []string{"--quiet", "registry:logout"}
+	if t.Global {
+		args = append(args, "--global")
+	} else {
+		args = append(args, t.App)
+	}
+	args = append(args, t.Server)
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		return TaskOutputErrorFromExec(state, err, result)
+	}
+
+	state.Changed = true
+	state.State = StateAbsent
+	return state
+}
+
+// init registers the RegistryAuthTask with the task registry
+func init() {
+	RegisterTask(&RegistryAuthTask{})
+}

--- a/tasks/registry_auth_task_integration_test.go
+++ b/tasks/registry_auth_task_integration_test.go
@@ -1,0 +1,179 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"docket/subprocess"
+)
+
+// startTestRegistry boots a temporary `registry:2` container on a high port
+// and returns its server string (host:port). The caller must register cleanup.
+func startTestRegistry(t *testing.T) string {
+	t.Helper()
+
+	containerName := "docket-test-registry"
+
+	// best-effort cleanup of any previous run
+	subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "docker",
+		Args:    []string{"rm", "-f", containerName},
+	})
+
+	port := "5555"
+	server := "localhost:" + port
+
+	_, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "docker",
+		Args: []string{
+			"run", "-d", "--rm",
+			"--name", containerName,
+			"-p", port + ":5000",
+			"registry:2",
+		},
+	})
+	if err != nil {
+		t.Skipf("skipping integration test: failed to start registry:2 container: %v", err)
+	}
+	t.Cleanup(func() {
+		subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "docker",
+			Args:    []string{"rm", "-f", containerName},
+		})
+	})
+
+	// wait until the registry is reachable
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "curl",
+			Args:    []string{"-sf", "http://" + server + "/v2/"},
+		})
+		if err == nil && result.ExitCode == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Skip("skipping integration test: registry container did not become ready in time")
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	return server
+}
+
+func TestIntegrationRegistryAuthApp(t *testing.T) {
+	skipIfNoDokkuT(t)
+	server := startTestRegistry(t)
+
+	appName := "docket-test-registry-auth"
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// best-effort cleanup of any leftover credential
+	(&RegistryAuthTask{App: appName, Server: server, State: StateAbsent}).Execute()
+
+	// log in
+	loginTask := RegistryAuthTask{
+		App:      appName,
+		Server:   server,
+		Username: "testuser",
+		Password: "testpassword",
+		State:    StatePresent,
+	}
+	result := loginTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to log in: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on login")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// log out
+	logoutTask := RegistryAuthTask{App: appName, Server: server, State: StateAbsent}
+	result = logoutTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to log out: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on logout")
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}
+
+func TestIntegrationRegistryAuthGlobal(t *testing.T) {
+	skipIfNoDokkuT(t)
+	server := startTestRegistry(t)
+
+	// best-effort cleanup of any leftover global credential
+	(&RegistryAuthTask{Global: true, Server: server, State: StateAbsent}).Execute()
+	t.Cleanup(func() {
+		(&RegistryAuthTask{Global: true, Server: server, State: StateAbsent}).Execute()
+	})
+
+	loginTask := RegistryAuthTask{
+		Global:   true,
+		Server:   server,
+		Username: "testuser",
+		Password: "testpassword",
+		State:    StatePresent,
+	}
+	result := loginTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to log in globally: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on global login")
+	}
+
+	logoutTask := RegistryAuthTask{Global: true, Server: server, State: StateAbsent}
+	result = logoutTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to log out globally: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on global logout")
+	}
+}
+
+func TestIntegrationRegistryAuthPasswordNotInArgs(t *testing.T) {
+	// Verify that the password is fed via stdin and never appears in argv. This
+	// runs against a fake `dokku` that records argv and stdin to /tmp files.
+	// Skipped unless dokku is real - we want to hit the actual subprocess path.
+	skipIfNoDokkuT(t)
+
+	// We exercise the real registry:login against the test registry and then
+	// scan dokku's logs / running processes is too brittle; instead, do a
+	// surface-level check: verify that with a password containing whitespace,
+	// the command still succeeds (which it could not if the password were
+	// being naively quoted into argv).
+	server := startTestRegistry(t)
+	appName := "docket-test-registry-auth-stdin"
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	pw := "p@ss with spaces and 'quotes\""
+	loginTask := RegistryAuthTask{
+		App:      appName,
+		Server:   server,
+		Username: "u",
+		Password: pw,
+		State:    StatePresent,
+	}
+	result := loginTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("login with whitespace password failed: %v", result.Error)
+	}
+	if strings.Contains(result.Message, pw) {
+		t.Errorf("password should not appear in task message")
+	}
+
+	(&RegistryAuthTask{App: appName, Server: server, State: StateAbsent}).Execute()
+}

--- a/tasks/registry_auth_task_test.go
+++ b/tasks/registry_auth_task_test.go
@@ -1,0 +1,115 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRegistryAuthTaskInvalidState(t *testing.T) {
+	task := RegistryAuthTask{App: "test-app", Server: "docker.io", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestRegistryAuthTaskMissingApp(t *testing.T) {
+	task := RegistryAuthTask{Server: "docker.io", Username: "u", Password: "p", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'app' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestRegistryAuthTaskGlobalWithApp(t *testing.T) {
+	task := RegistryAuthTask{App: "test-app", Global: true, Server: "docker.io", Username: "u", Password: "p", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestRegistryAuthTaskMissingServer(t *testing.T) {
+	for _, st := range []State{StatePresent, StateAbsent} {
+		task := RegistryAuthTask{App: "test-app", Username: "u", Password: "p", State: st}
+		result := task.Execute()
+		if result.Error == nil {
+			t.Fatalf("expected error with empty server (state=%s)", st)
+		}
+		if !strings.Contains(result.Error.Error(), "'server' is required") {
+			t.Errorf("state=%s: unexpected error: %v", st, result.Error)
+		}
+	}
+}
+
+func TestRegistryAuthTaskPresentMissingUsername(t *testing.T) {
+	task := RegistryAuthTask{App: "test-app", Server: "docker.io", Password: "p", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without username should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'username' and 'password' are required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestRegistryAuthTaskPresentMissingPassword(t *testing.T) {
+	task := RegistryAuthTask{App: "test-app", Server: "docker.io", Username: "u", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without password should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'username' and 'password' are required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestGetTasksRegistryAuthTaskParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: log in to ghcr
+      dokku_registry_auth:
+        app: test-app
+        server: ghcr.io
+        username: deploy-bot
+        password: ghp_examplepat
+        state: present
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("log in to ghcr")
+	if task == nil {
+		t.Fatal("task 'log in to ghcr' not found")
+	}
+
+	authTask, ok := task.(*RegistryAuthTask)
+	if !ok {
+		t.Fatalf("task is not a RegistryAuthTask (type is %T)", task)
+	}
+	if authTask.App != "test-app" {
+		t.Errorf("App = %q, want %q", authTask.App, "test-app")
+	}
+	if authTask.Server != "ghcr.io" {
+		t.Errorf("Server = %q, want %q", authTask.Server, "ghcr.io")
+	}
+	if authTask.Username != "deploy-bot" {
+		t.Errorf("Username = %q, want %q", authTask.Username, "deploy-bot")
+	}
+	if authTask.Password != "ghp_examplepat" {
+		t.Errorf("Password = %q, want %q", authTask.Password, "ghp_examplepat")
+	}
+	if authTask.State != StatePresent {
+		t.Errorf("State = %q, want %q", authTask.State, StatePresent)
+	}
+}


### PR DESCRIPTION
Wraps `dokku registry:login` and `registry:logout` for per-app and `--global` use, with the password fed via `--password-stdin` so it never appears in argv. Idempotency is best-effort: dokku's `registry:logout` no-ops cleanly when not authenticated, while `registry:login` is rerun unconditionally since there is no public dokku command to inspect stored credentials.

Closes #12