### PR TITLE
feat: add acl_app_task

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,5 +52,7 @@ jobs:
         run: sudo dokku plugin:install https://github.com/dokku-community/dokku-global-cert.git global-cert
       - name: install dokku letsencrypt plugin
         run: sudo dokku plugin:install https://github.com/dokku/dokku-letsencrypt.git letsencrypt
+      - name: install dokku acl plugin
+        run: sudo dokku plugin:install https://github.com/dokku-community/dokku-acl.git acl
       - name: run integration tests
         run: sudo go test -v -count=1 -run TestIntegration ./tasks/

--- a/docs/dokku_acl_app.md
+++ b/docs/dokku_acl_app.md
@@ -1,0 +1,32 @@
+# dokku_acl_app
+
+Manages the dokku-acl access list for a dokku application
+
+## Grant users access to an app
+
+```yaml
+dokku_acl_app:
+    app: node-js-app
+    users:
+        - alice
+        - bob
+```
+
+## Revoke a user's access to an app
+
+```yaml
+dokku_acl_app:
+    app: node-js-app
+    users:
+        - bob
+    state: absent
+```
+
+## Clear the entire ACL for an app
+
+```yaml
+dokku_acl_app:
+    app: node-js-app
+    users: []
+    state: absent
+```

--- a/tasks/acl_app_task.go
+++ b/tasks/acl_app_task.go
@@ -1,0 +1,205 @@
+package tasks
+
+import (
+	"fmt"
+	"strings"
+
+	"docket/subprocess"
+)
+
+// AclAppTask manages the dokku-acl access list for a dokku application
+type AclAppTask struct {
+	// App is the name of the app
+	App string `required:"true" yaml:"app"`
+
+	// Users is the list of users to add or remove from the ACL
+	Users []string `required:"false" yaml:"users"`
+
+	// State is the desired state of the ACL entries
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// AclAppTaskExample contains an example of an AclAppTask
+type AclAppTaskExample struct {
+	// Name is the task name holding the AclAppTask description
+	Name string `yaml:"-"`
+
+	// AclAppTask is the AclAppTask configuration
+	AclAppTask AclAppTask `yaml:"dokku_acl_app"`
+}
+
+// GetName returns the name of the example
+func (e AclAppTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the acl app task
+func (t AclAppTask) Doc() string {
+	return "Manages the dokku-acl access list for a dokku application"
+}
+
+// Examples returns the examples for the acl app task
+func (t AclAppTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]AclAppTaskExample{
+		{
+			Name: "Grant users access to an app",
+			AclAppTask: AclAppTask{
+				App:   "node-js-app",
+				Users: []string{"alice", "bob"},
+			},
+		},
+		{
+			Name: "Revoke a user's access to an app",
+			AclAppTask: AclAppTask{
+				App:   "node-js-app",
+				Users: []string{"bob"},
+				State: StateAbsent,
+			},
+		},
+		{
+			Name: "Clear the entire ACL for an app",
+			AclAppTask: AclAppTask{
+				App:   "node-js-app",
+				State: StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute manages the app ACL
+func (t AclAppTask) Execute() TaskOutputState {
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		StatePresent: func() TaskOutputState { return addAclAppUsers(t) },
+		StateAbsent:  func() TaskOutputState { return removeAclAppUsers(t) },
+	})
+}
+
+// getAclAppUsers reads the current ACL for an app via `acl:list APP`. The
+// plugin emits one username per line; an empty ACL produces no output.
+func getAclAppUsers(app string) (map[string]bool, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "acl:list", app},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	users := map[string]bool{}
+	for _, line := range strings.Split(result.StdoutContents(), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		users[trimmed] = true
+	}
+	return users, nil
+}
+
+// addAclAppUsers adds users to an app's ACL, skipping ones already present
+func addAclAppUsers(t AclAppTask) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   StateAbsent,
+	}
+
+	if t.App == "" {
+		state.Error = fmt.Errorf("'app' is required")
+		return state
+	}
+	if len(t.Users) == 0 {
+		state.Error = fmt.Errorf("'users' must not be empty for state 'present'")
+		return state
+	}
+
+	current, err := getAclAppUsers(t.App)
+	if err != nil {
+		state.Error = err
+		state.Message = err.Error()
+		return state
+	}
+
+	var toAdd []string
+	for _, user := range t.Users {
+		if !current[user] {
+			toAdd = append(toAdd, user)
+		}
+	}
+
+	if len(toAdd) == 0 {
+		state.State = StatePresent
+		return state
+	}
+
+	for _, user := range toAdd {
+		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", "acl:add", t.App, user},
+		})
+		if err != nil {
+			return TaskOutputErrorFromExec(state, err, result)
+		}
+	}
+
+	state.Changed = true
+	state.State = StatePresent
+	return state
+}
+
+// removeAclAppUsers removes users from an app's ACL. With an empty Users list,
+// removes every entry currently in the ACL (i.e. clears it).
+func removeAclAppUsers(t AclAppTask) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   StatePresent,
+	}
+
+	if t.App == "" {
+		state.Error = fmt.Errorf("'app' is required")
+		return state
+	}
+
+	current, err := getAclAppUsers(t.App)
+	if err != nil {
+		state.Error = err
+		state.Message = err.Error()
+		return state
+	}
+
+	var toRemove []string
+	if len(t.Users) == 0 {
+		for user := range current {
+			toRemove = append(toRemove, user)
+		}
+	} else {
+		for _, user := range t.Users {
+			if current[user] {
+				toRemove = append(toRemove, user)
+			}
+		}
+	}
+
+	if len(toRemove) == 0 {
+		state.State = StateAbsent
+		return state
+	}
+
+	for _, user := range toRemove {
+		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", "acl:remove", t.App, user},
+		})
+		if err != nil {
+			return TaskOutputErrorFromExec(state, err, result)
+		}
+	}
+
+	state.Changed = true
+	state.State = StateAbsent
+	return state
+}
+
+// init registers the AclAppTask with the task registry
+func init() {
+	RegisterTask(&AclAppTask{})
+}

--- a/tasks/acl_app_task_integration_test.go
+++ b/tasks/acl_app_task_integration_test.go
@@ -1,0 +1,117 @@
+package tasks
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestIntegrationAclApp(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "acl")
+
+	appName := "docket-test-acl-app"
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	assertACL := func(t *testing.T, label string, want []string) {
+		t.Helper()
+		got, err := getAclAppUsers(appName)
+		if err != nil {
+			t.Fatalf("%s: getAclAppUsers failed: %v", label, err)
+		}
+		var gotSlice []string
+		for u := range got {
+			gotSlice = append(gotSlice, u)
+		}
+		sort.Strings(gotSlice)
+		sort.Strings(want)
+		if want == nil {
+			want = []string{}
+		}
+		if gotSlice == nil {
+			gotSlice = []string{}
+		}
+		if !reflect.DeepEqual(gotSlice, want) {
+			t.Errorf("%s: ACL = %v, want %v", label, gotSlice, want)
+		}
+	}
+
+	// initial state - empty ACL
+	assertACL(t, "initial", nil)
+
+	// add two users
+	addTask := AclAppTask{App: appName, Users: []string{"alice", "bob"}, State: StatePresent}
+	result := addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to add users: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first add")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+	assertACL(t, "after add", []string{"alice", "bob"})
+
+	// add same users again - idempotent
+	result = addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second add: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent add")
+	}
+	assertACL(t, "after idempotent add", []string{"alice", "bob"})
+
+	// remove one user
+	removeTask := AclAppTask{App: appName, Users: []string{"bob"}, State: StateAbsent}
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to remove user: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first remove")
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+	assertACL(t, "after remove bob", []string{"alice"})
+
+	// remove same user again - idempotent
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second remove: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent remove")
+	}
+	assertACL(t, "after idempotent remove", []string{"alice"})
+
+	// re-add bob and carol, then clear with empty users
+	if err := (AclAppTask{App: appName, Users: []string{"bob", "carol"}, State: StatePresent}).Execute().Error; err != nil {
+		t.Fatalf("failed to re-add users: %v", err)
+	}
+	assertACL(t, "after re-add", []string{"alice", "bob", "carol"})
+
+	clearTask := AclAppTask{App: appName, State: StateAbsent}
+	result = clearTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to clear ACL: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first clear")
+	}
+	assertACL(t, "after clear", nil)
+
+	// clear again - idempotent
+	result = clearTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second clear: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent clear")
+	}
+	assertACL(t, "after idempotent clear", nil)
+}

--- a/tasks/acl_app_task_test.go
+++ b/tasks/acl_app_task_test.go
@@ -1,0 +1,88 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAclAppTaskInvalidState(t *testing.T) {
+	task := AclAppTask{App: "test-app", Users: []string{"alice"}, State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestAclAppTaskPresentMissingApp(t *testing.T) {
+	task := AclAppTask{Users: []string{"alice"}, State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'app' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestAclAppTaskAbsentMissingApp(t *testing.T) {
+	task := AclAppTask{State: StateAbsent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'app' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestAclAppTaskPresentEmptyUsers(t *testing.T) {
+	task := AclAppTask{App: "test-app", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with empty users and state=present should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'users' must not be empty") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestGetTasksAclAppTaskParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: grant access
+      dokku_acl_app:
+        app: test-app
+        users:
+          - alice
+          - bob
+        state: present
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("grant access")
+	if task == nil {
+		t.Fatal("task 'grant access' not found")
+	}
+
+	aclTask, ok := task.(*AclAppTask)
+	if !ok {
+		t.Fatalf("task is not an AclAppTask (type is %T)", task)
+	}
+	if aclTask.App != "test-app" {
+		t.Errorf("App = %q, want %q", aclTask.App, "test-app")
+	}
+	if len(aclTask.Users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(aclTask.Users))
+	}
+	if aclTask.Users[0] != "alice" || aclTask.Users[1] != "bob" {
+		t.Errorf("Users = %v, want [alice, bob]", aclTask.Users)
+	}
+	if aclTask.State != StatePresent {
+		t.Errorf("State = %q, want %q", aclTask.State, StatePresent)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -157,6 +157,7 @@ func TestGetTasksWithTemplateContext(t *testing.T) {
 
 func TestRegisteredTasksExist(t *testing.T) {
 	expectedTasks := []string{
+		"dokku_acl_app",
 		"dokku_app",
 		"dokku_app_clone",
 		"dokku_app_json_property",
@@ -476,7 +477,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 52
+	expected := 53
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -487,6 +488,7 @@ func TestTaskDocStrings(t *testing.T) {
 		task Task
 		want string
 	}{
+		{&AclAppTask{}, "Manages the dokku-acl access list for a dokku application"},
 		{&AppTask{}, "Creates or destroys an app"},
 		{&AppCloneTask{}, "Clones an existing dokku app to a new app"},
 		{&AppJsonPropertyTask{}, "Manages the app.json configuration for a given dokku application"},


### PR DESCRIPTION
Wraps `dokku acl:add` and `acl:remove` from the `dokku-community/dokku-acl` plugin to manage which users can push to a given app. Idempotency reads the current ACL via `acl:list APP` (one user per line) and only invokes the per-user `acl:add` / `acl:remove` for entries that need changing. State `absent` with an empty `users` list clears the entire ACL, mirroring `buildpacks_task`. CI workflow installs the plugin and the integration test gates on it via `skipIfPluginMissingT(t, "acl")`.

Closes #192