### PR TITLE
feat: add acl_service_task

### DIFF
--- a/docs/dokku_acl_service.md
+++ b/docs/dokku_acl_service.md
@@ -1,0 +1,35 @@
+# dokku_acl_service
+
+Manages the dokku-acl access list for a dokku service
+
+## Grant users access to a redis service
+
+```yaml
+dokku_acl_service:
+    service: my-redis
+    type: redis
+    users:
+        - alice
+        - bob
+```
+
+## Revoke a user's access to a redis service
+
+```yaml
+dokku_acl_service:
+    service: my-redis
+    type: redis
+    users:
+        - bob
+    state: absent
+```
+
+## Clear the entire ACL for a redis service
+
+```yaml
+dokku_acl_service:
+    service: my-redis
+    type: redis
+    users: []
+    state: absent
+```

--- a/tasks/acl_service_task.go
+++ b/tasks/acl_service_task.go
@@ -1,0 +1,224 @@
+package tasks
+
+import (
+	"fmt"
+	"strings"
+
+	"docket/subprocess"
+)
+
+// AclServiceTask manages the dokku-acl access list for a dokku service
+type AclServiceTask struct {
+	// Service is the name of the service instance
+	Service string `required:"true" yaml:"service"`
+
+	// Type is the type of service (e.g. redis, postgres)
+	Type string `required:"true" yaml:"type"`
+
+	// Users is the list of users to add or remove from the ACL
+	Users []string `required:"false" yaml:"users"`
+
+	// State is the desired state of the ACL entries
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+}
+
+// AclServiceTaskExample contains an example of an AclServiceTask
+type AclServiceTaskExample struct {
+	// Name is the task name holding the AclServiceTask description
+	Name string `yaml:"-"`
+
+	// AclServiceTask is the AclServiceTask configuration
+	AclServiceTask AclServiceTask `yaml:"dokku_acl_service"`
+}
+
+// GetName returns the name of the example
+func (e AclServiceTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the acl service task
+func (t AclServiceTask) Doc() string {
+	return "Manages the dokku-acl access list for a dokku service"
+}
+
+// Examples returns the examples for the acl service task
+func (t AclServiceTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]AclServiceTaskExample{
+		{
+			Name: "Grant users access to a redis service",
+			AclServiceTask: AclServiceTask{
+				Service: "my-redis",
+				Type:    "redis",
+				Users:   []string{"alice", "bob"},
+			},
+		},
+		{
+			Name: "Revoke a user's access to a redis service",
+			AclServiceTask: AclServiceTask{
+				Service: "my-redis",
+				Type:    "redis",
+				Users:   []string{"bob"},
+				State:   StateAbsent,
+			},
+		},
+		{
+			Name: "Clear the entire ACL for a redis service",
+			AclServiceTask: AclServiceTask{
+				Service: "my-redis",
+				Type:    "redis",
+				State:   StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute manages the service ACL
+func (t AclServiceTask) Execute() TaskOutputState {
+	return DispatchState(t.State, map[State]func() TaskOutputState{
+		StatePresent: func() TaskOutputState { return addAclServiceUsers(t) },
+		StateAbsent:  func() TaskOutputState { return removeAclServiceUsers(t) },
+	})
+}
+
+// getAclServiceUsers reads the current ACL for a service via
+// `acl:list-service TYPE SERVICE`. The plugin's `cmd-acl-list-service`
+// emits one username per line on STDERR (via `ls -1 ... >&2`), unlike
+// `acl:list` which uses stdout, so we read stderr here.
+func getAclServiceUsers(serviceType, service string) (map[string]bool, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "acl:list-service", serviceType, service},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	users := map[string]bool{}
+	for _, line := range strings.Split(result.StderrContents(), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		users[trimmed] = true
+	}
+	return users, nil
+}
+
+// validateAclServiceTask checks the required fields shared by both states
+func validateAclServiceTask(t AclServiceTask) error {
+	if t.Service == "" {
+		return fmt.Errorf("'service' is required")
+	}
+	if t.Type == "" {
+		return fmt.Errorf("'type' is required")
+	}
+	return nil
+}
+
+// addAclServiceUsers adds users to a service's ACL, skipping ones already present
+func addAclServiceUsers(t AclServiceTask) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   StateAbsent,
+	}
+
+	if err := validateAclServiceTask(t); err != nil {
+		state.Error = err
+		return state
+	}
+	if len(t.Users) == 0 {
+		state.Error = fmt.Errorf("'users' must not be empty for state 'present'")
+		return state
+	}
+
+	current, err := getAclServiceUsers(t.Type, t.Service)
+	if err != nil {
+		state.Error = err
+		state.Message = err.Error()
+		return state
+	}
+
+	var toAdd []string
+	for _, user := range t.Users {
+		if !current[user] {
+			toAdd = append(toAdd, user)
+		}
+	}
+
+	if len(toAdd) == 0 {
+		state.State = StatePresent
+		return state
+	}
+
+	for _, user := range toAdd {
+		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", "acl:add-service", t.Type, t.Service, user},
+		})
+		if err != nil {
+			return TaskOutputErrorFromExec(state, err, result)
+		}
+	}
+
+	state.Changed = true
+	state.State = StatePresent
+	return state
+}
+
+// removeAclServiceUsers removes users from a service's ACL. With an empty
+// Users list, removes every entry currently in the ACL (i.e. clears it).
+func removeAclServiceUsers(t AclServiceTask) TaskOutputState {
+	state := TaskOutputState{
+		Changed: false,
+		State:   StatePresent,
+	}
+
+	if err := validateAclServiceTask(t); err != nil {
+		state.Error = err
+		return state
+	}
+
+	current, err := getAclServiceUsers(t.Type, t.Service)
+	if err != nil {
+		state.Error = err
+		state.Message = err.Error()
+		return state
+	}
+
+	var toRemove []string
+	if len(t.Users) == 0 {
+		for user := range current {
+			toRemove = append(toRemove, user)
+		}
+	} else {
+		for _, user := range t.Users {
+			if current[user] {
+				toRemove = append(toRemove, user)
+			}
+		}
+	}
+
+	if len(toRemove) == 0 {
+		state.State = StateAbsent
+		return state
+	}
+
+	for _, user := range toRemove {
+		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", "acl:remove-service", t.Type, t.Service, user},
+		})
+		if err != nil {
+			return TaskOutputErrorFromExec(state, err, result)
+		}
+	}
+
+	state.Changed = true
+	state.State = StateAbsent
+	return state
+}
+
+// init registers the AclServiceTask with the task registry
+func init() {
+	RegisterTask(&AclServiceTask{})
+}

--- a/tasks/acl_service_task_integration_test.go
+++ b/tasks/acl_service_task_integration_test.go
@@ -1,0 +1,125 @@
+package tasks
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestIntegrationAclService(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "acl")
+	skipIfPluginMissingT(t, "redis")
+
+	serviceType := "redis"
+	serviceName := "docket-test-acl-service"
+
+	// ensure clean state and create the redis service
+	destroyService(serviceType, serviceName)
+	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(); r.Error != nil {
+		t.Fatalf("failed to create redis service: %v", r.Error)
+	}
+	t.Cleanup(func() {
+		destroyService(serviceType, serviceName)
+	})
+
+	assertACL := func(t *testing.T, label string, want []string) {
+		t.Helper()
+		got, err := getAclServiceUsers(serviceType, serviceName)
+		if err != nil {
+			t.Fatalf("%s: getAclServiceUsers failed: %v", label, err)
+		}
+		var gotSlice []string
+		for u := range got {
+			gotSlice = append(gotSlice, u)
+		}
+		sort.Strings(gotSlice)
+		sort.Strings(want)
+		if want == nil {
+			want = []string{}
+		}
+		if gotSlice == nil {
+			gotSlice = []string{}
+		}
+		if !reflect.DeepEqual(gotSlice, want) {
+			t.Errorf("%s: ACL = %v, want %v", label, gotSlice, want)
+		}
+	}
+
+	// initial state - empty ACL
+	assertACL(t, "initial", nil)
+
+	// add two users
+	addTask := AclServiceTask{Service: serviceName, Type: serviceType, Users: []string{"alice", "bob"}, State: StatePresent}
+	result := addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to add users: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first add")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+	assertACL(t, "after add", []string{"alice", "bob"})
+
+	// add same users again - idempotent
+	result = addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second add: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent add")
+	}
+	assertACL(t, "after idempotent add", []string{"alice", "bob"})
+
+	// remove one user
+	removeTask := AclServiceTask{Service: serviceName, Type: serviceType, Users: []string{"bob"}, State: StateAbsent}
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to remove user: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first remove")
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+	assertACL(t, "after remove bob", []string{"alice"})
+
+	// remove same user again - idempotent
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second remove: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent remove")
+	}
+	assertACL(t, "after idempotent remove", []string{"alice"})
+
+	// re-add bob and carol, then clear with empty users
+	if err := (AclServiceTask{Service: serviceName, Type: serviceType, Users: []string{"bob", "carol"}, State: StatePresent}).Execute().Error; err != nil {
+		t.Fatalf("failed to re-add users: %v", err)
+	}
+	assertACL(t, "after re-add", []string{"alice", "bob", "carol"})
+
+	clearTask := AclServiceTask{Service: serviceName, Type: serviceType, State: StateAbsent}
+	result = clearTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to clear ACL: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first clear")
+	}
+	assertACL(t, "after clear", nil)
+
+	// clear again - idempotent
+	result = clearTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second clear: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent clear")
+	}
+	assertACL(t, "after idempotent clear", nil)
+}

--- a/tasks/acl_service_task_test.go
+++ b/tasks/acl_service_task_test.go
@@ -1,0 +1,96 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAclServiceTaskInvalidState(t *testing.T) {
+	task := AclServiceTask{Service: "my-redis", Type: "redis", Users: []string{"alice"}, State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestAclServiceTaskMissingService(t *testing.T) {
+	for _, st := range []State{StatePresent, StateAbsent} {
+		task := AclServiceTask{Type: "redis", Users: []string{"alice"}, State: st}
+		result := task.Execute()
+		if result.Error == nil {
+			t.Fatalf("Execute without service (state=%s) should return an error", st)
+		}
+		if !strings.Contains(result.Error.Error(), "'service' is required") {
+			t.Errorf("state=%s: unexpected error: %v", st, result.Error)
+		}
+	}
+}
+
+func TestAclServiceTaskMissingType(t *testing.T) {
+	for _, st := range []State{StatePresent, StateAbsent} {
+		task := AclServiceTask{Service: "my-redis", Users: []string{"alice"}, State: st}
+		result := task.Execute()
+		if result.Error == nil {
+			t.Fatalf("Execute without type (state=%s) should return an error", st)
+		}
+		if !strings.Contains(result.Error.Error(), "'type' is required") {
+			t.Errorf("state=%s: unexpected error: %v", st, result.Error)
+		}
+	}
+}
+
+func TestAclServiceTaskPresentEmptyUsers(t *testing.T) {
+	task := AclServiceTask{Service: "my-redis", Type: "redis", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with empty users and state=present should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'users' must not be empty") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestGetTasksAclServiceTaskParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: grant access
+      dokku_acl_service:
+        service: my-redis
+        type: redis
+        users:
+          - alice
+          - bob
+        state: present
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("grant access")
+	if task == nil {
+		t.Fatal("task 'grant access' not found")
+	}
+
+	aclTask, ok := task.(*AclServiceTask)
+	if !ok {
+		t.Fatalf("task is not an AclServiceTask (type is %T)", task)
+	}
+	if aclTask.Service != "my-redis" {
+		t.Errorf("Service = %q, want %q", aclTask.Service, "my-redis")
+	}
+	if aclTask.Type != "redis" {
+		t.Errorf("Type = %q, want %q", aclTask.Type, "redis")
+	}
+	if len(aclTask.Users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(aclTask.Users))
+	}
+	if aclTask.Users[0] != "alice" || aclTask.Users[1] != "bob" {
+		t.Errorf("Users = %v, want [alice, bob]", aclTask.Users)
+	}
+	if aclTask.State != StatePresent {
+		t.Errorf("State = %q, want %q", aclTask.State, StatePresent)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -158,6 +158,7 @@ func TestGetTasksWithTemplateContext(t *testing.T) {
 func TestRegisteredTasksExist(t *testing.T) {
 	expectedTasks := []string{
 		"dokku_acl_app",
+		"dokku_acl_service",
 		"dokku_app",
 		"dokku_app_clone",
 		"dokku_app_json_property",
@@ -477,7 +478,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 53
+	expected := 54
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -489,6 +490,7 @@ func TestTaskDocStrings(t *testing.T) {
 		want string
 	}{
 		{&AclAppTask{}, "Manages the dokku-acl access list for a dokku application"},
+		{&AclServiceTask{}, "Manages the dokku-acl access list for a dokku service"},
 		{&AppTask{}, "Creates or destroys an app"},
 		{&AppCloneTask{}, "Clones an existing dokku app to a new app"},
 		{&AppJsonPropertyTask{}, "Manages the app.json configuration for a given dokku application"},


### PR DESCRIPTION
Wraps `dokku acl:add-service` and `acl:remove-service` from the `dokku-community/dokku-acl` plugin to manage which users can manage a given service. Idempotency reads the current ACL via `acl:list-service TYPE SERVICE` and only invokes the per-user subcommands for entries that need changing. The plugin's `cmd-acl-list-service` writes its listing to stderr (`ls -1 ... >&2`) rather than stdout (unlike `acl:list`), so the parser reads `StderrContents()`. State `absent` with an empty `users` list clears the ACL, mirroring `acl_app_task` and `buildpacks_task`. Integration test creates a temporary redis service and exercises add / idempotent re-add / remove / idempotent re-remove / clear / idempotent re-clear; CI already installs both the acl and redis plugins.

Closes #193