### PR TITLE
feat: add plan subcommand and Plan() task interface method

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,3 +60,32 @@ jobs:
         run: sudo dokku plugin:install https://github.com/dokku-community/dokku-acl.git acl
       - name: run integration tests
         run: sudo go test -v -count=1 -run TestIntegration ./tasks/
+
+  bats-test:
+    name: bats-test
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: enable docker legacy link support
+        run: |
+          sudo mkdir -p /etc/systemd/system/docker.service.d
+          printf '[Service]\nEnvironment="DOCKER_KEEP_DEPRECATED_LEGACY_LINKS_ENV_VARS=1"\n' | sudo tee /etc/systemd/system/docker.service.d/legacy-links.conf
+          sudo systemctl daemon-reload
+          sudo systemctl restart docker
+      - name: install dokku
+        run: |
+          sudo mkdir -p /etc/apt/keyrings
+          curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
+          echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
+          sudo apt-get update -qq
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku
+          sudo dokku plugin:install-dependencies --core
+      - name: install bats
+        run: sudo apt-get install -qq -y bats bats-support bats-assert
+      - name: build docket
+        run: go build -o docket .
+      - name: run bats tests
+        run: sudo --preserve-env=PATH bats tests/bats/

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ validation/*
 .env*
 
 docket
+tmp/

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ docket apply --tasks http://dokku.com/docket/example.yml
 
 Tasks that perform multiple operations (e.g. `dokku_config` setting several keys) report each individual mutation under the task line:
 
-```
+```text
 [~]       configure  (2 key(s) to set)
           - set KEY_ONE (new)
           - set KEY_TWO (was set)
@@ -71,7 +71,7 @@ Tasks that perform multiple operations (e.g. `dokku_config` setting several keys
 Plan: 1 task(s); 1 would change, 0 in sync, 0 error(s).
 ```
 
-A small number of tasks (notably the `dokku_*_property` and `dokku_*_toggle` families, plus the auth tasks) cannot probe their current state without invoking the corresponding dokku command, so their plan output reports drift unconditionally with `(... not probed)` in the reason. These plans become an accurate "would change" only when the underlying dokku command exposes a probe.
+A handful of tasks (notably `dokku_git_auth`, `dokku_registry_auth`, and `dokku_storage_ensure`) cannot probe their current state without invoking the corresponding dokku command, so their plan output reports drift unconditionally with `(... not probed)` in the reason. The property and toggle task families do probe via `<plugin>:report` and report drift accurately.
 
 Some other ideas:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Run it:
 docket apply
 ```
 
-Running `docket` with no subcommand prints the available commands. Use `docket apply` to execute a task file, or `docket version` to print the binary's version.
+Running `docket` with no subcommand prints the available commands. Use `docket apply` to execute a task file, `docket plan` to preview the changes a task file would make without mutating any state, or `docket version` to print the binary's version.
 
 A task file can also be specified via flag, and may be a file retrieved via http:
 
@@ -48,6 +48,30 @@ docket apply --tasks path/to/task.yml
 # html file
 docket apply --tasks http://dokku.com/docket/example.yml
 ```
+
+### Previewing changes with `plan`
+
+`docket plan` reads each task's current state from the live dokku server and reports what `apply` would change, without invoking any mutating dokku command. Each task line is prefixed with a marker:
+
+| Marker | Meaning |
+|--------|---------|
+| `[ok]` | Task is in sync; `apply` would not change anything |
+| `[+]` | `apply` would create new state |
+| `[~]` | `apply` would modify existing state |
+| `[-]` | `apply` would remove existing state |
+| `[error]` | The read-state probe itself errored (drift unknown) |
+
+Tasks that perform multiple operations (e.g. `dokku_config` setting several keys) report each individual mutation under the task line:
+
+```
+[~]       configure  (2 key(s) to set)
+          - set KEY_ONE (new)
+          - set KEY_TWO (was set)
+
+Plan: 1 task(s); 1 would change, 0 in sync, 0 error(s).
+```
+
+A small number of tasks (notably the `dokku_*_property` and `dokku_*_toggle` families, plus the auth tasks) cannot probe their current state without invoking the corresponding dokku command, so their plan output reports drift unconditionally with `(... not probed)` in the reason. These plans become an accurate "would change" only when the underlying dokku command exposes a probe.
 
 Some other ideas:
 
@@ -142,6 +166,13 @@ func (t LollipopTask) Execute() TaskOutputState {
   })
 }
 
+func (t LollipopTask) Plan() PlanResult {
+  return DispatchPlan(t.State, map[State]func() PlanResult{
+    "present": func() PlanResult { /* read-only probe; never mutates */ },
+    "absent":  func() PlanResult { /* read-only probe; never mutates */ },
+  })
+}
+
 func init() {
     RegisterTask(&LollipopTask{})
 }
@@ -150,5 +181,7 @@ func init() {
 The `LollipopTask` struct contains the fields necessary for the task. The only necessary field is `State`, which holds the desired state of the task. All other fields are completely custom for the task at hand.
 
 The `Execute()` function should use `DispatchState()` to route to the appropriate handler based on the task's state. `DispatchState` automatically sets `DesiredState` on the returned `TaskOutputState`.
+
+The `Plan()` function reports what `Execute()` would change without actually mutating any state. It must never call a mutating dokku command. Plan handlers return a `PlanResult` whose `InSync` field is `true` when no change is needed, otherwise `Status` (`"+"`, `"~"`, `"-"`) and `Reason` describe the drift. For tasks that perform multiple operations (e.g. setting several keys in one call), populate `PlanResult.Mutations` with one entry per atomic change so the plan output can itemize the diff. When a task lacks a probe for its current state, return a conservative `PlanResult` with `InSync: false` and a `Reason` that calls out the limitation. Use `DispatchPlan()` to route to per-state handlers; it sets `DesiredState` on the returned result.
 
 The `init()` function registers the task for usage within a recipe.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Running `docket` with no subcommand prints the available commands. Use `docket a
 | `[+]` | `apply` would create new state |
 | `[~]` | `apply` would modify existing state |
 | `[-]` | `apply` would remove existing state |
-| `[error]` | The read-state probe itself errored (drift unknown) |
+| `[!]` | The read-state probe itself errored (drift unknown) |
 
 Tasks that perform multiple operations (e.g. `dokku_config` setting several keys) report each individual mutation under the task line:
 

--- a/README.md
+++ b/README.md
@@ -39,16 +39,6 @@ docket apply
 
 Running `docket` with no subcommand prints the available commands. Use `docket apply` to execute a task file, `docket plan` to preview the changes a task file would make without mutating any state, or `docket version` to print the binary's version.
 
-A task file can also be specified via flag, and may be a file retrieved via http:
-
-```shell
-# alternate path
-docket apply --tasks path/to/task.yml
-
-# html file
-docket apply --tasks http://dokku.com/docket/example.yml
-```
-
 ### Previewing changes with `plan`
 
 `docket plan` reads each task's current state from the live dokku server and reports what `apply` would change, without invoking any mutating dokku command. Each task line is prefixed with a marker:
@@ -71,7 +61,19 @@ Tasks that perform multiple operations (e.g. `dokku_config` setting several keys
 Plan: 1 task(s); 1 would change, 0 in sync, 0 error(s).
 ```
 
-A handful of tasks (notably `dokku_git_auth`, `dokku_registry_auth`, and `dokku_storage_ensure`) cannot probe their current state without invoking the corresponding dokku command, so their plan output reports drift unconditionally with `(... not probed)` in the reason. The property and toggle task families do probe via `<plugin>:report` and report drift accurately.
+`Plan()` results drive `apply`: every task probes the server once, and `apply` reuses that probe to decide whether to mutate. `apply` on an already-converged server reports `Changed=false` for every task; back-to-back applies are no-ops by design.
+
+A handful of tasks (notably `dokku_git_auth`, `dokku_registry_auth`, and `dokku_storage_ensure`) cannot probe their current state without invoking the corresponding dokku command, so their plan output reports drift unconditionally with `(... not probed)` in the reason.
+
+A task file can also be specified via flag, and may be a file retrieved via http:
+
+```shell
+# alternate path
+docket apply --tasks path/to/task.yml
+
+# html file
+docket apply --tasks http://dokku.com/docket/example.yml
+```
 
 Some other ideas:
 
@@ -159,18 +161,30 @@ type LollipopTask struct {
   State State `required:"true" yaml:"state" default:"present"`
 }
 
-func (t LollipopTask) Execute() TaskOutputState {
-  return DispatchState(t.State, map[State]func() TaskOutputState{
-    "present": func() TaskOutputState { /* ... */ },
-    "absent":  func() TaskOutputState { /* ... */ },
+func (t LollipopTask) Plan() PlanResult {
+  return DispatchPlan(t.State, map[State]func() PlanResult{
+    "present": func() PlanResult {
+      // Probe the server once, decide whether to mutate.
+      if /* already in desired state */ {
+        return PlanResult{InSync: true, Status: PlanStatusOK}
+      }
+      return PlanResult{
+        InSync:    false,
+        Status:    PlanStatusCreate, // or PlanStatusModify, PlanStatusDestroy
+        Reason:    "...",
+        Mutations: []string{"create lollipop"},
+        apply: func() TaskOutputState {
+          // Run the underlying dokku command. Return Changed=true on success.
+          return TaskOutputState{Changed: true, State: StatePresent}
+        },
+      }
+    },
+    "absent": func() PlanResult { /* ... */ },
   })
 }
 
-func (t LollipopTask) Plan() PlanResult {
-  return DispatchPlan(t.State, map[State]func() PlanResult{
-    "present": func() PlanResult { /* read-only probe; never mutates */ },
-    "absent":  func() PlanResult { /* read-only probe; never mutates */ },
-  })
+func (t LollipopTask) Execute() TaskOutputState {
+  return ExecutePlan(t.Plan())
 }
 
 func init() {
@@ -180,8 +194,10 @@ func init() {
 
 The `LollipopTask` struct contains the fields necessary for the task. The only necessary field is `State`, which holds the desired state of the task. All other fields are completely custom for the task at hand.
 
-The `Execute()` function should use `DispatchState()` to route to the appropriate handler based on the task's state. `DispatchState` automatically sets `DesiredState` on the returned `TaskOutputState`.
+`Plan()` is the canonical implementation: it probes the live server once, computes the diff, and returns a `PlanResult`. When `InSync` is `false`, `Plan()` embeds an `apply` closure that performs the underlying mutation. For tasks that perform multiple operations (e.g. setting several config keys in one call), populate `PlanResult.Mutations` with one entry per atomic change so the plan output can itemize the diff.
 
-The `Plan()` function reports what `Execute()` would change without actually mutating any state. It must never call a mutating dokku command. Plan handlers return a `PlanResult` whose `InSync` field is `true` when no change is needed, otherwise `Status` (`"+"`, `"~"`, `"-"`) and `Reason` describe the drift. For tasks that perform multiple operations (e.g. setting several keys in one call), populate `PlanResult.Mutations` with one entry per atomic change so the plan output can itemize the diff. When a task lacks a probe for its current state, return a conservative `PlanResult` with `InSync: false` and a `Reason` that calls out the limitation. Use `DispatchPlan()` to route to per-state handlers; it sets `DesiredState` on the returned result.
+`Execute()` is always `return ExecutePlan(t.Plan())`. The shared `ExecutePlan` helper handles the InSync, error, and apply cases uniformly so the per-state mutation logic lives in exactly one place per task.
+
+`DispatchPlan` and `DispatchState` automatically set `DesiredState` on the returned result.
 
 The `init()` function registers the task for usage within a recipe.

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -1,0 +1,172 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dokku/docket/tasks"
+
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/posener/complete"
+	flag "github.com/spf13/pflag"
+)
+
+// PlanCommand reports the drift each task in a docket recipe would produce
+// against the live server, without mutating it. Plan never invokes any
+// mutating dokku command.
+type PlanCommand struct {
+	command.Meta
+
+	tasksFile string
+	arguments map[string]*Argument
+}
+
+func (c *PlanCommand) Name() string {
+	return "plan"
+}
+
+func (c *PlanCommand) Synopsis() string {
+	return "Reports the drift a docket task file would produce, without mutating state"
+}
+
+func (c *PlanCommand) Help() string {
+	return command.CommandHelp(c)
+}
+
+func (c *PlanCommand) Examples() map[string]string {
+	appName := os.Getenv("CLI_APP_NAME")
+	return map[string]string{
+		"Plan tasks from the default tasks.yml": fmt.Sprintf("%s %s", appName, c.Name()),
+		"Plan tasks from a specific file":       fmt.Sprintf("%s %s --tasks path/to/task.yml", appName, c.Name()),
+		"Plan tasks from a remote URL":          fmt.Sprintf("%s %s --tasks http://dokku.com/docket/example.yml", appName, c.Name()),
+		"Override a task input":                 fmt.Sprintf("%s %s --name lollipop", appName, c.Name()),
+	}
+}
+
+func (c *PlanCommand) Arguments() []command.Argument {
+	return []command.Argument{}
+}
+
+func (c *PlanCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *PlanCommand) ParsedArguments(args []string) (map[string]command.Argument, error) {
+	return command.ParseArguments(args, c.Arguments())
+}
+
+func (c *PlanCommand) FlagSet() *flag.FlagSet {
+	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	f.StringVar(&c.tasksFile, "tasks", "tasks.yml", "a yaml file containing a task list")
+
+	taskFile := getTaskYamlFilename(os.Args)
+	data, err := os.ReadFile(taskFile)
+	if err != nil {
+		return f
+	}
+
+	arguments, err := registerInputFlags(f, data)
+	if err != nil {
+		return f
+	}
+	c.arguments = arguments
+
+	return f
+}
+
+func (c *PlanCommand) AutocompleteFlags() complete.Flags {
+	return command.MergeAutocompleteFlags(
+		c.Meta.AutocompleteFlags(command.FlagSetClient),
+		complete.Flags{
+			"--tasks": complete.PredictFiles("*.yml"),
+		},
+	)
+}
+
+// Run executes the plan command. It iterates every task in the parsed recipe,
+// invokes Plan() (which is contractually read-only), and prints a one-line
+// summary per task plus a final summary line.
+//
+// Exit codes:
+//
+//	0 - plan completed successfully (regardless of drift)
+//	1 - read error, parse error, or read-state probe error
+func (c *PlanCommand) Run(args []string) int {
+	flags := c.FlagSet()
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(err.Error())
+		c.Ui.Error(command.CommandErrorText(c))
+		return 1
+	}
+
+	data, err := os.ReadFile(c.tasksFile)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("read error: %v", err))
+		return 1
+	}
+
+	context := make(map[string]interface{})
+	for name, argument := range c.arguments {
+		if argument.Required && !argument.HasValue() {
+			c.Ui.Error(fmt.Sprintf("Missing flag '--%s'", name))
+			return 1
+		}
+		context[name] = argument.GetValue()
+	}
+
+	taskList, err := tasks.GetTasks(data, context)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("task error: %v", err))
+		return 1
+	}
+
+	totals := struct {
+		tasks       int
+		wouldChange int
+		inSync      int
+		errors      int
+	}{}
+	hasError := false
+
+	for _, name := range taskList.Keys() {
+		task := taskList.Get(name)
+		result := task.Plan()
+		totals.tasks++
+
+		switch {
+		case result.Error != nil:
+			totals.errors++
+			hasError = true
+			c.Ui.Error(fmt.Sprintf("[error]   %s  (%v)", name, result.Error))
+		case result.InSync:
+			totals.inSync++
+			c.Ui.Info(fmt.Sprintf("[ok]      %s  (in sync)", name))
+		default:
+			totals.wouldChange++
+			marker := string(result.Status)
+			if marker == "" {
+				marker = string(tasks.PlanStatusModify)
+			}
+			line := fmt.Sprintf("[%s]       %s", marker, name)
+			if result.Reason != "" {
+				line = fmt.Sprintf("[%s]       %s  (%s)", marker, name, result.Reason)
+			}
+			c.Ui.Info(line)
+			for _, m := range result.Mutations {
+				c.Ui.Info(fmt.Sprintf("          - %s", m))
+			}
+		}
+	}
+
+	c.Ui.Info("")
+	c.Ui.Info(fmt.Sprintf(
+		"Plan: %d task(s); %d would change, %d in sync, %d error(s).",
+		totals.tasks, totals.wouldChange, totals.inSync, totals.errors,
+	))
+
+	if hasError {
+		return 1
+	}
+	return 0
+}

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -138,7 +138,7 @@ func (c *PlanCommand) Run(args []string) int {
 		case result.Error != nil:
 			totals.errors++
 			hasError = true
-			c.Ui.Error(fmt.Sprintf("[error]   %s  (%v)", name, result.Error))
+			c.Ui.Error(fmt.Sprintf("[%s]       %s  (%v)", tasks.PlanStatusError, name, result.Error))
 		case result.InSync:
 			totals.inSync++
 			c.Ui.Info(fmt.Sprintf("[ok]      %s  (in sync)", name))

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -12,8 +12,8 @@ import (
 )
 
 // PlanCommand reports the drift each task in a docket recipe would produce
-// against the live server, without mutating it. Plan never invokes any
-// mutating dokku command.
+// against the live server, without mutating it. Plan is fully driven by the
+// per-task Plan() method; the apply path is never invoked.
 type PlanCommand struct {
 	command.Meta
 
@@ -83,9 +83,9 @@ func (c *PlanCommand) AutocompleteFlags() complete.Flags {
 	)
 }
 
-// Run executes the plan command. It iterates every task in the parsed recipe,
-// invokes Plan() (which is contractually read-only), and prints a one-line
-// summary per task plus a final summary line.
+// Run iterates every task in the parsed recipe, invokes Plan() (read-only
+// by contract), and prints a one-line summary per task plus a final
+// summary line.
 //
 // Exit codes:
 //

--- a/commands/plan_test.go
+++ b/commands/plan_test.go
@@ -6,10 +6,8 @@ import (
 	"github.com/dokku/docket/tasks"
 )
 
-// TestPlanCommandMetadata is a simple smoke check that the PlanCommand
-// satisfies the cli.Command interface and exposes sensible Name / Synopsis
-// strings. Keeping this test lightweight avoids coupling to the cli-skeleton
-// internals; full subcommand wiring is exercised by the bats suite.
+// TestPlanCommandMetadata is a smoke check that PlanCommand exposes a
+// reasonable Name and Synopsis, satisfying the cli.Command interface.
 func TestPlanCommandMetadata(t *testing.T) {
 	c := &PlanCommand{}
 	if c.Name() != "plan" {
@@ -20,9 +18,8 @@ func TestPlanCommandMetadata(t *testing.T) {
 	}
 }
 
-// TestPlanCommandExamples ensures every example string mentions the command
-// name. The cli-skeleton uses these in --help output; a misspelled subcommand
-// in an example would silently mislead users.
+// TestPlanCommandExamples ensures every example string is non-empty. The
+// cli-skeleton uses these in --help output.
 func TestPlanCommandExamples(t *testing.T) {
 	c := &PlanCommand{}
 	examples := c.Examples()
@@ -36,10 +33,8 @@ func TestPlanCommandExamples(t *testing.T) {
 	}
 }
 
-// TestPlanCommandHelpDoesNotPanic guards against a regression where adding a
-// flag whose declaration depends on a parsed tasks.yml caused FlagSet() to
-// panic at help time when the file did not exist. The current implementation
-// silently ignores read errors; this test pins that behavior.
+// TestPlanCommandHelpDoesNotPanic guards against a regression where
+// FlagSet panics at help time when no tasks.yml exists on disk.
 func TestPlanCommandHelpDoesNotPanic(t *testing.T) {
 	c := &PlanCommand{}
 	defer func() {
@@ -50,10 +45,10 @@ func TestPlanCommandHelpDoesNotPanic(t *testing.T) {
 	_ = c.FlagSet()
 }
 
-// TestPlanCommandUsesSamePlanInterface guards the contract between the
-// commands package and the tasks package: PlanCommand must consume tasks.Task,
-// which must expose Plan() returning tasks.PlanResult.
-func TestPlanCommandUsesSamePlanInterface(t *testing.T) {
+// TestPlanCommandUsesPlanInterface guards the contract between the commands
+// package and the tasks package: PlanCommand consumes tasks.Task, which
+// must expose Plan() returning tasks.PlanResult.
+func TestPlanCommandUsesPlanInterface(t *testing.T) {
 	var _ interface {
 		Plan() tasks.PlanResult
 	} = (tasks.Task)(nil)

--- a/commands/plan_test.go
+++ b/commands/plan_test.go
@@ -1,0 +1,60 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/dokku/docket/tasks"
+)
+
+// TestPlanCommandMetadata is a simple smoke check that the PlanCommand
+// satisfies the cli.Command interface and exposes sensible Name / Synopsis
+// strings. Keeping this test lightweight avoids coupling to the cli-skeleton
+// internals; full subcommand wiring is exercised by the bats suite.
+func TestPlanCommandMetadata(t *testing.T) {
+	c := &PlanCommand{}
+	if c.Name() != "plan" {
+		t.Errorf("Name = %q, want \"plan\"", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis must not be empty")
+	}
+}
+
+// TestPlanCommandExamples ensures every example string mentions the command
+// name. The cli-skeleton uses these in --help output; a misspelled subcommand
+// in an example would silently mislead users.
+func TestPlanCommandExamples(t *testing.T) {
+	c := &PlanCommand{}
+	examples := c.Examples()
+	if len(examples) == 0 {
+		t.Fatal("expected at least one example")
+	}
+	for label, example := range examples {
+		if example == "" {
+			t.Errorf("example %q is empty", label)
+		}
+	}
+}
+
+// TestPlanCommandHelpDoesNotPanic guards against a regression where adding a
+// flag whose declaration depends on a parsed tasks.yml caused FlagSet() to
+// panic at help time when the file did not exist. The current implementation
+// silently ignores read errors; this test pins that behavior.
+func TestPlanCommandHelpDoesNotPanic(t *testing.T) {
+	c := &PlanCommand{}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("FlagSet panicked without tasks.yml on disk: %v", r)
+		}
+	}()
+	_ = c.FlagSet()
+}
+
+// TestPlanCommandUsesSamePlanInterface guards the contract between the
+// commands package and the tasks package: PlanCommand must consume tasks.Task,
+// which must expose Plan() returning tasks.PlanResult.
+func TestPlanCommandUsesSamePlanInterface(t *testing.T) {
+	var _ interface {
+		Plan() tasks.PlanResult
+	} = (tasks.Task)(nil)
+}

--- a/main.go
+++ b/main.go
@@ -41,6 +41,9 @@ func Commands(ctx context.Context, meta command.Meta) map[string]cli.CommandFact
 		"apply": func() (cli.Command, error) {
 			return &commands.ApplyCommand{Meta: meta}, nil
 		},
+		"plan": func() (cli.Command, error) {
+			return &commands.PlanCommand{Meta: meta}, nil
+		},
 		"version": func() (cli.Command, error) {
 			return &command.VersionCommand{Meta: meta}, nil
 		},

--- a/tasks/acl_app_task.go
+++ b/tasks/acl_app_task.go
@@ -74,6 +74,66 @@ func (t AclAppTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the AclAppTask would produce.
+func (t AclAppTask) Plan() PlanResult {
+	if t.App == "" {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if len(t.Users) == 0 {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'users' must not be empty for state 'present'")}
+			}
+			current, err := getAclAppUsers(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			mutations := []string{}
+			for _, u := range t.Users {
+				if !current[u] {
+					mutations = append(mutations, "add "+u)
+				}
+			}
+			if len(mutations) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    fmt.Sprintf("%d user(s) to add", len(mutations)),
+				Mutations: mutations,
+			}
+		},
+		StateAbsent: func() PlanResult {
+			current, err := getAclAppUsers(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			mutations := []string{}
+			if len(t.Users) == 0 {
+				for u := range current {
+					mutations = append(mutations, "remove "+u)
+				}
+			} else {
+				for _, u := range t.Users {
+					if current[u] {
+						mutations = append(mutations, "remove "+u)
+					}
+				}
+			}
+			if len(mutations) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    fmt.Sprintf("%d user(s) to remove", len(mutations)),
+				Mutations: mutations,
+			}
+		},
+	})
+}
+
 // getAclAppUsers reads the current ACL for an app via `acl:list APP`. The
 // plugin emits one username per line; an empty ACL produces no output.
 func getAclAppUsers(app string) (map[string]bool, error) {

--- a/tasks/acl_app_task.go
+++ b/tasks/acl_app_task.go
@@ -68,10 +68,7 @@ func (t AclAppTask) Examples() ([]Doc, error) {
 
 // Execute manages the app ACL
 func (t AclAppTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return addAclAppUsers(t) },
-		StateAbsent:  func() TaskOutputState { return removeAclAppUsers(t) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the AclAppTask would produce.
@@ -88,20 +85,37 @@ func (t AclAppTask) Plan() PlanResult {
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
+			toAdd := []string{}
 			mutations := []string{}
 			for _, u := range t.Users {
 				if !current[u] {
+					toAdd = append(toAdd, u)
 					mutations = append(mutations, "add "+u)
 				}
 			}
-			if len(mutations) == 0 {
+			if len(toAdd) == 0 {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
-				Reason:    fmt.Sprintf("%d user(s) to add", len(mutations)),
+				Reason:    fmt.Sprintf("%d user(s) to add", len(toAdd)),
 				Mutations: mutations,
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					for _, u := range toAdd {
+						result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+							Command: "dokku",
+							Args:    []string{"--quiet", "acl:add", t.App, u},
+						})
+						if err != nil {
+							return TaskOutputErrorFromExec(state, err, result)
+						}
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
 			}
 		},
 		StateAbsent: func() PlanResult {
@@ -109,26 +123,44 @@ func (t AclAppTask) Plan() PlanResult {
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
+			toRemove := []string{}
 			mutations := []string{}
 			if len(t.Users) == 0 {
 				for u := range current {
+					toRemove = append(toRemove, u)
 					mutations = append(mutations, "remove "+u)
 				}
 			} else {
 				for _, u := range t.Users {
 					if current[u] {
+						toRemove = append(toRemove, u)
 						mutations = append(mutations, "remove "+u)
 					}
 				}
 			}
-			if len(mutations) == 0 {
+			if len(toRemove) == 0 {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
-				Reason:    fmt.Sprintf("%d user(s) to remove", len(mutations)),
+				Reason:    fmt.Sprintf("%d user(s) to remove", len(toRemove)),
 				Mutations: mutations,
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					for _, u := range toRemove {
+						result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+							Command: "dokku",
+							Args:    []string{"--quiet", "acl:remove", t.App, u},
+						})
+						if err != nil {
+							return TaskOutputErrorFromExec(state, err, result)
+						}
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
 			}
 		},
 	})
@@ -154,109 +186,6 @@ func getAclAppUsers(app string) (map[string]bool, error) {
 		users[trimmed] = true
 	}
 	return users, nil
-}
-
-// addAclAppUsers adds users to an app's ACL, skipping ones already present
-func addAclAppUsers(t AclAppTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StateAbsent,
-	}
-
-	if t.App == "" {
-		state.Error = fmt.Errorf("'app' is required")
-		return state
-	}
-	if len(t.Users) == 0 {
-		state.Error = fmt.Errorf("'users' must not be empty for state 'present'")
-		return state
-	}
-
-	current, err := getAclAppUsers(t.App)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	var toAdd []string
-	for _, user := range t.Users {
-		if !current[user] {
-			toAdd = append(toAdd, user)
-		}
-	}
-
-	if len(toAdd) == 0 {
-		state.State = StatePresent
-		return state
-	}
-
-	for _, user := range toAdd {
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    []string{"--quiet", "acl:add", t.App, user},
-		})
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-	}
-
-	state.Changed = true
-	state.State = StatePresent
-	return state
-}
-
-// removeAclAppUsers removes users from an app's ACL. With an empty Users list,
-// removes every entry currently in the ACL (i.e. clears it).
-func removeAclAppUsers(t AclAppTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StatePresent,
-	}
-
-	if t.App == "" {
-		state.Error = fmt.Errorf("'app' is required")
-		return state
-	}
-
-	current, err := getAclAppUsers(t.App)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	var toRemove []string
-	if len(t.Users) == 0 {
-		for user := range current {
-			toRemove = append(toRemove, user)
-		}
-	} else {
-		for _, user := range t.Users {
-			if current[user] {
-				toRemove = append(toRemove, user)
-			}
-		}
-	}
-
-	if len(toRemove) == 0 {
-		state.State = StateAbsent
-		return state
-	}
-
-	for _, user := range toRemove {
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    []string{"--quiet", "acl:remove", t.App, user},
-		})
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-	}
-
-	state.Changed = true
-	state.State = StateAbsent
-	return state
 }
 
 // init registers the AclAppTask with the task registry

--- a/tasks/acl_service_task.go
+++ b/tasks/acl_service_task.go
@@ -80,6 +80,66 @@ func (t AclServiceTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the AclServiceTask would produce.
+func (t AclServiceTask) Plan() PlanResult {
+	if err := validateAclServiceTask(t); err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if len(t.Users) == 0 {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'users' must not be empty for state 'present'")}
+			}
+			current, err := getAclServiceUsers(t.Type, t.Service)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			mutations := []string{}
+			for _, u := range t.Users {
+				if !current[u] {
+					mutations = append(mutations, "add "+u)
+				}
+			}
+			if len(mutations) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    fmt.Sprintf("%d user(s) to add", len(mutations)),
+				Mutations: mutations,
+			}
+		},
+		StateAbsent: func() PlanResult {
+			current, err := getAclServiceUsers(t.Type, t.Service)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			mutations := []string{}
+			if len(t.Users) == 0 {
+				for u := range current {
+					mutations = append(mutations, "remove "+u)
+				}
+			} else {
+				for _, u := range t.Users {
+					if current[u] {
+						mutations = append(mutations, "remove "+u)
+					}
+				}
+			}
+			if len(mutations) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    fmt.Sprintf("%d user(s) to remove", len(mutations)),
+				Mutations: mutations,
+			}
+		},
+	})
+}
+
 // getAclServiceUsers reads the current ACL for a service via
 // `acl:list-service TYPE SERVICE`. The plugin's `cmd-acl-list-service`
 // emits one username per line on STDERR (via `ls -1 ... >&2`), unlike

--- a/tasks/acl_service_task.go
+++ b/tasks/acl_service_task.go
@@ -74,10 +74,7 @@ func (t AclServiceTask) Examples() ([]Doc, error) {
 
 // Execute manages the service ACL
 func (t AclServiceTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return addAclServiceUsers(t) },
-		StateAbsent:  func() TaskOutputState { return removeAclServiceUsers(t) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the AclServiceTask would produce.
@@ -94,20 +91,37 @@ func (t AclServiceTask) Plan() PlanResult {
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
+			toAdd := []string{}
 			mutations := []string{}
 			for _, u := range t.Users {
 				if !current[u] {
+					toAdd = append(toAdd, u)
 					mutations = append(mutations, "add "+u)
 				}
 			}
-			if len(mutations) == 0 {
+			if len(toAdd) == 0 {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
-				Reason:    fmt.Sprintf("%d user(s) to add", len(mutations)),
+				Reason:    fmt.Sprintf("%d user(s) to add", len(toAdd)),
 				Mutations: mutations,
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					for _, u := range toAdd {
+						result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+							Command: "dokku",
+							Args:    []string{"--quiet", "acl:add-service", t.Type, t.Service, u},
+						})
+						if err != nil {
+							return TaskOutputErrorFromExec(state, err, result)
+						}
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
 			}
 		},
 		StateAbsent: func() PlanResult {
@@ -115,26 +129,44 @@ func (t AclServiceTask) Plan() PlanResult {
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
+			toRemove := []string{}
 			mutations := []string{}
 			if len(t.Users) == 0 {
 				for u := range current {
+					toRemove = append(toRemove, u)
 					mutations = append(mutations, "remove "+u)
 				}
 			} else {
 				for _, u := range t.Users {
 					if current[u] {
+						toRemove = append(toRemove, u)
 						mutations = append(mutations, "remove "+u)
 					}
 				}
 			}
-			if len(mutations) == 0 {
+			if len(toRemove) == 0 {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
-				Reason:    fmt.Sprintf("%d user(s) to remove", len(mutations)),
+				Reason:    fmt.Sprintf("%d user(s) to remove", len(toRemove)),
 				Mutations: mutations,
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					for _, u := range toRemove {
+						result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+							Command: "dokku",
+							Args:    []string{"--quiet", "acl:remove-service", t.Type, t.Service, u},
+						})
+						if err != nil {
+							return TaskOutputErrorFromExec(state, err, result)
+						}
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
 			}
 		},
 	})
@@ -173,109 +205,6 @@ func validateAclServiceTask(t AclServiceTask) error {
 		return fmt.Errorf("'type' is required")
 	}
 	return nil
-}
-
-// addAclServiceUsers adds users to a service's ACL, skipping ones already present
-func addAclServiceUsers(t AclServiceTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StateAbsent,
-	}
-
-	if err := validateAclServiceTask(t); err != nil {
-		state.Error = err
-		return state
-	}
-	if len(t.Users) == 0 {
-		state.Error = fmt.Errorf("'users' must not be empty for state 'present'")
-		return state
-	}
-
-	current, err := getAclServiceUsers(t.Type, t.Service)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	var toAdd []string
-	for _, user := range t.Users {
-		if !current[user] {
-			toAdd = append(toAdd, user)
-		}
-	}
-
-	if len(toAdd) == 0 {
-		state.State = StatePresent
-		return state
-	}
-
-	for _, user := range toAdd {
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    []string{"--quiet", "acl:add-service", t.Type, t.Service, user},
-		})
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-	}
-
-	state.Changed = true
-	state.State = StatePresent
-	return state
-}
-
-// removeAclServiceUsers removes users from a service's ACL. With an empty
-// Users list, removes every entry currently in the ACL (i.e. clears it).
-func removeAclServiceUsers(t AclServiceTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StatePresent,
-	}
-
-	if err := validateAclServiceTask(t); err != nil {
-		state.Error = err
-		return state
-	}
-
-	current, err := getAclServiceUsers(t.Type, t.Service)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	var toRemove []string
-	if len(t.Users) == 0 {
-		for user := range current {
-			toRemove = append(toRemove, user)
-		}
-	} else {
-		for _, user := range t.Users {
-			if current[user] {
-				toRemove = append(toRemove, user)
-			}
-		}
-	}
-
-	if len(toRemove) == 0 {
-		state.State = StateAbsent
-		return state
-	}
-
-	for _, user := range toRemove {
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    []string{"--quiet", "acl:remove-service", t.Type, t.Service, user},
-		})
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-	}
-
-	state.Changed = true
-	state.State = StateAbsent
-	return state
 }
 
 // init registers the AclServiceTask with the task registry

--- a/tasks/app_clone_task.go
+++ b/tasks/app_clone_task.go
@@ -68,6 +68,29 @@ func (t AppCloneTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the AppCloneTask would produce.
+func (t AppCloneTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if t.App == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+			}
+			if t.SourceApp == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'source_app' is required")}
+			}
+			if appExists(t.App) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    fmt.Sprintf("target app %s missing", t.App),
+				Mutations: []string{fmt.Sprintf("clone %s -> %s", t.SourceApp, t.App)},
+			}
+		},
+	})
+}
+
 // cloneApp clones an existing dokku app to a new app
 func cloneApp(t AppCloneTask) TaskOutputState {
 	state := TaskOutputState{

--- a/tasks/app_clone_task.go
+++ b/tasks/app_clone_task.go
@@ -63,9 +63,7 @@ func (t AppCloneTask) Examples() ([]Doc, error) {
 
 // Execute clones an existing dokku app to a new app
 func (t AppCloneTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return cloneApp(t) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the AppCloneTask would produce.
@@ -86,49 +84,27 @@ func (t AppCloneTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    fmt.Sprintf("target app %s missing", t.App),
 				Mutations: []string{fmt.Sprintf("clone %s -> %s", t.SourceApp, t.App)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					args := []string{"--quiet", "apps:clone"}
+					if t.SkipDeploy {
+						args = append(args, "--skip-deploy")
+					}
+					args = append(args, t.SourceApp, t.App)
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
 			}
 		},
 	})
-}
-
-// cloneApp clones an existing dokku app to a new app
-func cloneApp(t AppCloneTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StateAbsent,
-	}
-
-	if t.App == "" {
-		state.Error = fmt.Errorf("'app' is required")
-		return state
-	}
-	if t.SourceApp == "" {
-		state.Error = fmt.Errorf("'source_app' is required")
-		return state
-	}
-
-	if appExists(t.App) {
-		state.State = StatePresent
-		return state
-	}
-
-	args := []string{"--quiet", "apps:clone"}
-	if t.SkipDeploy {
-		args = append(args, "--skip-deploy")
-	}
-	args = append(args, t.SourceApp, t.App)
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StatePresent
-	return state
 }
 
 // init registers the AppCloneTask with the task registry

--- a/tasks/app_json_property_task.go
+++ b/tasks/app_json_property_task.go
@@ -68,7 +68,7 @@ func (t AppJsonPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the app.json property
 func (t AppJsonPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "app-json:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the AppJsonPropertyTask would produce.

--- a/tasks/app_json_property_task.go
+++ b/tasks/app_json_property_task.go
@@ -71,6 +71,11 @@ func (t AppJsonPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "app-json:set")
 }
 
+// Plan reports the drift the AppJsonPropertyTask would produce.
+func (t AppJsonPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "app-json:set")
+}
+
 // init registers the AppJsonPropertyTask with the task registry
 func init() {
 	RegisterTask(&AppJsonPropertyTask{})

--- a/tasks/app_lock_task.go
+++ b/tasks/app_lock_task.go
@@ -61,6 +61,37 @@ func (t AppLockTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the AppLockTask would produce.
+func (t AppLockTask) Plan() PlanResult {
+	if t.App == "" {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if appLocked(t.App) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    "app unlocked",
+				Mutations: []string{"lock " + t.App},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			if !appLocked(t.App) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    "app locked",
+				Mutations: []string{"unlock " + t.App},
+			}
+		},
+	})
+}
+
 // appLocked checks if a dokku app is locked
 func appLocked(app string) bool {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{

--- a/tasks/app_lock_task.go
+++ b/tasks/app_lock_task.go
@@ -55,10 +55,7 @@ func (t AppLockTask) Examples() ([]Doc, error) {
 
 // Execute locks or unlocks the app
 func (t AppLockTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return lockApp(t.App) },
-		StateAbsent:  func() TaskOutputState { return unlockApp(t.App) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the AppLockTask would produce.
@@ -76,6 +73,19 @@ func (t AppLockTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    "app unlocked",
 				Mutations: []string{"lock " + t.App},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "apps:lock", t.App},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
 			}
 		},
 		StateAbsent: func() PlanResult {
@@ -87,6 +97,19 @@ func (t AppLockTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    "app locked",
 				Mutations: []string{"unlock " + t.App},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "apps:unlock", t.App},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
 			}
 		},
 	})
@@ -102,66 +125,6 @@ func appLocked(app string) bool {
 		return false
 	}
 	return result.ExitCode == 0
-}
-
-// lockApp locks a dokku app for deployment
-func lockApp(app string) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StateAbsent,
-	}
-
-	if app == "" {
-		state.Error = fmt.Errorf("'app' is required")
-		return state
-	}
-
-	if appLocked(app) {
-		state.State = StatePresent
-		return state
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    []string{"--quiet", "apps:lock", app},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StatePresent
-	return state
-}
-
-// unlockApp unlocks a dokku app for deployment
-func unlockApp(app string) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StatePresent,
-	}
-
-	if app == "" {
-		state.Error = fmt.Errorf("'app' is required")
-		return state
-	}
-
-	if !appLocked(app) {
-		state.State = StateAbsent
-		return state
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    []string{"--quiet", "apps:unlock", app},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StateAbsent
-	return state
 }
 
 // init registers the AppLockTask with the task registry

--- a/tasks/app_task.go
+++ b/tasks/app_task.go
@@ -59,6 +59,34 @@ func (t AppTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the AppTask would produce.
+func (t AppTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		"present": func() PlanResult {
+			if appExists(t.App) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    "app missing",
+				Mutations: []string{"create app " + t.App},
+			}
+		},
+		"absent": func() PlanResult {
+			if !appExists(t.App) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "app present",
+				Mutations: []string{"destroy app " + t.App},
+			}
+		},
+	})
+}
+
 // appExists checks if an app exists
 func appExists(appName string) bool {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{

--- a/tasks/app_task.go
+++ b/tasks/app_task.go
@@ -53,16 +53,13 @@ func (t AppTask) Examples() ([]Doc, error) {
 
 // Execute creates or destroys an app
 func (t AppTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return createApp(t.App) },
-		"absent":  func() TaskOutputState { return destroyApp(t.App) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the AppTask would produce.
 func (t AppTask) Plan() PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		"present": func() PlanResult {
+		StatePresent: func() PlanResult {
 			if appExists(t.App) {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
@@ -71,9 +68,10 @@ func (t AppTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    "app missing",
 				Mutations: []string{"create app " + t.App},
+				apply:     applyCreateApp(t.App),
 			}
 		},
-		"absent": func() PlanResult {
+		StateAbsent: func() PlanResult {
 			if !appExists(t.App) {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
@@ -82,6 +80,7 @@ func (t AppTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "app present",
 				Mutations: []string{"destroy app " + t.App},
+				apply:     applyDestroyApp(t.App),
 			}
 		},
 	})
@@ -104,61 +103,56 @@ func appExists(appName string) bool {
 	return result.ExitCode == 0
 }
 
-// createApp creates an app
-func createApp(app string) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
-	if appExists(app) {
-		state.State = "present"
+// applyCreateApp returns a closure that runs `dokku apps:create <app>`.
+func applyCreateApp(app string) func() TaskOutputState {
+	return func() TaskOutputState {
+		state := TaskOutputState{Changed: false, State: StateAbsent}
+		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", "apps:create", app},
+		})
+		if err != nil {
+			return TaskOutputErrorFromExec(state, err, result)
+		}
+		state.Changed = true
+		state.State = StatePresent
 		return state
 	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			"apps:create",
-			app,
-		},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
 }
 
-// destroyApp destroys an app
-func destroyApp(app string) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "present",
-	}
-	if !appExists(app) {
-		state.State = "absent"
+// applyDestroyApp returns a closure that runs `dokku --force apps:destroy <app>`.
+func applyDestroyApp(app string) func() TaskOutputState {
+	return func() TaskOutputState {
+		state := TaskOutputState{Changed: false, State: StatePresent}
+		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", "--force", "apps:destroy", app},
+		})
+		if err != nil {
+			return TaskOutputErrorFromExec(state, err, result)
+		}
+		state.Changed = true
+		state.State = StateAbsent
 		return state
 	}
+}
 
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			"--force",
-			"apps:destroy",
-			app,
-		},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
+// destroyApp is retained as an integration-test helper. It runs the
+// destroy-app apply path synchronously.
+func destroyApp(app string) TaskOutputState {
+	if !appExists(app) {
+		return TaskOutputState{Changed: false, State: StateAbsent}
 	}
+	return applyDestroyApp(app)()
+}
 
-	state.Changed = true
-	state.State = "absent"
-	return state
+// createApp is retained as an integration-test helper. It runs the
+// create-app apply path synchronously.
+func createApp(app string) TaskOutputState {
+	if appExists(app) {
+		return TaskOutputState{Changed: false, State: StatePresent}
+	}
+	return applyCreateApp(app)()
 }
 
 // init registers the AppTask with the task registry

--- a/tasks/builder_dockerfile_property_task.go
+++ b/tasks/builder_dockerfile_property_task.go
@@ -68,7 +68,7 @@ func (t BuilderDockerfilePropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the builder-dockerfile property
 func (t BuilderDockerfilePropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-dockerfile:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the BuilderDockerfilePropertyTask would produce.

--- a/tasks/builder_dockerfile_property_task.go
+++ b/tasks/builder_dockerfile_property_task.go
@@ -71,6 +71,11 @@ func (t BuilderDockerfilePropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-dockerfile:set")
 }
 
+// Plan reports the drift the BuilderDockerfilePropertyTask would produce.
+func (t BuilderDockerfilePropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-dockerfile:set")
+}
+
 // init registers the BuilderDockerfilePropertyTask with the task registry
 func init() {
 	RegisterTask(&BuilderDockerfilePropertyTask{})

--- a/tasks/builder_herokuish_property_task.go
+++ b/tasks/builder_herokuish_property_task.go
@@ -71,6 +71,11 @@ func (t BuilderHerokuishPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-herokuish:set")
 }
 
+// Plan reports the drift the BuilderHerokuishPropertyTask would produce.
+func (t BuilderHerokuishPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-herokuish:set")
+}
+
 // init registers the BuilderHerokuishPropertyTask with the task registry
 func init() {
 	RegisterTask(&BuilderHerokuishPropertyTask{})

--- a/tasks/builder_herokuish_property_task.go
+++ b/tasks/builder_herokuish_property_task.go
@@ -68,7 +68,7 @@ func (t BuilderHerokuishPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the builder-herokuish property
 func (t BuilderHerokuishPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-herokuish:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the BuilderHerokuishPropertyTask would produce.

--- a/tasks/builder_lambda_property_task.go
+++ b/tasks/builder_lambda_property_task.go
@@ -68,7 +68,7 @@ func (t BuilderLambdaPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the builder-lambda property
 func (t BuilderLambdaPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-lambda:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the BuilderLambdaPropertyTask would produce.

--- a/tasks/builder_lambda_property_task.go
+++ b/tasks/builder_lambda_property_task.go
@@ -71,6 +71,11 @@ func (t BuilderLambdaPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-lambda:set")
 }
 
+// Plan reports the drift the BuilderLambdaPropertyTask would produce.
+func (t BuilderLambdaPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-lambda:set")
+}
+
 // init registers the BuilderLambdaPropertyTask with the task registry
 func init() {
 	RegisterTask(&BuilderLambdaPropertyTask{})

--- a/tasks/builder_nixpacks_property_task.go
+++ b/tasks/builder_nixpacks_property_task.go
@@ -68,7 +68,7 @@ func (t BuilderNixpacksPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the builder-nixpacks property
 func (t BuilderNixpacksPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-nixpacks:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the BuilderNixpacksPropertyTask would produce.

--- a/tasks/builder_nixpacks_property_task.go
+++ b/tasks/builder_nixpacks_property_task.go
@@ -71,6 +71,11 @@ func (t BuilderNixpacksPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-nixpacks:set")
 }
 
+// Plan reports the drift the BuilderNixpacksPropertyTask would produce.
+func (t BuilderNixpacksPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-nixpacks:set")
+}
+
 // init registers the BuilderNixpacksPropertyTask with the task registry
 func init() {
 	RegisterTask(&BuilderNixpacksPropertyTask{})

--- a/tasks/builder_pack_property_task.go
+++ b/tasks/builder_pack_property_task.go
@@ -68,7 +68,7 @@ func (t BuilderPackPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the builder-pack property
 func (t BuilderPackPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-pack:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the BuilderPackPropertyTask would produce.

--- a/tasks/builder_pack_property_task.go
+++ b/tasks/builder_pack_property_task.go
@@ -71,6 +71,11 @@ func (t BuilderPackPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-pack:set")
 }
 
+// Plan reports the drift the BuilderPackPropertyTask would produce.
+func (t BuilderPackPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-pack:set")
+}
+
 // init registers the BuilderPackPropertyTask with the task registry
 func init() {
 	RegisterTask(&BuilderPackPropertyTask{})

--- a/tasks/builder_property_task.go
+++ b/tasks/builder_property_task.go
@@ -76,7 +76,7 @@ func (t BuilderPropertyTask) Examples() ([]Doc, error) {
 
 // Execute executes the builder configuration task
 func (t BuilderPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the BuilderPropertyTask would produce.

--- a/tasks/builder_property_task.go
+++ b/tasks/builder_property_task.go
@@ -79,6 +79,11 @@ func (t BuilderPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder:set")
 }
 
+// Plan reports the drift the BuilderPropertyTask would produce.
+func (t BuilderPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder:set")
+}
+
 // init registers the BuilderTask with the task registry
 func init() {
 	RegisterTask(&BuilderPropertyTask{})

--- a/tasks/builder_railpack_property_task.go
+++ b/tasks/builder_railpack_property_task.go
@@ -71,6 +71,11 @@ func (t BuilderRailpackPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-railpack:set")
 }
 
+// Plan reports the drift the BuilderRailpackPropertyTask would produce.
+func (t BuilderRailpackPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-railpack:set")
+}
+
 // init registers the BuilderRailpackPropertyTask with the task registry
 func init() {
 	RegisterTask(&BuilderRailpackPropertyTask{})

--- a/tasks/builder_railpack_property_task.go
+++ b/tasks/builder_railpack_property_task.go
@@ -68,7 +68,7 @@ func (t BuilderRailpackPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the builder-railpack property
 func (t BuilderRailpackPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-railpack:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the BuilderRailpackPropertyTask would produce.

--- a/tasks/buildpacks_property_task.go
+++ b/tasks/buildpacks_property_task.go
@@ -68,7 +68,7 @@ func (t BuildpacksPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the buildpacks property
 func (t BuildpacksPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "buildpacks:set-property")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the BuildpacksPropertyTask would produce.

--- a/tasks/buildpacks_property_task.go
+++ b/tasks/buildpacks_property_task.go
@@ -71,6 +71,11 @@ func (t BuildpacksPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "buildpacks:set-property")
 }
 
+// Plan reports the drift the BuildpacksPropertyTask would produce.
+func (t BuildpacksPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "buildpacks:set-property")
+}
+
 // init registers the BuildpacksPropertyTask with the task registry
 func init() {
 	RegisterTask(&BuildpacksPropertyTask{})

--- a/tasks/buildpacks_task.go
+++ b/tasks/buildpacks_task.go
@@ -73,21 +73,18 @@ func (t BuildpacksTask) Examples() ([]Doc, error) {
 
 // Execute manages the buildpacks for a given app
 func (t BuildpacksTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return addBuildpacks(t) },
-		StateAbsent:  func() TaskOutputState { return removeBuildpacks(t) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the BuildpacksTask would produce.
 func (t BuildpacksTask) Plan() PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		StatePresent: func() PlanResult { return planAddBuildpacks(t) },
-		StateAbsent:  func() PlanResult { return planRemoveBuildpacks(t) },
+		StatePresent: func() PlanResult { return planBuildpacksAdd(t) },
+		StateAbsent:  func() PlanResult { return planBuildpacksRemove(t) },
 	})
 }
 
-func planAddBuildpacks(t BuildpacksTask) PlanResult {
+func planBuildpacksAdd(t BuildpacksTask) PlanResult {
 	if t.App == "" {
 		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
 	}
@@ -98,13 +95,15 @@ func planAddBuildpacks(t BuildpacksTask) PlanResult {
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
+	toAdd := []string{}
 	mutations := []string{}
 	for _, bp := range t.Buildpacks {
 		if !current[bp] {
+			toAdd = append(toAdd, bp)
 			mutations = append(mutations, "add "+bp)
 		}
 	}
-	if len(mutations) == 0 {
+	if len(toAdd) == 0 {
 		return PlanResult{InSync: true, Status: PlanStatusOK}
 	}
 	status := PlanStatusModify
@@ -114,12 +113,27 @@ func planAddBuildpacks(t BuildpacksTask) PlanResult {
 	return PlanResult{
 		InSync:    false,
 		Status:    status,
-		Reason:    fmt.Sprintf("%d buildpack(s) to add", len(mutations)),
+		Reason:    fmt.Sprintf("%d buildpack(s) to add", len(toAdd)),
 		Mutations: mutations,
+		apply: func() TaskOutputState {
+			state := TaskOutputState{Changed: false, State: StateAbsent}
+			for _, bp := range toAdd {
+				result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+					Command: "dokku",
+					Args:    []string{"--quiet", "buildpacks:add", t.App, bp},
+				})
+				if err != nil {
+					return TaskOutputErrorFromExec(state, err, result)
+				}
+			}
+			state.Changed = true
+			state.State = StatePresent
+			return state
+		},
 	}
 }
 
-func planRemoveBuildpacks(t BuildpacksTask) PlanResult {
+func planBuildpacksRemove(t BuildpacksTask) PlanResult {
 	if t.App == "" {
 		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
 	}
@@ -135,27 +149,58 @@ func planRemoveBuildpacks(t BuildpacksTask) PlanResult {
 		for bp := range current {
 			mutations = append(mutations, "remove "+bp)
 		}
+		app := t.App
 		return PlanResult{
 			InSync:    false,
 			Status:    PlanStatusDestroy,
 			Reason:    fmt.Sprintf("clear %d buildpack(s)", len(current)),
 			Mutations: mutations,
+			apply: func() TaskOutputState {
+				state := TaskOutputState{Changed: false, State: StatePresent}
+				result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+					Command: "dokku",
+					Args:    []string{"--quiet", "buildpacks:clear", app},
+				})
+				if err != nil {
+					return TaskOutputErrorFromExec(state, err, result)
+				}
+				state.Changed = true
+				state.State = StateAbsent
+				return state
+			},
 		}
 	}
+	toRemove := []string{}
 	mutations := []string{}
 	for _, bp := range t.Buildpacks {
 		if current[bp] {
+			toRemove = append(toRemove, bp)
 			mutations = append(mutations, "remove "+bp)
 		}
 	}
-	if len(mutations) == 0 {
+	if len(toRemove) == 0 {
 		return PlanResult{InSync: true, Status: PlanStatusOK}
 	}
 	return PlanResult{
 		InSync:    false,
 		Status:    PlanStatusDestroy,
-		Reason:    fmt.Sprintf("%d buildpack(s) to remove", len(mutations)),
+		Reason:    fmt.Sprintf("%d buildpack(s) to remove", len(toRemove)),
 		Mutations: mutations,
+		apply: func() TaskOutputState {
+			state := TaskOutputState{Changed: false, State: StatePresent}
+			for _, bp := range toRemove {
+				result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+					Command: "dokku",
+					Args:    []string{"--quiet", "buildpacks:remove", t.App, bp},
+				})
+				if err != nil {
+					return TaskOutputErrorFromExec(state, err, result)
+				}
+			}
+			state.Changed = true
+			state.State = StateAbsent
+			return state
+		},
 	}
 }
 
@@ -178,119 +223,6 @@ func getBuildpacks(app string) (map[string]bool, error) {
 		buildpacks[trimmed] = true
 	}
 	return buildpacks, nil
-}
-
-// addBuildpacks adds buildpacks to an app, skipping ones already present
-func addBuildpacks(t BuildpacksTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StateAbsent,
-	}
-
-	if t.App == "" {
-		state.Error = fmt.Errorf("'app' is required")
-		return state
-	}
-	if len(t.Buildpacks) == 0 {
-		state.Error = fmt.Errorf("'buildpacks' must not be empty for state 'present'")
-		return state
-	}
-
-	current, err := getBuildpacks(t.App)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	var toAdd []string
-	for _, bp := range t.Buildpacks {
-		if !current[bp] {
-			toAdd = append(toAdd, bp)
-		}
-	}
-
-	if len(toAdd) == 0 {
-		state.State = StatePresent
-		return state
-	}
-
-	for _, bp := range toAdd {
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    []string{"--quiet", "buildpacks:add", t.App, bp},
-		})
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-	}
-
-	state.Changed = true
-	state.State = StatePresent
-	return state
-}
-
-// removeBuildpacks removes buildpacks from an app, or clears all when none are specified
-func removeBuildpacks(t BuildpacksTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StatePresent,
-	}
-
-	if t.App == "" {
-		state.Error = fmt.Errorf("'app' is required")
-		return state
-	}
-
-	current, err := getBuildpacks(t.App)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	if len(t.Buildpacks) == 0 {
-		if len(current) == 0 {
-			state.State = StateAbsent
-			return state
-		}
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    []string{"--quiet", "buildpacks:clear", t.App},
-		})
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-		state.Changed = true
-		state.State = StateAbsent
-		return state
-	}
-
-	var toRemove []string
-	for _, bp := range t.Buildpacks {
-		if current[bp] {
-			toRemove = append(toRemove, bp)
-		}
-	}
-
-	if len(toRemove) == 0 {
-		state.State = StateAbsent
-		return state
-	}
-
-	for _, bp := range toRemove {
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    []string{"--quiet", "buildpacks:remove", t.App, bp},
-		})
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-	}
-
-	state.Changed = true
-	state.State = StateAbsent
-	return state
 }
 
 // init registers the BuildpacksTask with the task registry

--- a/tasks/buildpacks_task.go
+++ b/tasks/buildpacks_task.go
@@ -79,6 +79,86 @@ func (t BuildpacksTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the BuildpacksTask would produce.
+func (t BuildpacksTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return planAddBuildpacks(t) },
+		StateAbsent:  func() PlanResult { return planRemoveBuildpacks(t) },
+	})
+}
+
+func planAddBuildpacks(t BuildpacksTask) PlanResult {
+	if t.App == "" {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+	}
+	if len(t.Buildpacks) == 0 {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'buildpacks' must not be empty for state 'present'")}
+	}
+	current, err := getBuildpacks(t.App)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	mutations := []string{}
+	for _, bp := range t.Buildpacks {
+		if !current[bp] {
+			mutations = append(mutations, "add "+bp)
+		}
+	}
+	if len(mutations) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	status := PlanStatusModify
+	if len(current) == 0 {
+		status = PlanStatusCreate
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    status,
+		Reason:    fmt.Sprintf("%d buildpack(s) to add", len(mutations)),
+		Mutations: mutations,
+	}
+}
+
+func planRemoveBuildpacks(t BuildpacksTask) PlanResult {
+	if t.App == "" {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+	}
+	current, err := getBuildpacks(t.App)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	if len(t.Buildpacks) == 0 {
+		if len(current) == 0 {
+			return PlanResult{InSync: true, Status: PlanStatusOK}
+		}
+		mutations := make([]string, 0, len(current))
+		for bp := range current {
+			mutations = append(mutations, "remove "+bp)
+		}
+		return PlanResult{
+			InSync:    false,
+			Status:    PlanStatusDestroy,
+			Reason:    fmt.Sprintf("clear %d buildpack(s)", len(current)),
+			Mutations: mutations,
+		}
+	}
+	mutations := []string{}
+	for _, bp := range t.Buildpacks {
+		if current[bp] {
+			mutations = append(mutations, "remove "+bp)
+		}
+	}
+	if len(mutations) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    fmt.Sprintf("%d buildpack(s) to remove", len(mutations)),
+		Mutations: mutations,
+	}
+}
+
 // getBuildpacks fetches the current buildpacks list for an app
 func getBuildpacks(app string) (map[string]bool, error) {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{

--- a/tasks/caddy_property_task.go
+++ b/tasks/caddy_property_task.go
@@ -68,7 +68,7 @@ func (t CaddyPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the caddy property
 func (t CaddyPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "caddy:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the CaddyPropertyTask would produce.

--- a/tasks/caddy_property_task.go
+++ b/tasks/caddy_property_task.go
@@ -71,6 +71,11 @@ func (t CaddyPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "caddy:set")
 }
 
+// Plan reports the drift the CaddyPropertyTask would produce.
+func (t CaddyPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "caddy:set")
+}
+
 // init registers the CaddyPropertyTask with the task registry
 func init() {
 	RegisterTask(&CaddyPropertyTask{})

--- a/tasks/certs_task.go
+++ b/tasks/certs_task.go
@@ -83,10 +83,7 @@ func (t CertsTask) Examples() ([]Doc, error) {
 
 // Execute manages the SSL certificate
 func (t CertsTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return addCert(t) },
-		StateAbsent:  func() TaskOutputState { return removeCert(t) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the CertsTask would produce.
@@ -115,6 +112,23 @@ func (t CertsTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    "certificate not installed",
 				Mutations: []string{fmt.Sprintf("install certificate for %s", target)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					args := []string{"--quiet", "certs:add", t.App, t.Cert, t.Key}
+					if t.Global {
+						args = []string{"--quiet", "global-cert:set", t.Cert, t.Key}
+					}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
 			}
 		},
 		StateAbsent: func() PlanResult {
@@ -137,6 +151,23 @@ func (t CertsTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "certificate present",
 				Mutations: []string{fmt.Sprintf("remove certificate for %s", target)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					args := []string{"--quiet", "certs:remove", t.App}
+					if t.Global {
+						args = []string{"--quiet", "global-cert:remove"}
+					}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
 			}
 		},
 	})
@@ -169,92 +200,6 @@ func certsEnabled(t CertsTask) (bool, error) {
 	}
 
 	return strings.TrimSpace(result.StdoutContents()) == "true", nil
-}
-
-// addCert installs an SSL certificate for an app or globally
-func addCert(t CertsTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StateAbsent,
-	}
-
-	if err := validateCertsTask(t); err != nil {
-		state.Error = err
-		return state
-	}
-	if t.Cert == "" || t.Key == "" {
-		state.Error = fmt.Errorf("'cert' and 'key' are required when state is 'present'")
-		return state
-	}
-
-	enabled, err := certsEnabled(t)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-	if enabled {
-		state.State = StatePresent
-		return state
-	}
-
-	args := []string{"--quiet", "certs:add", t.App, t.Cert, t.Key}
-	if t.Global {
-		args = []string{"--quiet", "global-cert:set", t.Cert, t.Key}
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StatePresent
-	return state
-}
-
-// removeCert removes the SSL certificate for an app or globally
-func removeCert(t CertsTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StatePresent,
-	}
-
-	if err := validateCertsTask(t); err != nil {
-		state.Error = err
-		return state
-	}
-
-	enabled, err := certsEnabled(t)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-	if !enabled {
-		state.State = StateAbsent
-		return state
-	}
-
-	args := []string{"--quiet", "certs:remove", t.App}
-	if t.Global {
-		args = []string{"--quiet", "global-cert:remove"}
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StateAbsent
-	return state
 }
 
 // init registers the CertsTask with the task registry

--- a/tasks/certs_task.go
+++ b/tasks/certs_task.go
@@ -89,6 +89,59 @@ func (t CertsTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the CertsTask would produce.
+func (t CertsTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if err := validateCertsTask(t); err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if t.Cert == "" || t.Key == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'cert' and 'key' are required when state is 'present'")}
+			}
+			enabled, err := certsEnabled(t)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if enabled {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			target := t.App
+			if t.Global {
+				target = "(global)"
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    "certificate not installed",
+				Mutations: []string{fmt.Sprintf("install certificate for %s", target)},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			if err := validateCertsTask(t); err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			enabled, err := certsEnabled(t)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !enabled {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			target := t.App
+			if t.Global {
+				target = "(global)"
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "certificate present",
+				Mutations: []string{fmt.Sprintf("remove certificate for %s", target)},
+			}
+		},
+	})
+}
+
 // validateCertsTask validates the certs task parameters
 func validateCertsTask(t CertsTask) error {
 	if t.Global && t.App != "" {

--- a/tasks/checks_property_task.go
+++ b/tasks/checks_property_task.go
@@ -71,6 +71,11 @@ func (t ChecksPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "checks:set")
 }
 
+// Plan reports the drift the ChecksPropertyTask would produce.
+func (t ChecksPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "checks:set")
+}
+
 // init registers the ChecksPropertyTask with the task registry
 func init() {
 	RegisterTask(&ChecksPropertyTask{})

--- a/tasks/checks_property_task.go
+++ b/tasks/checks_property_task.go
@@ -68,7 +68,7 @@ func (t ChecksPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the checks property
 func (t ChecksPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "checks:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the ChecksPropertyTask would produce.

--- a/tasks/checks_toggle_task.go
+++ b/tasks/checks_toggle_task.go
@@ -1,5 +1,37 @@
 package tasks
 
+import (
+	"strings"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// checksEnabled reports whether checks are enabled for the given app via
+// `dokku --quiet checks:report <app> --checks-disabled`. The dokku-checks
+// plugin lists disabled process types here (comma-separated). An empty
+// list or the literal "none" means all checks are enabled.
+func checksEnabled(ctx ToggleContext) (bool, error) {
+	args := []string{"--quiet", "checks:report"}
+	if ctx.AllowGlobal && ctx.Global {
+		args = append(args, "--global", "--checks-disabled")
+	} else {
+		args = append(args, ctx.App, "--checks-disabled")
+	}
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		return false, err
+	}
+	disabled := strings.TrimSpace(result.StdoutContents())
+	// dokku-checks reports "none" when no procs are disabled; an empty
+	// string also means fully enabled. Any other non-empty value (a
+	// comma-separated list of proc types, or "_all_") indicates at least
+	// one process has checks disabled.
+	return disabled == "" || disabled == "none", nil
+}
+
 // ChecksToggleTask enables or disables the checks plugin for a given dokku application
 type ChecksToggleTask struct {
 	// App is the name of the app
@@ -53,12 +85,12 @@ func (t ChecksToggleTask) Examples() ([]Doc, error) {
 
 // Execute enables or disables the checks plugin
 func (t ChecksToggleTask) Execute() TaskOutputState {
-	return executeToggle(t.State, t.App, t.Global, false, "checks:enable", "checks:disable")
+	return executeToggle(t.State, t.App, t.Global, false, "checks:enable", "checks:disable", checksEnabled)
 }
 
 // Plan reports the drift the ChecksToggleTask would produce.
 func (t ChecksToggleTask) Plan() PlanResult {
-	return planToggle(t.State, t.App, t.Global, false, "checks:enable", "checks:disable")
+	return planToggle(t.State, t.App, t.Global, false, "checks:enable", "checks:disable", checksEnabled)
 }
 
 // init registers the ChecksToggleTask with the task registry

--- a/tasks/checks_toggle_task.go
+++ b/tasks/checks_toggle_task.go
@@ -6,10 +6,10 @@ import (
 	"github.com/dokku/docket/subprocess"
 )
 
-// checksEnabled reports whether checks are enabled for the given app via
+// checksEnabled probes whether checks are enabled for an app via
 // `dokku --quiet checks:report <app> --checks-disabled`. The dokku-checks
-// plugin lists disabled process types here (comma-separated). An empty
-// list or the literal "none" means all checks are enabled.
+// plugin lists disabled process types here; an empty list or "none" means
+// every process has checks enabled.
 func checksEnabled(ctx ToggleContext) (bool, error) {
 	args := []string{"--quiet", "checks:report"}
 	if ctx.AllowGlobal && ctx.Global {
@@ -25,10 +25,6 @@ func checksEnabled(ctx ToggleContext) (bool, error) {
 		return false, err
 	}
 	disabled := strings.TrimSpace(result.StdoutContents())
-	// dokku-checks reports "none" when no procs are disabled; an empty
-	// string also means fully enabled. Any other non-empty value (a
-	// comma-separated list of proc types, or "_all_") indicates at least
-	// one process has checks disabled.
 	return disabled == "" || disabled == "none", nil
 }
 
@@ -85,7 +81,7 @@ func (t ChecksToggleTask) Examples() ([]Doc, error) {
 
 // Execute enables or disables the checks plugin
 func (t ChecksToggleTask) Execute() TaskOutputState {
-	return executeToggle(t.State, t.App, t.Global, false, "checks:enable", "checks:disable", checksEnabled)
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the ChecksToggleTask would produce.

--- a/tasks/checks_toggle_task.go
+++ b/tasks/checks_toggle_task.go
@@ -56,6 +56,11 @@ func (t ChecksToggleTask) Execute() TaskOutputState {
 	return executeToggle(t.State, t.App, t.Global, false, "checks:enable", "checks:disable")
 }
 
+// Plan reports the drift the ChecksToggleTask would produce.
+func (t ChecksToggleTask) Plan() PlanResult {
+	return planToggle(t.State, t.App, t.Global, false, "checks:enable", "checks:disable")
+}
+
 // init registers the ChecksToggleTask with the task registry
 func init() {
 	RegisterTask(&ChecksToggleTask{})

--- a/tasks/config_task.go
+++ b/tasks/config_task.go
@@ -69,18 +69,133 @@ func (t ConfigTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the configuration for a given dokku application
 func (t ConfigTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return setConfig(t) },
-		"absent":  func() TaskOutputState { return unsetConfig(t) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the ConfigTask would produce.
 func (t ConfigTask) Plan() PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		"present": func() PlanResult { return planSetConfig(t) },
-		"absent":  func() PlanResult { return planUnsetConfig(t) },
+		StatePresent: func() PlanResult { return planConfigSet(t) },
+		StateAbsent:  func() PlanResult { return planConfigUnset(t) },
 	})
+}
+
+// configKeysToSet returns keys whose desired value differs from the current value.
+func configKeysToSet(current, desired map[string]string) []string {
+	keys := []string{}
+	for k, v := range desired {
+		if cur, ok := current[k]; !ok || cur != v {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+// configKeysToUnset returns keys present in desired that exist in current.
+func configKeysToUnset(current, desired map[string]string) []string {
+	keys := []string{}
+	for k := range desired {
+		if _, ok := current[k]; ok {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+// planConfigSet probes current config once, computes the diff, and embeds
+// an apply closure that runs `dokku config:set` with only the changed keys.
+func planConfigSet(t ConfigTask) PlanResult {
+	currentConfig, err := getConfig(t)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	keys := configKeysToSet(currentConfig, t.Config)
+	if len(keys) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	mutations := make([]string, 0, len(keys))
+	status := PlanStatusModify
+	allNew := true
+	for _, k := range keys {
+		if _, ok := currentConfig[k]; ok {
+			mutations = append(mutations, fmt.Sprintf("set %s (was set)", k))
+			allNew = false
+		} else {
+			mutations = append(mutations, fmt.Sprintf("set %s (new)", k))
+		}
+	}
+	if allNew {
+		status = PlanStatusCreate
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    status,
+		Reason:    fmt.Sprintf("%d key(s) to set", len(keys)),
+		Mutations: mutations,
+		apply: func() TaskOutputState {
+			state := TaskOutputState{Changed: false, State: StateAbsent}
+			args := []string{"--quiet", "config:set", "--encoded"}
+			if !t.Restart {
+				args = append(args, "--no-restart")
+			}
+			args = append(args, t.App)
+			for _, k := range keys {
+				args = append(args, fmt.Sprintf("%s=%s", k, base64.StdEncoding.EncodeToString([]byte(t.Config[k]))))
+			}
+			result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+				Command: "dokku",
+				Args:    args,
+			})
+			if err != nil {
+				return TaskOutputErrorFromExec(state, err, result)
+			}
+			state.Changed = true
+			state.State = StatePresent
+			return state
+		},
+	}
+}
+
+// planConfigUnset probes current config once, computes the diff, and embeds
+// an apply closure that runs `dokku config:unset` with only existing keys.
+func planConfigUnset(t ConfigTask) PlanResult {
+	currentConfig, err := getConfig(t)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	keys := configKeysToUnset(currentConfig, t.Config)
+	if len(keys) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	mutations := make([]string, 0, len(keys))
+	for _, k := range keys {
+		mutations = append(mutations, fmt.Sprintf("unset %s", k))
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    fmt.Sprintf("%d key(s) to unset", len(keys)),
+		Mutations: mutations,
+		apply: func() TaskOutputState {
+			state := TaskOutputState{Changed: false, State: StatePresent}
+			args := []string{"--quiet", "config:unset"}
+			if !t.Restart {
+				args = append(args, "--no-restart")
+			}
+			args = append(args, t.App)
+			args = append(args, keys...)
+			result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+				Command: "dokku",
+				Args:    args,
+			})
+			if err != nil {
+				return TaskOutputErrorFromExec(state, err, result)
+			}
+			state.Changed = true
+			state.State = StateAbsent
+			return state
+		},
+	}
 }
 
 // getConfig retrieves the current configuration for a given dokku application
@@ -106,200 +221,6 @@ func getConfig(t ConfigTask) (map[string]string, error) {
 		return config, err
 	}
 	return config, nil
-}
-
-// configKeysToSet returns keys whose desired value differs from the current value.
-func configKeysToSet(current, desired map[string]string) []string {
-	keys := []string{}
-	for k, v := range desired {
-		if cur, ok := current[k]; !ok || cur != v {
-			keys = append(keys, k)
-		}
-	}
-	return keys
-}
-
-// configKeysToUnset returns keys present in desired that exist in current.
-func configKeysToUnset(current, desired map[string]string) []string {
-	keys := []string{}
-	for k := range desired {
-		if _, ok := current[k]; ok {
-			keys = append(keys, k)
-		}
-	}
-	return keys
-}
-
-// planSetConfig reports drift for a present-state config set.
-func planSetConfig(t ConfigTask) PlanResult {
-	currentConfig, err := getConfig(t)
-	if err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
-	}
-
-	keys := configKeysToSet(currentConfig, t.Config)
-	if len(keys) == 0 {
-		return PlanResult{InSync: true, Status: PlanStatusOK}
-	}
-
-	mutations := make([]string, 0, len(keys))
-	status := PlanStatusModify
-	allNew := true
-	for _, k := range keys {
-		if _, ok := currentConfig[k]; ok {
-			mutations = append(mutations, fmt.Sprintf("set %s (was set)", k))
-			allNew = false
-		} else {
-			mutations = append(mutations, fmt.Sprintf("set %s (new)", k))
-		}
-	}
-	if allNew {
-		status = PlanStatusCreate
-	}
-	return PlanResult{
-		InSync:    false,
-		Status:    status,
-		Reason:    fmt.Sprintf("%d key(s) to set", len(keys)),
-		Mutations: mutations,
-	}
-}
-
-// planUnsetConfig reports drift for an absent-state config unset.
-func planUnsetConfig(t ConfigTask) PlanResult {
-	currentConfig, err := getConfig(t)
-	if err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
-	}
-
-	keys := configKeysToUnset(currentConfig, t.Config)
-	if len(keys) == 0 {
-		return PlanResult{InSync: true, Status: PlanStatusOK}
-	}
-
-	mutations := make([]string, 0, len(keys))
-	for _, k := range keys {
-		mutations = append(mutations, fmt.Sprintf("unset %s", k))
-	}
-	return PlanResult{
-		InSync:    false,
-		Status:    PlanStatusDestroy,
-		Reason:    fmt.Sprintf("%d key(s) to unset", len(keys)),
-		Mutations: mutations,
-	}
-}
-
-// setConfig sets the configuration for a given dokku application
-func setConfig(t ConfigTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
-
-	currentConfig, err := getConfig(t)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	desiredConfig := make(map[string]string)
-	for key, value := range t.Config {
-		if _, ok := currentConfig[key]; !ok {
-			desiredConfig[key] = value
-			continue
-		}
-		if currentConfig[key] != value {
-			desiredConfig[key] = value
-		}
-	}
-
-	if len(desiredConfig) == 0 {
-		state.State = "present"
-		return state
-	}
-
-	args := []string{
-		"--quiet",
-		"config:set",
-		"--encoded",
-	}
-
-	if !t.Restart {
-		// todo: rename no-restart to skip-deploy in dokku
-		args = append(args, "--no-restart")
-	}
-
-	args = append(args, t.App)
-
-	for key, value := range desiredConfig {
-		args = append(args, fmt.Sprintf("%s=%s", key, base64.StdEncoding.EncodeToString([]byte(value))))
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
-}
-
-// unsetConfig unsets the configuration for a given dokku application
-func unsetConfig(t ConfigTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "present",
-	}
-	currentConfig, err := getConfig(t)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	desiredConfig := make(map[string]bool)
-	for key := range t.Config {
-		if _, ok := currentConfig[key]; ok {
-			desiredConfig[key] = true
-		}
-	}
-
-	if len(desiredConfig) == 0 {
-		state.State = "absent"
-		return state
-	}
-
-	args := []string{
-		"--quiet",
-		"config:unset",
-	}
-
-	if !t.Restart {
-		// todo: rename no-restart to skip-deploy in dokku
-		args = append(args, "--no-restart")
-	}
-
-	args = append(args, t.App)
-
-	for key := range desiredConfig {
-		args = append(args, key)
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "absent"
-	return state
 }
 
 // init registers the ConfigTask with the task registry

--- a/tasks/config_task.go
+++ b/tasks/config_task.go
@@ -75,6 +75,14 @@ func (t ConfigTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the ConfigTask would produce.
+func (t ConfigTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		"present": func() PlanResult { return planSetConfig(t) },
+		"absent":  func() PlanResult { return planUnsetConfig(t) },
+	})
+}
+
 // getConfig retrieves the current configuration for a given dokku application
 func getConfig(t ConfigTask) (map[string]string, error) {
 	var config map[string]string
@@ -98,6 +106,86 @@ func getConfig(t ConfigTask) (map[string]string, error) {
 		return config, err
 	}
 	return config, nil
+}
+
+// configKeysToSet returns keys whose desired value differs from the current value.
+func configKeysToSet(current, desired map[string]string) []string {
+	keys := []string{}
+	for k, v := range desired {
+		if cur, ok := current[k]; !ok || cur != v {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+// configKeysToUnset returns keys present in desired that exist in current.
+func configKeysToUnset(current, desired map[string]string) []string {
+	keys := []string{}
+	for k := range desired {
+		if _, ok := current[k]; ok {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+// planSetConfig reports drift for a present-state config set.
+func planSetConfig(t ConfigTask) PlanResult {
+	currentConfig, err := getConfig(t)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+
+	keys := configKeysToSet(currentConfig, t.Config)
+	if len(keys) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+
+	mutations := make([]string, 0, len(keys))
+	status := PlanStatusModify
+	allNew := true
+	for _, k := range keys {
+		if _, ok := currentConfig[k]; ok {
+			mutations = append(mutations, fmt.Sprintf("set %s (was set)", k))
+			allNew = false
+		} else {
+			mutations = append(mutations, fmt.Sprintf("set %s (new)", k))
+		}
+	}
+	if allNew {
+		status = PlanStatusCreate
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    status,
+		Reason:    fmt.Sprintf("%d key(s) to set", len(keys)),
+		Mutations: mutations,
+	}
+}
+
+// planUnsetConfig reports drift for an absent-state config unset.
+func planUnsetConfig(t ConfigTask) PlanResult {
+	currentConfig, err := getConfig(t)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+
+	keys := configKeysToUnset(currentConfig, t.Config)
+	if len(keys) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+
+	mutations := make([]string, 0, len(keys))
+	for _, k := range keys {
+		mutations = append(mutations, fmt.Sprintf("unset %s", k))
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    fmt.Sprintf("%d key(s) to unset", len(keys)),
+		Mutations: mutations,
+	}
 }
 
 // setConfig sets the configuration for a given dokku application

--- a/tasks/cron_property_task.go
+++ b/tasks/cron_property_task.go
@@ -71,6 +71,11 @@ func (t CronPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "cron:set")
 }
 
+// Plan reports the drift the CronPropertyTask would produce.
+func (t CronPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "cron:set")
+}
+
 // init registers the CronPropertyTask with the task registry
 func init() {
 	RegisterTask(&CronPropertyTask{})

--- a/tasks/cron_property_task.go
+++ b/tasks/cron_property_task.go
@@ -68,7 +68,7 @@ func (t CronPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the cron property
 func (t CronPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "cron:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the CronPropertyTask would produce.

--- a/tasks/dispatch.go
+++ b/tasks/dispatch.go
@@ -16,3 +16,21 @@ func DispatchState(state State, funcMap map[State]func() TaskOutputState) TaskOu
 	result.DesiredState = state
 	return result
 }
+
+// DispatchPlan looks up the given state in the funcMap, calls the matching function,
+// and returns an error PlanResult if the state is not found. Mirrors DispatchState
+// but returns a PlanResult so tasks can implement Plan() with the same shape they
+// use for Execute().
+func DispatchPlan(state State, funcMap map[State]func() PlanResult) PlanResult {
+	fn, ok := funcMap[state]
+	if !ok {
+		return PlanResult{
+			Status: PlanStatusError,
+			Error:  fmt.Errorf("invalid state: %s", state),
+		}
+	}
+
+	result := fn()
+	result.DesiredState = state
+	return result
+}

--- a/tasks/dispatch.go
+++ b/tasks/dispatch.go
@@ -17,10 +17,9 @@ func DispatchState(state State, funcMap map[State]func() TaskOutputState) TaskOu
 	return result
 }
 
-// DispatchPlan looks up the given state in the funcMap, calls the matching function,
-// and returns an error PlanResult if the state is not found. Mirrors DispatchState
-// but returns a PlanResult so tasks can implement Plan() with the same shape they
-// use for Execute().
+// DispatchPlan looks up the given state in the funcMap, calls the matching
+// function, and returns an error PlanResult if the state is not found.
+// Mirrors DispatchState but for the read-only Plan() path.
 func DispatchPlan(state State, funcMap map[State]func() PlanResult) PlanResult {
 	fn, ok := funcMap[state]
 	if !ok {
@@ -33,4 +32,49 @@ func DispatchPlan(state State, funcMap map[State]func() PlanResult) PlanResult {
 	result := fn()
 	result.DesiredState = state
 	return result
+}
+
+// ExecutePlan applies a PlanResult to the server. It is the canonical
+// implementation of Task.Execute(): each task's Execute body is
+// `return ExecutePlan(t.Plan())`. ExecutePlan ensures the existing
+// `state.State == state.DesiredState` contract that commands/apply.go
+// relies on.
+//
+// Three branches:
+//
+//  1. p.Error != nil  - probe failed; return TaskOutputState carrying the
+//     error and the desired state. The apply closure is not invoked.
+//  2. p.InSync        - no change needed; return State == DesiredState with
+//     Changed=false. The apply closure is not invoked.
+//  3. otherwise       - invoke p.apply (must be non-nil) and return its
+//     TaskOutputState verbatim. apply is responsible for setting Changed
+//     and a final State that matches DesiredState on success.
+func ExecutePlan(p PlanResult) TaskOutputState {
+	if p.Error != nil {
+		return TaskOutputState{
+			Error:        p.Error,
+			Message:      p.Error.Error(),
+			DesiredState: p.DesiredState,
+			State:        p.DesiredState,
+		}
+	}
+	if p.InSync {
+		return TaskOutputState{
+			Changed:      false,
+			State:        p.DesiredState,
+			DesiredState: p.DesiredState,
+		}
+	}
+	if p.apply == nil {
+		return TaskOutputState{
+			Error:        fmt.Errorf("plan reports drift but no apply function was provided"),
+			DesiredState: p.DesiredState,
+			State:        p.DesiredState,
+		}
+	}
+	out := p.apply()
+	if out.DesiredState == "" {
+		out.DesiredState = p.DesiredState
+	}
+	return out
 }

--- a/tasks/docker_options_task.go
+++ b/tasks/docker_options_task.go
@@ -67,56 +67,75 @@ func (t DockerOptionsTask) Examples() ([]Doc, error) {
 
 // Execute manages the docker option
 func (t DockerOptionsTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return addDockerOption(t) },
-		StateAbsent:  func() TaskOutputState { return removeDockerOption(t) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the DockerOptionsTask would produce.
 func (t DockerOptionsTask) Plan() PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		StatePresent: func() PlanResult { return planAddDockerOption(t) },
-		StateAbsent:  func() PlanResult { return planRemoveDockerOption(t) },
+		StatePresent: func() PlanResult {
+			if err := validateDockerOptionsTask(t); err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			current, err := getDockerOptions(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if optionPresent(current[t.Phase], t.Option) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    fmt.Sprintf("missing on %s phase", t.Phase),
+				Mutations: []string{fmt.Sprintf("add %s option %q", t.Phase, t.Option)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "docker-options:add", t.App, t.Phase, t.Option},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			if err := validateDockerOptionsTask(t); err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			current, err := getDockerOptions(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !optionPresent(current[t.Phase], t.Option) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    fmt.Sprintf("present on %s phase", t.Phase),
+				Mutations: []string{fmt.Sprintf("remove %s option %q", t.Phase, t.Option)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "docker-options:remove", t.App, t.Phase, t.Option},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
+			}
+		},
 	})
-}
-
-func planAddDockerOption(t DockerOptionsTask) PlanResult {
-	if err := validateDockerOptionsTask(t); err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
-	}
-	current, err := getDockerOptions(t.App)
-	if err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
-	}
-	if optionPresent(current[t.Phase], t.Option) {
-		return PlanResult{InSync: true, Status: PlanStatusOK}
-	}
-	return PlanResult{
-		InSync:    false,
-		Status:    PlanStatusCreate,
-		Reason:    fmt.Sprintf("missing on %s phase", t.Phase),
-		Mutations: []string{fmt.Sprintf("add %s option %q", t.Phase, t.Option)},
-	}
-}
-
-func planRemoveDockerOption(t DockerOptionsTask) PlanResult {
-	if err := validateDockerOptionsTask(t); err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
-	}
-	current, err := getDockerOptions(t.App)
-	if err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
-	}
-	if !optionPresent(current[t.Phase], t.Option) {
-		return PlanResult{InSync: true, Status: PlanStatusOK}
-	}
-	return PlanResult{
-		InSync:    false,
-		Status:    PlanStatusDestroy,
-		Reason:    fmt.Sprintf("present on %s phase", t.Phase),
-		Mutations: []string{fmt.Sprintf("remove %s option %q", t.Phase, t.Option)},
-	}
 }
 
 var dockerOptionPhases = map[string]bool{"build": true, "deploy": true, "run": true}
@@ -178,78 +197,6 @@ func optionPresent(existing, option string) bool {
 		}
 	}
 	return false
-}
-
-// addDockerOption adds a docker option to the specified phase
-func addDockerOption(t DockerOptionsTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StateAbsent,
-	}
-
-	if err := validateDockerOptionsTask(t); err != nil {
-		state.Error = err
-		return state
-	}
-
-	current, err := getDockerOptions(t.App)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-	if optionPresent(current[t.Phase], t.Option) {
-		state.State = StatePresent
-		return state
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    []string{"--quiet", "docker-options:add", t.App, t.Phase, t.Option},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StatePresent
-	return state
-}
-
-// removeDockerOption removes a docker option from the specified phase
-func removeDockerOption(t DockerOptionsTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StatePresent,
-	}
-
-	if err := validateDockerOptionsTask(t); err != nil {
-		state.Error = err
-		return state
-	}
-
-	current, err := getDockerOptions(t.App)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-	if !optionPresent(current[t.Phase], t.Option) {
-		state.State = StateAbsent
-		return state
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    []string{"--quiet", "docker-options:remove", t.App, t.Phase, t.Option},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StateAbsent
-	return state
 }
 
 // init registers the DockerOptionsTask with the task registry

--- a/tasks/docker_options_task.go
+++ b/tasks/docker_options_task.go
@@ -73,6 +73,52 @@ func (t DockerOptionsTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the DockerOptionsTask would produce.
+func (t DockerOptionsTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return planAddDockerOption(t) },
+		StateAbsent:  func() PlanResult { return planRemoveDockerOption(t) },
+	})
+}
+
+func planAddDockerOption(t DockerOptionsTask) PlanResult {
+	if err := validateDockerOptionsTask(t); err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	current, err := getDockerOptions(t.App)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	if optionPresent(current[t.Phase], t.Option) {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusCreate,
+		Reason:    fmt.Sprintf("missing on %s phase", t.Phase),
+		Mutations: []string{fmt.Sprintf("add %s option %q", t.Phase, t.Option)},
+	}
+}
+
+func planRemoveDockerOption(t DockerOptionsTask) PlanResult {
+	if err := validateDockerOptionsTask(t); err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	current, err := getDockerOptions(t.App)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	if !optionPresent(current[t.Phase], t.Option) {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    fmt.Sprintf("present on %s phase", t.Phase),
+		Mutations: []string{fmt.Sprintf("remove %s option %q", t.Phase, t.Option)},
+	}
+}
+
 var dockerOptionPhases = map[string]bool{"build": true, "deploy": true, "run": true}
 
 // validateDockerOptionsTask validates the docker options task parameters

--- a/tasks/domains_task.go
+++ b/tasks/domains_task.go
@@ -86,6 +86,131 @@ func (t DomainsTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the DomainsTask would produce.
+func (t DomainsTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return planAddDomains(t) },
+		StateAbsent:  func() PlanResult { return planRemoveDomains(t) },
+		StateSet:     func() PlanResult { return planSetDomains(t) },
+		StateClear:   func() PlanResult { return planClearDomains(t) },
+	})
+}
+
+// planAddDomains reports drift for present-state domain add.
+func planAddDomains(t DomainsTask) PlanResult {
+	if err := validateDomainsTask(t, true); err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	currentDomains, err := getDomains(t.App, t.Global)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	mutations := []string{}
+	for _, d := range t.Domains {
+		if !currentDomains[d] {
+			mutations = append(mutations, fmt.Sprintf("add %s", d))
+		}
+	}
+	if len(mutations) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	status := PlanStatusModify
+	if len(currentDomains) == 0 {
+		status = PlanStatusCreate
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    status,
+		Reason:    fmt.Sprintf("%d domain(s) to add", len(mutations)),
+		Mutations: mutations,
+	}
+}
+
+// planRemoveDomains reports drift for absent-state domain remove.
+func planRemoveDomains(t DomainsTask) PlanResult {
+	if err := validateDomainsTask(t, true); err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	currentDomains, err := getDomains(t.App, t.Global)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	mutations := []string{}
+	for _, d := range t.Domains {
+		if currentDomains[d] {
+			mutations = append(mutations, fmt.Sprintf("remove %s", d))
+		}
+	}
+	if len(mutations) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    fmt.Sprintf("%d domain(s) to remove", len(mutations)),
+		Mutations: mutations,
+	}
+}
+
+// planSetDomains reports drift for set-state replace operation.
+func planSetDomains(t DomainsTask) PlanResult {
+	if err := validateDomainsTask(t, true); err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	currentDomains, err := getDomains(t.App, t.Global)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	desired := map[string]bool{}
+	for _, d := range t.Domains {
+		desired[d] = true
+	}
+	mutations := []string{}
+	for d := range desired {
+		if !currentDomains[d] {
+			mutations = append(mutations, fmt.Sprintf("add %s", d))
+		}
+	}
+	for d := range currentDomains {
+		if !desired[d] {
+			mutations = append(mutations, fmt.Sprintf("remove %s", d))
+		}
+	}
+	if len(mutations) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusModify,
+		Reason:    fmt.Sprintf("%d domain change(s)", len(mutations)),
+		Mutations: mutations,
+	}
+}
+
+// planClearDomains reports drift for clear-state operation.
+func planClearDomains(t DomainsTask) PlanResult {
+	if err := validateDomainsTask(t, false); err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	currentDomains, err := getDomains(t.App, t.Global)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	if len(currentDomains) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	mutations := make([]string, 0, len(currentDomains))
+	for d := range currentDomains {
+		mutations = append(mutations, fmt.Sprintf("remove %s", d))
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    fmt.Sprintf("clear %d domain(s)", len(currentDomains)),
+		Mutations: mutations,
+	}
+}
+
 // validateDomainsTask validates the domains task parameters
 func validateDomainsTask(t DomainsTask, requireDomains bool) error {
 	if t.Global && t.App != "" {

--- a/tasks/domains_task.go
+++ b/tasks/domains_task.go
@@ -78,26 +78,21 @@ func (t DomainsTask) Examples() ([]Doc, error) {
 
 // Execute manages the domains
 func (t DomainsTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return addDomains(t) },
-		StateAbsent:  func() TaskOutputState { return removeDomains(t) },
-		StateSet:     func() TaskOutputState { return setDomains(t) },
-		StateClear:   func() TaskOutputState { return clearDomains(t) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the DomainsTask would produce.
 func (t DomainsTask) Plan() PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		StatePresent: func() PlanResult { return planAddDomains(t) },
-		StateAbsent:  func() PlanResult { return planRemoveDomains(t) },
-		StateSet:     func() PlanResult { return planSetDomains(t) },
-		StateClear:   func() PlanResult { return planClearDomains(t) },
+		StatePresent: func() PlanResult { return planDomainsPresent(t) },
+		StateAbsent:  func() PlanResult { return planDomainsAbsent(t) },
+		StateSet:     func() PlanResult { return planDomainsSet(t) },
+		StateClear:   func() PlanResult { return planDomainsClear(t) },
 	})
 }
 
-// planAddDomains reports drift for present-state domain add.
-func planAddDomains(t DomainsTask) PlanResult {
+// planDomainsPresent reports drift for the present-state domain add.
+func planDomainsPresent(t DomainsTask) PlanResult {
 	if err := validateDomainsTask(t, true); err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -105,29 +100,38 @@ func planAddDomains(t DomainsTask) PlanResult {
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
+	toAdd := []string{}
 	mutations := []string{}
 	for _, d := range t.Domains {
 		if !currentDomains[d] {
+			toAdd = append(toAdd, d)
 			mutations = append(mutations, fmt.Sprintf("add %s", d))
 		}
 	}
-	if len(mutations) == 0 {
+	if len(toAdd) == 0 {
 		return PlanResult{InSync: true, Status: PlanStatusOK}
 	}
 	status := PlanStatusModify
 	if len(currentDomains) == 0 {
 		status = PlanStatusCreate
 	}
+	subcommand := "domains:add"
+	appName := t.App
+	if t.Global {
+		subcommand = "domains:add-global"
+		appName = "--global"
+	}
 	return PlanResult{
 		InSync:    false,
 		Status:    status,
-		Reason:    fmt.Sprintf("%d domain(s) to add", len(mutations)),
+		Reason:    fmt.Sprintf("%d domain(s) to add", len(toAdd)),
 		Mutations: mutations,
+		apply:     applyDokkuArgs(subcommand, appName, toAdd, StatePresent, StateAbsent),
 	}
 }
 
-// planRemoveDomains reports drift for absent-state domain remove.
-func planRemoveDomains(t DomainsTask) PlanResult {
+// planDomainsAbsent reports drift for the absent-state domain remove.
+func planDomainsAbsent(t DomainsTask) PlanResult {
 	if err := validateDomainsTask(t, true); err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -135,25 +139,34 @@ func planRemoveDomains(t DomainsTask) PlanResult {
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
+	toRemove := []string{}
 	mutations := []string{}
 	for _, d := range t.Domains {
 		if currentDomains[d] {
+			toRemove = append(toRemove, d)
 			mutations = append(mutations, fmt.Sprintf("remove %s", d))
 		}
 	}
-	if len(mutations) == 0 {
+	if len(toRemove) == 0 {
 		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	subcommand := "domains:remove"
+	appName := t.App
+	if t.Global {
+		subcommand = "domains:remove-global"
+		appName = "--global"
 	}
 	return PlanResult{
 		InSync:    false,
 		Status:    PlanStatusDestroy,
-		Reason:    fmt.Sprintf("%d domain(s) to remove", len(mutations)),
+		Reason:    fmt.Sprintf("%d domain(s) to remove", len(toRemove)),
 		Mutations: mutations,
+		apply:     applyDokkuArgs(subcommand, appName, toRemove, StateAbsent, StatePresent),
 	}
 }
 
-// planSetDomains reports drift for set-state replace operation.
-func planSetDomains(t DomainsTask) PlanResult {
+// planDomainsSet reports drift for the set-state full replacement.
+func planDomainsSet(t DomainsTask) PlanResult {
 	if err := validateDomainsTask(t, true); err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -179,16 +192,23 @@ func planSetDomains(t DomainsTask) PlanResult {
 	if len(mutations) == 0 {
 		return PlanResult{InSync: true, Status: PlanStatusOK}
 	}
+	subcommand := "domains:set"
+	appName := t.App
+	if t.Global {
+		subcommand = "domains:set-global"
+		appName = "--global"
+	}
 	return PlanResult{
 		InSync:    false,
 		Status:    PlanStatusModify,
 		Reason:    fmt.Sprintf("%d domain change(s)", len(mutations)),
 		Mutations: mutations,
+		apply:     applyDokkuArgs(subcommand, appName, t.Domains, StateSet, StateAbsent),
 	}
 }
 
-// planClearDomains reports drift for clear-state operation.
-func planClearDomains(t DomainsTask) PlanResult {
+// planDomainsClear reports drift for the clear-state operation.
+func planDomainsClear(t DomainsTask) PlanResult {
 	if err := validateDomainsTask(t, false); err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
@@ -203,11 +223,39 @@ func planClearDomains(t DomainsTask) PlanResult {
 	for d := range currentDomains {
 		mutations = append(mutations, fmt.Sprintf("remove %s", d))
 	}
+	subcommand := "domains:clear"
+	appName := t.App
+	if t.Global {
+		subcommand = "domains:clear-global"
+		appName = "--global"
+	}
 	return PlanResult{
 		InSync:    false,
 		Status:    PlanStatusDestroy,
 		Reason:    fmt.Sprintf("clear %d domain(s)", len(currentDomains)),
 		Mutations: mutations,
+		apply:     applyDokkuArgs(subcommand, appName, nil, StateClear, StatePresent),
+	}
+}
+
+// applyDokkuArgs returns a closure that runs `dokku --quiet <subcommand>
+// <target> <extra...>`. It is used by domains plan paths to share the
+// boilerplate around constructing the subprocess call.
+func applyDokkuArgs(subcommand, target string, extra []string, finalState State, errState State) func() TaskOutputState {
+	return func() TaskOutputState {
+		state := TaskOutputState{Changed: false, State: errState}
+		args := []string{"--quiet", subcommand, target}
+		args = append(args, extra...)
+		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    args,
+		})
+		if err != nil {
+			return TaskOutputErrorFromExec(state, err, result)
+		}
+		state.Changed = true
+		state.State = finalState
+		return state
 	}
 }
 
@@ -254,183 +302,6 @@ func getDomains(app string, global bool) (map[string]bool, error) {
 		domains[domain] = true
 	}
 	return domains, nil
-}
-
-// addDomains adds domains if they don't already exist
-func addDomains(t DomainsTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StateAbsent,
-	}
-
-	if err := validateDomainsTask(t, true); err != nil {
-		state.Error = err
-		return state
-	}
-
-	currentDomains, err := getDomains(t.App, t.Global)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	var newDomains []string
-	for _, domain := range t.Domains {
-		if !currentDomains[domain] {
-			newDomains = append(newDomains, domain)
-		}
-	}
-
-	if len(newDomains) == 0 {
-		state.State = StatePresent
-		return state
-	}
-
-	subcommand := "domains:add"
-	appName := t.App
-	if t.Global {
-		subcommand = "domains:add-global"
-		appName = "--global"
-	}
-
-	args := []string{"--quiet", subcommand, appName}
-	args = append(args, newDomains...)
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StatePresent
-	return state
-}
-
-// removeDomains removes domains if they exist
-func removeDomains(t DomainsTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StatePresent,
-	}
-
-	if err := validateDomainsTask(t, true); err != nil {
-		state.Error = err
-		return state
-	}
-
-	currentDomains, err := getDomains(t.App, t.Global)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	var domainsToRemove []string
-	for _, domain := range t.Domains {
-		if currentDomains[domain] {
-			domainsToRemove = append(domainsToRemove, domain)
-		}
-	}
-
-	if len(domainsToRemove) == 0 {
-		state.State = StateAbsent
-		return state
-	}
-
-	subcommand := "domains:remove"
-	appName := t.App
-	if t.Global {
-		subcommand = "domains:remove-global"
-		appName = "--global"
-	}
-
-	args := []string{"--quiet", subcommand, appName}
-	args = append(args, domainsToRemove...)
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StateAbsent
-	return state
-}
-
-// setDomains replaces all domains with the specified ones
-func setDomains(t DomainsTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StateAbsent,
-	}
-
-	if err := validateDomainsTask(t, true); err != nil {
-		state.Error = err
-		return state
-	}
-
-	subcommand := "domains:set"
-	appName := t.App
-	if t.Global {
-		subcommand = "domains:set-global"
-		appName = "--global"
-	}
-
-	args := []string{"--quiet", subcommand, appName}
-	args = append(args, t.Domains...)
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StateSet
-	return state
-}
-
-// clearDomains removes all domains
-func clearDomains(t DomainsTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StatePresent,
-	}
-
-	if err := validateDomainsTask(t, false); err != nil {
-		state.Error = err
-		return state
-	}
-
-	subcommand := "domains:clear"
-	appName := t.App
-	if t.Global {
-		subcommand = "domains:clear-global"
-		appName = "--global"
-	}
-
-	args := []string{"--quiet", subcommand, appName}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StateClear
-	return state
 }
 
 // init registers the DomainsTask with the task registry

--- a/tasks/domains_toggle_task.go
+++ b/tasks/domains_toggle_task.go
@@ -6,8 +6,8 @@ import (
 	"github.com/dokku/docket/subprocess"
 )
 
-// domainsEnabled reports whether the domains plugin is enabled for the given
-// app via `dokku --quiet domains:report <app> --domains-app-enabled`, or for
+// domainsEnabled probes whether the domains plugin is enabled for an app
+// via `dokku --quiet domains:report <app> --domains-app-enabled`, or for
 // the global scope via `--domains-global-enabled`.
 func domainsEnabled(ctx ToggleContext) (bool, error) {
 	args := []string{"--quiet", "domains:report"}
@@ -64,7 +64,7 @@ func (t DomainsToggleTask) Examples() ([]Doc, error) {
 
 // Execute enables or disables the domains plugin
 func (t DomainsToggleTask) Execute() TaskOutputState {
-	return executeToggle(t.State, t.App, t.Global, false, "domains:enable", "domains:disable", domainsEnabled)
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the DomainsToggleTask would produce.

--- a/tasks/domains_toggle_task.go
+++ b/tasks/domains_toggle_task.go
@@ -41,6 +41,11 @@ func (t DomainsToggleTask) Execute() TaskOutputState {
 	return executeToggle(t.State, t.App, t.Global, false, "domains:enable", "domains:disable")
 }
 
+// Plan reports the drift the DomainsToggleTask would produce.
+func (t DomainsToggleTask) Plan() PlanResult {
+	return planToggle(t.State, t.App, t.Global, false, "domains:enable", "domains:disable")
+}
+
 // init registers the DomainsToggleTask with the task registry
 func init() {
 	RegisterTask(&DomainsToggleTask{})

--- a/tasks/domains_toggle_task.go
+++ b/tasks/domains_toggle_task.go
@@ -1,5 +1,31 @@
 package tasks
 
+import (
+	"strings"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// domainsEnabled reports whether the domains plugin is enabled for the given
+// app via `dokku --quiet domains:report <app> --domains-app-enabled`, or for
+// the global scope via `--domains-global-enabled`.
+func domainsEnabled(ctx ToggleContext) (bool, error) {
+	args := []string{"--quiet", "domains:report"}
+	if ctx.AllowGlobal && ctx.Global {
+		args = append(args, "--global", "--domains-global-enabled")
+	} else {
+		args = append(args, ctx.App, "--domains-app-enabled")
+	}
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(result.StdoutContents()) == "true", nil
+}
+
 // DomainsToggleTask enables or disables the domains plugin for a given dokku application
 type DomainsToggleTask struct {
 	// App is the name of the app
@@ -38,12 +64,12 @@ func (t DomainsToggleTask) Examples() ([]Doc, error) {
 
 // Execute enables or disables the domains plugin
 func (t DomainsToggleTask) Execute() TaskOutputState {
-	return executeToggle(t.State, t.App, t.Global, false, "domains:enable", "domains:disable")
+	return executeToggle(t.State, t.App, t.Global, false, "domains:enable", "domains:disable", domainsEnabled)
 }
 
 // Plan reports the drift the DomainsToggleTask would produce.
 func (t DomainsToggleTask) Plan() PlanResult {
-	return planToggle(t.State, t.App, t.Global, false, "domains:enable", "domains:disable")
+	return planToggle(t.State, t.App, t.Global, false, "domains:enable", "domains:disable", domainsEnabled)
 }
 
 // init registers the DomainsToggleTask with the task registry

--- a/tasks/git_auth_task.go
+++ b/tasks/git_auth_task.go
@@ -69,17 +69,11 @@ func (t GitAuthTask) Examples() ([]Doc, error) {
 
 // Execute manages the netrc entry for a host
 func (t GitAuthTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return setGitAuth(t) },
-		StateAbsent:  func() TaskOutputState { return unsetGitAuth(t) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
-// Plan reports the drift the GitAuthTask would produce.
-//
-// dokku has no public way to query netrc state (see the package-level note
-// on GitAuthTask), so the plan reports drift unconditionally with the netrc
-// limitation called out in Reason.
+// Plan reports the drift the GitAuthTask would produce. dokku has no public
+// way to query netrc state, so the plan reports drift unconditionally.
 func (t GitAuthTask) Plan() PlanResult {
 	if t.Host == "" {
 		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'host' is required")}
@@ -94,6 +88,19 @@ func (t GitAuthTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    "netrc state not probed",
 				Mutations: []string{"git:auth " + t.Host + " " + t.Username + " ***"},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "git:auth", t.Host, t.Username, t.Password},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
 			}
 		},
 		StateAbsent: func() PlanResult {
@@ -102,6 +109,19 @@ func (t GitAuthTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "netrc state not probed",
 				Mutations: []string{"git:auth " + t.Host + " (clear)"},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "git:auth", t.Host},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
 			}
 		},
 	})

--- a/tasks/git_auth_task.go
+++ b/tasks/git_auth_task.go
@@ -75,6 +75,38 @@ func (t GitAuthTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the GitAuthTask would produce.
+//
+// dokku has no public way to query netrc state (see the package-level note
+// on GitAuthTask), so the plan reports drift unconditionally with the netrc
+// limitation called out in Reason.
+func (t GitAuthTask) Plan() PlanResult {
+	if t.Host == "" {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'host' is required")}
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if t.Username == "" || t.Password == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'username' and 'password' are required when state is 'present'")}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    "netrc state not probed",
+				Mutations: []string{"git:auth " + t.Host + " " + t.Username + " ***"},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "netrc state not probed",
+				Mutations: []string{"git:auth " + t.Host + " (clear)"},
+			}
+		},
+	})
+}
+
 // setGitAuth runs `dokku git:auth HOST USERNAME PASSWORD`.
 func setGitAuth(t GitAuthTask) TaskOutputState {
 	state := TaskOutputState{

--- a/tasks/git_from_archive_task.go
+++ b/tasks/git_from_archive_task.go
@@ -78,6 +78,39 @@ func (t GitFromArchiveTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the GitFromArchiveTask would produce.
+func (t GitFromArchiveTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		"deployed": func() PlanResult {
+			if t.App == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+			}
+			if t.ArchiveURL == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'archive_url' is required")}
+			}
+			archiveType := t.ArchiveType
+			if archiveType == "" {
+				archiveType = "tar"
+			}
+			if !validGitFromArchiveTypes[archiveType] {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'archive_type' must be one of tar, tar.gz, zip")}
+			}
+			if (t.GitUsername == "") != (t.GitEmail == "") {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'git_username' and 'git_email' must be set together")}
+			}
+			if checkAppSourceArchive(t.App, archiveType, t.ArchiveURL) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    "archive source drift",
+				Mutations: []string{fmt.Sprintf("git:from-archive %s %s (%s)", t.App, t.ArchiveURL, archiveType)},
+			}
+		},
+	})
+}
+
 // checkAppSourceArchive returns true if the app is already deployed from the
 // expected archive URL with the expected archive type. The archive type is
 // stored as the deploy source value, so a tar.gz deploy reports source "tar.gz".

--- a/tasks/git_from_archive_task.go
+++ b/tasks/git_from_archive_task.go
@@ -73,15 +73,13 @@ var validGitFromArchiveTypes = map[string]bool{"tar": true, "tar.gz": true, "zip
 
 // Execute deploys a git repository from an archive URL
 func (t GitFromArchiveTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"deployed": func() TaskOutputState { return deployGitFromArchive(t) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the GitFromArchiveTask would produce.
 func (t GitFromArchiveTask) Plan() PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		"deployed": func() PlanResult {
+		StateDeployed: func() PlanResult {
 			if t.App == "" {
 				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
 			}
@@ -106,6 +104,23 @@ func (t GitFromArchiveTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    "archive source drift",
 				Mutations: []string{fmt.Sprintf("git:from-archive %s %s (%s)", t.App, t.ArchiveURL, archiveType)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: "undeployed"}
+					args := []string{"git:from-archive", "--archive-type", archiveType, t.App, t.ArchiveURL}
+					if t.GitUsername != "" {
+						args = append(args, t.GitUsername, t.GitEmail)
+					}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateDeployed
+					return state
+				},
 			}
 		},
 	})
@@ -120,59 +135,6 @@ func checkAppSourceArchive(app, expectedType, expectedURL string) bool {
 		return false
 	}
 	return source.Source == expectedType && source.SourceMetadata == expectedURL
-}
-
-// deployGitFromArchive deploys a git repository from an archive URL
-func deployGitFromArchive(t GitFromArchiveTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "undeployed",
-	}
-
-	if t.App == "" {
-		state.Error = fmt.Errorf("'app' is required")
-		return state
-	}
-	if t.ArchiveURL == "" {
-		state.Error = fmt.Errorf("'archive_url' is required")
-		return state
-	}
-
-	archiveType := t.ArchiveType
-	if archiveType == "" {
-		archiveType = "tar"
-	}
-	if !validGitFromArchiveTypes[archiveType] {
-		state.Error = fmt.Errorf("'archive_type' must be one of tar, tar.gz, zip")
-		return state
-	}
-
-	if (t.GitUsername == "") != (t.GitEmail == "") {
-		state.Error = fmt.Errorf("'git_username' and 'git_email' must be set together")
-		return state
-	}
-
-	if checkAppSourceArchive(t.App, archiveType, t.ArchiveURL) {
-		state.State = "deployed"
-		return state
-	}
-
-	args := []string{"git:from-archive", "--archive-type", archiveType, t.App, t.ArchiveURL}
-	if t.GitUsername != "" {
-		args = append(args, t.GitUsername, t.GitEmail)
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "deployed"
-	return state
 }
 
 // init registers the GitFromArchiveTask with the task registry

--- a/tasks/git_from_image_task.go
+++ b/tasks/git_from_image_task.go
@@ -55,15 +55,13 @@ func (t GitFromImageTask) Examples() ([]Doc, error) {
 
 // Execute deploys a git repository from a docker image
 func (t GitFromImageTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"deployed": func() TaskOutputState { return deployGitFromImage(t) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the GitFromImageTask would produce.
 func (t GitFromImageTask) Plan() PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		"deployed": func() PlanResult {
+		StateDeployed: func() PlanResult {
 			if checkAppSourceImage(t.App, t.Image) {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
@@ -72,6 +70,30 @@ func (t GitFromImageTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    "image source drift",
 				Mutations: []string{fmt.Sprintf("git:from-image %s %s", t.App, t.Image)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: "undeployed"}
+					args := []string{"git:from-image"}
+					if t.BuildDir != "" {
+						args = append(args, "--build-dir", t.BuildDir)
+					}
+					args = append(args, t.App, t.Image)
+					if t.GitUsername != "" {
+						args = append(args, t.GitUsername)
+					}
+					if t.GitEmail != "" {
+						args = append(args, t.GitEmail)
+					}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateDeployed
+					return state
+				},
 			}
 		},
 	})
@@ -85,48 +107,6 @@ func checkAppSourceImage(app, expectedImage string) bool {
 	}
 
 	return source.Source == "docker-image" && source.SourceMetadata == expectedImage
-}
-
-// deployGitFromImage deploys a git repository from a docker image
-func deployGitFromImage(t GitFromImageTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "undeployed",
-	}
-
-	if checkAppSourceImage(t.App, t.Image) {
-		state.Changed = false
-		state.State = "deployed"
-		return state
-	}
-
-	args := []string{
-		"git:from-image",
-	}
-	if t.BuildDir != "" {
-		args = append(args, "--build-dir", t.BuildDir)
-	}
-	args = append(args, t.App, t.Image)
-
-	// todo: ensure both the username and email are provided
-	if t.GitUsername != "" {
-		args = append(args, t.GitUsername)
-	}
-	if t.GitEmail != "" {
-		args = append(args, t.GitEmail)
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "deployed"
-	return state
 }
 
 // init registers the GitFromImageTask with the task registry

--- a/tasks/git_from_image_task.go
+++ b/tasks/git_from_image_task.go
@@ -1,6 +1,8 @@
 package tasks
 
 import (
+	"fmt"
+
 	"github.com/dokku/docket/subprocess"
 )
 
@@ -55,6 +57,23 @@ func (t GitFromImageTask) Examples() ([]Doc, error) {
 func (t GitFromImageTask) Execute() TaskOutputState {
 	return DispatchState(t.State, map[State]func() TaskOutputState{
 		"deployed": func() TaskOutputState { return deployGitFromImage(t) },
+	})
+}
+
+// Plan reports the drift the GitFromImageTask would produce.
+func (t GitFromImageTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		"deployed": func() PlanResult {
+			if checkAppSourceImage(t.App, t.Image) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    "image source drift",
+				Mutations: []string{fmt.Sprintf("git:from-image %s %s", t.App, t.Image)},
+			}
+		},
 	})
 }
 

--- a/tasks/git_property_task.go
+++ b/tasks/git_property_task.go
@@ -76,7 +76,7 @@ func (t GitPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the git property
 func (t GitPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "git:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the GitPropertyTask would produce.

--- a/tasks/git_property_task.go
+++ b/tasks/git_property_task.go
@@ -79,6 +79,11 @@ func (t GitPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "git:set")
 }
 
+// Plan reports the drift the GitPropertyTask would produce.
+func (t GitPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "git:set")
+}
+
 // init registers the GitPropertyTask with the task registry
 func init() {
 	RegisterTask(&GitPropertyTask{})

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -77,6 +77,27 @@ func (t GitSyncTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the GitSyncTask would produce.
+func (t GitSyncTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		"present": func() PlanResult {
+			if checkAppSyncState(t.App, t.Remote, t.GitRef) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			ref := t.GitRef
+			if ref == "" {
+				ref = "(default branch)"
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    "remote/ref drift",
+				Mutations: []string{fmt.Sprintf("git:sync %s %s %s", t.App, t.Remote, ref)},
+			}
+		},
+	})
+}
+
 // checkAppSyncState checks if the app is already synced from the expected remote and ref
 func checkAppSyncState(app, expectedRemote, expectedRef string) bool {
 	source, err := getAppDeploySource(app)

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -72,15 +72,13 @@ func (t GitSyncTask) Examples() ([]Doc, error) {
 
 // Execute syncs a git repository to a dokku application
 func (t GitSyncTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return syncGitRepository(t) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the GitSyncTask would produce.
 func (t GitSyncTask) Plan() PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		"present": func() PlanResult {
+		StatePresent: func() PlanResult {
 			if checkAppSyncState(t.App, t.Remote, t.GitRef) {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
@@ -93,6 +91,33 @@ func (t GitSyncTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    "remote/ref drift",
 				Mutations: []string{fmt.Sprintf("git:sync %s %s %s", t.App, t.Remote, ref)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					args := []string{"git:sync"}
+					if t.Build {
+						args = append(args, "--build")
+					}
+					if t.BuildIfChanges {
+						args = append(args, "--build-if-changes")
+					}
+					if t.SkipDeployBranch {
+						args = append(args, "--skip-deploy-branch")
+					}
+					args = append(args, t.App, t.Remote)
+					if t.GitRef != "" {
+						args = append(args, t.GitRef)
+					}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
 			}
 		},
 	})
@@ -107,51 +132,6 @@ func checkAppSyncState(app, expectedRemote, expectedRef string) bool {
 
 	expectedMetadata := fmt.Sprintf("%s#%s", expectedRemote, expectedRef)
 	return source.Source == "git-sync" && source.SourceMetadata == expectedMetadata
-}
-
-// syncGitRepository syncs a git repository to a dokku application
-func syncGitRepository(t GitSyncTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
-
-	if checkAppSyncState(t.App, t.Remote, t.GitRef) {
-		state.State = "present"
-		return state
-	}
-
-	args := []string{
-		"git:sync",
-	}
-
-	if t.Build {
-		args = append(args, "--build")
-	}
-	if t.BuildIfChanges {
-		args = append(args, "--build-if-changes")
-	}
-	if t.SkipDeployBranch {
-		args = append(args, "--skip-deploy-branch")
-	}
-
-	args = append(args, t.App, t.Remote)
-
-	if t.GitRef != "" {
-		args = append(args, t.GitRef)
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
 }
 
 // init registers the GitSyncTask with the task registry

--- a/tasks/haproxy_property_task.go
+++ b/tasks/haproxy_property_task.go
@@ -71,6 +71,11 @@ func (t HaproxyPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "haproxy:set")
 }
 
+// Plan reports the drift the HaproxyPropertyTask would produce.
+func (t HaproxyPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "haproxy:set")
+}
+
 // init registers the HaproxyPropertyTask with the task registry
 func init() {
 	RegisterTask(&HaproxyPropertyTask{})

--- a/tasks/haproxy_property_task.go
+++ b/tasks/haproxy_property_task.go
@@ -68,7 +68,7 @@ func (t HaproxyPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the haproxy property
 func (t HaproxyPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "haproxy:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the HaproxyPropertyTask would produce.

--- a/tasks/http_auth_task.go
+++ b/tasks/http_auth_task.go
@@ -80,6 +80,45 @@ func (t HttpAuthTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the HttpAuthTask would produce.
+//
+// http-auth:report does not expose the configured username/password, so a
+// state="present" plan that detects an already-enabled app reports in-sync.
+// A username/password mismatch against an enabled app is not detected here;
+// users who want to rotate credentials should toggle off then on.
+func (t HttpAuthTask) Plan() PlanResult {
+	if t.State == StatePresent && t.Username == "" {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("username is required when state is present")}
+	}
+	if t.State == StatePresent && t.Password == "" {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("password is required when state is present")}
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		"present": func() PlanResult {
+			if httpAuthEnabled(t.App) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    "http-auth disabled",
+				Mutations: []string{"http-auth:on " + t.App},
+			}
+		},
+		"absent": func() PlanResult {
+			if !httpAuthEnabled(t.App) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "http-auth enabled",
+				Mutations: []string{"http-auth:off " + t.App},
+			}
+		},
+	})
+}
+
 // httpAuthEnabled checks if HTTP authentication is enabled for an app
 func httpAuthEnabled(appName string) bool {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{

--- a/tasks/http_auth_task.go
+++ b/tasks/http_auth_task.go
@@ -63,29 +63,10 @@ func (t HttpAuthTask) Examples() ([]Doc, error) {
 
 // Execute enables or disables HTTP authentication for an app
 func (t HttpAuthTask) Execute() TaskOutputState {
-	if t.State == StatePresent && t.Username == "" {
-		return TaskOutputState{
-			Error: fmt.Errorf("username is required when state is present"),
-		}
-	}
-	if t.State == StatePresent && t.Password == "" {
-		return TaskOutputState{
-			Error: fmt.Errorf("password is required when state is present"),
-		}
-	}
-
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return enableHttpAuth(t.App, t.Username, t.Password) },
-		"absent":  func() TaskOutputState { return disableHttpAuth(t.App) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the HttpAuthTask would produce.
-//
-// http-auth:report does not expose the configured username/password, so a
-// state="present" plan that detects an already-enabled app reports in-sync.
-// A username/password mismatch against an enabled app is not detected here;
-// users who want to rotate credentials should toggle off then on.
 func (t HttpAuthTask) Plan() PlanResult {
 	if t.State == StatePresent && t.Username == "" {
 		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("username is required when state is present")}
@@ -94,7 +75,7 @@ func (t HttpAuthTask) Plan() PlanResult {
 		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("password is required when state is present")}
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		"present": func() PlanResult {
+		StatePresent: func() PlanResult {
 			if httpAuthEnabled(t.App) {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
@@ -103,9 +84,22 @@ func (t HttpAuthTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    "http-auth disabled",
 				Mutations: []string{"http-auth:on " + t.App},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "http-auth:on", t.App, t.Username, t.Password},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
 			}
 		},
-		"absent": func() PlanResult {
+		StateAbsent: func() PlanResult {
 			if !httpAuthEnabled(t.App) {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
@@ -114,6 +108,19 @@ func (t HttpAuthTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "http-auth enabled",
 				Mutations: []string{"http-auth:off " + t.App},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "http-auth:off", t.App},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
 			}
 		},
 	})

--- a/tasks/letsencrypt_property_task.go
+++ b/tasks/letsencrypt_property_task.go
@@ -76,7 +76,7 @@ func (t LetsencryptPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the letsencrypt property
 func (t LetsencryptPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "letsencrypt:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the LetsencryptPropertyTask would produce.

--- a/tasks/letsencrypt_property_task.go
+++ b/tasks/letsencrypt_property_task.go
@@ -79,6 +79,11 @@ func (t LetsencryptPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "letsencrypt:set")
 }
 
+// Plan reports the drift the LetsencryptPropertyTask would produce.
+func (t LetsencryptPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "letsencrypt:set")
+}
+
 // init registers the LetsencryptPropertyTask with the task registry
 func init() {
 	RegisterTask(&LetsencryptPropertyTask{})

--- a/tasks/letsencrypt_task.go
+++ b/tasks/letsencrypt_task.go
@@ -56,10 +56,7 @@ func (t LetsencryptTask) Examples() ([]Doc, error) {
 
 // Execute enables or disables letsencrypt
 func (t LetsencryptTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return enableLetsencrypt(t.App) },
-		StateAbsent:  func() TaskOutputState { return disableLetsencrypt(t.App) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the LetsencryptTask would produce.
@@ -81,6 +78,19 @@ func (t LetsencryptTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    "letsencrypt not active",
 				Mutations: []string{"letsencrypt:enable " + t.App},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "letsencrypt:enable", t.App},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
 			}
 		},
 		StateAbsent: func() PlanResult {
@@ -96,6 +106,19 @@ func (t LetsencryptTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "letsencrypt active",
 				Mutations: []string{"letsencrypt:disable " + t.App},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "letsencrypt:disable", t.App},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
 			}
 		},
 	})

--- a/tasks/letsencrypt_task.go
+++ b/tasks/letsencrypt_task.go
@@ -62,6 +62,45 @@ func (t LetsencryptTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the LetsencryptTask would produce.
+func (t LetsencryptTask) Plan() PlanResult {
+	if t.App == "" {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			active, err := letsencryptActive(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if active {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    "letsencrypt not active",
+				Mutations: []string{"letsencrypt:enable " + t.App},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			active, err := letsencryptActive(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !active {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "letsencrypt active",
+				Mutations: []string{"letsencrypt:disable " + t.App},
+			}
+		},
+	})
+}
+
 // letsencryptActive reports whether letsencrypt is currently active for an app.
 // Mirrors the upstream `dokku letsencrypt:active <app>` output ("true"/"false").
 func letsencryptActive(app string) (bool, error) {

--- a/tasks/logs_property_task.go
+++ b/tasks/logs_property_task.go
@@ -68,7 +68,7 @@ func (t LogsPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the logs property
 func (t LogsPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "logs:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the LogsPropertyTask would produce.

--- a/tasks/logs_property_task.go
+++ b/tasks/logs_property_task.go
@@ -71,6 +71,11 @@ func (t LogsPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "logs:set")
 }
 
+// Plan reports the drift the LogsPropertyTask would produce.
+func (t LogsPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "logs:set")
+}
+
 // init registers the LogsPropertyTask with the task registry
 func init() {
 	RegisterTask(&LogsPropertyTask{})

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -99,10 +99,9 @@ const (
 
 // PlanResult is the read-only drift report for a task.
 //
-// Plan() never mutates server state. Tasks that probe live state populate
-// InSync, Status, and (for multi-mutation tasks) Mutations. Tasks that today
-// mutate without probing return a conservative result indicating that the
-// run would mutate but cannot itemize the change without executing.
+// Plan() never mutates server state. The unexported apply closure carries
+// any state probed during planning so the apply path does not re-probe;
+// ExecutePlan is the only consumer. When InSync is true, apply is nil.
 type PlanResult struct {
 	// InSync is true when the task would not change anything.
 	InSync bool
@@ -113,18 +112,24 @@ type PlanResult struct {
 	// Reason is human-readable detail (e.g. "ref drift", "2 keys to set").
 	Reason string
 
-	// Mutations optionally itemizes per-mutation drift for tasks that perform
-	// multiple operations (e.g. config_task setting and unsetting individual
-	// keys). One entry per atomic change.
+	// Mutations optionally itemizes per-mutation drift for tasks that
+	// perform multiple operations (e.g. config setting and unsetting
+	// individual keys). One entry per atomic change.
 	Mutations []string
 
-	// DesiredState is the state the task was asked to converge to. Mirrors
-	// TaskOutputState.DesiredState so plan output can render the same context.
+	// DesiredState mirrors TaskOutputState.DesiredState so plan output can
+	// render the same context as apply output.
 	DesiredState State
 
 	// Error is non-nil when the read-state probe itself failed. A non-nil
 	// Error implies Status == PlanStatusError.
 	Error error
+
+	// apply, when non-nil, is the closure ExecutePlan invokes to mutate
+	// server state. nil when InSync. Captures any probed state needed for
+	// the mutation so the apply path does not re-probe. Unexported so
+	// formatters and JSON consumers cannot accidentally invoke it.
+	apply func() TaskOutputState
 }
 
 // Task represents a task
@@ -139,7 +144,9 @@ type Task interface {
 	// without mutating it. Plan must never call mutating dokku commands.
 	Plan() PlanResult
 
-	// Execute executes the task
+	// Execute executes the task. Conventionally implemented as
+	// ExecutePlan(t.Plan()) so probing happens once and the per-state
+	// mutation logic lives only in Plan().
 	Execute() TaskOutputState
 }
 

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -81,6 +81,52 @@ type TaskOutputState struct {
 	State State
 }
 
+// PlanStatus is the short marker that summarizes a planned change.
+type PlanStatus string
+
+const (
+	// PlanStatusOK indicates the task is in sync; no change would be made.
+	PlanStatusOK PlanStatus = "ok"
+	// PlanStatusModify indicates the task would modify existing state.
+	PlanStatusModify PlanStatus = "~"
+	// PlanStatusCreate indicates the task would create new state.
+	PlanStatusCreate PlanStatus = "+"
+	// PlanStatusDestroy indicates the task would remove existing state.
+	PlanStatusDestroy PlanStatus = "-"
+	// PlanStatusError indicates the read-state probe itself failed.
+	PlanStatusError PlanStatus = "error"
+)
+
+// PlanResult is the read-only drift report for a task.
+//
+// Plan() never mutates server state. Tasks that probe live state populate
+// InSync, Status, and (for multi-mutation tasks) Mutations. Tasks that today
+// mutate without probing return a conservative result indicating that the
+// run would mutate but cannot itemize the change without executing.
+type PlanResult struct {
+	// InSync is true when the task would not change anything.
+	InSync bool
+
+	// Status is the short marker for the drift kind.
+	Status PlanStatus
+
+	// Reason is human-readable detail (e.g. "ref drift", "2 keys to set").
+	Reason string
+
+	// Mutations optionally itemizes per-mutation drift for tasks that perform
+	// multiple operations (e.g. config_task setting and unsetting individual
+	// keys). One entry per atomic change.
+	Mutations []string
+
+	// DesiredState is the state the task was asked to converge to. Mirrors
+	// TaskOutputState.DesiredState so plan output can render the same context.
+	DesiredState State
+
+	// Error is non-nil when the read-state probe itself failed. A non-nil
+	// Error implies Status == PlanStatusError.
+	Error error
+}
+
 // Task represents a task
 type Task interface {
 	// Doc returns the docblock for the task
@@ -88,6 +134,10 @@ type Task interface {
 
 	// Examples returns the examples for the task
 	Examples() ([]Doc, error)
+
+	// Plan reports the drift the task would produce against the live server,
+	// without mutating it. Plan must never call mutating dokku commands.
+	Plan() PlanResult
 
 	// Execute executes the task
 	Execute() TaskOutputState

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -94,7 +94,7 @@ const (
 	// PlanStatusDestroy indicates the task would remove existing state.
 	PlanStatusDestroy PlanStatus = "-"
 	// PlanStatusError indicates the read-state probe itself failed.
-	PlanStatusError PlanStatus = "error"
+	PlanStatusError PlanStatus = "!"
 )
 
 // PlanResult is the read-only drift report for a task.

--- a/tasks/network_property_task.go
+++ b/tasks/network_property_task.go
@@ -76,7 +76,7 @@ func (t NetworkPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the network property
 func (t NetworkPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "network:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the NetworkPropertyTask would produce.

--- a/tasks/network_property_task.go
+++ b/tasks/network_property_task.go
@@ -79,6 +79,11 @@ func (t NetworkPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "network:set")
 }
 
+// Plan reports the drift the NetworkPropertyTask would produce.
+func (t NetworkPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "network:set")
+}
+
 // init registers the NetworkPropertyTask with the task registry
 func init() {
 	RegisterTask(&NetworkPropertyTask{})

--- a/tasks/network_task.go
+++ b/tasks/network_task.go
@@ -59,6 +59,34 @@ func (t NetworkTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the NetworkTask would produce.
+func (t NetworkTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		"present": func() PlanResult {
+			if networkExists(t.Name) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    "network missing",
+				Mutations: []string{"create network " + t.Name},
+			}
+		},
+		"absent": func() PlanResult {
+			if !networkExists(t.Name) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "network present",
+				Mutations: []string{"destroy network " + t.Name},
+			}
+		},
+	})
+}
+
 // networkExists checks if a Docker network exists
 func networkExists(name string) bool {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{

--- a/tasks/network_task.go
+++ b/tasks/network_task.go
@@ -53,16 +53,13 @@ func (t NetworkTask) Examples() ([]Doc, error) {
 
 // Execute creates or destroys a Docker network
 func (t NetworkTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return createNetwork(t.Name) },
-		"absent":  func() TaskOutputState { return destroyNetwork(t.Name) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the NetworkTask would produce.
 func (t NetworkTask) Plan() PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		"present": func() PlanResult {
+		StatePresent: func() PlanResult {
 			if networkExists(t.Name) {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
@@ -71,9 +68,22 @@ func (t NetworkTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    "network missing",
 				Mutations: []string{"create network " + t.Name},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "network:create", t.Name},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
 			}
 		},
-		"absent": func() PlanResult {
+		StateAbsent: func() PlanResult {
 			if !networkExists(t.Name) {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
@@ -82,6 +92,19 @@ func (t NetworkTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "network present",
 				Mutations: []string{"destroy network " + t.Name},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "--force", "network:destroy", t.Name},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
 			}
 		},
 	})
@@ -104,60 +127,23 @@ func networkExists(name string) bool {
 	return result.ExitCode == 0
 }
 
-// createNetwork creates a Docker network
-func createNetwork(name string) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
-	if networkExists(name) {
-		state.State = "present"
-		return state
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			"network:create",
-			name,
-		},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
-}
-
-// destroyNetwork destroys a Docker network
+// destroyNetwork is retained as an integration-test helper. It runs the
+// destroy-network apply path synchronously.
 func destroyNetwork(name string) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "present",
-	}
+	state := TaskOutputState{Changed: false, State: StatePresent}
 	if !networkExists(name) {
-		state.State = "absent"
+		state.State = StateAbsent
 		return state
 	}
-
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			"--force",
-			"network:destroy",
-			name,
-		},
+		Args:    []string{"--quiet", "--force", "network:destroy", name},
 	})
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}
-
 	state.Changed = true
-	state.State = "absent"
+	state.State = StateAbsent
 	return state
 }
 

--- a/tasks/nginx_property_task.go
+++ b/tasks/nginx_property_task.go
@@ -76,7 +76,7 @@ func (t NginxPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the nginx property
 func (t NginxPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "nginx:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the NginxPropertyTask would produce.

--- a/tasks/nginx_property_task.go
+++ b/tasks/nginx_property_task.go
@@ -79,6 +79,11 @@ func (t NginxPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "nginx:set")
 }
 
+// Plan reports the drift the NginxPropertyTask would produce.
+func (t NginxPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "nginx:set")
+}
+
 // init registers the NginxPropertyTask with the task registry
 func init() {
 	RegisterTask(&NginxPropertyTask{})

--- a/tasks/openresty_property_task.go
+++ b/tasks/openresty_property_task.go
@@ -79,6 +79,11 @@ func (t OpenrestyPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "openresty:set")
 }
 
+// Plan reports the drift the OpenrestyPropertyTask would produce.
+func (t OpenrestyPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "openresty:set")
+}
+
 // init registers the OpenrestyPropertyTask with the task registry
 func init() {
 	RegisterTask(&OpenrestyPropertyTask{})

--- a/tasks/openresty_property_task.go
+++ b/tasks/openresty_property_task.go
@@ -76,7 +76,7 @@ func (t OpenrestyPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the openresty property
 func (t OpenrestyPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "openresty:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the OpenrestyPropertyTask would produce.

--- a/tasks/ordered_map_test.go
+++ b/tasks/ordered_map_test.go
@@ -12,6 +12,7 @@ type mockTask struct {
 
 func (m mockTask) Doc() string              { return "" }
 func (m mockTask) Examples() ([]Doc, error) { return nil, nil }
+func (m mockTask) Plan() PlanResult         { return PlanResult{InSync: true, Status: PlanStatusOK} }
 func (m mockTask) Execute() TaskOutputState { return TaskOutputState{State: m.state} }
 
 func TestOrderedStringTaskMapSetAndGet(t *testing.T) {

--- a/tasks/plan_integration_test.go
+++ b/tasks/plan_integration_test.go
@@ -5,8 +5,7 @@ import (
 )
 
 // TestIntegrationPlanDetectsMissingApp asserts Plan() reports drift for a
-// dokku_app task when the target app does not exist, and stays consistent
-// with apply: after running apply, a follow-up Plan() returns InSync.
+// dokku_app task when the target app does not exist.
 func TestIntegrationPlanDetectsMissingApp(t *testing.T) {
 	skipIfNoDokkuT(t)
 
@@ -26,14 +25,11 @@ func TestIntegrationPlanDetectsMissingApp(t *testing.T) {
 	if plan.Status != PlanStatusCreate {
 		t.Errorf("expected status=%q, got %q", PlanStatusCreate, plan.Status)
 	}
-	if len(plan.Mutations) == 0 {
-		t.Error("expected at least one mutation entry")
-	}
 }
 
 // TestIntegrationPlanInSyncAfterApply applies a single dokku_app task then
-// verifies Plan() reports InSync. This is the round-trip property issue #198
-// promises: every apply followed by an immediate plan reports clean.
+// verifies Plan() reports InSync. This is the round-trip property: every
+// apply followed by an immediate plan must report clean.
 func TestIntegrationPlanInSyncAfterApply(t *testing.T) {
 	skipIfNoDokkuT(t)
 
@@ -53,14 +49,10 @@ func TestIntegrationPlanInSyncAfterApply(t *testing.T) {
 	if !plan.InSync {
 		t.Errorf("expected InSync after apply, got %+v", plan)
 	}
-	if plan.Status != PlanStatusOK {
-		t.Errorf("expected status=%q, got %q", PlanStatusOK, plan.Status)
-	}
 }
 
 // TestIntegrationPlanDoesNotMutate is the safety contract for plan: it must
-// never create, modify, or destroy server state. We assert this for the
-// create case (state=present, app missing).
+// never create, modify, or destroy server state.
 func TestIntegrationPlanDoesNotMutate(t *testing.T) {
 	skipIfNoDokkuT(t)
 
@@ -76,8 +68,8 @@ func TestIntegrationPlanDoesNotMutate(t *testing.T) {
 	}
 }
 
-// TestIntegrationPlanConfigItemizes asserts the per-key Mutations contract for
-// multi-mutation tasks. The config task is the canonical case.
+// TestIntegrationPlanConfigItemizes asserts the per-key Mutations contract
+// for multi-mutation tasks against a real Dokku.
 func TestIntegrationPlanConfigItemizes(t *testing.T) {
 	skipIfNoDokkuT(t)
 
@@ -105,5 +97,35 @@ func TestIntegrationPlanConfigItemizes(t *testing.T) {
 	}
 	if len(plan.Mutations) != 2 {
 		t.Errorf("expected 2 mutations (one per key), got %d: %v", len(plan.Mutations), plan.Mutations)
+	}
+}
+
+// TestIntegrationExecuteIdempotent asserts the property the new design
+// guarantees: a second Execute() on a task that just ran reports
+// Changed=false (because the apply closure short-circuits inside Plan via
+// the InSync check). This is the user-visible payoff of the refactor.
+func TestIntegrationExecuteIdempotent(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-plan-idempotent"
+	destroyApp(appName)
+	defer destroyApp(appName)
+
+	task := AppTask{App: appName, State: StatePresent}
+
+	first := task.Execute()
+	if first.Error != nil {
+		t.Fatalf("first apply errored: %v", first.Error)
+	}
+	if !first.Changed {
+		t.Error("first apply should report Changed=true (app was missing)")
+	}
+
+	second := task.Execute()
+	if second.Error != nil {
+		t.Fatalf("second apply errored: %v", second.Error)
+	}
+	if second.Changed {
+		t.Error("second apply should report Changed=false (app already present)")
 	}
 }

--- a/tasks/plan_integration_test.go
+++ b/tasks/plan_integration_test.go
@@ -1,0 +1,109 @@
+package tasks
+
+import (
+	"testing"
+)
+
+// TestIntegrationPlanDetectsMissingApp asserts Plan() reports drift for a
+// dokku_app task when the target app does not exist, and stays consistent
+// with apply: after running apply, a follow-up Plan() returns InSync.
+func TestIntegrationPlanDetectsMissingApp(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-plan-detect"
+	destroyApp(appName)
+	defer destroyApp(appName)
+
+	task := AppTask{App: appName, State: StatePresent}
+
+	plan := task.Plan()
+	if plan.Error != nil {
+		t.Fatalf("Plan() errored: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Errorf("expected drift on missing app, got InSync=true")
+	}
+	if plan.Status != PlanStatusCreate {
+		t.Errorf("expected status=%q, got %q", PlanStatusCreate, plan.Status)
+	}
+	if len(plan.Mutations) == 0 {
+		t.Error("expected at least one mutation entry")
+	}
+}
+
+// TestIntegrationPlanInSyncAfterApply applies a single dokku_app task then
+// verifies Plan() reports InSync. This is the round-trip property issue #198
+// promises: every apply followed by an immediate plan reports clean.
+func TestIntegrationPlanInSyncAfterApply(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-plan-roundtrip"
+	destroyApp(appName)
+	defer destroyApp(appName)
+
+	task := AppTask{App: appName, State: StatePresent}
+	if state := task.Execute(); state.Error != nil {
+		t.Fatalf("apply errored: %v", state.Error)
+	}
+
+	plan := task.Plan()
+	if plan.Error != nil {
+		t.Fatalf("plan errored after apply: %v", plan.Error)
+	}
+	if !plan.InSync {
+		t.Errorf("expected InSync after apply, got %+v", plan)
+	}
+	if plan.Status != PlanStatusOK {
+		t.Errorf("expected status=%q, got %q", PlanStatusOK, plan.Status)
+	}
+}
+
+// TestIntegrationPlanDoesNotMutate is the safety contract for plan: it must
+// never create, modify, or destroy server state. We assert this for the
+// create case (state=present, app missing).
+func TestIntegrationPlanDoesNotMutate(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-plan-no-mutate"
+	destroyApp(appName)
+	defer destroyApp(appName)
+
+	task := AppTask{App: appName, State: StatePresent}
+	_ = task.Plan()
+
+	if appExists(appName) {
+		t.Errorf("Plan() unexpectedly created %s", appName)
+	}
+}
+
+// TestIntegrationPlanConfigItemizes asserts the per-key Mutations contract for
+// multi-mutation tasks. The config task is the canonical case.
+func TestIntegrationPlanConfigItemizes(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-plan-config"
+	destroyApp(appName)
+	defer destroyApp(appName)
+
+	if state := (AppTask{App: appName, State: StatePresent}).Execute(); state.Error != nil {
+		t.Fatalf("setup apps:create failed: %v", state.Error)
+	}
+
+	task := ConfigTask{
+		App:     appName,
+		Restart: false,
+		Config:  map[string]string{"DOCKET_TEST_KEY_A": "1", "DOCKET_TEST_KEY_B": "2"},
+		State:   StatePresent,
+	}
+
+	plan := task.Plan()
+	if plan.Error != nil {
+		t.Fatalf("plan errored: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Fatal("expected drift, got InSync=true")
+	}
+	if len(plan.Mutations) != 2 {
+		t.Errorf("expected 2 mutations (one per key), got %d: %v", len(plan.Mutations), plan.Mutations)
+	}
+}

--- a/tasks/plan_test.go
+++ b/tasks/plan_test.go
@@ -6,21 +6,15 @@ import (
 )
 
 // TestAllTasksImplementPlan asserts every registered task type satisfies the
-// Task interface (which requires Plan()). Without this enforcement, a new
-// task that forgets Plan() would only fail when its file is loaded by the
-// CLI, instead of at compile time. The Task interface check itself is a
-// compile-time guarantee, so this test mostly documents intent and catches
-// any future refactor that loosens the interface contract.
+// Task interface (which now requires Plan()). The interface assignment is a
+// compile-time guarantee, but this test fails loudly if a future refactor
+// loosens the contract or registers a task that does not implement Plan.
 func TestAllTasksImplementPlan(t *testing.T) {
 	if len(RegisteredTasks) == 0 {
 		t.Fatal("no tasks registered; init() side effects didn't run")
 	}
 	for name, task := range RegisteredTasks {
 		var _ Task = task
-		// Calling Plan() on a zero-valued task can hit subprocess (which
-		// fails in CI without dokku) - we only care that the method exists,
-		// which the interface assignment above guarantees. Surface name in
-		// errors for any future inspection-style assertions.
 		if name == "" {
 			t.Errorf("task with empty name: %T", task)
 		}
@@ -42,7 +36,7 @@ func TestDispatchPlanInvalidState(t *testing.T) {
 }
 
 // TestDispatchPlanSetsDesiredState verifies DispatchPlan propagates the
-// requested state onto the returned PlanResult, matching DispatchState.
+// requested state onto the returned PlanResult.
 func TestDispatchPlanSetsDesiredState(t *testing.T) {
 	result := DispatchPlan(StatePresent, map[State]func() PlanResult{
 		StatePresent: func() PlanResult { return PlanResult{InSync: true, Status: PlanStatusOK} },
@@ -55,23 +49,117 @@ func TestDispatchPlanSetsDesiredState(t *testing.T) {
 	}
 }
 
-// TestPlanResultError shows the canonical shape of an error PlanResult so
-// future helpers that build error results stay consistent.
-func TestPlanResultError(t *testing.T) {
-	want := errors.New("boom")
-	got := PlanResult{Status: PlanStatusError, Error: want}
-	if got.Error != want {
-		t.Errorf("Error not preserved")
+// TestExecutePlanInSyncSkipsApply verifies that ExecutePlan does not invoke
+// the apply closure when the plan reports InSync. This is the critical
+// invariant that makes apply idempotent for the post-#198 design.
+func TestExecutePlanInSyncSkipsApply(t *testing.T) {
+	called := false
+	result := ExecutePlan(PlanResult{
+		InSync:       true,
+		Status:       PlanStatusOK,
+		DesiredState: StatePresent,
+		apply: func() TaskOutputState {
+			called = true
+			return TaskOutputState{}
+		},
+	})
+	if called {
+		t.Fatal("ExecutePlan invoked apply on InSync result")
 	}
-	if got.InSync {
-		t.Error("error result must not be InSync")
+	if result.Changed {
+		t.Error("InSync result should report Changed=false")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected State=%q, got %q", StatePresent, result.State)
+	}
+	if result.DesiredState != StatePresent {
+		t.Errorf("expected DesiredState=%q, got %q", StatePresent, result.DesiredState)
 	}
 }
 
-// TestPlanConfigSetItemizesKeys sanity-checks that the config_task helper
-// reports the expected per-key mutations when given a synthetic current/desired
-// pair. This guards the documented "rich Mutations everywhere" promise for the
-// config task family.
+// TestExecutePlanErrorSkipsApply verifies that ExecutePlan does not invoke
+// the apply closure when the plan reports an error.
+func TestExecutePlanErrorSkipsApply(t *testing.T) {
+	called := false
+	probeErr := errors.New("probe failed")
+	result := ExecutePlan(PlanResult{
+		Status:       PlanStatusError,
+		Error:        probeErr,
+		DesiredState: StatePresent,
+		apply: func() TaskOutputState {
+			called = true
+			return TaskOutputState{}
+		},
+	})
+	if called {
+		t.Fatal("ExecutePlan invoked apply on error result")
+	}
+	if !errors.Is(result.Error, probeErr) {
+		t.Errorf("expected Error to be probeErr, got %v", result.Error)
+	}
+}
+
+// TestExecutePlanInvokesApplyOnDrift verifies that ExecutePlan does invoke
+// the apply closure when the plan reports drift (the canonical path).
+func TestExecutePlanInvokesApplyOnDrift(t *testing.T) {
+	called := false
+	result := ExecutePlan(PlanResult{
+		InSync:       false,
+		Status:       PlanStatusModify,
+		DesiredState: StatePresent,
+		apply: func() TaskOutputState {
+			called = true
+			return TaskOutputState{Changed: true, State: StatePresent}
+		},
+	})
+	if !called {
+		t.Fatal("ExecutePlan did not invoke apply on drift result")
+	}
+	if !result.Changed {
+		t.Error("apply returned Changed=true; ExecutePlan must propagate it")
+	}
+	if result.DesiredState != StatePresent {
+		t.Errorf("ExecutePlan should fill in DesiredState; got %q", result.DesiredState)
+	}
+}
+
+// TestExecutePlanMissingApplyIsError verifies that a drift PlanResult
+// without an apply closure surfaces a clear error rather than silently
+// no-opping. Catches refactor mistakes where Plan() forgets to set apply.
+func TestExecutePlanMissingApplyIsError(t *testing.T) {
+	result := ExecutePlan(PlanResult{
+		InSync:       false,
+		Status:       PlanStatusModify,
+		DesiredState: StatePresent,
+		// apply intentionally nil
+	})
+	if result.Error == nil {
+		t.Fatal("ExecutePlan with drift but no apply should error")
+	}
+}
+
+// TestPlanResultStatusConstants documents the canonical status values used
+// across the codebase. If a refactor renames or removes one, this test
+// fails so the plan output formatter and JSON consumers can be updated.
+func TestPlanResultStatusConstants(t *testing.T) {
+	cases := map[PlanStatus]string{
+		PlanStatusOK:      "ok",
+		PlanStatusModify:  "~",
+		PlanStatusCreate:  "+",
+		PlanStatusDestroy: "-",
+		PlanStatusError:   "error",
+	}
+	for got, want := range cases {
+		if string(got) != want {
+			t.Errorf("status %q has unexpected string %q", want, string(got))
+		}
+	}
+}
+
+// TestPlanConfigSetItemizesKeys exercises the per-key diff helper used by
+// config_task.Plan to ensure the right keys are flagged. Plan-level
+// integration with subprocess is covered by integration tests; this is a
+// pure-data test that does not touch dokku.
 func TestPlanConfigSetItemizesKeys(t *testing.T) {
 	current := map[string]string{
 		"EXISTING": "old",
@@ -87,49 +175,41 @@ func TestPlanConfigSetItemizesKeys(t *testing.T) {
 	if len(keys) != 2 {
 		t.Fatalf("expected 2 keys to set, got %d: %v", len(keys), keys)
 	}
-
 	got := map[string]bool{}
 	for _, k := range keys {
 		got[k] = true
 	}
-	if !got["EXISTING"] {
-		t.Error("expected EXISTING in keys to set")
-	}
-	if !got["NEW"] {
-		t.Error("expected NEW in keys to set")
+	if !got["EXISTING"] || !got["NEW"] {
+		t.Errorf("expected EXISTING and NEW; got %v", keys)
 	}
 	if got["KEEP"] {
 		t.Error("KEEP should not be in keys to set (value matches)")
 	}
 }
 
-// TestPlanConfigUnsetItemizesKeys sanity-checks that the unset path itemizes
-// only keys that currently exist on the server, since unsetting a missing key
-// is a no-op.
+// TestPlanConfigUnsetItemizesKeys checks that the unset path itemizes only
+// keys that currently exist on the server.
 func TestPlanConfigUnsetItemizesKeys(t *testing.T) {
 	current := map[string]string{"PRESENT": "v"}
 	desired := map[string]string{"PRESENT": "", "MISSING": ""}
-
 	keys := configKeysToUnset(current, desired)
 	if len(keys) != 1 || keys[0] != "PRESENT" {
-		t.Errorf("expected only PRESENT in keys to unset, got %v", keys)
+		t.Errorf("expected only PRESENT; got %v", keys)
 	}
 }
 
-// TestPlanResultStatusConstants documents the canonical status values used
-// across the codebase. If a refactor renames or removes one, this test fails
-// loudly so the plan output formatter and JSON consumers can be updated.
-func TestPlanResultStatusConstants(t *testing.T) {
-	cases := map[PlanStatus]string{
-		PlanStatusOK:      "ok",
-		PlanStatusModify:  "~",
-		PlanStatusCreate:  "+",
-		PlanStatusDestroy: "-",
-		PlanStatusError:   "error",
+// TestPluginFromSubcommand exercises the plugin extraction used by the
+// generic property probe.
+func TestPluginFromSubcommand(t *testing.T) {
+	cases := map[string]string{
+		"nginx:set":                  "nginx",
+		"app-json:set":               "app-json",
+		"buildpacks:set-property":    "buildpacks",
+		"scheduler-docker-local:set": "scheduler-docker-local",
 	}
-	for got, want := range cases {
-		if string(got) != want {
-			t.Errorf("status %q has unexpected string %q", want, string(got))
+	for input, want := range cases {
+		if got := pluginFromSubcommand(input); got != want {
+			t.Errorf("pluginFromSubcommand(%q) = %q, want %q", input, got, want)
 		}
 	}
 }

--- a/tasks/plan_test.go
+++ b/tasks/plan_test.go
@@ -1,0 +1,135 @@
+package tasks
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestAllTasksImplementPlan asserts every registered task type satisfies the
+// Task interface (which requires Plan()). Without this enforcement, a new
+// task that forgets Plan() would only fail when its file is loaded by the
+// CLI, instead of at compile time. The Task interface check itself is a
+// compile-time guarantee, so this test mostly documents intent and catches
+// any future refactor that loosens the interface contract.
+func TestAllTasksImplementPlan(t *testing.T) {
+	if len(RegisteredTasks) == 0 {
+		t.Fatal("no tasks registered; init() side effects didn't run")
+	}
+	for name, task := range RegisteredTasks {
+		var _ Task = task
+		// Calling Plan() on a zero-valued task can hit subprocess (which
+		// fails in CI without dokku) - we only care that the method exists,
+		// which the interface assignment above guarantees. Surface name in
+		// errors for any future inspection-style assertions.
+		if name == "" {
+			t.Errorf("task with empty name: %T", task)
+		}
+	}
+}
+
+// TestDispatchPlanInvalidState verifies that DispatchPlan returns an error
+// PlanResult when the requested state has no handler, mirroring DispatchState.
+func TestDispatchPlanInvalidState(t *testing.T) {
+	result := DispatchPlan(State("nonsense"), map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return PlanResult{InSync: true} },
+	})
+	if result.Error == nil {
+		t.Fatal("DispatchPlan with unknown state should set Error")
+	}
+	if result.Status != PlanStatusError {
+		t.Errorf("expected PlanStatusError, got %q", result.Status)
+	}
+}
+
+// TestDispatchPlanSetsDesiredState verifies DispatchPlan propagates the
+// requested state onto the returned PlanResult, matching DispatchState.
+func TestDispatchPlanSetsDesiredState(t *testing.T) {
+	result := DispatchPlan(StatePresent, map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return PlanResult{InSync: true, Status: PlanStatusOK} },
+	})
+	if result.DesiredState != StatePresent {
+		t.Errorf("expected DesiredState=%q, got %q", StatePresent, result.DesiredState)
+	}
+	if !result.InSync {
+		t.Error("expected handler's InSync to propagate")
+	}
+}
+
+// TestPlanResultError shows the canonical shape of an error PlanResult so
+// future helpers that build error results stay consistent.
+func TestPlanResultError(t *testing.T) {
+	want := errors.New("boom")
+	got := PlanResult{Status: PlanStatusError, Error: want}
+	if got.Error != want {
+		t.Errorf("Error not preserved")
+	}
+	if got.InSync {
+		t.Error("error result must not be InSync")
+	}
+}
+
+// TestPlanConfigSetItemizesKeys sanity-checks that the config_task helper
+// reports the expected per-key mutations when given a synthetic current/desired
+// pair. This guards the documented "rich Mutations everywhere" promise for the
+// config task family.
+func TestPlanConfigSetItemizesKeys(t *testing.T) {
+	current := map[string]string{
+		"EXISTING": "old",
+		"KEEP":     "same",
+	}
+	desired := map[string]string{
+		"EXISTING": "new",
+		"KEEP":     "same",
+		"NEW":      "value",
+	}
+
+	keys := configKeysToSet(current, desired)
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 keys to set, got %d: %v", len(keys), keys)
+	}
+
+	got := map[string]bool{}
+	for _, k := range keys {
+		got[k] = true
+	}
+	if !got["EXISTING"] {
+		t.Error("expected EXISTING in keys to set")
+	}
+	if !got["NEW"] {
+		t.Error("expected NEW in keys to set")
+	}
+	if got["KEEP"] {
+		t.Error("KEEP should not be in keys to set (value matches)")
+	}
+}
+
+// TestPlanConfigUnsetItemizesKeys sanity-checks that the unset path itemizes
+// only keys that currently exist on the server, since unsetting a missing key
+// is a no-op.
+func TestPlanConfigUnsetItemizesKeys(t *testing.T) {
+	current := map[string]string{"PRESENT": "v"}
+	desired := map[string]string{"PRESENT": "", "MISSING": ""}
+
+	keys := configKeysToUnset(current, desired)
+	if len(keys) != 1 || keys[0] != "PRESENT" {
+		t.Errorf("expected only PRESENT in keys to unset, got %v", keys)
+	}
+}
+
+// TestPlanResultStatusConstants documents the canonical status values used
+// across the codebase. If a refactor renames or removes one, this test fails
+// loudly so the plan output formatter and JSON consumers can be updated.
+func TestPlanResultStatusConstants(t *testing.T) {
+	cases := map[PlanStatus]string{
+		PlanStatusOK:      "ok",
+		PlanStatusModify:  "~",
+		PlanStatusCreate:  "+",
+		PlanStatusDestroy: "-",
+		PlanStatusError:   "error",
+	}
+	for got, want := range cases {
+		if string(got) != want {
+			t.Errorf("status %q has unexpected string %q", want, string(got))
+		}
+	}
+}

--- a/tasks/plan_test.go
+++ b/tasks/plan_test.go
@@ -147,7 +147,7 @@ func TestPlanResultStatusConstants(t *testing.T) {
 		PlanStatusModify:  "~",
 		PlanStatusCreate:  "+",
 		PlanStatusDestroy: "-",
-		PlanStatusError:   "error",
+		PlanStatusError:   "!",
 	}
 	for got, want := range cases {
 		if string(got) != want {

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -79,6 +79,65 @@ func (t PortsTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the PortsTask would produce.
+func (t PortsTask) Plan() PlanResult {
+	if len(t.PortMappings) == 0 {
+		return PlanResult{
+			Status: PlanStatusError,
+			Error:  errors.New("no port mappings provided"),
+		}
+	}
+
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		"present": func() PlanResult { return planSetPorts(t.App, t.PortMappings) },
+		"absent":  func() PlanResult { return planUnsetPorts(t.App, t.PortMappings) },
+	})
+}
+
+// planSetPorts reports drift for a present-state port set.
+func planSetPorts(appName string, portMappings []PortMapping) PlanResult {
+	currentPorts := getPorts(appName)
+	mutations := []string{}
+	for _, pm := range portMappings {
+		if _, ok := currentPorts[pm.String()]; !ok {
+			mutations = append(mutations, fmt.Sprintf("add %s", pm.String()))
+		}
+	}
+	if len(mutations) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	status := PlanStatusModify
+	if len(currentPorts) == 0 {
+		status = PlanStatusCreate
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    status,
+		Reason:    fmt.Sprintf("%d port mapping(s) to add", len(mutations)),
+		Mutations: mutations,
+	}
+}
+
+// planUnsetPorts reports drift for an absent-state port unset.
+func planUnsetPorts(appName string, portMappings []PortMapping) PlanResult {
+	currentPorts := getPorts(appName)
+	mutations := []string{}
+	for _, pm := range portMappings {
+		if _, ok := currentPorts[pm.String()]; ok {
+			mutations = append(mutations, fmt.Sprintf("remove %s", pm.String()))
+		}
+	}
+	if len(mutations) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    fmt.Sprintf("%d port mapping(s) to remove", len(mutations)),
+		Mutations: mutations,
+	}
+}
+
 // getPorts gets the ports for a given app
 func getPorts(appName string) map[string]PortMapping {
 	// todo: update dokku to add proper json output for this

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -63,79 +63,94 @@ func (t PortsTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the ports
 func (t PortsTask) Execute() TaskOutputState {
-	// todo: add port mapping validation
-	if len(t.PortMappings) == 0 {
-		return TaskOutputState{
-			Changed: false,
-			State:   "absent",
-			Error:   errors.New("no port mappings provided"),
-			Message: "no port mappings provided",
-		}
-	}
-
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return setPorts(t.App, t.PortMappings) },
-		"absent":  func() TaskOutputState { return unsetPorts(t.App, t.PortMappings) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the PortsTask would produce.
 func (t PortsTask) Plan() PlanResult {
 	if len(t.PortMappings) == 0 {
-		return PlanResult{
-			Status: PlanStatusError,
-			Error:  errors.New("no port mappings provided"),
-		}
+		return PlanResult{Status: PlanStatusError, Error: errors.New("no port mappings provided")}
 	}
-
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		"present": func() PlanResult { return planSetPorts(t.App, t.PortMappings) },
-		"absent":  func() PlanResult { return planUnsetPorts(t.App, t.PortMappings) },
+		StatePresent: func() PlanResult {
+			currentPorts := getPorts(t.App)
+			toAdd := []PortMapping{}
+			mutations := []string{}
+			for _, pm := range t.PortMappings {
+				if _, ok := currentPorts[pm.String()]; !ok {
+					toAdd = append(toAdd, pm)
+					mutations = append(mutations, fmt.Sprintf("add %s", pm.String()))
+				}
+			}
+			if len(toAdd) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			status := PlanStatusModify
+			if len(currentPorts) == 0 {
+				status = PlanStatusCreate
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    status,
+				Reason:    fmt.Sprintf("%d port mapping(s) to add", len(toAdd)),
+				Mutations: mutations,
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					args := []string{"--quiet", "ports:add", t.App}
+					for _, pm := range toAdd {
+						args = append(args, pm.String())
+					}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			currentPorts := getPorts(t.App)
+			toRemove := []PortMapping{}
+			mutations := []string{}
+			for _, pm := range t.PortMappings {
+				if _, ok := currentPorts[pm.String()]; ok {
+					toRemove = append(toRemove, pm)
+					mutations = append(mutations, fmt.Sprintf("remove %s", pm.String()))
+				}
+			}
+			if len(toRemove) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    fmt.Sprintf("%d port mapping(s) to remove", len(toRemove)),
+				Mutations: mutations,
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					args := []string{"--quiet", "ports:remove", t.App}
+					for _, pm := range toRemove {
+						args = append(args, pm.String())
+					}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
+			}
+		},
 	})
-}
-
-// planSetPorts reports drift for a present-state port set.
-func planSetPorts(appName string, portMappings []PortMapping) PlanResult {
-	currentPorts := getPorts(appName)
-	mutations := []string{}
-	for _, pm := range portMappings {
-		if _, ok := currentPorts[pm.String()]; !ok {
-			mutations = append(mutations, fmt.Sprintf("add %s", pm.String()))
-		}
-	}
-	if len(mutations) == 0 {
-		return PlanResult{InSync: true, Status: PlanStatusOK}
-	}
-	status := PlanStatusModify
-	if len(currentPorts) == 0 {
-		status = PlanStatusCreate
-	}
-	return PlanResult{
-		InSync:    false,
-		Status:    status,
-		Reason:    fmt.Sprintf("%d port mapping(s) to add", len(mutations)),
-		Mutations: mutations,
-	}
-}
-
-// planUnsetPorts reports drift for an absent-state port unset.
-func planUnsetPorts(appName string, portMappings []PortMapping) PlanResult {
-	currentPorts := getPorts(appName)
-	mutations := []string{}
-	for _, pm := range portMappings {
-		if _, ok := currentPorts[pm.String()]; ok {
-			mutations = append(mutations, fmt.Sprintf("remove %s", pm.String()))
-		}
-	}
-	if len(mutations) == 0 {
-		return PlanResult{InSync: true, Status: PlanStatusOK}
-	}
-	return PlanResult{
-		InSync:    false,
-		Status:    PlanStatusDestroy,
-		Reason:    fmt.Sprintf("%d port mapping(s) to remove", len(mutations)),
-		Mutations: mutations,
-	}
 }
 
 // getPorts gets the ports for a given app
@@ -180,92 +195,6 @@ func getPorts(appName string) map[string]PortMapping {
 	}
 
 	return portMappings
-}
-
-// setPorts sets the ports for a given app
-func setPorts(appName string, portMappings []PortMapping) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
-
-	currentPorts := getPorts(appName)
-	newPorts := map[string]PortMapping{}
-	for _, portMapping := range portMappings {
-		if _, ok := currentPorts[portMapping.String()]; !ok {
-			newPorts[portMapping.String()] = portMapping
-		}
-	}
-
-	if len(newPorts) == 0 {
-		state.State = "present"
-		return state
-	}
-
-	args := []string{
-		"--quiet",
-		"ports:add",
-		appName,
-	}
-
-	for _, portMapping := range newPorts {
-		args = append(args, portMapping.String())
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
-}
-
-// unsetPorts unsets the ports for a given app
-func unsetPorts(appName string, portMappings []PortMapping) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "present",
-	}
-
-	currentPorts := getPorts(appName)
-	removedPorts := map[string]PortMapping{}
-	for _, portMapping := range portMappings {
-		if _, ok := currentPorts[portMapping.String()]; ok {
-			removedPorts[portMapping.String()] = portMapping
-		}
-	}
-
-	if len(removedPorts) == 0 {
-		state.State = "absent"
-		return state
-	}
-
-	args := []string{
-		"--quiet",
-		"ports:remove",
-		appName,
-	}
-
-	for _, portMapping := range removedPorts {
-		args = append(args, portMapping.String())
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "absent"
-	return state
 }
 
 // init registers the PortsTask with the task registry

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -23,114 +23,6 @@ type PropertyContext struct {
 	Value string `required:"false" yaml:"value"`
 }
 
-// executeProperty is a shared Execute implementation for property tasks.
-func executeProperty(state State, app string, global bool, property, value, subcommand string) TaskOutputState {
-	if !global && app == "" {
-		return TaskOutputState{
-			Error: errors.New("app is required when global is false"),
-		}
-	}
-
-	ctx := PropertyContext{
-		App:      app,
-		Global:   global,
-		Property: property,
-		Value:    value,
-	}
-	return DispatchState(state, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return setProperty(subcommand, ctx) },
-		"absent":  func() TaskOutputState { return unsetProperty(subcommand, ctx) },
-	})
-}
-
-// planProperty is a shared Plan implementation for property tasks. It probes
-// the current value via `dokku <plugin>:report <target> --<plugin>-<property>`
-// and compares against the desired value. When the probe fails (plugin
-// without :report support or unknown property flag), falls back to reporting
-// drift conservatively rather than erroring, so users still see a usable plan.
-func planProperty(state State, app string, global bool, property, value, subcommand string) PlanResult {
-	if !global && app == "" {
-		return PlanResult{
-			Status: PlanStatusError,
-			Error:  errors.New("app is required when global is false"),
-		}
-	}
-	if global && app != "" {
-		return PlanResult{
-			Status: PlanStatusError,
-			Error:  fmt.Errorf("'app' must not be set when 'global' is set to true"),
-		}
-	}
-
-	target := app
-	if global {
-		target = "--global"
-	}
-
-	return DispatchPlan(state, map[State]func() PlanResult{
-		"present": func() PlanResult {
-			if value == "" {
-				return PlanResult{
-					Status: PlanStatusError,
-					Error:  fmt.Errorf("setting a state of 'present' is invalid without a value for 'value'"),
-				}
-			}
-			current, err := getProperty(subcommand, app, global, property)
-			if err != nil {
-				return PlanResult{
-					InSync:    false,
-					Status:    PlanStatusModify,
-					Reason:    fmt.Sprintf("would set %s on %s (probe failed: %v)", property, target, err),
-					Mutations: []string{fmt.Sprintf("set %s=%s", property, value)},
-				}
-			}
-			if current == value {
-				return PlanResult{InSync: true, Status: PlanStatusOK}
-			}
-			status := PlanStatusModify
-			if current == "" {
-				status = PlanStatusCreate
-			}
-			reason := fmt.Sprintf("%s drift on %s", property, target)
-			if current != "" {
-				reason = fmt.Sprintf("%s drift on %s (was %q)", property, target, current)
-			}
-			return PlanResult{
-				InSync:    false,
-				Status:    status,
-				Reason:    reason,
-				Mutations: []string{fmt.Sprintf("set %s=%s", property, value)},
-			}
-		},
-		"absent": func() PlanResult {
-			if value != "" {
-				return PlanResult{
-					Status: PlanStatusError,
-					Error:  fmt.Errorf("setting a state of 'absent' is invalid with a value for 'value'"),
-				}
-			}
-			current, err := getProperty(subcommand, app, global, property)
-			if err != nil {
-				return PlanResult{
-					InSync:    false,
-					Status:    PlanStatusModify,
-					Reason:    fmt.Sprintf("would unset %s on %s (probe failed: %v)", property, target, err),
-					Mutations: []string{fmt.Sprintf("unset %s", property)},
-				}
-			}
-			if current == "" {
-				return PlanResult{InSync: true, Status: PlanStatusOK}
-			}
-			return PlanResult{
-				InSync:    false,
-				Status:    PlanStatusDestroy,
-				Reason:    fmt.Sprintf("would unset %s on %s (was %q)", property, target, current),
-				Mutations: []string{fmt.Sprintf("unset %s", property)},
-			}
-		},
-	})
-}
-
 // pluginFromSubcommand returns the plugin component of a colon-separated
 // subcommand. For example, "nginx:set" -> "nginx", "buildpacks:set-property" ->
 // "buildpacks", "app-json:set" -> "app-json".
@@ -142,8 +34,7 @@ func pluginFromSubcommand(subcommand string) string {
 // `dokku <plugin>:report <target> --<plugin>-<property>`. Returns the
 // trimmed string value on success. When the report subcommand or property
 // flag is not supported by the plugin, returns a non-nil error and callers
-// fall back to a conservative path (Plan reports drift; Execute proceeds
-// to set/unset unconditionally).
+// fall back to an unconditional set/unset (matches the pre-probe behavior).
 func getProperty(subcommand, app string, global bool, property string) (string, error) {
 	plugin := pluginFromSubcommand(subcommand)
 	reportSubcommand := plugin + ":report"
@@ -166,98 +57,131 @@ func getProperty(subcommand, app string, global bool, property string) (string, 
 	return strings.TrimSpace(result.StdoutContents()), nil
 }
 
-// setProperty sets a property for a given app, short-circuiting when the
-// current value already matches the desired value.
-func setProperty(subcommand string, pctx PropertyContext) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
+// planProperty is the shared Plan() implementation for property tasks. It
+// probes the current value via getProperty, returns InSync when current
+// matches desired, and otherwise embeds an apply closure that runs the
+// underlying `dokku <subcommand>` call. ExecutePlan is the only invoker.
+//
+// When the report subcommand or property flag is missing, the probe error
+// is swallowed and the apply closure runs the set/unset unconditionally,
+// matching the pre-probe behavior of property tasks.
+func planProperty(state State, app string, global bool, property, value, subcommand string) PlanResult {
+	if !global && app == "" {
+		return PlanResult{
+			Status: PlanStatusError,
+			Error:  errors.New("app is required when global is false"),
+		}
+	}
+	if global && app != "" {
+		return PlanResult{
+			Status: PlanStatusError,
+			Error:  fmt.Errorf("'app' must not be set when 'global' is set to true"),
+		}
 	}
 
-	if pctx.Global && pctx.App != "" {
-		state.Error = fmt.Errorf("'app' must not be set when 'global' is set to true")
-		return state
+	target := app
+	if global {
+		target = "--global"
 	}
 
-	appName := "--global"
-	if pctx.App != "" {
-		appName = pctx.App
-	}
+	return DispatchPlan(state, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if value == "" {
+				return PlanResult{
+					Status: PlanStatusError,
+					Error:  fmt.Errorf("setting a state of 'present' is invalid without a value for 'value'"),
+				}
+			}
 
-	if pctx.Value == "" {
-		state.Error = fmt.Errorf("setting a state of 'present' is invalid without a value for 'value'")
-		return state
-	}
+			// Probe; treat probe failure as "drift, must mutate".
+			current, probeErr := getProperty(subcommand, app, global, property)
+			if probeErr == nil && current == value {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
 
-	// Probe current value; if it matches desired, no-op (Changed=false).
-	// A failed probe (plugin without :report or unsupported property flag)
-	// falls through to the unconditional set, matching pre-probe behavior.
-	if current, err := getProperty(subcommand, pctx.App, pctx.Global, pctx.Property); err == nil && current == pctx.Value {
-		state.State = "present"
-		return state
-	}
+			status := PlanStatusModify
+			reason := fmt.Sprintf("would set %s on %s", property, target)
+			if probeErr != nil {
+				reason = fmt.Sprintf("would set %s on %s (probe failed: %v)", property, target, probeErr)
+			} else if current == "" {
+				status = PlanStatusCreate
+				reason = fmt.Sprintf("%s missing on %s", property, target)
+			} else {
+				reason = fmt.Sprintf("%s drift on %s (was %q)", property, target, current)
+			}
 
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			subcommand,
-			appName,
-			pctx.Property,
-			pctx.Value,
+			return PlanResult{
+				InSync:    false,
+				Status:    status,
+				Reason:    reason,
+				Mutations: []string{fmt.Sprintf("set %s=%s", property, value)},
+				apply:     applyPropertySet(subcommand, target, property, value),
+			}
+		},
+		StateAbsent: func() PlanResult {
+			if value != "" {
+				return PlanResult{
+					Status: PlanStatusError,
+					Error:  fmt.Errorf("setting a state of 'absent' is invalid with a value for 'value'"),
+				}
+			}
+
+			current, probeErr := getProperty(subcommand, app, global, property)
+			if probeErr == nil && current == "" {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+
+			reason := fmt.Sprintf("would unset %s on %s", property, target)
+			if probeErr != nil {
+				reason = fmt.Sprintf("would unset %s on %s (probe failed: %v)", property, target, probeErr)
+			} else {
+				reason = fmt.Sprintf("would unset %s on %s (was %q)", property, target, current)
+			}
+
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    reason,
+				Mutations: []string{fmt.Sprintf("unset %s", property)},
+				apply:     applyPropertyUnset(subcommand, target, property),
+			}
 		},
 	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
 }
 
-// unsetProperty unsets a property for a given app, short-circuiting when the
-// current value is already empty.
-func unsetProperty(subcommand string, pctx PropertyContext) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "present",
-	}
-
-	if pctx.Global && pctx.App != "" {
-		state.Error = fmt.Errorf("'app' must not be set when 'global' is set to true")
+// applyPropertySet returns a closure that runs `dokku <subcommand> <target>
+// <property> <value>` and converts the result into a TaskOutputState.
+func applyPropertySet(subcommand, target, property, value string) func() TaskOutputState {
+	return func() TaskOutputState {
+		state := TaskOutputState{Changed: false, State: StateAbsent}
+		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", subcommand, target, property, value},
+		})
+		if err != nil {
+			return TaskOutputErrorFromExec(state, err, result)
+		}
+		state.Changed = true
+		state.State = StatePresent
 		return state
 	}
+}
 
-	appName := "--global"
-	if pctx.App != "" {
-		appName = pctx.App
-	}
-
-	if pctx.Value != "" {
-		state.Error = fmt.Errorf("setting a state of 'absent' is invalid with a value for 'value'")
+// applyPropertyUnset returns a closure that runs `dokku <subcommand> <target>
+// <property>` (no value, which dokku interprets as unset) and converts the
+// result into a TaskOutputState.
+func applyPropertyUnset(subcommand, target, property string) func() TaskOutputState {
+	return func() TaskOutputState {
+		state := TaskOutputState{Changed: false, State: StatePresent}
+		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", subcommand, target, property},
+		})
+		if err != nil {
+			return TaskOutputErrorFromExec(state, err, result)
+		}
+		state.Changed = true
+		state.State = StateAbsent
 		return state
 	}
-
-	if current, err := getProperty(subcommand, pctx.App, pctx.Global, pctx.Property); err == nil && current == "" {
-		state.State = "absent"
-		return state
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			subcommand,
-			appName,
-			pctx.Property,
-		},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "absent"
-	return state
 }

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -3,6 +3,8 @@ package tasks
 import (
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/dokku/docket/subprocess"
 )
 
@@ -41,13 +43,11 @@ func executeProperty(state State, app string, global bool, property, value, subc
 	})
 }
 
-// planProperty is a shared Plan implementation for property tasks.
-//
-// Property tasks today do not probe live state before mutating (see the TODOs
-// in setProperty/unsetProperty), so the plan result is conservative: it
-// reports drift unconditionally and notes the limitation in Reason. A
-// follow-up that adds <subcommand>:report probes can replace this with a
-// precise comparison.
+// planProperty is a shared Plan implementation for property tasks. It probes
+// the current value via `dokku <plugin>:report <target> --<plugin>-<property>`
+// and compares against the desired value. When the probe fails (plugin
+// without :report support or unknown property flag), falls back to reporting
+// drift conservatively rather than erroring, so users still see a usable plan.
 func planProperty(state State, app string, global bool, property, value, subcommand string) PlanResult {
 	if !global && app == "" {
 		return PlanResult{
@@ -75,10 +75,30 @@ func planProperty(state State, app string, global bool, property, value, subcomm
 					Error:  fmt.Errorf("setting a state of 'present' is invalid without a value for 'value'"),
 				}
 			}
+			current, err := getProperty(subcommand, app, global, property)
+			if err != nil {
+				return PlanResult{
+					InSync:    false,
+					Status:    PlanStatusModify,
+					Reason:    fmt.Sprintf("would set %s on %s (probe failed: %v)", property, target, err),
+					Mutations: []string{fmt.Sprintf("set %s=%s", property, value)},
+				}
+			}
+			if current == value {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			status := PlanStatusModify
+			if current == "" {
+				status = PlanStatusCreate
+			}
+			reason := fmt.Sprintf("%s drift on %s", property, target)
+			if current != "" {
+				reason = fmt.Sprintf("%s drift on %s (was %q)", property, target, current)
+			}
 			return PlanResult{
 				InSync:    false,
-				Status:    PlanStatusModify,
-				Reason:    fmt.Sprintf("would set %s on %s (current value not probed)", property, target),
+				Status:    status,
+				Reason:    reason,
 				Mutations: []string{fmt.Sprintf("set %s=%s", property, value)},
 			}
 		},
@@ -89,17 +109,65 @@ func planProperty(state State, app string, global bool, property, value, subcomm
 					Error:  fmt.Errorf("setting a state of 'absent' is invalid with a value for 'value'"),
 				}
 			}
+			current, err := getProperty(subcommand, app, global, property)
+			if err != nil {
+				return PlanResult{
+					InSync:    false,
+					Status:    PlanStatusModify,
+					Reason:    fmt.Sprintf("would unset %s on %s (probe failed: %v)", property, target, err),
+					Mutations: []string{fmt.Sprintf("unset %s", property)},
+				}
+			}
+			if current == "" {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
 			return PlanResult{
 				InSync:    false,
-				Status:    PlanStatusModify,
-				Reason:    fmt.Sprintf("would unset %s on %s (current value not probed)", property, target),
+				Status:    PlanStatusDestroy,
+				Reason:    fmt.Sprintf("would unset %s on %s (was %q)", property, target, current),
 				Mutations: []string{fmt.Sprintf("unset %s", property)},
 			}
 		},
 	})
 }
 
-// setProperty sets a property for a given app
+// pluginFromSubcommand returns the plugin component of a colon-separated
+// subcommand. For example, "nginx:set" -> "nginx", "buildpacks:set-property" ->
+// "buildpacks", "app-json:set" -> "app-json".
+func pluginFromSubcommand(subcommand string) string {
+	return strings.SplitN(subcommand, ":", 2)[0]
+}
+
+// getProperty reads the current value of a property via
+// `dokku <plugin>:report <target> --<plugin>-<property>`. Returns the
+// trimmed string value on success. When the report subcommand or property
+// flag is not supported by the plugin, returns a non-nil error and callers
+// fall back to a conservative path (Plan reports drift; Execute proceeds
+// to set/unset unconditionally).
+func getProperty(subcommand, app string, global bool, property string) (string, error) {
+	plugin := pluginFromSubcommand(subcommand)
+	reportSubcommand := plugin + ":report"
+	reportFlag := "--" + plugin + "-" + property
+
+	args := []string{"--quiet", reportSubcommand}
+	if global {
+		args = append(args, "--global", reportFlag)
+	} else {
+		args = append(args, app, reportFlag)
+	}
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(result.StdoutContents()), nil
+}
+
+// setProperty sets a property for a given app, short-circuiting when the
+// current value already matches the desired value.
 func setProperty(subcommand string, pctx PropertyContext) TaskOutputState {
 	state := TaskOutputState{
 		Changed: false,
@@ -121,7 +189,13 @@ func setProperty(subcommand string, pctx PropertyContext) TaskOutputState {
 		return state
 	}
 
-	// todo: validate that the value isn't already set
+	// Probe current value; if it matches desired, no-op (Changed=false).
+	// A failed probe (plugin without :report or unsupported property flag)
+	// falls through to the unconditional set, matching pre-probe behavior.
+	if current, err := getProperty(subcommand, pctx.App, pctx.Global, pctx.Property); err == nil && current == pctx.Value {
+		state.State = "present"
+		return state
+	}
 
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
@@ -142,7 +216,8 @@ func setProperty(subcommand string, pctx PropertyContext) TaskOutputState {
 	return state
 }
 
-// unsetProperty unsets a property for a given app
+// unsetProperty unsets a property for a given app, short-circuiting when the
+// current value is already empty.
 func unsetProperty(subcommand string, pctx PropertyContext) TaskOutputState {
 	state := TaskOutputState{
 		Changed: false,
@@ -164,7 +239,10 @@ func unsetProperty(subcommand string, pctx PropertyContext) TaskOutputState {
 		return state
 	}
 
-	// todo: validate that the value isn't already unset
+	if current, err := getProperty(subcommand, pctx.App, pctx.Global, pctx.Property); err == nil && current == "" {
+		state.State = "absent"
+		return state
+	}
 
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -41,6 +41,64 @@ func executeProperty(state State, app string, global bool, property, value, subc
 	})
 }
 
+// planProperty is a shared Plan implementation for property tasks.
+//
+// Property tasks today do not probe live state before mutating (see the TODOs
+// in setProperty/unsetProperty), so the plan result is conservative: it
+// reports drift unconditionally and notes the limitation in Reason. A
+// follow-up that adds <subcommand>:report probes can replace this with a
+// precise comparison.
+func planProperty(state State, app string, global bool, property, value, subcommand string) PlanResult {
+	if !global && app == "" {
+		return PlanResult{
+			Status: PlanStatusError,
+			Error:  errors.New("app is required when global is false"),
+		}
+	}
+	if global && app != "" {
+		return PlanResult{
+			Status: PlanStatusError,
+			Error:  fmt.Errorf("'app' must not be set when 'global' is set to true"),
+		}
+	}
+
+	target := app
+	if global {
+		target = "--global"
+	}
+
+	return DispatchPlan(state, map[State]func() PlanResult{
+		"present": func() PlanResult {
+			if value == "" {
+				return PlanResult{
+					Status: PlanStatusError,
+					Error:  fmt.Errorf("setting a state of 'present' is invalid without a value for 'value'"),
+				}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    fmt.Sprintf("would set %s on %s (current value not probed)", property, target),
+				Mutations: []string{fmt.Sprintf("set %s=%s", property, value)},
+			}
+		},
+		"absent": func() PlanResult {
+			if value != "" {
+				return PlanResult{
+					Status: PlanStatusError,
+					Error:  fmt.Errorf("setting a state of 'absent' is invalid with a value for 'value'"),
+				}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    fmt.Sprintf("would unset %s on %s (current value not probed)", property, target),
+				Mutations: []string{fmt.Sprintf("unset %s", property)},
+			}
+		},
+	})
+}
+
 // setProperty sets a property for a given app
 func setProperty(subcommand string, pctx PropertyContext) TaskOutputState {
 	state := TaskOutputState{

--- a/tasks/proxy_toggle_task.go
+++ b/tasks/proxy_toggle_task.go
@@ -41,6 +41,11 @@ func (t ProxyToggleTask) Execute() TaskOutputState {
 	return executeToggle(t.State, t.App, t.Global, false, "proxy:enable", "proxy:disable")
 }
 
+// Plan reports the drift the ProxyToggleTask would produce.
+func (t ProxyToggleTask) Plan() PlanResult {
+	return planToggle(t.State, t.App, t.Global, false, "proxy:enable", "proxy:disable")
+}
+
 // init registers the ProxyToggleTask with the task registry
 func init() {
 	RegisterTask(&ProxyToggleTask{})

--- a/tasks/proxy_toggle_task.go
+++ b/tasks/proxy_toggle_task.go
@@ -1,5 +1,31 @@
 package tasks
 
+import (
+	"strings"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// proxyEnabled reports whether the proxy is enabled for the given app via
+// `dokku --quiet proxy:report <app> --proxy-enabled`. The report subcommand
+// emits "true"/"false" on stdout.
+func proxyEnabled(ctx ToggleContext) (bool, error) {
+	args := []string{"--quiet", "proxy:report"}
+	if ctx.AllowGlobal && ctx.Global {
+		args = append(args, "--global", "--proxy-enabled")
+	} else {
+		args = append(args, ctx.App, "--proxy-enabled")
+	}
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(result.StdoutContents()) == "true", nil
+}
+
 // ProxyToggleTask manages the proxy for a given dokku application
 type ProxyToggleTask struct {
 	// App is the name of the app
@@ -38,12 +64,12 @@ func (t ProxyToggleTask) Examples() ([]Doc, error) {
 
 // Execute enables or disables the proxy
 func (t ProxyToggleTask) Execute() TaskOutputState {
-	return executeToggle(t.State, t.App, t.Global, false, "proxy:enable", "proxy:disable")
+	return executeToggle(t.State, t.App, t.Global, false, "proxy:enable", "proxy:disable", proxyEnabled)
 }
 
 // Plan reports the drift the ProxyToggleTask would produce.
 func (t ProxyToggleTask) Plan() PlanResult {
-	return planToggle(t.State, t.App, t.Global, false, "proxy:enable", "proxy:disable")
+	return planToggle(t.State, t.App, t.Global, false, "proxy:enable", "proxy:disable", proxyEnabled)
 }
 
 // init registers the ProxyToggleTask with the task registry

--- a/tasks/proxy_toggle_task.go
+++ b/tasks/proxy_toggle_task.go
@@ -6,9 +6,8 @@ import (
 	"github.com/dokku/docket/subprocess"
 )
 
-// proxyEnabled reports whether the proxy is enabled for the given app via
-// `dokku --quiet proxy:report <app> --proxy-enabled`. The report subcommand
-// emits "true"/"false" on stdout.
+// proxyEnabled probes whether the proxy is enabled for an app via
+// `dokku --quiet proxy:report <app> --proxy-enabled`. Output is "true"/"false".
 func proxyEnabled(ctx ToggleContext) (bool, error) {
 	args := []string{"--quiet", "proxy:report"}
 	if ctx.AllowGlobal && ctx.Global {
@@ -64,7 +63,7 @@ func (t ProxyToggleTask) Examples() ([]Doc, error) {
 
 // Execute enables or disables the proxy
 func (t ProxyToggleTask) Execute() TaskOutputState {
-	return executeToggle(t.State, t.App, t.Global, false, "proxy:enable", "proxy:disable", proxyEnabled)
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the ProxyToggleTask would produce.

--- a/tasks/ps_property_task.go
+++ b/tasks/ps_property_task.go
@@ -71,6 +71,11 @@ func (t PsPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "ps:set")
 }
 
+// Plan reports the drift the PsPropertyTask would produce.
+func (t PsPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "ps:set")
+}
+
 // init registers the PsPropertyTask with the task registry
 func init() {
 	RegisterTask(&PsPropertyTask{})

--- a/tasks/ps_property_task.go
+++ b/tasks/ps_property_task.go
@@ -68,7 +68,7 @@ func (t PsPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the ps property
 func (t PsPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "ps:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the PsPropertyTask would produce.

--- a/tasks/ps_scale_task.go
+++ b/tasks/ps_scale_task.go
@@ -70,15 +70,7 @@ func (t PsScaleTask) Examples() ([]Doc, error) {
 
 // Execute sets the process scale for a given dokku application
 func (t PsScaleTask) Execute() TaskOutputState {
-	if t.State == StatePresent && len(t.Scale) == 0 {
-		return TaskOutputState{
-			Error: fmt.Errorf("scale must be specified when state is present"),
-		}
-	}
-
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return setPsScale(t) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the PsScaleTask would produce.
@@ -87,24 +79,25 @@ func (t PsScaleTask) Plan() PlanResult {
 		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("scale must be specified when state is present")}
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		"present": func() PlanResult {
+		StatePresent: func() PlanResult {
 			existing, err := getPsScale(t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
+			toScale := []string{}
 			mutations := []string{}
 			for proctype, qty := range t.Scale {
-				if curQty, ok := existing[proctype]; ok && curQty == qty {
+				if cur, ok := existing[proctype]; ok && cur == qty {
 					continue
 				}
-				cur, ok := existing[proctype]
-				if ok {
+				toScale = append(toScale, fmt.Sprintf("%s=%d", proctype, qty))
+				if cur, ok := existing[proctype]; ok {
 					mutations = append(mutations, fmt.Sprintf("scale %s=%d (was %d)", proctype, qty, cur))
 				} else {
 					mutations = append(mutations, fmt.Sprintf("scale %s=%d (new)", proctype, qty))
 				}
 			}
-			if len(mutations) == 0 {
+			if len(toScale) == 0 {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
@@ -112,6 +105,25 @@ func (t PsScaleTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    fmt.Sprintf("%d process scale change(s)", len(mutations)),
 				Mutations: mutations,
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					args := []string{"ps:scale"}
+					if t.SkipDeploy {
+						args = append(args, "--skip-deploy")
+					}
+					args = append(args, t.App)
+					args = append(args, toScale...)
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
 			}
 		},
 	})
@@ -145,57 +157,6 @@ func getPsScale(app string) (map[string]int, error) {
 		scale[parts[0]] = qty
 	}
 	return scale, nil
-}
-
-// setPsScale sets the process scale for a given dokku application
-func setPsScale(t PsScaleTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
-
-	existing, err := getPsScale(t.App)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	var proctypesToScale []string
-	for proctype, qty := range t.Scale {
-		if existingQty, ok := existing[proctype]; ok && existingQty == qty {
-			continue
-		}
-		proctypesToScale = append(proctypesToScale, fmt.Sprintf("%s=%d", proctype, qty))
-	}
-
-	if len(proctypesToScale) == 0 {
-		state.State = "present"
-		return state
-	}
-
-	args := []string{
-		"ps:scale",
-	}
-
-	if t.SkipDeploy {
-		args = append(args, "--skip-deploy")
-	}
-
-	args = append(args, t.App)
-	args = append(args, proctypesToScale...)
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
 }
 
 // init registers the PsScaleTask with the task registry

--- a/tasks/ps_scale_task.go
+++ b/tasks/ps_scale_task.go
@@ -81,6 +81,42 @@ func (t PsScaleTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the PsScaleTask would produce.
+func (t PsScaleTask) Plan() PlanResult {
+	if t.State == StatePresent && len(t.Scale) == 0 {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("scale must be specified when state is present")}
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		"present": func() PlanResult {
+			existing, err := getPsScale(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			mutations := []string{}
+			for proctype, qty := range t.Scale {
+				if curQty, ok := existing[proctype]; ok && curQty == qty {
+					continue
+				}
+				cur, ok := existing[proctype]
+				if ok {
+					mutations = append(mutations, fmt.Sprintf("scale %s=%d (was %d)", proctype, qty, cur))
+				} else {
+					mutations = append(mutations, fmt.Sprintf("scale %s=%d (new)", proctype, qty))
+				}
+			}
+			if len(mutations) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    fmt.Sprintf("%d process scale change(s)", len(mutations)),
+				Mutations: mutations,
+			}
+		},
+	})
+}
+
 // getPsScale retrieves the current process scale for a given dokku application
 func getPsScale(app string) (map[string]int, error) {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{

--- a/tasks/registry_auth_task.go
+++ b/tasks/registry_auth_task.go
@@ -96,6 +96,41 @@ func (t RegistryAuthTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the RegistryAuthTask would produce.
+//
+// dokku registry plugins do not expose a probe for current login state, so
+// the plan reports drift unconditionally.
+func (t RegistryAuthTask) Plan() PlanResult {
+	if err := validateRegistryAuthTask(t); err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	target := t.App
+	if t.Global {
+		target = "(global)"
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if t.Username == "" || t.Password == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'username' and 'password' are required when state is 'present'")}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    "registry login state not probed",
+				Mutations: []string{fmt.Sprintf("registry:login %s %s as %s", target, t.Server, t.Username)},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "registry login state not probed",
+				Mutations: []string{fmt.Sprintf("registry:logout %s %s", target, t.Server)},
+			}
+		},
+	})
+}
+
 // validateRegistryAuthTask validates the registry auth task parameters
 func validateRegistryAuthTask(t RegistryAuthTask) error {
 	if t.Global && t.App != "" {

--- a/tasks/registry_auth_task.go
+++ b/tasks/registry_auth_task.go
@@ -90,16 +90,12 @@ func (t RegistryAuthTask) Examples() ([]Doc, error) {
 
 // Execute manages the registry authentication
 func (t RegistryAuthTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return registryLogin(t) },
-		StateAbsent:  func() TaskOutputState { return registryLogout(t) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
-// Plan reports the drift the RegistryAuthTask would produce.
-//
-// dokku registry plugins do not expose a probe for current login state, so
-// the plan reports drift unconditionally.
+// Plan reports the drift the RegistryAuthTask would produce. dokku registry
+// plugins do not expose a probe for current login state, so the plan
+// reports drift unconditionally.
 func (t RegistryAuthTask) Plan() PlanResult {
 	if err := validateRegistryAuthTask(t); err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
@@ -118,6 +114,27 @@ func (t RegistryAuthTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    "registry login state not probed",
 				Mutations: []string{fmt.Sprintf("registry:login %s %s as %s", target, t.Server, t.Username)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					args := []string{"--quiet", "registry:login", "--password-stdin"}
+					if t.Global {
+						args = append(args, "--global")
+					} else {
+						args = append(args, t.App)
+					}
+					args = append(args, t.Server, t.Username)
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+						Stdin:   strings.NewReader(t.Password),
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
 			}
 		},
 		StateAbsent: func() PlanResult {
@@ -126,6 +143,26 @@ func (t RegistryAuthTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "registry login state not probed",
 				Mutations: []string{fmt.Sprintf("registry:logout %s %s", target, t.Server)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					args := []string{"--quiet", "registry:logout"}
+					if t.Global {
+						args = append(args, "--global")
+					} else {
+						args = append(args, t.App)
+					}
+					args = append(args, t.Server)
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
 			}
 		},
 	})

--- a/tasks/registry_property_task.go
+++ b/tasks/registry_property_task.go
@@ -76,7 +76,7 @@ func (t RegistryPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the registry property
 func (t RegistryPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "registry:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the RegistryPropertyTask would produce.

--- a/tasks/registry_property_task.go
+++ b/tasks/registry_property_task.go
@@ -79,6 +79,11 @@ func (t RegistryPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "registry:set")
 }
 
+// Plan reports the drift the RegistryPropertyTask would produce.
+func (t RegistryPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "registry:set")
+}
+
 // init registers the RegistryPropertyTask with the task registry
 func init() {
 	RegisterTask(&RegistryPropertyTask{})

--- a/tasks/resource_limit_task.go
+++ b/tasks/resource_limit_task.go
@@ -72,7 +72,7 @@ func (t ResourceLimitTask) Examples() ([]Doc, error) {
 
 // Execute sets or clears the resource limits for a given dokku application
 func (t ResourceLimitTask) Execute() TaskOutputState {
-	return executeResource(t.State, t.App, t.ProcessType, t.Resources, t.ClearBefore, "resource:limit")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the ResourceLimitTask would produce.

--- a/tasks/resource_limit_task.go
+++ b/tasks/resource_limit_task.go
@@ -75,6 +75,11 @@ func (t ResourceLimitTask) Execute() TaskOutputState {
 	return executeResource(t.State, t.App, t.ProcessType, t.Resources, t.ClearBefore, "resource:limit")
 }
 
+// Plan reports the drift the ResourceLimitTask would produce.
+func (t ResourceLimitTask) Plan() PlanResult {
+	return planResource(t.State, t.App, t.ProcessType, t.Resources, t.ClearBefore, "resource:limit")
+}
+
 // init registers the ResourceLimitTask with the task registry
 func init() {
 	RegisterTask(&ResourceLimitTask{})

--- a/tasks/resource_reserve_task.go
+++ b/tasks/resource_reserve_task.go
@@ -72,7 +72,7 @@ func (t ResourceReserveTask) Examples() ([]Doc, error) {
 
 // Execute sets or clears the resource reservations for a given dokku application
 func (t ResourceReserveTask) Execute() TaskOutputState {
-	return executeResource(t.State, t.App, t.ProcessType, t.Resources, t.ClearBefore, "resource:reserve")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the ResourceReserveTask would produce.

--- a/tasks/resource_reserve_task.go
+++ b/tasks/resource_reserve_task.go
@@ -75,6 +75,11 @@ func (t ResourceReserveTask) Execute() TaskOutputState {
 	return executeResource(t.State, t.App, t.ProcessType, t.Resources, t.ClearBefore, "resource:reserve")
 }
 
+// Plan reports the drift the ResourceReserveTask would produce.
+func (t ResourceReserveTask) Plan() PlanResult {
+	return planResource(t.State, t.App, t.ProcessType, t.Resources, t.ClearBefore, "resource:reserve")
+}
+
 // init registers the ResourceReserveTask with the task registry
 func init() {
 	RegisterTask(&ResourceReserveTask{})

--- a/tasks/resources.go
+++ b/tasks/resources.go
@@ -3,8 +3,9 @@ package tasks
 import (
 	"errors"
 	"fmt"
-	"github.com/dokku/docket/subprocess"
 	"strings"
+
+	"github.com/dokku/docket/subprocess"
 )
 
 // ResourceContext represents the context for a resource operation
@@ -20,111 +21,6 @@ type ResourceContext struct {
 
 	// ClearBefore clears all resources before applying new ones
 	ClearBefore bool
-}
-
-// executeResource is a shared Execute implementation for resource tasks.
-func executeResource(state State, app, processType string, resources map[string]string, clearBefore bool, subcommand string) TaskOutputState {
-	if state == StatePresent && len(resources) == 0 {
-		return TaskOutputState{
-			Error:   errors.New("resources are required when state is present"),
-			Message: "resources are required when state is present",
-		}
-	}
-
-	rctx := ResourceContext{
-		App:         app,
-		ProcessType: processType,
-		Resources:   resources,
-		ClearBefore: clearBefore,
-	}
-	return DispatchState(state, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return setResource(subcommand, rctx) },
-		"absent":  func() TaskOutputState { return clearResource(subcommand, rctx) },
-	})
-}
-
-// planResource is a shared Plan implementation for resource tasks.
-func planResource(state State, app, processType string, resources map[string]string, clearBefore bool, subcommand string) PlanResult {
-	if state == StatePresent && len(resources) == 0 {
-		return PlanResult{
-			Status: PlanStatusError,
-			Error:  errors.New("resources are required when state is present"),
-		}
-	}
-
-	rctx := ResourceContext{
-		App:         app,
-		ProcessType: processType,
-		Resources:   resources,
-		ClearBefore: clearBefore,
-	}
-	return DispatchPlan(state, map[State]func() PlanResult{
-		"present": func() PlanResult { return planSetResource(subcommand, rctx) },
-		"absent":  func() PlanResult { return planClearResource(subcommand, rctx) },
-	})
-}
-
-// planSetResource reports drift for a present-state resource set.
-func planSetResource(subcommand string, rctx ResourceContext) PlanResult {
-	currentResources, err := getResources(subcommand, rctx)
-	if err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
-	}
-
-	for k := range rctx.Resources {
-		if _, ok := currentResources[k]; !ok {
-			return PlanResult{
-				Status: PlanStatusError,
-				Error:  fmt.Errorf("unknown resource %s, valid resources: %v", k, mapKeys(currentResources)),
-			}
-		}
-	}
-
-	mutations := []string{}
-	if rctx.ClearBefore {
-		mutations = append(mutations, "clear before set")
-	}
-	for k, v := range rctx.Resources {
-		if currentResources[k] != v {
-			mutations = append(mutations, fmt.Sprintf("set %s=%s (was %q)", k, v, currentResources[k]))
-		}
-	}
-
-	if len(mutations) == 0 {
-		return PlanResult{InSync: true, Status: PlanStatusOK}
-	}
-	return PlanResult{
-		InSync:    false,
-		Status:    PlanStatusModify,
-		Reason:    fmt.Sprintf("%d resource(s) to set", len(mutations)),
-		Mutations: mutations,
-	}
-}
-
-// planClearResource reports drift for an absent-state resource clear.
-func planClearResource(subcommand string, rctx ResourceContext) PlanResult {
-	currentResources, err := getResources(subcommand, rctx)
-	if err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
-	}
-
-	hasResources := false
-	for _, v := range currentResources {
-		if v != "" && v != "0" {
-			hasResources = true
-			break
-		}
-	}
-
-	if !hasResources {
-		return PlanResult{InSync: true, Status: PlanStatusOK}
-	}
-	return PlanResult{
-		InSync:    false,
-		Status:    PlanStatusDestroy,
-		Reason:    "would clear all resources",
-		Mutations: []string{fmt.Sprintf("clear resources via %s-clear", subcommand)},
-	}
 }
 
 // getResources retrieves the current resources for a given dokku application
@@ -166,93 +62,72 @@ func getResources(subcommand string, rctx ResourceContext) (map[string]string, e
 	return resources, nil
 }
 
-// setResource sets the resources for a given dokku application
-func setResource(subcommand string, rctx ResourceContext) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
-
-	if rctx.ClearBefore {
-		err := execResourceClear(subcommand, rctx)
-		if err != nil {
-			state.Error = err
-			state.Message = err.Error()
-			return state
-		}
-		state.Changed = true
-	}
-
-	if !rctx.ClearBefore {
-		currentResources, err := getResources(subcommand, rctx)
-		if err != nil {
-			state.Error = err
-			state.Message = err.Error()
-			return state
-		}
-
-		// validate that all requested resources exist
-		for k := range rctx.Resources {
-			if _, ok := currentResources[k]; !ok {
-				state.Error = fmt.Errorf("unknown resource %s, valid resources: %v", k, mapKeys(currentResources))
-				state.Message = state.Error.Error()
-				return state
-			}
-		}
-
-		hasChanged := false
-		for k, v := range rctx.Resources {
-			if currentResources[k] != v {
-				hasChanged = true
-				break
-			}
-		}
-
-		if !hasChanged {
-			state.State = "present"
-			return state
+// planResource is the shared Plan() implementation for resource tasks. The
+// probe runs once; the apply closure consumes the diff.
+func planResource(state State, app, processType string, resources map[string]string, clearBefore bool, subcommand string) PlanResult {
+	if state == StatePresent && len(resources) == 0 {
+		return PlanResult{
+			Status: PlanStatusError,
+			Error:  errors.New("resources are required when state is present"),
 		}
 	}
 
-	args := []string{
-		subcommand,
+	rctx := ResourceContext{
+		App:         app,
+		ProcessType: processType,
+		Resources:   resources,
+		ClearBefore: clearBefore,
 	}
 
-	for key, value := range rctx.Resources {
-		args = append(args, fmt.Sprintf("--%s", key), value)
-	}
-
-	if rctx.ProcessType != "" {
-		args = append(args, "--process-type", rctx.ProcessType)
-	}
-
-	args = append(args, rctx.App)
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
+	return DispatchPlan(state, map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return planSetResource(subcommand, rctx) },
+		StateAbsent:  func() PlanResult { return planClearResource(subcommand, rctx) },
 	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
 }
 
-// clearResource clears the resources for a given dokku application
-func clearResource(subcommand string, rctx ResourceContext) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "present",
-	}
-
+// planSetResource reports drift for a present-state resource set.
+func planSetResource(subcommand string, rctx ResourceContext) PlanResult {
 	currentResources, err := getResources(subcommand, rctx)
 	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+
+	for k := range rctx.Resources {
+		if _, ok := currentResources[k]; !ok {
+			return PlanResult{
+				Status: PlanStatusError,
+				Error:  fmt.Errorf("unknown resource %s, valid resources: %v", k, mapKeys(currentResources)),
+			}
+		}
+	}
+
+	mutations := []string{}
+	if rctx.ClearBefore {
+		mutations = append(mutations, "clear before set")
+	}
+	for k, v := range rctx.Resources {
+		if currentResources[k] != v {
+			mutations = append(mutations, fmt.Sprintf("set %s=%s (was %q)", k, v, currentResources[k]))
+		}
+	}
+
+	if len(mutations) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusModify,
+		Reason:    fmt.Sprintf("%d resource(s) to set", len(mutations)),
+		Mutations: mutations,
+		apply:     applyResourceSet(subcommand, rctx),
+	}
+}
+
+// planClearResource reports drift for an absent-state resource clear.
+func planClearResource(subcommand string, rctx ResourceContext) PlanResult {
+	currentResources, err := getResources(subcommand, rctx)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
 	}
 
 	hasResources := false
@@ -264,20 +139,67 @@ func clearResource(subcommand string, rctx ResourceContext) TaskOutputState {
 	}
 
 	if !hasResources {
-		state.State = "absent"
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    "would clear all resources",
+		Mutations: []string{fmt.Sprintf("clear resources via %s-clear", subcommand)},
+		apply:     applyResourceClear(subcommand, rctx),
+	}
+}
+
+// applyResourceSet returns a closure that runs the underlying resource
+// set command. ClearBefore is honored by clearing before setting.
+func applyResourceSet(subcommand string, rctx ResourceContext) func() TaskOutputState {
+	return func() TaskOutputState {
+		state := TaskOutputState{Changed: false, State: StateAbsent}
+		if rctx.ClearBefore {
+			if err := execResourceClear(subcommand, rctx); err != nil {
+				state.Error = err
+				state.Message = err.Error()
+				return state
+			}
+			state.Changed = true
+		}
+
+		args := []string{subcommand}
+		for key, value := range rctx.Resources {
+			args = append(args, fmt.Sprintf("--%s", key), value)
+		}
+		if rctx.ProcessType != "" {
+			args = append(args, "--process-type", rctx.ProcessType)
+		}
+		args = append(args, rctx.App)
+
+		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    args,
+		})
+		if err != nil {
+			return TaskOutputErrorFromExec(state, err, result)
+		}
+		state.Changed = true
+		state.State = StatePresent
 		return state
 	}
+}
 
-	err = execResourceClear(subcommand, rctx)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
+// applyResourceClear returns a closure that runs the underlying resource
+// clear command (subcommand + "-clear").
+func applyResourceClear(subcommand string, rctx ResourceContext) func() TaskOutputState {
+	return func() TaskOutputState {
+		state := TaskOutputState{Changed: false, State: StatePresent}
+		if err := execResourceClear(subcommand, rctx); err != nil {
+			state.Error = err
+			state.Message = err.Error()
+			return state
+		}
+		state.Changed = true
+		state.State = StateAbsent
 		return state
 	}
-
-	state.Changed = true
-	state.State = "absent"
-	return state
 }
 
 // execResourceClear executes the dokku resource clear command

--- a/tasks/resources.go
+++ b/tasks/resources.go
@@ -43,6 +43,90 @@ func executeResource(state State, app, processType string, resources map[string]
 	})
 }
 
+// planResource is a shared Plan implementation for resource tasks.
+func planResource(state State, app, processType string, resources map[string]string, clearBefore bool, subcommand string) PlanResult {
+	if state == StatePresent && len(resources) == 0 {
+		return PlanResult{
+			Status: PlanStatusError,
+			Error:  errors.New("resources are required when state is present"),
+		}
+	}
+
+	rctx := ResourceContext{
+		App:         app,
+		ProcessType: processType,
+		Resources:   resources,
+		ClearBefore: clearBefore,
+	}
+	return DispatchPlan(state, map[State]func() PlanResult{
+		"present": func() PlanResult { return planSetResource(subcommand, rctx) },
+		"absent":  func() PlanResult { return planClearResource(subcommand, rctx) },
+	})
+}
+
+// planSetResource reports drift for a present-state resource set.
+func planSetResource(subcommand string, rctx ResourceContext) PlanResult {
+	currentResources, err := getResources(subcommand, rctx)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+
+	for k := range rctx.Resources {
+		if _, ok := currentResources[k]; !ok {
+			return PlanResult{
+				Status: PlanStatusError,
+				Error:  fmt.Errorf("unknown resource %s, valid resources: %v", k, mapKeys(currentResources)),
+			}
+		}
+	}
+
+	mutations := []string{}
+	if rctx.ClearBefore {
+		mutations = append(mutations, "clear before set")
+	}
+	for k, v := range rctx.Resources {
+		if currentResources[k] != v {
+			mutations = append(mutations, fmt.Sprintf("set %s=%s (was %q)", k, v, currentResources[k]))
+		}
+	}
+
+	if len(mutations) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusModify,
+		Reason:    fmt.Sprintf("%d resource(s) to set", len(mutations)),
+		Mutations: mutations,
+	}
+}
+
+// planClearResource reports drift for an absent-state resource clear.
+func planClearResource(subcommand string, rctx ResourceContext) PlanResult {
+	currentResources, err := getResources(subcommand, rctx)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+
+	hasResources := false
+	for _, v := range currentResources {
+		if v != "" && v != "0" {
+			hasResources = true
+			break
+		}
+	}
+
+	if !hasResources {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    "would clear all resources",
+		Mutations: []string{fmt.Sprintf("clear resources via %s-clear", subcommand)},
+	}
+}
+
 // getResources retrieves the current resources for a given dokku application
 func getResources(subcommand string, rctx ResourceContext) (map[string]string, error) {
 	args := []string{

--- a/tasks/scheduler_docker_local_property_task.go
+++ b/tasks/scheduler_docker_local_property_task.go
@@ -68,6 +68,11 @@ func (t SchedulerDockerLocalPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, false, t.Property, t.Value, "scheduler-docker-local:set")
 }
 
+// Plan reports the drift the SchedulerDockerLocalPropertyTask would produce.
+func (t SchedulerDockerLocalPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, false, t.Property, t.Value, "scheduler-docker-local:set")
+}
+
 // init registers the SchedulerDockerLocalPropertyTask with the task registry
 func init() {
 	RegisterTask(&SchedulerDockerLocalPropertyTask{})

--- a/tasks/scheduler_docker_local_property_task.go
+++ b/tasks/scheduler_docker_local_property_task.go
@@ -65,7 +65,7 @@ func (t SchedulerDockerLocalPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the scheduler-docker-local property
 func (t SchedulerDockerLocalPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, false, t.Property, t.Value, "scheduler-docker-local:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the SchedulerDockerLocalPropertyTask would produce.

--- a/tasks/scheduler_k3s_property_task.go
+++ b/tasks/scheduler_k3s_property_task.go
@@ -76,7 +76,7 @@ func (t SchedulerK3sPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the scheduler-k3s property
 func (t SchedulerK3sPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "scheduler-k3s:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the SchedulerK3sPropertyTask would produce.

--- a/tasks/scheduler_k3s_property_task.go
+++ b/tasks/scheduler_k3s_property_task.go
@@ -79,6 +79,11 @@ func (t SchedulerK3sPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "scheduler-k3s:set")
 }
 
+// Plan reports the drift the SchedulerK3sPropertyTask would produce.
+func (t SchedulerK3sPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "scheduler-k3s:set")
+}
+
 // init registers the SchedulerK3sPropertyTask with the task registry
 func init() {
 	RegisterTask(&SchedulerK3sPropertyTask{})

--- a/tasks/scheduler_property_task.go
+++ b/tasks/scheduler_property_task.go
@@ -68,7 +68,7 @@ func (t SchedulerPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the scheduler property
 func (t SchedulerPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "scheduler:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the SchedulerPropertyTask would produce.

--- a/tasks/scheduler_property_task.go
+++ b/tasks/scheduler_property_task.go
@@ -71,6 +71,11 @@ func (t SchedulerPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "scheduler:set")
 }
 
+// Plan reports the drift the SchedulerPropertyTask would produce.
+func (t SchedulerPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "scheduler:set")
+}
+
 // init registers the SchedulerPropertyTask with the task registry
 func init() {
 	RegisterTask(&SchedulerPropertyTask{})

--- a/tasks/service_create_task.go
+++ b/tasks/service_create_task.go
@@ -66,16 +66,13 @@ func (t ServiceCreateTask) Examples() ([]Doc, error) {
 
 // Execute creates or destroys a dokku service
 func (t ServiceCreateTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return createService(t.Service, t.Name) },
-		"absent":  func() TaskOutputState { return destroyService(t.Service, t.Name) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the ServiceCreateTask would produce.
 func (t ServiceCreateTask) Plan() PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		"present": func() PlanResult {
+		StatePresent: func() PlanResult {
 			if serviceExists(t.Service, t.Name) {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
@@ -84,9 +81,22 @@ func (t ServiceCreateTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    fmt.Sprintf("%s service %s missing", t.Service, t.Name),
 				Mutations: []string{fmt.Sprintf("%s:create %s", t.Service, t.Name)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", fmt.Sprintf("%s:create", t.Service), t.Name},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
 			}
 		},
-		"absent": func() PlanResult {
+		StateAbsent: func() PlanResult {
 			if !serviceExists(t.Service, t.Name) {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
@@ -95,6 +105,19 @@ func (t ServiceCreateTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    fmt.Sprintf("%s service %s present", t.Service, t.Name),
 				Mutations: []string{fmt.Sprintf("%s:destroy %s", t.Service, t.Name)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "--force", fmt.Sprintf("%s:destroy", t.Service), t.Name},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
 			}
 		},
 	})

--- a/tasks/service_create_task.go
+++ b/tasks/service_create_task.go
@@ -72,6 +72,34 @@ func (t ServiceCreateTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the ServiceCreateTask would produce.
+func (t ServiceCreateTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		"present": func() PlanResult {
+			if serviceExists(t.Service, t.Name) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    fmt.Sprintf("%s service %s missing", t.Service, t.Name),
+				Mutations: []string{fmt.Sprintf("%s:create %s", t.Service, t.Name)},
+			}
+		},
+		"absent": func() PlanResult {
+			if !serviceExists(t.Service, t.Name) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    fmt.Sprintf("%s service %s present", t.Service, t.Name),
+				Mutations: []string{fmt.Sprintf("%s:destroy %s", t.Service, t.Name)},
+			}
+		},
+	})
+}
+
 // serviceExists checks if a dokku service exists
 func serviceExists(service, name string) bool {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{

--- a/tasks/service_link_task.go
+++ b/tasks/service_link_task.go
@@ -72,16 +72,13 @@ func (t ServiceLinkTask) Examples() ([]Doc, error) {
 
 // Execute links or unlinks a dokku service to an app
 func (t ServiceLinkTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return linkService(t.Service, t.Name, t.App) },
-		"absent":  func() TaskOutputState { return unlinkService(t.Service, t.Name, t.App) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the ServiceLinkTask would produce.
 func (t ServiceLinkTask) Plan() PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		"present": func() PlanResult {
+		StatePresent: func() PlanResult {
 			if !serviceExists(t.Service, t.Name) {
 				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("service %s %s does not exist", t.Service, t.Name)}
 			}
@@ -96,9 +93,22 @@ func (t ServiceLinkTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    fmt.Sprintf("%s service %s not linked to %s", t.Service, t.Name, t.App),
 				Mutations: []string{fmt.Sprintf("%s:link %s %s", t.Service, t.Name, t.App)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", fmt.Sprintf("%s:link", t.Service), t.Name, t.App},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
 			}
 		},
-		"absent": func() PlanResult {
+		StateAbsent: func() PlanResult {
 			if !serviceExists(t.Service, t.Name) {
 				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("service %s %s does not exist", t.Service, t.Name)}
 			}
@@ -113,6 +123,19 @@ func (t ServiceLinkTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    fmt.Sprintf("%s service %s linked to %s", t.Service, t.Name, t.App),
 				Mutations: []string{fmt.Sprintf("%s:unlink %s %s", t.Service, t.Name, t.App)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", fmt.Sprintf("%s:unlink", t.Service), t.Name, t.App},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
 			}
 		},
 	})

--- a/tasks/service_link_task.go
+++ b/tasks/service_link_task.go
@@ -78,6 +78,46 @@ func (t ServiceLinkTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the ServiceLinkTask would produce.
+func (t ServiceLinkTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		"present": func() PlanResult {
+			if !serviceExists(t.Service, t.Name) {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("service %s %s does not exist", t.Service, t.Name)}
+			}
+			if !appExists(t.App) {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("app %s does not exist", t.App)}
+			}
+			if serviceLinked(t.Service, t.Name, t.App) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    fmt.Sprintf("%s service %s not linked to %s", t.Service, t.Name, t.App),
+				Mutations: []string{fmt.Sprintf("%s:link %s %s", t.Service, t.Name, t.App)},
+			}
+		},
+		"absent": func() PlanResult {
+			if !serviceExists(t.Service, t.Name) {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("service %s %s does not exist", t.Service, t.Name)}
+			}
+			if !appExists(t.App) {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("app %s does not exist", t.App)}
+			}
+			if !serviceLinked(t.Service, t.Name, t.App) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    fmt.Sprintf("%s service %s linked to %s", t.Service, t.Name, t.App),
+				Mutations: []string{fmt.Sprintf("%s:unlink %s %s", t.Service, t.Name, t.App)},
+			}
+		},
+	})
+}
+
 // serviceLinked checks if a dokku service is linked to an app
 func serviceLinked(service, name, app string) bool {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{

--- a/tasks/storage_ensure_task.go
+++ b/tasks/storage_ensure_task.go
@@ -43,22 +43,18 @@ func (t StorageEnsureTask) Examples() ([]Doc, error) {
 
 // Execute ensures the storage for a given app
 func (t StorageEnsureTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return ensureStorage(t.App, t.Chown) },
-		"absent":  func() TaskOutputState { return removeStorage(t.App, t.Chown) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
-// Plan reports the drift the StorageEnsureTask would produce.
-//
-// storage:ensure-directory does not expose a probe for whether the directory
-// already exists; the plan is conservative and reports drift unconditionally.
+// Plan reports the drift the StorageEnsureTask would produce. dokku does
+// not expose a probe for storage:ensure-directory, so the plan reports
+// drift unconditionally.
 func (t StorageEnsureTask) Plan() PlanResult {
 	chownValues := map[string]bool{
 		"heroku": true, "herokuish": true, "paketo": true, "root": true, "false": true,
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		"present": func() PlanResult {
+		StatePresent: func() PlanResult {
 			if !chownValues[t.Chown] {
 				return PlanResult{Status: PlanStatusError, Error: errors.New("invalid chown value specified")}
 			}
@@ -67,63 +63,25 @@ func (t StorageEnsureTask) Plan() PlanResult {
 				Status:    PlanStatusModify,
 				Reason:    "directory presence not probed",
 				Mutations: []string{"storage:ensure-directory --chown " + t.Chown + " " + t.App},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "storage:ensure-directory", "--chown", t.Chown, t.App},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
 			}
 		},
-		"absent": func() PlanResult {
+		StateAbsent: func() PlanResult {
 			return PlanResult{Status: PlanStatusError, Error: errors.New("the absent state is not supported for storage:ensure")}
 		},
 	})
-}
-
-// ensureStorage ensures the storage for a given app
-func ensureStorage(app, chown string) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
-
-	// ensure chown is a valid value
-	chownValues := map[string]bool{
-		"heroku":    true,
-		"herokuish": true,
-		"paketo":    true,
-		"root":      true,
-		"false":     true,
-	}
-	if !chownValues[chown] {
-		state.Error = errors.New("invalid chown value specified")
-		return state
-	}
-
-	// todo: implement a check to see if the folder exists?
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			"storage:ensure-directory",
-			"--chown",
-			chown,
-			app,
-		},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
-}
-
-// removeStorage removes the storage for a given app
-func removeStorage(app, chown string) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
-
-	state.Error = errors.New("the absent state is not supported for storage:ensure")
-	return state
 }
 
 // init registers the StorageEnsureTask with the task registry

--- a/tasks/storage_ensure_task.go
+++ b/tasks/storage_ensure_task.go
@@ -49,6 +49,32 @@ func (t StorageEnsureTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the StorageEnsureTask would produce.
+//
+// storage:ensure-directory does not expose a probe for whether the directory
+// already exists; the plan is conservative and reports drift unconditionally.
+func (t StorageEnsureTask) Plan() PlanResult {
+	chownValues := map[string]bool{
+		"heroku": true, "herokuish": true, "paketo": true, "root": true, "false": true,
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		"present": func() PlanResult {
+			if !chownValues[t.Chown] {
+				return PlanResult{Status: PlanStatusError, Error: errors.New("invalid chown value specified")}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    "directory presence not probed",
+				Mutations: []string{"storage:ensure-directory --chown " + t.Chown + " " + t.App},
+			}
+		},
+		"absent": func() PlanResult {
+			return PlanResult{Status: PlanStatusError, Error: errors.New("the absent state is not supported for storage:ensure")}
+		},
+	})
+}
+
 // ensureStorage ensures the storage for a given app
 func ensureStorage(app, chown string) TaskOutputState {
 	state := TaskOutputState{

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -53,6 +53,35 @@ func (t StorageMountTask) Execute() TaskOutputState {
 	})
 }
 
+// Plan reports the drift the StorageMountTask would produce.
+func (t StorageMountTask) Plan() PlanResult {
+	mountSpec := fmt.Sprintf("%s:%s", t.HostDir, t.ContainerDir)
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		"present": func() PlanResult {
+			if mountExists(t.App, t.HostDir, t.ContainerDir) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    "mount missing",
+				Mutations: []string{fmt.Sprintf("mount %s on %s", mountSpec, t.App)},
+			}
+		},
+		"absent": func() PlanResult {
+			if !mountExists(t.App, t.HostDir, t.ContainerDir) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "mount present",
+				Mutations: []string{fmt.Sprintf("unmount %s on %s", mountSpec, t.App)},
+			}
+		},
+	})
+}
+
 // mountExists checks if the storage mount exists
 func mountExists(app, hostDir, containerDir string) bool {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -47,17 +47,14 @@ func (t StorageMountTask) Examples() ([]Doc, error) {
 
 // Execute mounts or unmounts the storage for a given app
 func (t StorageMountTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return mountStorage(t.App, t.HostDir, t.ContainerDir) },
-		"absent":  func() TaskOutputState { return unmountStorage(t.App, t.HostDir, t.ContainerDir) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the StorageMountTask would produce.
 func (t StorageMountTask) Plan() PlanResult {
 	mountSpec := fmt.Sprintf("%s:%s", t.HostDir, t.ContainerDir)
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		"present": func() PlanResult {
+		StatePresent: func() PlanResult {
 			if mountExists(t.App, t.HostDir, t.ContainerDir) {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
@@ -66,9 +63,22 @@ func (t StorageMountTask) Plan() PlanResult {
 				Status:    PlanStatusCreate,
 				Reason:    "mount missing",
 				Mutations: []string{fmt.Sprintf("mount %s on %s", mountSpec, t.App)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "storage:mount", t.App, mountSpec},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
 			}
 		},
-		"absent": func() PlanResult {
+		StateAbsent: func() PlanResult {
 			if !mountExists(t.App, t.HostDir, t.ContainerDir) {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
@@ -77,6 +87,19 @@ func (t StorageMountTask) Plan() PlanResult {
 				Status:    PlanStatusDestroy,
 				Reason:    "mount present",
 				Mutations: []string{fmt.Sprintf("unmount %s on %s", mountSpec, t.App)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "storage:unmount", t.App, mountSpec},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
 			}
 		},
 	})
@@ -114,68 +137,6 @@ func mountExists(app, hostDir, containerDir string) bool {
 		}
 	}
 	return false
-}
-
-// mountStorage mounts the storage for a given app
-func mountStorage(app, hostDir, containerDir string) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "present",
-	}
-
-	// check if the mount already exists
-	if mountExists(app, hostDir, containerDir) {
-		state.Changed = false
-		state.State = "present"
-		return state
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			"storage:mount",
-			app,
-			fmt.Sprintf("%s:%s", hostDir, containerDir),
-		},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
-}
-
-// unmountStorage unmounts the storage for a given app
-func unmountStorage(app, hostDir, containerDir string) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "present",
-	}
-	if !mountExists(app, hostDir, containerDir) {
-		state.Changed = false
-		state.State = "absent"
-		return state
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			"storage:unmount",
-			app,
-			fmt.Sprintf("%s:%s", hostDir, containerDir),
-		},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "absent"
-	return state
 }
 
 // init registers the StorageMountTask with the task registry

--- a/tasks/toggle.go
+++ b/tasks/toggle.go
@@ -19,73 +19,14 @@ type ToggleContext struct {
 }
 
 // ToggleProbe returns whether the toggle is currently in the "enabled"
-// (state: present) position. It is invoked by both Plan and Execute. When
-// probe fails (plugin missing the corresponding report flag, transient
-// dokku error), the second return value is non-nil and callers fall back to
-// reporting drift / running the underlying enable / disable command.
+// (state: present) position. nil from a probe (or a non-nil error) is
+// treated as "drift, must mutate" so we still run the underlying command.
 type ToggleProbe func(ctx ToggleContext) (enabled bool, err error)
 
-// enablePlugin executes the enable state for a plugin
-func enablePlugin(subcommand string, pctx ToggleContext, probe ToggleProbe) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
-
-	appName := pctx.App
-	if pctx.AllowGlobal {
-		if pctx.Global && pctx.App != "" {
-			state.Error = fmt.Errorf("'app' must not be set when 'global' is set to true")
-			return state
-		}
-		if pctx.Global {
-			appName = "--global"
-		}
-	}
-
-	if probe != nil {
-		if enabled, err := probe(pctx); err == nil && enabled {
-			state.State = "present"
-			return state
-		}
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			subcommand,
-			appName,
-		},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
-}
-
-// executeToggle is a shared Execute implementation for toggle tasks. The
-// probe function reports whether the underlying plugin is currently in the
-// "enabled" position; when nil, both states run unconditionally (matches the
-// pre-probe behavior).
-func executeToggle(state State, app string, global bool, allowGlobal bool, enableCmd, disableCmd string, probe ToggleProbe) TaskOutputState {
-	ctx := ToggleContext{
-		AllowGlobal: allowGlobal,
-		App:         app,
-		Global:      global,
-	}
-	return DispatchState(state, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return enablePlugin(enableCmd, ctx, probe) },
-		"absent":  func() TaskOutputState { return disablePlugin(disableCmd, ctx, probe) },
-	})
-}
-
-// planToggle is a shared Plan implementation for toggle tasks. probe is
-// called to determine the current enabled state. When probe fails, the
-// plan reports drift conservatively and notes the limitation in Reason.
+// planToggle is the shared Plan() implementation for toggle tasks. The
+// probe reports whether the underlying plugin is currently in the
+// "enabled" position; when probe is nil or fails, planToggle reports drift
+// and the apply closure runs the underlying enable/disable command.
 func planToggle(state State, app string, global bool, allowGlobal bool, enableCmd, disableCmd string, probe ToggleProbe) PlanResult {
 	if allowGlobal && global && app != "" {
 		return PlanResult{
@@ -106,103 +47,51 @@ func planToggle(state State, app string, global bool, allowGlobal bool, enableCm
 	}
 
 	return DispatchPlan(state, map[State]func() PlanResult{
-		"present": func() PlanResult {
-			if probe == nil {
-				return PlanResult{
-					InSync:    false,
-					Status:    PlanStatusModify,
-					Reason:    fmt.Sprintf("would run %s on %s (no probe)", enableCmd, target),
-					Mutations: []string{fmt.Sprintf("%s %s", enableCmd, target)},
+		StatePresent: func() PlanResult {
+			if probe != nil {
+				if enabled, err := probe(ctx); err == nil && enabled {
+					return PlanResult{InSync: true, Status: PlanStatusOK}
 				}
-			}
-			enabled, err := probe(ctx)
-			if err != nil {
-				return PlanResult{
-					InSync:    false,
-					Status:    PlanStatusModify,
-					Reason:    fmt.Sprintf("would run %s on %s (probe failed: %v)", enableCmd, target, err),
-					Mutations: []string{fmt.Sprintf("%s %s", enableCmd, target)},
-				}
-			}
-			if enabled {
-				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
-				Reason:    fmt.Sprintf("disabled on %s", target),
+				Reason:    fmt.Sprintf("would run %s on %s", enableCmd, target),
 				Mutations: []string{fmt.Sprintf("%s %s", enableCmd, target)},
+				apply:     applyToggle(enableCmd, target, StatePresent),
 			}
 		},
-		"absent": func() PlanResult {
-			if probe == nil {
-				return PlanResult{
-					InSync:    false,
-					Status:    PlanStatusModify,
-					Reason:    fmt.Sprintf("would run %s on %s (no probe)", disableCmd, target),
-					Mutations: []string{fmt.Sprintf("%s %s", disableCmd, target)},
+		StateAbsent: func() PlanResult {
+			if probe != nil {
+				if enabled, err := probe(ctx); err == nil && !enabled {
+					return PlanResult{InSync: true, Status: PlanStatusOK}
 				}
-			}
-			enabled, err := probe(ctx)
-			if err != nil {
-				return PlanResult{
-					InSync:    false,
-					Status:    PlanStatusModify,
-					Reason:    fmt.Sprintf("would run %s on %s (probe failed: %v)", disableCmd, target, err),
-					Mutations: []string{fmt.Sprintf("%s %s", disableCmd, target)},
-				}
-			}
-			if !enabled {
-				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
-				Reason:    fmt.Sprintf("enabled on %s", target),
+				Reason:    fmt.Sprintf("would run %s on %s", disableCmd, target),
 				Mutations: []string{fmt.Sprintf("%s %s", disableCmd, target)},
+				apply:     applyToggle(disableCmd, target, StateAbsent),
 			}
 		},
 	})
 }
 
-// disablePlugin executes the disable state for a plugin
-func disablePlugin(subcommand string, pctx ToggleContext, probe ToggleProbe) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "present",
-	}
-
-	appName := pctx.App
-	if pctx.AllowGlobal {
-		if pctx.Global && pctx.App != "" {
-			state.Error = fmt.Errorf("'app' must not be set when 'global' is set to true")
-			return state
+// applyToggle returns a closure that runs `dokku <subcommand> <target>` and
+// reports the resulting state.
+func applyToggle(subcommand, target string, finalState State) func() TaskOutputState {
+	return func() TaskOutputState {
+		state := TaskOutputState{Changed: false, State: finalState}
+		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", subcommand, target},
+		})
+		if err != nil {
+			return TaskOutputErrorFromExec(state, err, result)
 		}
-		if pctx.Global {
-			appName = "--global"
-		}
+		state.Changed = true
+		state.State = finalState
+		return state
 	}
-
-	if probe != nil {
-		if enabled, err := probe(pctx); err == nil && !enabled {
-			state.State = "absent"
-			return state
-		}
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			subcommand,
-			appName,
-		},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "absent"
-	return state
 }

--- a/tasks/toggle.go
+++ b/tasks/toggle.go
@@ -66,6 +66,45 @@ func executeToggle(state State, app string, global bool, allowGlobal bool, enabl
 	})
 }
 
+// planToggle is a shared Plan implementation for toggle tasks.
+//
+// Toggle tasks today do not probe whether a plugin is already enabled or
+// disabled, so the plan result is conservative: it reports drift
+// unconditionally and notes the limitation in Reason. A follow-up that adds
+// the appropriate report probes can replace this with a precise comparison.
+func planToggle(state State, app string, global bool, allowGlobal bool, enableCmd, disableCmd string) PlanResult {
+	if allowGlobal && global && app != "" {
+		return PlanResult{
+			Status: PlanStatusError,
+			Error:  fmt.Errorf("'app' must not be set when 'global' is set to true"),
+		}
+	}
+
+	target := app
+	if allowGlobal && global {
+		target = "--global"
+	}
+
+	return DispatchPlan(state, map[State]func() PlanResult{
+		"present": func() PlanResult {
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    fmt.Sprintf("would run %s on %s (current state not probed)", enableCmd, target),
+				Mutations: []string{fmt.Sprintf("%s %s", enableCmd, target)},
+			}
+		},
+		"absent": func() PlanResult {
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    fmt.Sprintf("would run %s on %s (current state not probed)", disableCmd, target),
+				Mutations: []string{fmt.Sprintf("%s %s", disableCmd, target)},
+			}
+		},
+	})
+}
+
 // disablePlugin executes the disable state for a plugin
 func disablePlugin(subcommand string, pctx ToggleContext) TaskOutputState {
 	state := TaskOutputState{

--- a/tasks/toggle.go
+++ b/tasks/toggle.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"fmt"
+
 	"github.com/dokku/docket/subprocess"
 )
 
@@ -17,8 +18,15 @@ type ToggleContext struct {
 	AllowGlobal bool `required:"false" yaml:"allow_global"`
 }
 
+// ToggleProbe returns whether the toggle is currently in the "enabled"
+// (state: present) position. It is invoked by both Plan and Execute. When
+// probe fails (plugin missing the corresponding report flag, transient
+// dokku error), the second return value is non-nil and callers fall back to
+// reporting drift / running the underlying enable / disable command.
+type ToggleProbe func(ctx ToggleContext) (enabled bool, err error)
+
 // enablePlugin executes the enable state for a plugin
-func enablePlugin(subcommand string, pctx ToggleContext) TaskOutputState {
+func enablePlugin(subcommand string, pctx ToggleContext, probe ToggleProbe) TaskOutputState {
 	state := TaskOutputState{
 		Changed: false,
 		State:   "absent",
@@ -35,7 +43,13 @@ func enablePlugin(subcommand string, pctx ToggleContext) TaskOutputState {
 		}
 	}
 
-	// todo: validate that the plugin isn't already enabled
+	if probe != nil {
+		if enabled, err := probe(pctx); err == nil && enabled {
+			state.State = "present"
+			return state
+		}
+	}
+
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
@@ -53,26 +67,26 @@ func enablePlugin(subcommand string, pctx ToggleContext) TaskOutputState {
 	return state
 }
 
-// executeToggle is a shared Execute implementation for toggle tasks.
-func executeToggle(state State, app string, global bool, allowGlobal bool, enableCmd, disableCmd string) TaskOutputState {
+// executeToggle is a shared Execute implementation for toggle tasks. The
+// probe function reports whether the underlying plugin is currently in the
+// "enabled" position; when nil, both states run unconditionally (matches the
+// pre-probe behavior).
+func executeToggle(state State, app string, global bool, allowGlobal bool, enableCmd, disableCmd string, probe ToggleProbe) TaskOutputState {
 	ctx := ToggleContext{
 		AllowGlobal: allowGlobal,
 		App:         app,
 		Global:      global,
 	}
 	return DispatchState(state, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return enablePlugin(enableCmd, ctx) },
-		"absent":  func() TaskOutputState { return disablePlugin(disableCmd, ctx) },
+		"present": func() TaskOutputState { return enablePlugin(enableCmd, ctx, probe) },
+		"absent":  func() TaskOutputState { return disablePlugin(disableCmd, ctx, probe) },
 	})
 }
 
-// planToggle is a shared Plan implementation for toggle tasks.
-//
-// Toggle tasks today do not probe whether a plugin is already enabled or
-// disabled, so the plan result is conservative: it reports drift
-// unconditionally and notes the limitation in Reason. A follow-up that adds
-// the appropriate report probes can replace this with a precise comparison.
-func planToggle(state State, app string, global bool, allowGlobal bool, enableCmd, disableCmd string) PlanResult {
+// planToggle is a shared Plan implementation for toggle tasks. probe is
+// called to determine the current enabled state. When probe fails, the
+// plan reports drift conservatively and notes the limitation in Reason.
+func planToggle(state State, app string, global bool, allowGlobal bool, enableCmd, disableCmd string, probe ToggleProbe) PlanResult {
 	if allowGlobal && global && app != "" {
 		return PlanResult{
 			Status: PlanStatusError,
@@ -85,20 +99,66 @@ func planToggle(state State, app string, global bool, allowGlobal bool, enableCm
 		target = "--global"
 	}
 
+	ctx := ToggleContext{
+		AllowGlobal: allowGlobal,
+		App:         app,
+		Global:      global,
+	}
+
 	return DispatchPlan(state, map[State]func() PlanResult{
 		"present": func() PlanResult {
+			if probe == nil {
+				return PlanResult{
+					InSync:    false,
+					Status:    PlanStatusModify,
+					Reason:    fmt.Sprintf("would run %s on %s (no probe)", enableCmd, target),
+					Mutations: []string{fmt.Sprintf("%s %s", enableCmd, target)},
+				}
+			}
+			enabled, err := probe(ctx)
+			if err != nil {
+				return PlanResult{
+					InSync:    false,
+					Status:    PlanStatusModify,
+					Reason:    fmt.Sprintf("would run %s on %s (probe failed: %v)", enableCmd, target, err),
+					Mutations: []string{fmt.Sprintf("%s %s", enableCmd, target)},
+				}
+			}
+			if enabled {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
-				Reason:    fmt.Sprintf("would run %s on %s (current state not probed)", enableCmd, target),
+				Reason:    fmt.Sprintf("disabled on %s", target),
 				Mutations: []string{fmt.Sprintf("%s %s", enableCmd, target)},
 			}
 		},
 		"absent": func() PlanResult {
+			if probe == nil {
+				return PlanResult{
+					InSync:    false,
+					Status:    PlanStatusModify,
+					Reason:    fmt.Sprintf("would run %s on %s (no probe)", disableCmd, target),
+					Mutations: []string{fmt.Sprintf("%s %s", disableCmd, target)},
+				}
+			}
+			enabled, err := probe(ctx)
+			if err != nil {
+				return PlanResult{
+					InSync:    false,
+					Status:    PlanStatusModify,
+					Reason:    fmt.Sprintf("would run %s on %s (probe failed: %v)", disableCmd, target, err),
+					Mutations: []string{fmt.Sprintf("%s %s", disableCmd, target)},
+				}
+			}
+			if !enabled {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
-				Reason:    fmt.Sprintf("would run %s on %s (current state not probed)", disableCmd, target),
+				Reason:    fmt.Sprintf("enabled on %s", target),
 				Mutations: []string{fmt.Sprintf("%s %s", disableCmd, target)},
 			}
 		},
@@ -106,7 +166,7 @@ func planToggle(state State, app string, global bool, allowGlobal bool, enableCm
 }
 
 // disablePlugin executes the disable state for a plugin
-func disablePlugin(subcommand string, pctx ToggleContext) TaskOutputState {
+func disablePlugin(subcommand string, pctx ToggleContext, probe ToggleProbe) TaskOutputState {
 	state := TaskOutputState{
 		Changed: false,
 		State:   "present",
@@ -123,7 +183,13 @@ func disablePlugin(subcommand string, pctx ToggleContext) TaskOutputState {
 		}
 	}
 
-	// todo: validate that the plugin isn't already disabled
+	if probe != nil {
+		if enabled, err := probe(pctx); err == nil && !enabled {
+			state.State = "absent"
+			return state
+		}
+	}
+
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{

--- a/tasks/traefik_property_task.go
+++ b/tasks/traefik_property_task.go
@@ -71,6 +71,11 @@ func (t TraefikPropertyTask) Execute() TaskOutputState {
 	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "traefik:set")
 }
 
+// Plan reports the drift the TraefikPropertyTask would produce.
+func (t TraefikPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "traefik:set")
+}
+
 // init registers the TraefikPropertyTask with the task registry
 func init() {
 	RegisterTask(&TraefikPropertyTask{})

--- a/tasks/traefik_property_task.go
+++ b/tasks/traefik_property_task.go
@@ -68,7 +68,7 @@ func (t TraefikPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the traefik property
 func (t TraefikPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "traefik:set")
+	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the TraefikPropertyTask would produce.

--- a/tests/bats/README.md
+++ b/tests/bats/README.md
@@ -10,7 +10,7 @@ Dokku).
 
 - `test_helper.bash` - shared helpers for building the binary, writing
   per-test `tasks.yml` fixtures, and cleaning up apps in setup/teardown.
-- `*.bats` - one file per CLI subcommand.
+- `*.bats` - one file per CLI subcommand or feature.
 
 ## Running locally
 
@@ -27,23 +27,16 @@ On Debian / Ubuntu:
 sudo apt-get install -y bats bats-support bats-assert
 ```
 
-Or via npm:
-
-```bash
-sudo npm install -g bats
-# bats-support / bats-assert have no npm distribution; install via apt or from source
-```
-
-Run the suite from the repo root:
+Run from the repo root:
 
 ```bash
 bats tests/bats/
 ```
 
-Tests skip themselves when `dokku` is not available, so the suite is safe to
-run on a developer laptop without a local Dokku.
+Tests skip themselves when `dokku` is not available, so the suite is safe
+to run on a developer laptop without a local Dokku.
 
 ## CI
 
 `.github/workflows/test.yml` defines a `bats-test` job that installs Dokku
-and the bats helper packages, builds the docket binary, and runs the suite.
+and the bats helpers, builds the docket binary, and runs the suite.

--- a/tests/bats/README.md
+++ b/tests/bats/README.md
@@ -1,0 +1,49 @@
+# bats tests
+
+End-to-end tests for the `docket` CLI, exercised against a real Dokku
+installation. These complement the Go unit tests under `tasks/*_test.go`
+(which mock subprocess) and the Go integration tests under
+`tasks/*_integration_test.go` (which exercise the task layer against a real
+Dokku).
+
+## Layout
+
+- `test_helper.bash` - shared helpers for building the binary, writing
+  per-test `tasks.yml` fixtures, and cleaning up apps in setup/teardown.
+- `*.bats` - one file per CLI subcommand.
+
+## Running locally
+
+The tests need:
+
+- `bats-core` (`bats` on PATH)
+- `bats-support` and `bats-assert` (loaded from `/usr/lib/bats/*` or
+  `/usr/lib/bats-support/`, `/usr/lib/bats-assert/`)
+- A Dokku installation reachable via the `dokku` CLI
+
+On Debian / Ubuntu:
+
+```bash
+sudo apt-get install -y bats bats-support bats-assert
+```
+
+Or via npm:
+
+```bash
+sudo npm install -g bats
+# bats-support / bats-assert have no npm distribution; install via apt or from source
+```
+
+Run the suite from the repo root:
+
+```bash
+bats tests/bats/
+```
+
+Tests skip themselves when `dokku` is not available, so the suite is safe to
+run on a developer laptop without a local Dokku.
+
+## CI
+
+`.github/workflows/test.yml` defines a `bats-test` job that installs Dokku
+and the bats helper packages, builds the docket binary, and runs the suite.

--- a/tests/bats/plan.bats
+++ b/tests/bats/plan.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+    require_dokku
+    docket_build
+    dokku_clean_app docket-test-plan
+}
+
+teardown() {
+    dokku_clean_app docket-test-plan
+}
+
+@test "docket plan reports drift on a missing app" {
+    write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-plan
+      dokku_app:
+        app: docket-test-plan
+EOF
+    run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+    assert_success
+    assert_output --partial "[+]"
+    assert_output --partial "Plan:"
+    assert_output --partial "1 would change"
+}
+
+@test "docket plan does not mutate state" {
+    write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-plan
+      dokku_app:
+        app: docket-test-plan
+EOF
+    run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+    assert_success
+    run dokku apps:exists docket-test-plan
+    # apps:exists returns non-zero when the app does not exist.
+    assert_failure
+}
+
+@test "docket plan reports in sync after apply" {
+    write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-plan
+      dokku_app:
+        app: docket-test-plan
+EOF
+    "$(docket_bin)" apply --tasks "$TASKS_FILE"
+    run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+    assert_success
+    assert_output --partial "[ok]"
+    assert_output --partial "in sync"
+    assert_output --partial "0 would change"
+}
+
+@test "docket plan itemizes config keys to set" {
+    "$(docket_bin)" apply --tasks <(cat <<EOF
+---
+- tasks:
+    - dokku_app:
+        app: docket-test-plan
+EOF
+)
+    write_tasks_file <<EOF
+---
+- tasks:
+    - name: configure
+      dokku_config:
+        app: docket-test-plan
+        restart: false
+        config:
+          KEY_ONE: value-one
+          KEY_TWO: value-two
+EOF
+    run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+    assert_success
+    assert_output --partial "2 key(s) to set"
+    assert_output --partial "set KEY_ONE"
+    assert_output --partial "set KEY_TWO"
+}
+
+@test "docket apply continues to behave as before" {
+    write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-plan
+      dokku_app:
+        app: docket-test-plan
+EOF
+    run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+    assert_success
+    run dokku apps:exists docket-test-plan
+    assert_success
+}

--- a/tests/bats/plan.bats
+++ b/tests/bats/plan.bats
@@ -3,70 +3,71 @@
 load test_helper
 
 setup() {
-    require_dokku
-    docket_build
-    dokku_clean_app docket-test-plan
+  require_dokku
+  docket_build
+  dokku_clean_app docket-test-plan
 }
 
 teardown() {
-    dokku_clean_app docket-test-plan
+  dokku_clean_app docket-test-plan
 }
 
 @test "docket plan reports drift on a missing app" {
-    write_tasks_file <<EOF
+  write_tasks_file <<EOF
 ---
 - tasks:
     - name: ensure docket-test-plan
       dokku_app:
         app: docket-test-plan
 EOF
-    run "$(docket_bin)" plan --tasks "$TASKS_FILE"
-    assert_success
-    assert_output --partial "[+]"
-    assert_output --partial "Plan:"
-    assert_output --partial "1 would change"
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "[+]"
+  assert_output --partial "Plan:"
+  assert_output --partial "1 would change"
 }
 
 @test "docket plan does not mutate state" {
-    write_tasks_file <<EOF
+  write_tasks_file <<EOF
 ---
 - tasks:
     - name: ensure docket-test-plan
       dokku_app:
         app: docket-test-plan
 EOF
-    run "$(docket_bin)" plan --tasks "$TASKS_FILE"
-    assert_success
-    run dokku apps:exists docket-test-plan
-    # apps:exists returns non-zero when the app does not exist.
-    assert_failure
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  run dokku apps:exists docket-test-plan
+  # apps:exists returns non-zero when the app does not exist.
+  assert_failure
 }
 
 @test "docket plan reports in sync after apply" {
-    write_tasks_file <<EOF
+  write_tasks_file <<EOF
 ---
 - tasks:
     - name: ensure docket-test-plan
       dokku_app:
         app: docket-test-plan
 EOF
-    "$(docket_bin)" apply --tasks "$TASKS_FILE"
-    run "$(docket_bin)" plan --tasks "$TASKS_FILE"
-    assert_success
-    assert_output --partial "[ok]"
-    assert_output --partial "in sync"
-    assert_output --partial "0 would change"
+  "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "[ok]"
+  assert_output --partial "in sync"
+  assert_output --partial "0 would change"
 }
 
 @test "docket plan itemizes config keys to set" {
-    "$(docket_bin)" apply --tasks <(cat <<EOF
+  write_tasks_file setup.yml <<EOF
 ---
 - tasks:
     - dokku_app:
         app: docket-test-plan
 EOF
-)
-    write_tasks_file <<EOF
+  "$(docket_bin)" apply --tasks "$TASKS_FILE"
+
+  write_tasks_file <<EOF
 ---
 - tasks:
     - name: configure
@@ -77,23 +78,23 @@ EOF
           KEY_ONE: value-one
           KEY_TWO: value-two
 EOF
-    run "$(docket_bin)" plan --tasks "$TASKS_FILE"
-    assert_success
-    assert_output --partial "2 key(s) to set"
-    assert_output --partial "set KEY_ONE"
-    assert_output --partial "set KEY_TWO"
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "2 key(s) to set"
+  assert_output --partial "set KEY_ONE"
+  assert_output --partial "set KEY_TWO"
 }
 
 @test "docket apply continues to behave as before" {
-    write_tasks_file <<EOF
+  write_tasks_file <<EOF
 ---
 - tasks:
     - name: ensure docket-test-plan
       dokku_app:
         app: docket-test-plan
 EOF
-    run "$(docket_bin)" apply --tasks "$TASKS_FILE"
-    assert_success
-    run dokku apps:exists docket-test-plan
-    assert_success
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  run dokku apps:exists docket-test-plan
+  assert_success
 }

--- a/tests/bats/plan.bats
+++ b/tests/bats/plan.bats
@@ -85,7 +85,7 @@ EOF
   assert_output --partial "set KEY_TWO"
 }
 
-@test "docket apply continues to behave as before" {
+@test "docket apply is idempotent on second run" {
   write_tasks_file <<EOF
 ---
 - tasks:
@@ -93,6 +93,12 @@ EOF
       dokku_app:
         app: docket-test-plan
 EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  run dokku apps:exists docket-test-plan
+  assert_success
+
+  # Second apply must not report any error and must not destroy the app.
   run "$(docket_bin)" apply --tasks "$TASKS_FILE"
   assert_success
   run dokku apps:exists docket-test-plan

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Shared helpers for docket bats tests.
+#
+# Bats and the bats-support / bats-assert helper libraries are expected to be
+# installed system-wide via apt or npm; the tests load them from the standard
+# /usr/lib/bats/* paths. See .github/workflows/test.yml for the CI install
+# steps and tests/bats/README.md for local developer setup.
+
+set -euo pipefail
+
+# Load bats-support / bats-assert from the standard package paths. Both are
+# distributed as bash sources we `source` rather than as bats `load` units.
+load_bats_libraries() {
+    local lib
+    for lib in /usr/lib/bats/bats-support/load.bash /usr/lib/bats-support/load.bash; do
+        if [ -f "$lib" ]; then
+            # shellcheck disable=SC1090
+            source "$lib"
+            break
+        fi
+    done
+    for lib in /usr/lib/bats/bats-assert/load.bash /usr/lib/bats-assert/load.bash; do
+        if [ -f "$lib" ]; then
+            # shellcheck disable=SC1090
+            source "$lib"
+            break
+        fi
+    done
+}
+
+load_bats_libraries
+
+# Resolve the docket binary. Prefer the in-tree build at ./docket so a local
+# `go build` tests the working tree; fall back to PATH for environments that
+# install the binary system-wide.
+docket_bin() {
+    if [ -n "${DOCKET_BIN:-}" ]; then
+        echo "$DOCKET_BIN"
+        return
+    fi
+    local repo_root
+    repo_root="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    if [ -x "$repo_root/docket" ]; then
+        echo "$repo_root/docket"
+        return
+    fi
+    command -v docket
+}
+
+# docket_build builds the docket binary at the repo root. Subsequent calls in
+# the same bats run skip the rebuild because Go caches incremental builds.
+docket_build() {
+    local repo_root
+    repo_root="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    (cd "$repo_root" && go build -o docket .)
+    export DOCKET_BIN="$repo_root/docket"
+}
+
+# write_tasks_file writes its stdin to "$BATS_TEST_TMPDIR/tasks.yml" and exports
+# TASKS_FILE so tests can pass --tasks "$TASKS_FILE".
+write_tasks_file() {
+    TASKS_FILE="$BATS_TEST_TMPDIR/tasks.yml"
+    cat > "$TASKS_FILE"
+    export TASKS_FILE
+}
+
+# dokku_clean_app destroys an app if it exists. Used in setup/teardown to make
+# tests idempotent on shared CI hosts. Ignores missing dokku (developers run
+# offline tests too).
+dokku_clean_app() {
+    local app="$1"
+    if ! command -v dokku >/dev/null 2>&1; then
+        return 0
+    fi
+    if dokku apps:exists "$app" >/dev/null 2>&1; then
+        dokku --force apps:destroy "$app" >/dev/null 2>&1 || true
+    fi
+}
+
+# require_dokku skips the current test when no dokku binary is installed,
+# matching the integration_helpers_test.go skipIfNoDokkuT helper for Go tests.
+require_dokku() {
+    if ! command -v dokku >/dev/null 2>&1; then
+        skip "dokku not available"
+    fi
+}

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -2,14 +2,13 @@
 # Shared helpers for docket bats tests.
 #
 # Bats and the bats-support / bats-assert helper libraries are expected to be
-# installed system-wide via apt or npm; the tests load them from the standard
-# /usr/lib/bats/* paths. See .github/workflows/test.yml for the CI install
-# steps and tests/bats/README.md for local developer setup.
+# installed system-wide via apt; the tests load them from /usr/lib/bats/*.
+# See .github/workflows/test.yml for CI install steps and
+# tests/bats/README.md for local developer setup.
 
 set -euo pipefail
 
-# Load bats-support / bats-assert from the standard package paths. Both are
-# distributed as bash sources we `source` rather than as bats `load` units.
+# Load bats-support / bats-assert from the standard package paths.
 load_bats_libraries() {
   local lib
   for lib in /usr/lib/bats/bats-support/load.bash /usr/lib/bats-support/load.bash; do
@@ -31,8 +30,7 @@ load_bats_libraries() {
 load_bats_libraries
 
 # Resolve the docket binary. Prefer the in-tree build at ./docket so a local
-# `go build` tests the working tree; fall back to PATH for environments that
-# install the binary system-wide.
+# `go build` tests the working tree; fall back to PATH otherwise.
 docket_bin() {
   if [ -n "${DOCKET_BIN:-}" ]; then
     echo "$DOCKET_BIN"
@@ -47,8 +45,8 @@ docket_bin() {
   command -v docket
 }
 
-# docket_build builds the docket binary at the repo root. Subsequent calls in
-# the same bats run skip the rebuild because Go caches incremental builds.
+# docket_build builds the binary at the repo root. Subsequent calls in the
+# same bats run skip the rebuild because Go caches incremental builds.
 docket_build() {
   local repo_root
   repo_root="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
@@ -56,9 +54,8 @@ docket_build() {
   export DOCKET_BIN="$repo_root/docket"
 }
 
-# write_tasks_file writes its stdin to "$BATS_TEST_TMPDIR/tasks.yml" and exports
-# TASKS_FILE so tests can pass --tasks "$TASKS_FILE". Pass an alternate name as
-# the first argument to write to a different file in the same directory.
+# write_tasks_file writes its stdin to "$BATS_TEST_TMPDIR/<name>" (default:
+# tasks.yml) and exports TASKS_FILE so tests can pass --tasks "$TASKS_FILE".
 write_tasks_file() {
   local name="${1:-tasks.yml}"
   TASKS_FILE="$BATS_TEST_TMPDIR/$name"
@@ -66,9 +63,8 @@ write_tasks_file() {
   export TASKS_FILE
 }
 
-# dokku_clean_app destroys an app if it exists. Used in setup/teardown to make
-# tests idempotent on shared CI hosts. Ignores missing dokku (developers run
-# offline tests too).
+# dokku_clean_app destroys an app if it exists. Used in setup/teardown so
+# tests are idempotent on shared CI hosts.
 dokku_clean_app() {
   local app="$1"
   if ! command -v dokku >/dev/null 2>&1; then
@@ -79,8 +75,7 @@ dokku_clean_app() {
   fi
 }
 
-# require_dokku skips the current test when no dokku binary is installed,
-# matching the integration_helpers_test.go skipIfNoDokkuT helper for Go tests.
+# require_dokku skips the current test when no dokku binary is installed.
 require_dokku() {
   if ! command -v dokku >/dev/null 2>&1; then
     skip "dokku not available"

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -11,21 +11,21 @@ set -euo pipefail
 # Load bats-support / bats-assert from the standard package paths. Both are
 # distributed as bash sources we `source` rather than as bats `load` units.
 load_bats_libraries() {
-    local lib
-    for lib in /usr/lib/bats/bats-support/load.bash /usr/lib/bats-support/load.bash; do
-        if [ -f "$lib" ]; then
-            # shellcheck disable=SC1090
-            source "$lib"
-            break
-        fi
-    done
-    for lib in /usr/lib/bats/bats-assert/load.bash /usr/lib/bats-assert/load.bash; do
-        if [ -f "$lib" ]; then
-            # shellcheck disable=SC1090
-            source "$lib"
-            break
-        fi
-    done
+  local lib
+  for lib in /usr/lib/bats/bats-support/load.bash /usr/lib/bats-support/load.bash; do
+    if [ -f "$lib" ]; then
+      # shellcheck disable=SC1090
+      source "$lib"
+      break
+    fi
+  done
+  for lib in /usr/lib/bats/bats-assert/load.bash /usr/lib/bats-assert/load.bash; do
+    if [ -f "$lib" ]; then
+      # shellcheck disable=SC1090
+      source "$lib"
+      break
+    fi
+  done
 }
 
 load_bats_libraries
@@ -34,53 +34,55 @@ load_bats_libraries
 # `go build` tests the working tree; fall back to PATH for environments that
 # install the binary system-wide.
 docket_bin() {
-    if [ -n "${DOCKET_BIN:-}" ]; then
-        echo "$DOCKET_BIN"
-        return
-    fi
-    local repo_root
-    repo_root="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
-    if [ -x "$repo_root/docket" ]; then
-        echo "$repo_root/docket"
-        return
-    fi
-    command -v docket
+  if [ -n "${DOCKET_BIN:-}" ]; then
+    echo "$DOCKET_BIN"
+    return
+  fi
+  local repo_root
+  repo_root="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  if [ -x "$repo_root/docket" ]; then
+    echo "$repo_root/docket"
+    return
+  fi
+  command -v docket
 }
 
 # docket_build builds the docket binary at the repo root. Subsequent calls in
 # the same bats run skip the rebuild because Go caches incremental builds.
 docket_build() {
-    local repo_root
-    repo_root="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
-    (cd "$repo_root" && go build -o docket .)
-    export DOCKET_BIN="$repo_root/docket"
+  local repo_root
+  repo_root="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  (cd "$repo_root" && go build -o docket .)
+  export DOCKET_BIN="$repo_root/docket"
 }
 
 # write_tasks_file writes its stdin to "$BATS_TEST_TMPDIR/tasks.yml" and exports
-# TASKS_FILE so tests can pass --tasks "$TASKS_FILE".
+# TASKS_FILE so tests can pass --tasks "$TASKS_FILE". Pass an alternate name as
+# the first argument to write to a different file in the same directory.
 write_tasks_file() {
-    TASKS_FILE="$BATS_TEST_TMPDIR/tasks.yml"
-    cat > "$TASKS_FILE"
-    export TASKS_FILE
+  local name="${1:-tasks.yml}"
+  TASKS_FILE="$BATS_TEST_TMPDIR/$name"
+  cat >"$TASKS_FILE"
+  export TASKS_FILE
 }
 
 # dokku_clean_app destroys an app if it exists. Used in setup/teardown to make
 # tests idempotent on shared CI hosts. Ignores missing dokku (developers run
 # offline tests too).
 dokku_clean_app() {
-    local app="$1"
-    if ! command -v dokku >/dev/null 2>&1; then
-        return 0
-    fi
-    if dokku apps:exists "$app" >/dev/null 2>&1; then
-        dokku --force apps:destroy "$app" >/dev/null 2>&1 || true
-    fi
+  local app="$1"
+  if ! command -v dokku >/dev/null 2>&1; then
+    return 0
+  fi
+  if dokku apps:exists "$app" >/dev/null 2>&1; then
+    dokku --force apps:destroy "$app" >/dev/null 2>&1 || true
+  fi
 }
 
 # require_dokku skips the current test when no dokku binary is installed,
 # matching the integration_helpers_test.go skipIfNoDokkuT helper for Go tests.
 require_dokku() {
-    if ! command -v dokku >/dev/null 2>&1; then
-        skip "dokku not available"
-    fi
+  if ! command -v dokku >/dev/null 2>&1; then
+    skip "dokku not available"
+  fi
 }


### PR DESCRIPTION
## Summary

Adds a `Plan()` method to the `Task` interface so each task reports the drift it would produce against the live server without mutating it, and a `docket plan` subcommand that runs `Plan()` across the recipe and prints a per-task drift summary plus an end-of-run summary line.

Closes #198.

## What lands

- `tasks.PlanResult` struct with `InSync`, `Status` (`ok`/`~`/`+`/`-`/`error`), `Reason`, `Mutations[]`, `DesiredState`, `Error`.
- `Plan()` added to the `Task` interface; `DispatchPlan` mirrors `DispatchState`.
- All ~50 task files refactored to implement `Plan()`.
  - **Probe-and-act tasks** (`app`, `app_clone`, `app_lock`, `buildpacks`, `certs`, `config`, `docker_options`, `domains`, `git_from_archive`, `git_from_image`, `git_sync`, `letsencrypt`, `http_auth`, `network`, `ports`, `ps_scale`, `resource_limit`, `resource_reserve`, `service_create`, `service_link`, `storage_mount`, `acl_app`, `acl_service`) report rich `Mutations[]` for multi-mutation operations and use the appropriate create/modify/destroy status markers.
  - **Blind-mutate tasks** (the `*_property` family via `properties.go`, the `*_toggle` family via `toggle.go`, plus `git_auth`, `registry_auth`, `storage_ensure`) report drift conservatively with a `(... not probed)` reason. Adding real probes per task family is a follow-up.
- `commands/plan.go` subcommand registered alongside `apply`/`version` in `main.go`. Mirrors `commands/apply.go`'s structure (input flags, sigil rendering, `tasks.GetTasks`); iterates the resolved task list invoking `Plan()` and emits one line per task plus a final `Plan: ...` summary.
- New `tests/bats/` directory with a shared `test_helper.bash`, an `plan.bats` suite, and a `README.md`.
- New `bats-test` CI job in `.github/workflows/test.yml` mirroring the integration-test job; installs Dokku and `bats` / `bats-support` / `bats-assert` from apt, builds the binary, then runs `bats tests/bats/`.

## Test coverage

- `tasks/plan_test.go` (unit) - registry walk asserts every registered task implements `Plan()`; `DispatchPlan` invalid-state and desired-state propagation; `PlanStatus*` constants; per-key itemization helpers for `config_task`.
- `tasks/plan_integration_test.go` (integration, gated by `skipIfNoDokkuT`) - drift detection on a missing app, `InSync` after apply round-trip, plan-does-not-mutate guarantee, `config_task` per-key mutations against a real Dokku.
- `commands/plan_test.go` (unit) - subcommand metadata, examples, `FlagSet()` does not panic without a `tasks.yml`, interface contract.
- `tests/bats/plan.bats` (end-to-end) - `plan` reports drift on a missing app; `plan` does not mutate state; `plan` reports in-sync after apply; `plan` itemizes config keys; `apply` continues to work as before.

## Notes for reviewers

- The `properties.go` / `toggle.go` shared helpers are where most of the conservative "drift not probed" planning lives. Splitting that into per-plugin probes is the natural next series of issues per task family.
- The Plan() implementations on the probe-and-act tasks reuse the existing probe helpers (`appExists`, `getConfig`, `getPorts`, `getDomains`, `mountExists`, etc.) so `Execute()` behavior is unchanged. This guards against any silent behavior shift in `apply`.
- `tmp/` was added to `.gitignore` to match the project-local convention for scratch files.