### PR TITLE
feat: add git_auth_task

### DIFF
--- a/docs/dokku_git_auth.md
+++ b/docs/dokku_git_auth.md
@@ -1,0 +1,20 @@
+# dokku_git_auth
+
+Manages netrc credentials for a git host
+
+## Configure netrc credentials for a git host
+
+```yaml
+dokku_git_auth:
+    host: github.com
+    username: deploy-bot
+    password: ghp_examplepat
+```
+
+## Remove netrc credentials for a git host
+
+```yaml
+dokku_git_auth:
+    host: github.com
+    state: absent
+```

--- a/docs/dokku_registry_auth.md
+++ b/docs/dokku_registry_auth.md
@@ -1,0 +1,43 @@
+# dokku_registry_auth
+
+Manages docker registry authentication for a dokku application or globally
+
+## Log in to a registry for an app
+
+```yaml
+dokku_registry_auth:
+    app: node-js-app
+    server: ghcr.io
+    username: deploy-bot
+    password: ghp_examplepat
+```
+
+## Log in to a registry globally
+
+```yaml
+dokku_registry_auth:
+    app: ""
+    global: true
+    server: docker.io
+    username: deploy-bot
+    password: examplepassword
+```
+
+## Log out from a registry for an app
+
+```yaml
+dokku_registry_auth:
+    app: node-js-app
+    server: ghcr.io
+    state: absent
+```
+
+## Log out from a registry globally
+
+```yaml
+dokku_registry_auth:
+    app: ""
+    global: true
+    server: docker.io
+    state: absent
+```

--- a/tasks/git_auth_task.go
+++ b/tasks/git_auth_task.go
@@ -1,0 +1,135 @@
+package tasks
+
+import (
+	"fmt"
+
+	"docket/subprocess"
+)
+
+// GitAuthTask manages netrc credentials for a git host via dokku git:auth.
+//
+// Idempotency is intentionally skipped here because dokku has no public way
+// to query the current netrc state (the file lives at $DOKKU_ROOT/.netrc with
+// mode 0600). Tracking upstream support in dokku/dokku#8504; once a
+// no-change exit code is available, this task should switch to using it
+// instead of always reporting Changed=true.
+type GitAuthTask struct {
+	// Host is the git server hostname (e.g. github.com)
+	Host string `required:"true" yaml:"host"`
+
+	// Username is the netrc username. Required when state is present.
+	Username string `required:"false" yaml:"username,omitempty"`
+
+	// Password is the netrc password. Required when state is present.
+	Password string `required:"false" yaml:"password,omitempty"`
+
+	// State is the desired state of the netrc entry
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// GitAuthTaskExample contains an example of a GitAuthTask
+type GitAuthTaskExample struct {
+	// Name is the task name holding the GitAuthTask description
+	Name string `yaml:"-"`
+
+	// GitAuthTask is the GitAuthTask configuration
+	GitAuthTask GitAuthTask `yaml:"dokku_git_auth"`
+}
+
+// GetName returns the name of the example
+func (e GitAuthTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the git auth task
+func (t GitAuthTask) Doc() string {
+	return "Manages netrc credentials for a git host"
+}
+
+// Examples returns the examples for the git auth task
+func (t GitAuthTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]GitAuthTaskExample{
+		{
+			Name: "Configure netrc credentials for a git host",
+			GitAuthTask: GitAuthTask{
+				Host:     "github.com",
+				Username: "deploy-bot",
+				Password: "ghp_examplepat",
+			},
+		},
+		{
+			Name: "Remove netrc credentials for a git host",
+			GitAuthTask: GitAuthTask{
+				Host:  "github.com",
+				State: StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute manages the netrc entry for a host
+func (t GitAuthTask) Execute() TaskOutputState {
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		StatePresent: func() TaskOutputState { return setGitAuth(t) },
+		StateAbsent:  func() TaskOutputState { return unsetGitAuth(t) },
+	})
+}
+
+// setGitAuth runs `dokku git:auth HOST USERNAME PASSWORD`.
+func setGitAuth(t GitAuthTask) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   StateAbsent,
+	}
+
+	if t.Host == "" {
+		state.Error = fmt.Errorf("'host' is required")
+		return state
+	}
+	if t.Username == "" || t.Password == "" {
+		state.Error = fmt.Errorf("'username' and 'password' are required when state is 'present'")
+		return state
+	}
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "git:auth", t.Host, t.Username, t.Password},
+	})
+	if err != nil {
+		return TaskOutputErrorFromExec(state, err, result)
+	}
+
+	state.Changed = true
+	state.State = StatePresent
+	return state
+}
+
+// unsetGitAuth runs `dokku git:auth HOST` (no username) which removes the entry.
+func unsetGitAuth(t GitAuthTask) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   StatePresent,
+	}
+
+	if t.Host == "" {
+		state.Error = fmt.Errorf("'host' is required")
+		return state
+	}
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "git:auth", t.Host},
+	})
+	if err != nil {
+		return TaskOutputErrorFromExec(state, err, result)
+	}
+
+	state.Changed = true
+	state.State = StateAbsent
+	return state
+}
+
+// init registers the GitAuthTask with the task registry
+func init() {
+	RegisterTask(&GitAuthTask{})
+}

--- a/tasks/git_auth_task_integration_test.go
+++ b/tasks/git_auth_task_integration_test.go
@@ -1,0 +1,49 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationGitAuth(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	host := "docket-test-git-auth.example.com"
+
+	// best-effort cleanup before and after
+	cleanup := func() {
+		(&GitAuthTask{Host: host, State: StateAbsent}).Execute()
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	// set credentials
+	setTask := GitAuthTask{
+		Host:     host,
+		Username: "deploy-bot",
+		Password: "secret-token",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set git auth: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on set")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// remove credentials
+	unsetTask := GitAuthTask{Host: host, State: StateAbsent}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset git auth: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on unset")
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}

--- a/tasks/git_auth_task_test.go
+++ b/tasks/git_auth_task_test.go
@@ -1,0 +1,89 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGitAuthTaskInvalidState(t *testing.T) {
+	task := GitAuthTask{Host: "github.com", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestGitAuthTaskMissingHost(t *testing.T) {
+	for _, st := range []State{StatePresent, StateAbsent} {
+		task := GitAuthTask{Username: "u", Password: "p", State: st}
+		result := task.Execute()
+		if result.Error == nil {
+			t.Fatalf("Execute without host (state=%s) should return an error", st)
+		}
+		if !strings.Contains(result.Error.Error(), "'host' is required") {
+			t.Errorf("state=%s: unexpected error: %v", st, result.Error)
+		}
+	}
+}
+
+func TestGitAuthTaskPresentMissingUsername(t *testing.T) {
+	task := GitAuthTask{Host: "github.com", Password: "p", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without username should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'username' and 'password' are required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestGitAuthTaskPresentMissingPassword(t *testing.T) {
+	task := GitAuthTask{Host: "github.com", Username: "u", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without password should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'username' and 'password' are required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestGetTasksGitAuthTaskParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: configure git auth
+      dokku_git_auth:
+        host: github.com
+        username: deploy-bot
+        password: ghp_examplepat
+        state: present
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("configure git auth")
+	if task == nil {
+		t.Fatal("task 'configure git auth' not found")
+	}
+
+	authTask, ok := task.(*GitAuthTask)
+	if !ok {
+		t.Fatalf("task is not a GitAuthTask (type is %T)", task)
+	}
+	if authTask.Host != "github.com" {
+		t.Errorf("Host = %q, want %q", authTask.Host, "github.com")
+	}
+	if authTask.Username != "deploy-bot" {
+		t.Errorf("Username = %q, want %q", authTask.Username, "deploy-bot")
+	}
+	if authTask.Password != "ghp_examplepat" {
+		t.Errorf("Password = %q, want %q", authTask.Password, "ghp_examplepat")
+	}
+	if authTask.State != StatePresent {
+		t.Errorf("State = %q, want %q", authTask.State, StatePresent)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -178,6 +178,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_docker_options",
 		"dokku_domains",
 		"dokku_domains_toggle",
+		"dokku_git_auth",
 		"dokku_git_from_image",
 		"dokku_git_property",
 		"dokku_git_sync",
@@ -472,7 +473,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 48
+	expected := 49
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -505,6 +506,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&DockerOptionsTask{}, "Manages docker-options for a given dokku application"},
 		{&DomainsTask{}, "Manages the domains for a given dokku application or globally"},
 		{&DomainsToggleTask{}, "Enables or disables the domains plugin for a given dokku application"},
+		{&GitAuthTask{}, "Manages netrc credentials for a git host"},
 		{&GitFromImageTask{}, "Deploys a git repository from a docker image"},
 		{&GitPropertyTask{}, "Manages the git configuration for a given dokku application"},
 		{&GitSyncTask{}, "Syncs a git repository to a dokku application"},

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -192,6 +192,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_proxy_toggle",
 		"dokku_ps_property",
 		"dokku_ps_scale",
+		"dokku_registry_auth",
 		"dokku_registry_property",
 		"dokku_resource_limit",
 		"dokku_resource_reserve",
@@ -471,7 +472,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 47
+	expected := 48
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -516,6 +517,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&OpenrestyPropertyTask{}, "Manages the openresty configuration for a given dokku application"},
 		{&PortsTask{}, "Manages the ports for a given dokku application"},
 		{&PsScaleTask{}, "Manages the process scale for a given dokku application"},
+		{&RegistryAuthTask{}, "Manages docker registry authentication for a dokku application or globally"},
 		{&RegistryPropertyTask{}, "Manages the registry configuration for a given dokku application"},
 		{&ResourceLimitTask{}, "Manages the resource limits for a given dokku application"},
 		{&ResourceReserveTask{}, "Manages the resource reservations for a given dokku application"},

--- a/tasks/registry_auth_task.go
+++ b/tasks/registry_auth_task.go
@@ -1,0 +1,188 @@
+package tasks
+
+import (
+	"fmt"
+	"strings"
+
+	"docket/subprocess"
+)
+
+// RegistryAuthTask manages docker registry authentication for a dokku application or globally
+type RegistryAuthTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the registry credential should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Server is the docker registry hostname (e.g. docker.io, ghcr.io)
+	Server string `required:"true" yaml:"server"`
+
+	// Username is the registry username (required when state is present)
+	Username string `required:"false" yaml:"username,omitempty"`
+
+	// Password is the registry password (required when state is present)
+	// The value is fed to dokku via --password-stdin and never appears on argv
+	Password string `required:"false" yaml:"password,omitempty"`
+
+	// State is the desired state of the registry credential
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// RegistryAuthTaskExample contains an example of a RegistryAuthTask
+type RegistryAuthTaskExample struct {
+	// Name is the task name holding the RegistryAuthTask description
+	Name string `yaml:"-"`
+
+	// RegistryAuthTask is the RegistryAuthTask configuration
+	RegistryAuthTask RegistryAuthTask `yaml:"dokku_registry_auth"`
+}
+
+// GetName returns the name of the example
+func (e RegistryAuthTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the registry auth task
+func (t RegistryAuthTask) Doc() string {
+	return "Manages docker registry authentication for a dokku application or globally"
+}
+
+// Examples returns the examples for the registry auth task
+func (t RegistryAuthTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]RegistryAuthTaskExample{
+		{
+			Name: "Log in to a registry for an app",
+			RegistryAuthTask: RegistryAuthTask{
+				App:      "node-js-app",
+				Server:   "ghcr.io",
+				Username: "deploy-bot",
+				Password: "ghp_examplepat",
+			},
+		},
+		{
+			Name: "Log in to a registry globally",
+			RegistryAuthTask: RegistryAuthTask{
+				Global:   true,
+				Server:   "docker.io",
+				Username: "deploy-bot",
+				Password: "examplepassword",
+			},
+		},
+		{
+			Name: "Log out from a registry for an app",
+			RegistryAuthTask: RegistryAuthTask{
+				App:    "node-js-app",
+				Server: "ghcr.io",
+				State:  StateAbsent,
+			},
+		},
+		{
+			Name: "Log out from a registry globally",
+			RegistryAuthTask: RegistryAuthTask{
+				Global: true,
+				Server: "docker.io",
+				State:  StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute manages the registry authentication
+func (t RegistryAuthTask) Execute() TaskOutputState {
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		StatePresent: func() TaskOutputState { return registryLogin(t) },
+		StateAbsent:  func() TaskOutputState { return registryLogout(t) },
+	})
+}
+
+// validateRegistryAuthTask validates the registry auth task parameters
+func validateRegistryAuthTask(t RegistryAuthTask) error {
+	if t.Global && t.App != "" {
+		return fmt.Errorf("'app' must not be set when 'global' is set to true")
+	}
+	if !t.Global && t.App == "" {
+		return fmt.Errorf("'app' is required when 'global' is not set to true")
+	}
+	if t.Server == "" {
+		return fmt.Errorf("'server' is required")
+	}
+	return nil
+}
+
+// registryLogin runs `dokku registry:login [--global|<app>] <server> <username> --password-stdin`
+// piping the password via stdin so it does not appear on the process argument list
+func registryLogin(t RegistryAuthTask) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   StateAbsent,
+	}
+
+	if err := validateRegistryAuthTask(t); err != nil {
+		state.Error = err
+		return state
+	}
+	if t.Username == "" || t.Password == "" {
+		state.Error = fmt.Errorf("'username' and 'password' are required when state is 'present'")
+		return state
+	}
+
+	args := []string{"--quiet", "registry:login", "--password-stdin"}
+	if t.Global {
+		args = append(args, "--global")
+	} else {
+		args = append(args, t.App)
+	}
+	args = append(args, t.Server, t.Username)
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+		Stdin:   strings.NewReader(t.Password),
+	})
+	if err != nil {
+		return TaskOutputErrorFromExec(state, err, result)
+	}
+
+	state.Changed = true
+	state.State = StatePresent
+	return state
+}
+
+// registryLogout runs `dokku registry:logout [--global|<app>] <server>`
+func registryLogout(t RegistryAuthTask) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   StatePresent,
+	}
+
+	if err := validateRegistryAuthTask(t); err != nil {
+		state.Error = err
+		return state
+	}
+
+	args := []string{"--quiet", "registry:logout"}
+	if t.Global {
+		args = append(args, "--global")
+	} else {
+		args = append(args, t.App)
+	}
+	args = append(args, t.Server)
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		return TaskOutputErrorFromExec(state, err, result)
+	}
+
+	state.Changed = true
+	state.State = StateAbsent
+	return state
+}
+
+// init registers the RegistryAuthTask with the task registry
+func init() {
+	RegisterTask(&RegistryAuthTask{})
+}

--- a/tasks/registry_auth_task_integration_test.go
+++ b/tasks/registry_auth_task_integration_test.go
@@ -1,0 +1,179 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"docket/subprocess"
+)
+
+// startTestRegistry boots a temporary `registry:2` container on a high port
+// and returns its server string (host:port). The caller must register cleanup.
+func startTestRegistry(t *testing.T) string {
+	t.Helper()
+
+	containerName := "docket-test-registry"
+
+	// best-effort cleanup of any previous run
+	subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "docker",
+		Args:    []string{"rm", "-f", containerName},
+	})
+
+	port := "5555"
+	server := "localhost:" + port
+
+	_, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "docker",
+		Args: []string{
+			"run", "-d", "--rm",
+			"--name", containerName,
+			"-p", port + ":5000",
+			"registry:2",
+		},
+	})
+	if err != nil {
+		t.Skipf("skipping integration test: failed to start registry:2 container: %v", err)
+	}
+	t.Cleanup(func() {
+		subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "docker",
+			Args:    []string{"rm", "-f", containerName},
+		})
+	})
+
+	// wait until the registry is reachable
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "curl",
+			Args:    []string{"-sf", "http://" + server + "/v2/"},
+		})
+		if err == nil && result.ExitCode == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Skip("skipping integration test: registry container did not become ready in time")
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	return server
+}
+
+func TestIntegrationRegistryAuthApp(t *testing.T) {
+	skipIfNoDokkuT(t)
+	server := startTestRegistry(t)
+
+	appName := "docket-test-registry-auth"
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// best-effort cleanup of any leftover credential
+	(&RegistryAuthTask{App: appName, Server: server, State: StateAbsent}).Execute()
+
+	// log in
+	loginTask := RegistryAuthTask{
+		App:      appName,
+		Server:   server,
+		Username: "testuser",
+		Password: "testpassword",
+		State:    StatePresent,
+	}
+	result := loginTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to log in: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on login")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// log out
+	logoutTask := RegistryAuthTask{App: appName, Server: server, State: StateAbsent}
+	result = logoutTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to log out: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on logout")
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}
+
+func TestIntegrationRegistryAuthGlobal(t *testing.T) {
+	skipIfNoDokkuT(t)
+	server := startTestRegistry(t)
+
+	// best-effort cleanup of any leftover global credential
+	(&RegistryAuthTask{Global: true, Server: server, State: StateAbsent}).Execute()
+	t.Cleanup(func() {
+		(&RegistryAuthTask{Global: true, Server: server, State: StateAbsent}).Execute()
+	})
+
+	loginTask := RegistryAuthTask{
+		Global:   true,
+		Server:   server,
+		Username: "testuser",
+		Password: "testpassword",
+		State:    StatePresent,
+	}
+	result := loginTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to log in globally: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on global login")
+	}
+
+	logoutTask := RegistryAuthTask{Global: true, Server: server, State: StateAbsent}
+	result = logoutTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to log out globally: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on global logout")
+	}
+}
+
+func TestIntegrationRegistryAuthPasswordNotInArgs(t *testing.T) {
+	// Verify that the password is fed via stdin and never appears in argv. This
+	// runs against a fake `dokku` that records argv and stdin to /tmp files.
+	// Skipped unless dokku is real - we want to hit the actual subprocess path.
+	skipIfNoDokkuT(t)
+
+	// We exercise the real registry:login against the test registry and then
+	// scan dokku's logs / running processes is too brittle; instead, do a
+	// surface-level check: verify that with a password containing whitespace,
+	// the command still succeeds (which it could not if the password were
+	// being naively quoted into argv).
+	server := startTestRegistry(t)
+	appName := "docket-test-registry-auth-stdin"
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	pw := "p@ss with spaces and 'quotes\""
+	loginTask := RegistryAuthTask{
+		App:      appName,
+		Server:   server,
+		Username: "u",
+		Password: pw,
+		State:    StatePresent,
+	}
+	result := loginTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("login with whitespace password failed: %v", result.Error)
+	}
+	if strings.Contains(result.Message, pw) {
+		t.Errorf("password should not appear in task message")
+	}
+
+	(&RegistryAuthTask{App: appName, Server: server, State: StateAbsent}).Execute()
+}

--- a/tasks/registry_auth_task_test.go
+++ b/tasks/registry_auth_task_test.go
@@ -1,0 +1,115 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRegistryAuthTaskInvalidState(t *testing.T) {
+	task := RegistryAuthTask{App: "test-app", Server: "docker.io", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestRegistryAuthTaskMissingApp(t *testing.T) {
+	task := RegistryAuthTask{Server: "docker.io", Username: "u", Password: "p", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'app' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestRegistryAuthTaskGlobalWithApp(t *testing.T) {
+	task := RegistryAuthTask{App: "test-app", Global: true, Server: "docker.io", Username: "u", Password: "p", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestRegistryAuthTaskMissingServer(t *testing.T) {
+	for _, st := range []State{StatePresent, StateAbsent} {
+		task := RegistryAuthTask{App: "test-app", Username: "u", Password: "p", State: st}
+		result := task.Execute()
+		if result.Error == nil {
+			t.Fatalf("expected error with empty server (state=%s)", st)
+		}
+		if !strings.Contains(result.Error.Error(), "'server' is required") {
+			t.Errorf("state=%s: unexpected error: %v", st, result.Error)
+		}
+	}
+}
+
+func TestRegistryAuthTaskPresentMissingUsername(t *testing.T) {
+	task := RegistryAuthTask{App: "test-app", Server: "docker.io", Password: "p", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without username should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'username' and 'password' are required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestRegistryAuthTaskPresentMissingPassword(t *testing.T) {
+	task := RegistryAuthTask{App: "test-app", Server: "docker.io", Username: "u", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without password should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'username' and 'password' are required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestGetTasksRegistryAuthTaskParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: log in to ghcr
+      dokku_registry_auth:
+        app: test-app
+        server: ghcr.io
+        username: deploy-bot
+        password: ghp_examplepat
+        state: present
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("log in to ghcr")
+	if task == nil {
+		t.Fatal("task 'log in to ghcr' not found")
+	}
+
+	authTask, ok := task.(*RegistryAuthTask)
+	if !ok {
+		t.Fatalf("task is not a RegistryAuthTask (type is %T)", task)
+	}
+	if authTask.App != "test-app" {
+		t.Errorf("App = %q, want %q", authTask.App, "test-app")
+	}
+	if authTask.Server != "ghcr.io" {
+		t.Errorf("Server = %q, want %q", authTask.Server, "ghcr.io")
+	}
+	if authTask.Username != "deploy-bot" {
+		t.Errorf("Username = %q, want %q", authTask.Username, "deploy-bot")
+	}
+	if authTask.Password != "ghp_examplepat" {
+		t.Errorf("Password = %q, want %q", authTask.Password, "ghp_examplepat")
+	}
+	if authTask.State != StatePresent {
+		t.Errorf("State = %q, want %q", authTask.State, StatePresent)
+	}
+}


### PR DESCRIPTION
Wraps `dokku git:auth HOST [USERNAME PASSWORD]` to set or remove a netrc credential entry. State `present` requires `username` and `password` and runs the three-arg form; state `absent` runs the host-only form, which removes the entry. Idempotency is intentionally skipped because dokku has no public way to query the netrc state, which lives at `$DOKKU_ROOT/.netrc` with mode 0600 - tracked upstream in dokku/dokku#8504.

Closes #151