### PR TITLE
feat: add letsencrypt_task

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,5 +50,7 @@ jobs:
         run: sudo dokku plugin:install https://github.com/dokku/dokku-http-auth.git http-auth
       - name: install dokku global-cert plugin
         run: sudo dokku plugin:install https://github.com/dokku-community/dokku-global-cert.git global-cert
+      - name: install dokku letsencrypt plugin
+        run: sudo dokku plugin:install https://github.com/dokku/dokku-letsencrypt.git letsencrypt
       - name: run integration tests
         run: sudo go test -v -count=1 -run TestIntegration ./tasks/

--- a/docs/dokku_letsencrypt.md
+++ b/docs/dokku_letsencrypt.md
@@ -1,0 +1,18 @@
+# dokku_letsencrypt
+
+Enables or disables letsencrypt SSL certificates for a dokku application
+
+## Enable letsencrypt for an app
+
+```yaml
+dokku_letsencrypt:
+    app: node-js-app
+```
+
+## Disable letsencrypt for an app
+
+```yaml
+dokku_letsencrypt:
+    app: node-js-app
+    state: absent
+```

--- a/docs/dokku_letsencrypt_property.md
+++ b/docs/dokku_letsencrypt_property.md
@@ -1,0 +1,39 @@
+# dokku_letsencrypt_property
+
+Manages the letsencrypt configuration for a given dokku application
+
+## Setting the letsencrypt email for an app
+
+```yaml
+dokku_letsencrypt_property:
+    app: node-js-app
+    property: email
+    value: admin@example.com
+```
+
+## Setting the dns provider for an app
+
+```yaml
+dokku_letsencrypt_property:
+    app: node-js-app
+    property: dns-provider
+    value: namecheap
+```
+
+## Setting a dns-provider-* env var globally
+
+```yaml
+dokku_letsencrypt_property:
+    app: ""
+    global: true
+    property: dns-provider-NAMECHEAP_API_USER
+    value: deploy-bot
+```
+
+## Clearing the letsencrypt email for an app
+
+```yaml
+dokku_letsencrypt_property:
+    app: node-js-app
+    property: email
+```

--- a/tasks/letsencrypt_property_task.go
+++ b/tasks/letsencrypt_property_task.go
@@ -1,0 +1,85 @@
+package tasks
+
+// LetsencryptPropertyTask manages the letsencrypt configuration for a given dokku application
+type LetsencryptPropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app"`
+
+	// Global is a flag indicating if the letsencrypt configuration should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty"`
+
+	// Property is the name of the letsencrypt property to set
+	Property string `required:"true" yaml:"property"`
+
+	// Value is the value to set for the letsencrypt property
+	Value string `required:"false" yaml:"value,omitempty"`
+
+	// State is the desired state of the letsencrypt configuration
+	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// LetsencryptPropertyTaskExample contains an example of a LetsencryptPropertyTask
+type LetsencryptPropertyTaskExample struct {
+	// Name is the task name holding the LetsencryptPropertyTask description
+	Name string `yaml:"-"`
+
+	// LetsencryptPropertyTask is the LetsencryptPropertyTask configuration
+	LetsencryptPropertyTask LetsencryptPropertyTask `yaml:"dokku_letsencrypt_property"`
+}
+
+// GetName returns the name of the example
+func (e LetsencryptPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the letsencrypt property task
+func (t LetsencryptPropertyTask) Doc() string {
+	return "Manages the letsencrypt configuration for a given dokku application"
+}
+
+// Examples returns the examples for the letsencrypt property task
+func (t LetsencryptPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]LetsencryptPropertyTaskExample{
+		{
+			Name: "Setting the letsencrypt email for an app",
+			LetsencryptPropertyTask: LetsencryptPropertyTask{
+				App:      "node-js-app",
+				Property: "email",
+				Value:    "admin@example.com",
+			},
+		},
+		{
+			Name: "Setting the dns provider for an app",
+			LetsencryptPropertyTask: LetsencryptPropertyTask{
+				App:      "node-js-app",
+				Property: "dns-provider",
+				Value:    "namecheap",
+			},
+		},
+		{
+			Name: "Setting a dns-provider-* env var globally",
+			LetsencryptPropertyTask: LetsencryptPropertyTask{
+				Global:   true,
+				Property: "dns-provider-NAMECHEAP_API_USER",
+				Value:    "deploy-bot",
+			},
+		},
+		{
+			Name: "Clearing the letsencrypt email for an app",
+			LetsencryptPropertyTask: LetsencryptPropertyTask{
+				App:      "node-js-app",
+				Property: "email",
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the letsencrypt property
+func (t LetsencryptPropertyTask) Execute() TaskOutputState {
+	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "letsencrypt:set")
+}
+
+// init registers the LetsencryptPropertyTask with the task registry
+func init() {
+	RegisterTask(&LetsencryptPropertyTask{})
+}

--- a/tasks/letsencrypt_property_task_integration_test.go
+++ b/tasks/letsencrypt_property_task_integration_test.go
@@ -1,0 +1,45 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationLetsencryptProperty(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "letsencrypt")
+
+	appName := "docket-test-letsencrypt"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// set letsencrypt property
+	setTask := LetsencryptPropertyTask{
+		App:      appName,
+		Property: "email",
+		Value:    "admin@example.com",
+		State:    StatePresent,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set letsencrypt property: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// unset letsencrypt property
+	unsetTask := LetsencryptPropertyTask{
+		App:      appName,
+		Property: "email",
+		State:    StateAbsent,
+	}
+	result = unsetTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unset letsencrypt property: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+}

--- a/tasks/letsencrypt_property_task_test.go
+++ b/tasks/letsencrypt_property_task_test.go
@@ -1,0 +1,71 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLetsencryptPropertyTaskInvalidState(t *testing.T) {
+	task := LetsencryptPropertyTask{App: "test-app", Property: "email", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestLetsencryptPropertyTaskMissingApp(t *testing.T) {
+	task := LetsencryptPropertyTask{Property: "email", Value: "admin@example.com", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestLetsencryptPropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := LetsencryptPropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "email",
+		Value:    "admin@example.com",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestLetsencryptPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := LetsencryptPropertyTask{
+		App:      "test-app",
+		Property: "email",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestLetsencryptPropertyTaskAbsentWithValue(t *testing.T) {
+	task := LetsencryptPropertyTask{
+		App:      "test-app",
+		Property: "email",
+		Value:    "admin@example.com",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}

--- a/tasks/letsencrypt_task.go
+++ b/tasks/letsencrypt_task.go
@@ -1,0 +1,153 @@
+package tasks
+
+import (
+	"fmt"
+	"strings"
+
+	"docket/subprocess"
+)
+
+// LetsencryptTask enables or disables the dokku-letsencrypt plugin for a dokku app
+type LetsencryptTask struct {
+	// App is the name of the app
+	App string `required:"true" yaml:"app"`
+
+	// State is the desired state of the letsencrypt integration
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// LetsencryptTaskExample contains an example of a LetsencryptTask
+type LetsencryptTaskExample struct {
+	// Name is the task name holding the LetsencryptTask description
+	Name string `yaml:"-"`
+
+	// LetsencryptTask is the LetsencryptTask configuration
+	LetsencryptTask LetsencryptTask `yaml:"dokku_letsencrypt"`
+}
+
+// GetName returns the name of the example
+func (e LetsencryptTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the letsencrypt task
+func (t LetsencryptTask) Doc() string {
+	return "Enables or disables letsencrypt SSL certificates for a dokku application"
+}
+
+// Examples returns the examples for the letsencrypt task
+func (t LetsencryptTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]LetsencryptTaskExample{
+		{
+			Name: "Enable letsencrypt for an app",
+			LetsencryptTask: LetsencryptTask{
+				App: "node-js-app",
+			},
+		},
+		{
+			Name: "Disable letsencrypt for an app",
+			LetsencryptTask: LetsencryptTask{
+				App:   "node-js-app",
+				State: StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute enables or disables letsencrypt
+func (t LetsencryptTask) Execute() TaskOutputState {
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		StatePresent: func() TaskOutputState { return enableLetsencrypt(t.App) },
+		StateAbsent:  func() TaskOutputState { return disableLetsencrypt(t.App) },
+	})
+}
+
+// letsencryptActive reports whether letsencrypt is currently active for an app.
+// Mirrors the upstream `dokku letsencrypt:active <app>` output ("true"/"false").
+func letsencryptActive(app string) (bool, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "letsencrypt:active", app},
+	})
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(result.StdoutContents()) == "true", nil
+}
+
+// enableLetsencrypt runs `dokku letsencrypt:enable APP` if not already active
+func enableLetsencrypt(app string) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   StateAbsent,
+	}
+
+	if app == "" {
+		state.Error = fmt.Errorf("'app' is required")
+		return state
+	}
+
+	active, err := letsencryptActive(app)
+	if err != nil {
+		state.Error = err
+		state.Message = err.Error()
+		return state
+	}
+	if active {
+		state.State = StatePresent
+		return state
+	}
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "letsencrypt:enable", app},
+	})
+	if err != nil {
+		return TaskOutputErrorFromExec(state, err, result)
+	}
+
+	state.Changed = true
+	state.State = StatePresent
+	return state
+}
+
+// disableLetsencrypt runs `dokku letsencrypt:disable APP` if currently active
+func disableLetsencrypt(app string) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   StatePresent,
+	}
+
+	if app == "" {
+		state.Error = fmt.Errorf("'app' is required")
+		return state
+	}
+
+	active, err := letsencryptActive(app)
+	if err != nil {
+		state.Error = err
+		state.Message = err.Error()
+		return state
+	}
+	if !active {
+		state.State = StateAbsent
+		return state
+	}
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "letsencrypt:disable", app},
+	})
+	if err != nil {
+		return TaskOutputErrorFromExec(state, err, result)
+	}
+
+	state.Changed = true
+	state.State = StateAbsent
+	return state
+}
+
+// init registers the LetsencryptTask with the task registry
+func init() {
+	RegisterTask(&LetsencryptTask{})
+}

--- a/tasks/letsencrypt_task_integration_test.go
+++ b/tasks/letsencrypt_task_integration_test.go
@@ -1,0 +1,52 @@
+package tasks
+
+import (
+	"testing"
+)
+
+// TestIntegrationLetsencrypt exercises the idempotency paths that do not
+// require an ACME server: the `letsencrypt:active` check on a fresh app and
+// the `disable` no-op when nothing is configured. The full `enable` flow
+// requires a mock ACME server (e.g. pebble) plus lego cert-trust plumbing
+// inside the dokku-letsencrypt plugin's container, which is out of scope
+// for this CI configuration; tracked for follow-up.
+func TestIntegrationLetsencrypt(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "letsencrypt")
+
+	appName := "docket-test-letsencrypt"
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// fresh app should not be active
+	active, err := letsencryptActive(appName)
+	if err != nil {
+		t.Fatalf("letsencryptActive failed: %v", err)
+	}
+	if active {
+		t.Errorf("expected newly-created app to have letsencrypt inactive")
+	}
+
+	// disable on a non-active app is a no-op
+	disableTask := LetsencryptTask{App: appName, State: StateAbsent}
+	result := disableTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("disable on inactive app returned error: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on disable of inactive app")
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+
+	// disable again - still idempotent
+	result = disableTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("second disable returned error: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent disable")
+	}
+}

--- a/tasks/letsencrypt_task_test.go
+++ b/tasks/letsencrypt_task_test.go
@@ -1,0 +1,68 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLetsencryptTaskInvalidState(t *testing.T) {
+	task := LetsencryptTask{App: "test-app", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestLetsencryptTaskPresentMissingApp(t *testing.T) {
+	task := LetsencryptTask{State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'app' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestLetsencryptTaskAbsentMissingApp(t *testing.T) {
+	task := LetsencryptTask{State: StateAbsent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'app' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestGetTasksLetsencryptTaskParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: enable letsencrypt
+      dokku_letsencrypt:
+        app: test-app
+        state: present
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("enable letsencrypt")
+	if task == nil {
+		t.Fatal("task 'enable letsencrypt' not found")
+	}
+
+	leTask, ok := task.(*LetsencryptTask)
+	if !ok {
+		t.Fatalf("task is not a LetsencryptTask (type is %T)", task)
+	}
+	if leTask.App != "test-app" {
+		t.Errorf("App = %q, want %q", leTask.App, "test-app")
+	}
+	if leTask.State != StatePresent {
+		t.Errorf("State = %q, want %q", leTask.State, StatePresent)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -185,6 +185,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_git_sync",
 		"dokku_haproxy_property",
 		"dokku_http_auth",
+		"dokku_letsencrypt",
 		"dokku_letsencrypt_property",
 		"dokku_logs_property",
 		"dokku_network",
@@ -475,7 +476,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 51
+	expected := 52
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -515,6 +516,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&GitSyncTask{}, "Syncs a git repository to a dokku application"},
 		{&HaproxyPropertyTask{}, "Manages the haproxy configuration for a given dokku application"},
 		{&HttpAuthTask{}, "Manages HTTP authentication for a given dokku application"},
+		{&LetsencryptTask{}, "Enables or disables letsencrypt SSL certificates for a dokku application"},
 		{&LetsencryptPropertyTask{}, "Manages the letsencrypt configuration for a given dokku application"},
 		{&LogsPropertyTask{}, "Manages the logs configuration for a given dokku application"},
 		{&NetworkTask{}, "Creates or destroys a Docker network"},

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -185,6 +185,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_git_sync",
 		"dokku_haproxy_property",
 		"dokku_http_auth",
+		"dokku_letsencrypt_property",
 		"dokku_logs_property",
 		"dokku_network",
 		"dokku_network_property",
@@ -474,7 +475,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 50
+	expected := 51
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -514,6 +515,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&GitSyncTask{}, "Syncs a git repository to a dokku application"},
 		{&HaproxyPropertyTask{}, "Manages the haproxy configuration for a given dokku application"},
 		{&HttpAuthTask{}, "Manages HTTP authentication for a given dokku application"},
+		{&LetsencryptPropertyTask{}, "Manages the letsencrypt configuration for a given dokku application"},
 		{&LogsPropertyTask{}, "Manages the logs configuration for a given dokku application"},
 		{&NetworkTask{}, "Creates or destroys a Docker network"},
 		{&NetworkPropertyTask{}, "Manages the network property for a given dokku application"},


### PR DESCRIPTION
Wraps `dokku letsencrypt:enable` and `letsencrypt:disable` from the `dokku/dokku-letsencrypt` plugin. Idempotency reads `letsencrypt:active <app>` (which echoes "true"/"false") and skips the subcommand when already in the desired state. Integration test gates on the plugin via `skipIfPluginMissingT(t, "letsencrypt")` and exercises the no-ACME paths (initial inactive state, idempotent disable); the full enable cycle requires a mock ACME server (e.g. pebble) plus lego cert-trust plumbing inside the plugin's container, which is tracked for follow-up.

Closes #19