### PR TITLE
feat: add git_from_archive_task

### DIFF
--- a/docs/dokku_git_from_archive.md
+++ b/docs/dokku_git_from_archive.md
@@ -1,0 +1,22 @@
+# dokku_git_from_archive
+
+Deploys a git repository from an archive URL
+
+## Deploy a tar archive
+
+```yaml
+dokku_git_from_archive:
+    app: node-js-app
+    archive_url: https://example.com/release-1.0.0.tar
+```
+
+## Deploy a zip archive with author metadata
+
+```yaml
+dokku_git_from_archive:
+    app: node-js-app
+    archive_url: https://example.com/release-1.0.0.zip
+    archive_type: zip
+    git_username: deploy-bot
+    git_email: deploy@example.com
+```

--- a/tasks/git_from_archive_task.go
+++ b/tasks/git_from_archive_task.go
@@ -1,0 +1,148 @@
+package tasks
+
+import (
+	"fmt"
+
+	"docket/subprocess"
+)
+
+// GitFromArchiveTask deploys a git repository from an archive URL
+type GitFromArchiveTask struct {
+	// App is the name of the app
+	App string `required:"true" yaml:"app"`
+
+	// ArchiveURL is the URL of the archive to deploy
+	ArchiveURL string `required:"true" yaml:"archive_url"`
+
+	// ArchiveType is the format of the archive
+	ArchiveType string `required:"false" yaml:"archive_type,omitempty" default:"tar" options:"tar,tar.gz,zip"`
+
+	// GitUsername is the git author username for the synthetic commit
+	GitUsername string `required:"false" yaml:"git_username,omitempty"`
+
+	// GitEmail is the git author email for the synthetic commit
+	GitEmail string `required:"false" yaml:"git_email,omitempty"`
+
+	// State is the desired state of the deployment
+	State State `required:"false" yaml:"state,omitempty" default:"deployed" options:"deployed"`
+}
+
+// GitFromArchiveTaskExample contains an example of a GitFromArchiveTask
+type GitFromArchiveTaskExample struct {
+	// Name is the task name holding the GitFromArchiveTask description
+	Name string `yaml:"-"`
+
+	// GitFromArchiveTask is the GitFromArchiveTask configuration
+	GitFromArchiveTask GitFromArchiveTask `yaml:"dokku_git_from_archive"`
+}
+
+// GetName returns the name of the example
+func (e GitFromArchiveTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the git from archive task
+func (t GitFromArchiveTask) Doc() string {
+	return "Deploys a git repository from an archive URL"
+}
+
+// Examples returns the examples for the git from archive task
+func (t GitFromArchiveTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]GitFromArchiveTaskExample{
+		{
+			Name: "Deploy a tar archive",
+			GitFromArchiveTask: GitFromArchiveTask{
+				App:        "node-js-app",
+				ArchiveURL: "https://example.com/release-1.0.0.tar",
+			},
+		},
+		{
+			Name: "Deploy a zip archive with author metadata",
+			GitFromArchiveTask: GitFromArchiveTask{
+				App:         "node-js-app",
+				ArchiveURL:  "https://example.com/release-1.0.0.zip",
+				ArchiveType: "zip",
+				GitUsername: "deploy-bot",
+				GitEmail:    "deploy@example.com",
+			},
+		},
+	})
+}
+
+var validGitFromArchiveTypes = map[string]bool{"tar": true, "tar.gz": true, "zip": true}
+
+// Execute deploys a git repository from an archive URL
+func (t GitFromArchiveTask) Execute() TaskOutputState {
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		"deployed": func() TaskOutputState { return deployGitFromArchive(t) },
+	})
+}
+
+// checkAppSourceArchive returns true if the app is already deployed from the
+// expected archive URL with the expected archive type. The archive type is
+// stored as the deploy source value, so a tar.gz deploy reports source "tar.gz".
+func checkAppSourceArchive(app, expectedType, expectedURL string) bool {
+	source, err := getAppDeploySource(app)
+	if err != nil {
+		return false
+	}
+	return source.Source == expectedType && source.SourceMetadata == expectedURL
+}
+
+// deployGitFromArchive deploys a git repository from an archive URL
+func deployGitFromArchive(t GitFromArchiveTask) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   "undeployed",
+	}
+
+	if t.App == "" {
+		state.Error = fmt.Errorf("'app' is required")
+		return state
+	}
+	if t.ArchiveURL == "" {
+		state.Error = fmt.Errorf("'archive_url' is required")
+		return state
+	}
+
+	archiveType := t.ArchiveType
+	if archiveType == "" {
+		archiveType = "tar"
+	}
+	if !validGitFromArchiveTypes[archiveType] {
+		state.Error = fmt.Errorf("'archive_type' must be one of tar, tar.gz, zip")
+		return state
+	}
+
+	if (t.GitUsername == "") != (t.GitEmail == "") {
+		state.Error = fmt.Errorf("'git_username' and 'git_email' must be set together")
+		return state
+	}
+
+	if checkAppSourceArchive(t.App, archiveType, t.ArchiveURL) {
+		state.State = "deployed"
+		return state
+	}
+
+	args := []string{"git:from-archive", "--archive-type", archiveType, t.App, t.ArchiveURL}
+	if t.GitUsername != "" {
+		args = append(args, t.GitUsername, t.GitEmail)
+	}
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		return TaskOutputErrorFromExec(state, err, result)
+	}
+
+	state.Changed = true
+	state.State = "deployed"
+	return state
+}
+
+// init registers the GitFromArchiveTask with the task registry
+func init() {
+	RegisterTask(&GitFromArchiveTask{})
+}

--- a/tasks/git_from_archive_task_integration_test.go
+++ b/tasks/git_from_archive_task_integration_test.go
@@ -1,0 +1,58 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationGitFromArchive(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-git-from-archive"
+	archiveURL := "https://github.com/dokku/smoke-test-app/archive/refs/heads/master.tar.gz"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// initial deploy
+	task := GitFromArchiveTask{
+		App:         appName,
+		ArchiveURL:  archiveURL,
+		ArchiveType: "tar.gz",
+		State:       "deployed",
+	}
+	result := task.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to deploy archive: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first deploy")
+	}
+	if result.State != "deployed" {
+		t.Errorf("expected state 'deployed', got '%s'", result.State)
+	}
+
+	// verify deploy-source metadata reflects the archive
+	source, err := getAppDeploySource(appName)
+	if err != nil {
+		t.Fatalf("getAppDeploySource failed: %v", err)
+	}
+	if source.Source != "tar.gz" {
+		t.Errorf("expected deploy source 'tar.gz', got %q", source.Source)
+	}
+	if source.SourceMetadata != archiveURL {
+		t.Errorf("expected deploy source metadata %q, got %q", archiveURL, source.SourceMetadata)
+	}
+
+	// re-deploy with same archive - should be idempotent
+	result = task.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second deploy: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent deploy")
+	}
+	if result.State != "deployed" {
+		t.Errorf("expected state 'deployed', got '%s'", result.State)
+	}
+}

--- a/tasks/git_from_archive_task_test.go
+++ b/tasks/git_from_archive_task_test.go
@@ -1,0 +1,129 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGitFromArchiveTaskInvalidState(t *testing.T) {
+	task := GitFromArchiveTask{App: "test-app", ArchiveURL: "https://example.com/a.tar", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestGitFromArchiveTaskMissingApp(t *testing.T) {
+	task := GitFromArchiveTask{ArchiveURL: "https://example.com/a.tar", State: "deployed"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'app' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestGitFromArchiveTaskMissingArchiveURL(t *testing.T) {
+	task := GitFromArchiveTask{App: "test-app", State: "deployed"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without archive_url should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'archive_url' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestGitFromArchiveTaskInvalidArchiveType(t *testing.T) {
+	task := GitFromArchiveTask{
+		App:         "test-app",
+		ArchiveURL:  "https://example.com/a.bz2",
+		ArchiveType: "bz2",
+		State:       "deployed",
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error for invalid archive_type")
+	}
+	if !strings.Contains(result.Error.Error(), "'archive_type' must be one of") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestGitFromArchiveTaskOnlyGitUsername(t *testing.T) {
+	task := GitFromArchiveTask{
+		App:         "test-app",
+		ArchiveURL:  "https://example.com/a.tar",
+		GitUsername: "deploy-bot",
+		State:       "deployed",
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when git_username is set without git_email")
+	}
+	if !strings.Contains(result.Error.Error(), "'git_username' and 'git_email' must be set together") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestGitFromArchiveTaskOnlyGitEmail(t *testing.T) {
+	task := GitFromArchiveTask{
+		App:        "test-app",
+		ArchiveURL: "https://example.com/a.tar",
+		GitEmail:   "deploy@example.com",
+		State:      "deployed",
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when git_email is set without git_username")
+	}
+	if !strings.Contains(result.Error.Error(), "'git_username' and 'git_email' must be set together") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestGetTasksGitFromArchiveTaskParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: deploy archive
+      dokku_git_from_archive:
+        app: test-app
+        archive_url: https://example.com/release.tar.gz
+        archive_type: tar.gz
+        git_username: deploy-bot
+        git_email: deploy@example.com
+        state: deployed
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("deploy archive")
+	if task == nil {
+		t.Fatal("task 'deploy archive' not found")
+	}
+
+	archTask, ok := task.(*GitFromArchiveTask)
+	if !ok {
+		t.Fatalf("task is not a GitFromArchiveTask (type is %T)", task)
+	}
+	if archTask.App != "test-app" {
+		t.Errorf("App = %q, want %q", archTask.App, "test-app")
+	}
+	if archTask.ArchiveURL != "https://example.com/release.tar.gz" {
+		t.Errorf("ArchiveURL = %q", archTask.ArchiveURL)
+	}
+	if archTask.ArchiveType != "tar.gz" {
+		t.Errorf("ArchiveType = %q, want %q", archTask.ArchiveType, "tar.gz")
+	}
+	if archTask.GitUsername != "deploy-bot" {
+		t.Errorf("GitUsername = %q", archTask.GitUsername)
+	}
+	if archTask.GitEmail != "deploy@example.com" {
+		t.Errorf("GitEmail = %q", archTask.GitEmail)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -179,6 +179,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_domains",
 		"dokku_domains_toggle",
 		"dokku_git_auth",
+		"dokku_git_from_archive",
 		"dokku_git_from_image",
 		"dokku_git_property",
 		"dokku_git_sync",
@@ -473,7 +474,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 49
+	expected := 50
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -507,6 +508,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&DomainsTask{}, "Manages the domains for a given dokku application or globally"},
 		{&DomainsToggleTask{}, "Enables or disables the domains plugin for a given dokku application"},
 		{&GitAuthTask{}, "Manages netrc credentials for a git host"},
+		{&GitFromArchiveTask{}, "Deploys a git repository from an archive URL"},
 		{&GitFromImageTask{}, "Deploys a git repository from a docker image"},
 		{&GitPropertyTask{}, "Manages the git configuration for a given dokku application"},
 		{&GitSyncTask{}, "Syncs a git repository to a dokku application"},


### PR DESCRIPTION
Wraps `dokku git:from-archive --archive-type <type> APP URL [USERNAME EMAIL]` for `tar`, `tar.gz`, and `zip` archives. Idempotency reuses `getAppDeploySource` and skips the deploy when `apps:report` already shows the matching `app-deploy-source` (the archive type) and `app-deploy-source-metadata` (the URL). Author overrides require both `git_username` and `git_email` together.

Closes #149