### PR TITLE
feat: add Plan() driving Execute() for every task

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,3 +60,32 @@ jobs:
         run: sudo dokku plugin:install https://github.com/dokku-community/dokku-acl.git acl
       - name: run integration tests
         run: sudo go test -v -count=1 -run TestIntegration ./tasks/
+
+  bats-test:
+    name: bats-test
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: enable docker legacy link support
+        run: |
+          sudo mkdir -p /etc/systemd/system/docker.service.d
+          printf '[Service]\nEnvironment="DOCKER_KEEP_DEPRECATED_LEGACY_LINKS_ENV_VARS=1"\n' | sudo tee /etc/systemd/system/docker.service.d/legacy-links.conf
+          sudo systemctl daemon-reload
+          sudo systemctl restart docker
+      - name: install dokku
+        run: |
+          sudo mkdir -p /etc/apt/keyrings
+          curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
+          echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
+          sudo apt-get update -qq
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku
+          sudo dokku plugin:install-dependencies --core
+      - name: install bats
+        run: sudo apt-get install -qq -y bats bats-support bats-assert
+      - name: build docket
+        run: go build -o docket .
+      - name: run bats tests
+        run: sudo --preserve-env=PATH bats tests/bats/

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ validation/*
 .env*
 
 docket
+tmp/

--- a/README.md
+++ b/README.md
@@ -37,7 +37,33 @@ Run it:
 docket apply
 ```
 
-Running `docket` with no subcommand prints the available commands. Use `docket apply` to execute a task file, or `docket version` to print the binary's version.
+Running `docket` with no subcommand prints the available commands. Use `docket apply` to execute a task file, `docket plan` to preview the changes a task file would make without mutating any state, or `docket version` to print the binary's version.
+
+### Previewing changes with `plan`
+
+`docket plan` reads each task's current state from the live dokku server and reports what `apply` would change, without invoking any mutating dokku command. Each task line is prefixed with a marker:
+
+| Marker | Meaning |
+|--------|---------|
+| `[ok]` | Task is in sync; `apply` would not change anything |
+| `[+]` | `apply` would create new state |
+| `[~]` | `apply` would modify existing state |
+| `[-]` | `apply` would remove existing state |
+| `[error]` | The read-state probe itself errored (drift unknown) |
+
+Tasks that perform multiple operations (e.g. `dokku_config` setting several keys) report each individual mutation under the task line:
+
+```text
+[~]       configure  (2 key(s) to set)
+          - set KEY_ONE (new)
+          - set KEY_TWO (was set)
+
+Plan: 1 task(s); 1 would change, 0 in sync, 0 error(s).
+```
+
+`Plan()` results drive `apply`: every task probes the server once, and `apply` reuses that probe to decide whether to mutate. `apply` on an already-converged server reports `Changed=false` for every task; back-to-back applies are no-ops by design.
+
+A handful of tasks (notably `dokku_git_auth`, `dokku_registry_auth`, and `dokku_storage_ensure`) cannot probe their current state without invoking the corresponding dokku command, so their plan output reports drift unconditionally with `(... not probed)` in the reason.
 
 A task file can also be specified via flag, and may be a file retrieved via http:
 
@@ -135,11 +161,30 @@ type LollipopTask struct {
   State State `required:"true" yaml:"state" default:"present"`
 }
 
-func (t LollipopTask) Execute() TaskOutputState {
-  return DispatchState(t.State, map[State]func() TaskOutputState{
-    "present": func() TaskOutputState { /* ... */ },
-    "absent":  func() TaskOutputState { /* ... */ },
+func (t LollipopTask) Plan() PlanResult {
+  return DispatchPlan(t.State, map[State]func() PlanResult{
+    "present": func() PlanResult {
+      // Probe the server once, decide whether to mutate.
+      if /* already in desired state */ {
+        return PlanResult{InSync: true, Status: PlanStatusOK}
+      }
+      return PlanResult{
+        InSync:    false,
+        Status:    PlanStatusCreate, // or PlanStatusModify, PlanStatusDestroy
+        Reason:    "...",
+        Mutations: []string{"create lollipop"},
+        apply: func() TaskOutputState {
+          // Run the underlying dokku command. Return Changed=true on success.
+          return TaskOutputState{Changed: true, State: StatePresent}
+        },
+      }
+    },
+    "absent": func() PlanResult { /* ... */ },
   })
+}
+
+func (t LollipopTask) Execute() TaskOutputState {
+  return ExecutePlan(t.Plan())
 }
 
 func init() {
@@ -149,6 +194,10 @@ func init() {
 
 The `LollipopTask` struct contains the fields necessary for the task. The only necessary field is `State`, which holds the desired state of the task. All other fields are completely custom for the task at hand.
 
-The `Execute()` function should use `DispatchState()` to route to the appropriate handler based on the task's state. `DispatchState` automatically sets `DesiredState` on the returned `TaskOutputState`.
+`Plan()` is the canonical implementation: it probes the live server once, computes the diff, and returns a `PlanResult`. When `InSync` is `false`, `Plan()` embeds an `apply` closure that performs the underlying mutation. For tasks that perform multiple operations (e.g. setting several config keys in one call), populate `PlanResult.Mutations` with one entry per atomic change so the plan output can itemize the diff.
+
+`Execute()` is always `return ExecutePlan(t.Plan())`. The shared `ExecutePlan` helper handles the InSync, error, and apply cases uniformly so the per-state mutation logic lives in exactly one place per task.
+
+`DispatchPlan` and `DispatchState` automatically set `DesiredState` on the returned result.
 
 The `init()` function registers the task for usage within a recipe.

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -1,0 +1,172 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dokku/docket/tasks"
+
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/posener/complete"
+	flag "github.com/spf13/pflag"
+)
+
+// PlanCommand reports the drift each task in a docket recipe would produce
+// against the live server, without mutating it. Plan is fully driven by the
+// per-task Plan() method; the apply path is never invoked.
+type PlanCommand struct {
+	command.Meta
+
+	tasksFile string
+	arguments map[string]*Argument
+}
+
+func (c *PlanCommand) Name() string {
+	return "plan"
+}
+
+func (c *PlanCommand) Synopsis() string {
+	return "Reports the drift a docket task file would produce, without mutating state"
+}
+
+func (c *PlanCommand) Help() string {
+	return command.CommandHelp(c)
+}
+
+func (c *PlanCommand) Examples() map[string]string {
+	appName := os.Getenv("CLI_APP_NAME")
+	return map[string]string{
+		"Plan tasks from the default tasks.yml": fmt.Sprintf("%s %s", appName, c.Name()),
+		"Plan tasks from a specific file":       fmt.Sprintf("%s %s --tasks path/to/task.yml", appName, c.Name()),
+		"Plan tasks from a remote URL":          fmt.Sprintf("%s %s --tasks http://dokku.com/docket/example.yml", appName, c.Name()),
+		"Override a task input":                 fmt.Sprintf("%s %s --name lollipop", appName, c.Name()),
+	}
+}
+
+func (c *PlanCommand) Arguments() []command.Argument {
+	return []command.Argument{}
+}
+
+func (c *PlanCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *PlanCommand) ParsedArguments(args []string) (map[string]command.Argument, error) {
+	return command.ParseArguments(args, c.Arguments())
+}
+
+func (c *PlanCommand) FlagSet() *flag.FlagSet {
+	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	f.StringVar(&c.tasksFile, "tasks", "tasks.yml", "a yaml file containing a task list")
+
+	taskFile := getTaskYamlFilename(os.Args)
+	data, err := os.ReadFile(taskFile)
+	if err != nil {
+		return f
+	}
+
+	arguments, err := registerInputFlags(f, data)
+	if err != nil {
+		return f
+	}
+	c.arguments = arguments
+
+	return f
+}
+
+func (c *PlanCommand) AutocompleteFlags() complete.Flags {
+	return command.MergeAutocompleteFlags(
+		c.Meta.AutocompleteFlags(command.FlagSetClient),
+		complete.Flags{
+			"--tasks": complete.PredictFiles("*.yml"),
+		},
+	)
+}
+
+// Run iterates every task in the parsed recipe, invokes Plan() (read-only
+// by contract), and prints a one-line summary per task plus a final
+// summary line.
+//
+// Exit codes:
+//
+//	0 - plan completed successfully (regardless of drift)
+//	1 - read error, parse error, or read-state probe error
+func (c *PlanCommand) Run(args []string) int {
+	flags := c.FlagSet()
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(err.Error())
+		c.Ui.Error(command.CommandErrorText(c))
+		return 1
+	}
+
+	data, err := os.ReadFile(c.tasksFile)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("read error: %v", err))
+		return 1
+	}
+
+	context := make(map[string]interface{})
+	for name, argument := range c.arguments {
+		if argument.Required && !argument.HasValue() {
+			c.Ui.Error(fmt.Sprintf("Missing flag '--%s'", name))
+			return 1
+		}
+		context[name] = argument.GetValue()
+	}
+
+	taskList, err := tasks.GetTasks(data, context)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("task error: %v", err))
+		return 1
+	}
+
+	totals := struct {
+		tasks       int
+		wouldChange int
+		inSync      int
+		errors      int
+	}{}
+	hasError := false
+
+	for _, name := range taskList.Keys() {
+		task := taskList.Get(name)
+		result := task.Plan()
+		totals.tasks++
+
+		switch {
+		case result.Error != nil:
+			totals.errors++
+			hasError = true
+			c.Ui.Error(fmt.Sprintf("[error]   %s  (%v)", name, result.Error))
+		case result.InSync:
+			totals.inSync++
+			c.Ui.Info(fmt.Sprintf("[ok]      %s  (in sync)", name))
+		default:
+			totals.wouldChange++
+			marker := string(result.Status)
+			if marker == "" {
+				marker = string(tasks.PlanStatusModify)
+			}
+			line := fmt.Sprintf("[%s]       %s", marker, name)
+			if result.Reason != "" {
+				line = fmt.Sprintf("[%s]       %s  (%s)", marker, name, result.Reason)
+			}
+			c.Ui.Info(line)
+			for _, m := range result.Mutations {
+				c.Ui.Info(fmt.Sprintf("          - %s", m))
+			}
+		}
+	}
+
+	c.Ui.Info("")
+	c.Ui.Info(fmt.Sprintf(
+		"Plan: %d task(s); %d would change, %d in sync, %d error(s).",
+		totals.tasks, totals.wouldChange, totals.inSync, totals.errors,
+	))
+
+	if hasError {
+		return 1
+	}
+	return 0
+}

--- a/commands/plan_test.go
+++ b/commands/plan_test.go
@@ -1,0 +1,55 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/dokku/docket/tasks"
+)
+
+// TestPlanCommandMetadata is a smoke check that PlanCommand exposes a
+// reasonable Name and Synopsis, satisfying the cli.Command interface.
+func TestPlanCommandMetadata(t *testing.T) {
+	c := &PlanCommand{}
+	if c.Name() != "plan" {
+		t.Errorf("Name = %q, want \"plan\"", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis must not be empty")
+	}
+}
+
+// TestPlanCommandExamples ensures every example string is non-empty. The
+// cli-skeleton uses these in --help output.
+func TestPlanCommandExamples(t *testing.T) {
+	c := &PlanCommand{}
+	examples := c.Examples()
+	if len(examples) == 0 {
+		t.Fatal("expected at least one example")
+	}
+	for label, example := range examples {
+		if example == "" {
+			t.Errorf("example %q is empty", label)
+		}
+	}
+}
+
+// TestPlanCommandHelpDoesNotPanic guards against a regression where
+// FlagSet panics at help time when no tasks.yml exists on disk.
+func TestPlanCommandHelpDoesNotPanic(t *testing.T) {
+	c := &PlanCommand{}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("FlagSet panicked without tasks.yml on disk: %v", r)
+		}
+	}()
+	_ = c.FlagSet()
+}
+
+// TestPlanCommandUsesPlanInterface guards the contract between the commands
+// package and the tasks package: PlanCommand consumes tasks.Task, which
+// must expose Plan() returning tasks.PlanResult.
+func TestPlanCommandUsesPlanInterface(t *testing.T) {
+	var _ interface {
+		Plan() tasks.PlanResult
+	} = (tasks.Task)(nil)
+}

--- a/main.go
+++ b/main.go
@@ -41,6 +41,9 @@ func Commands(ctx context.Context, meta command.Meta) map[string]cli.CommandFact
 		"apply": func() (cli.Command, error) {
 			return &commands.ApplyCommand{Meta: meta}, nil
 		},
+		"plan": func() (cli.Command, error) {
+			return &commands.PlanCommand{Meta: meta}, nil
+		},
 		"version": func() (cli.Command, error) {
 			return &command.VersionCommand{Meta: meta}, nil
 		},

--- a/tasks/acl_app_task.go
+++ b/tasks/acl_app_task.go
@@ -68,9 +68,101 @@ func (t AclAppTask) Examples() ([]Doc, error) {
 
 // Execute manages the app ACL
 func (t AclAppTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return addAclAppUsers(t) },
-		StateAbsent:  func() TaskOutputState { return removeAclAppUsers(t) },
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the AclAppTask would produce.
+func (t AclAppTask) Plan() PlanResult {
+	if t.App == "" {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if len(t.Users) == 0 {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'users' must not be empty for state 'present'")}
+			}
+			current, err := getAclAppUsers(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			toAdd := []string{}
+			mutations := []string{}
+			for _, u := range t.Users {
+				if !current[u] {
+					toAdd = append(toAdd, u)
+					mutations = append(mutations, "add "+u)
+				}
+			}
+			if len(toAdd) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    fmt.Sprintf("%d user(s) to add", len(toAdd)),
+				Mutations: mutations,
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					for _, u := range toAdd {
+						result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+							Command: "dokku",
+							Args:    []string{"--quiet", "acl:add", t.App, u},
+						})
+						if err != nil {
+							return TaskOutputErrorFromExec(state, err, result)
+						}
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			current, err := getAclAppUsers(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			toRemove := []string{}
+			mutations := []string{}
+			if len(t.Users) == 0 {
+				for u := range current {
+					toRemove = append(toRemove, u)
+					mutations = append(mutations, "remove "+u)
+				}
+			} else {
+				for _, u := range t.Users {
+					if current[u] {
+						toRemove = append(toRemove, u)
+						mutations = append(mutations, "remove "+u)
+					}
+				}
+			}
+			if len(toRemove) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    fmt.Sprintf("%d user(s) to remove", len(toRemove)),
+				Mutations: mutations,
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					for _, u := range toRemove {
+						result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+							Command: "dokku",
+							Args:    []string{"--quiet", "acl:remove", t.App, u},
+						})
+						if err != nil {
+							return TaskOutputErrorFromExec(state, err, result)
+						}
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
+			}
+		},
 	})
 }
 
@@ -94,109 +186,6 @@ func getAclAppUsers(app string) (map[string]bool, error) {
 		users[trimmed] = true
 	}
 	return users, nil
-}
-
-// addAclAppUsers adds users to an app's ACL, skipping ones already present
-func addAclAppUsers(t AclAppTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StateAbsent,
-	}
-
-	if t.App == "" {
-		state.Error = fmt.Errorf("'app' is required")
-		return state
-	}
-	if len(t.Users) == 0 {
-		state.Error = fmt.Errorf("'users' must not be empty for state 'present'")
-		return state
-	}
-
-	current, err := getAclAppUsers(t.App)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	var toAdd []string
-	for _, user := range t.Users {
-		if !current[user] {
-			toAdd = append(toAdd, user)
-		}
-	}
-
-	if len(toAdd) == 0 {
-		state.State = StatePresent
-		return state
-	}
-
-	for _, user := range toAdd {
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    []string{"--quiet", "acl:add", t.App, user},
-		})
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-	}
-
-	state.Changed = true
-	state.State = StatePresent
-	return state
-}
-
-// removeAclAppUsers removes users from an app's ACL. With an empty Users list,
-// removes every entry currently in the ACL (i.e. clears it).
-func removeAclAppUsers(t AclAppTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StatePresent,
-	}
-
-	if t.App == "" {
-		state.Error = fmt.Errorf("'app' is required")
-		return state
-	}
-
-	current, err := getAclAppUsers(t.App)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	var toRemove []string
-	if len(t.Users) == 0 {
-		for user := range current {
-			toRemove = append(toRemove, user)
-		}
-	} else {
-		for _, user := range t.Users {
-			if current[user] {
-				toRemove = append(toRemove, user)
-			}
-		}
-	}
-
-	if len(toRemove) == 0 {
-		state.State = StateAbsent
-		return state
-	}
-
-	for _, user := range toRemove {
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    []string{"--quiet", "acl:remove", t.App, user},
-		})
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-	}
-
-	state.Changed = true
-	state.State = StateAbsent
-	return state
 }
 
 // init registers the AclAppTask with the task registry

--- a/tasks/acl_service_task.go
+++ b/tasks/acl_service_task.go
@@ -74,9 +74,101 @@ func (t AclServiceTask) Examples() ([]Doc, error) {
 
 // Execute manages the service ACL
 func (t AclServiceTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return addAclServiceUsers(t) },
-		StateAbsent:  func() TaskOutputState { return removeAclServiceUsers(t) },
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the AclServiceTask would produce.
+func (t AclServiceTask) Plan() PlanResult {
+	if err := validateAclServiceTask(t); err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if len(t.Users) == 0 {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'users' must not be empty for state 'present'")}
+			}
+			current, err := getAclServiceUsers(t.Type, t.Service)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			toAdd := []string{}
+			mutations := []string{}
+			for _, u := range t.Users {
+				if !current[u] {
+					toAdd = append(toAdd, u)
+					mutations = append(mutations, "add "+u)
+				}
+			}
+			if len(toAdd) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    fmt.Sprintf("%d user(s) to add", len(toAdd)),
+				Mutations: mutations,
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					for _, u := range toAdd {
+						result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+							Command: "dokku",
+							Args:    []string{"--quiet", "acl:add-service", t.Type, t.Service, u},
+						})
+						if err != nil {
+							return TaskOutputErrorFromExec(state, err, result)
+						}
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			current, err := getAclServiceUsers(t.Type, t.Service)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			toRemove := []string{}
+			mutations := []string{}
+			if len(t.Users) == 0 {
+				for u := range current {
+					toRemove = append(toRemove, u)
+					mutations = append(mutations, "remove "+u)
+				}
+			} else {
+				for _, u := range t.Users {
+					if current[u] {
+						toRemove = append(toRemove, u)
+						mutations = append(mutations, "remove "+u)
+					}
+				}
+			}
+			if len(toRemove) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    fmt.Sprintf("%d user(s) to remove", len(toRemove)),
+				Mutations: mutations,
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					for _, u := range toRemove {
+						result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+							Command: "dokku",
+							Args:    []string{"--quiet", "acl:remove-service", t.Type, t.Service, u},
+						})
+						if err != nil {
+							return TaskOutputErrorFromExec(state, err, result)
+						}
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
+			}
+		},
 	})
 }
 
@@ -113,109 +205,6 @@ func validateAclServiceTask(t AclServiceTask) error {
 		return fmt.Errorf("'type' is required")
 	}
 	return nil
-}
-
-// addAclServiceUsers adds users to a service's ACL, skipping ones already present
-func addAclServiceUsers(t AclServiceTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StateAbsent,
-	}
-
-	if err := validateAclServiceTask(t); err != nil {
-		state.Error = err
-		return state
-	}
-	if len(t.Users) == 0 {
-		state.Error = fmt.Errorf("'users' must not be empty for state 'present'")
-		return state
-	}
-
-	current, err := getAclServiceUsers(t.Type, t.Service)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	var toAdd []string
-	for _, user := range t.Users {
-		if !current[user] {
-			toAdd = append(toAdd, user)
-		}
-	}
-
-	if len(toAdd) == 0 {
-		state.State = StatePresent
-		return state
-	}
-
-	for _, user := range toAdd {
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    []string{"--quiet", "acl:add-service", t.Type, t.Service, user},
-		})
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-	}
-
-	state.Changed = true
-	state.State = StatePresent
-	return state
-}
-
-// removeAclServiceUsers removes users from a service's ACL. With an empty
-// Users list, removes every entry currently in the ACL (i.e. clears it).
-func removeAclServiceUsers(t AclServiceTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StatePresent,
-	}
-
-	if err := validateAclServiceTask(t); err != nil {
-		state.Error = err
-		return state
-	}
-
-	current, err := getAclServiceUsers(t.Type, t.Service)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	var toRemove []string
-	if len(t.Users) == 0 {
-		for user := range current {
-			toRemove = append(toRemove, user)
-		}
-	} else {
-		for _, user := range t.Users {
-			if current[user] {
-				toRemove = append(toRemove, user)
-			}
-		}
-	}
-
-	if len(toRemove) == 0 {
-		state.State = StateAbsent
-		return state
-	}
-
-	for _, user := range toRemove {
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    []string{"--quiet", "acl:remove-service", t.Type, t.Service, user},
-		})
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-	}
-
-	state.Changed = true
-	state.State = StateAbsent
-	return state
 }
 
 // init registers the AclServiceTask with the task registry

--- a/tasks/app_clone_task.go
+++ b/tasks/app_clone_task.go
@@ -63,49 +63,48 @@ func (t AppCloneTask) Examples() ([]Doc, error) {
 
 // Execute clones an existing dokku app to a new app
 func (t AppCloneTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return cloneApp(t) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
-// cloneApp clones an existing dokku app to a new app
-func cloneApp(t AppCloneTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StateAbsent,
-	}
-
-	if t.App == "" {
-		state.Error = fmt.Errorf("'app' is required")
-		return state
-	}
-	if t.SourceApp == "" {
-		state.Error = fmt.Errorf("'source_app' is required")
-		return state
-	}
-
-	if appExists(t.App) {
-		state.State = StatePresent
-		return state
-	}
-
-	args := []string{"--quiet", "apps:clone"}
-	if t.SkipDeploy {
-		args = append(args, "--skip-deploy")
-	}
-	args = append(args, t.SourceApp, t.App)
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
+// Plan reports the drift the AppCloneTask would produce.
+func (t AppCloneTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if t.App == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+			}
+			if t.SourceApp == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'source_app' is required")}
+			}
+			if appExists(t.App) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    fmt.Sprintf("target app %s missing", t.App),
+				Mutations: []string{fmt.Sprintf("clone %s -> %s", t.SourceApp, t.App)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					args := []string{"--quiet", "apps:clone"}
+					if t.SkipDeploy {
+						args = append(args, "--skip-deploy")
+					}
+					args = append(args, t.SourceApp, t.App)
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
+			}
+		},
 	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StatePresent
-	return state
 }
 
 // init registers the AppCloneTask with the task registry

--- a/tasks/app_json_property_task.go
+++ b/tasks/app_json_property_task.go
@@ -68,7 +68,12 @@ func (t AppJsonPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the app.json property
 func (t AppJsonPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "app-json:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the AppJsonPropertyTask would produce.
+func (t AppJsonPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "app-json:set")
 }
 
 // init registers the AppJsonPropertyTask with the task registry

--- a/tasks/app_lock_task.go
+++ b/tasks/app_lock_task.go
@@ -55,9 +55,63 @@ func (t AppLockTask) Examples() ([]Doc, error) {
 
 // Execute locks or unlocks the app
 func (t AppLockTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return lockApp(t.App) },
-		StateAbsent:  func() TaskOutputState { return unlockApp(t.App) },
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the AppLockTask would produce.
+func (t AppLockTask) Plan() PlanResult {
+	if t.App == "" {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if appLocked(t.App) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    "app unlocked",
+				Mutations: []string{"lock " + t.App},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "apps:lock", t.App},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			if !appLocked(t.App) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    "app locked",
+				Mutations: []string{"unlock " + t.App},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "apps:unlock", t.App},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
+			}
+		},
 	})
 }
 
@@ -71,66 +125,6 @@ func appLocked(app string) bool {
 		return false
 	}
 	return result.ExitCode == 0
-}
-
-// lockApp locks a dokku app for deployment
-func lockApp(app string) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StateAbsent,
-	}
-
-	if app == "" {
-		state.Error = fmt.Errorf("'app' is required")
-		return state
-	}
-
-	if appLocked(app) {
-		state.State = StatePresent
-		return state
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    []string{"--quiet", "apps:lock", app},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StatePresent
-	return state
-}
-
-// unlockApp unlocks a dokku app for deployment
-func unlockApp(app string) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StatePresent,
-	}
-
-	if app == "" {
-		state.Error = fmt.Errorf("'app' is required")
-		return state
-	}
-
-	if !appLocked(app) {
-		state.State = StateAbsent
-		return state
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    []string{"--quiet", "apps:unlock", app},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StateAbsent
-	return state
 }
 
 // init registers the AppLockTask with the task registry

--- a/tasks/app_task.go
+++ b/tasks/app_task.go
@@ -53,9 +53,36 @@ func (t AppTask) Examples() ([]Doc, error) {
 
 // Execute creates or destroys an app
 func (t AppTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return createApp(t.App) },
-		"absent":  func() TaskOutputState { return destroyApp(t.App) },
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the AppTask would produce.
+func (t AppTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if appExists(t.App) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    "app missing",
+				Mutations: []string{"create app " + t.App},
+				apply:     applyCreateApp(t.App),
+			}
+		},
+		StateAbsent: func() PlanResult {
+			if !appExists(t.App) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "app present",
+				Mutations: []string{"destroy app " + t.App},
+				apply:     applyDestroyApp(t.App),
+			}
+		},
 	})
 }
 
@@ -76,61 +103,56 @@ func appExists(appName string) bool {
 	return result.ExitCode == 0
 }
 
-// createApp creates an app
-func createApp(app string) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
-	if appExists(app) {
-		state.State = "present"
+// applyCreateApp returns a closure that runs `dokku apps:create <app>`.
+func applyCreateApp(app string) func() TaskOutputState {
+	return func() TaskOutputState {
+		state := TaskOutputState{Changed: false, State: StateAbsent}
+		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", "apps:create", app},
+		})
+		if err != nil {
+			return TaskOutputErrorFromExec(state, err, result)
+		}
+		state.Changed = true
+		state.State = StatePresent
 		return state
 	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			"apps:create",
-			app,
-		},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
 }
 
-// destroyApp destroys an app
-func destroyApp(app string) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "present",
-	}
-	if !appExists(app) {
-		state.State = "absent"
+// applyDestroyApp returns a closure that runs `dokku --force apps:destroy <app>`.
+func applyDestroyApp(app string) func() TaskOutputState {
+	return func() TaskOutputState {
+		state := TaskOutputState{Changed: false, State: StatePresent}
+		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", "--force", "apps:destroy", app},
+		})
+		if err != nil {
+			return TaskOutputErrorFromExec(state, err, result)
+		}
+		state.Changed = true
+		state.State = StateAbsent
 		return state
 	}
+}
 
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			"--force",
-			"apps:destroy",
-			app,
-		},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
+// destroyApp is retained as an integration-test helper. It runs the
+// destroy-app apply path synchronously.
+func destroyApp(app string) TaskOutputState {
+	if !appExists(app) {
+		return TaskOutputState{Changed: false, State: StateAbsent}
 	}
+	return applyDestroyApp(app)()
+}
 
-	state.Changed = true
-	state.State = "absent"
-	return state
+// createApp is retained as an integration-test helper. It runs the
+// create-app apply path synchronously.
+func createApp(app string) TaskOutputState {
+	if appExists(app) {
+		return TaskOutputState{Changed: false, State: StatePresent}
+	}
+	return applyCreateApp(app)()
 }
 
 // init registers the AppTask with the task registry

--- a/tasks/builder_dockerfile_property_task.go
+++ b/tasks/builder_dockerfile_property_task.go
@@ -68,7 +68,12 @@ func (t BuilderDockerfilePropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the builder-dockerfile property
 func (t BuilderDockerfilePropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-dockerfile:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the BuilderDockerfilePropertyTask would produce.
+func (t BuilderDockerfilePropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-dockerfile:set")
 }
 
 // init registers the BuilderDockerfilePropertyTask with the task registry

--- a/tasks/builder_herokuish_property_task.go
+++ b/tasks/builder_herokuish_property_task.go
@@ -68,7 +68,12 @@ func (t BuilderHerokuishPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the builder-herokuish property
 func (t BuilderHerokuishPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-herokuish:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the BuilderHerokuishPropertyTask would produce.
+func (t BuilderHerokuishPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-herokuish:set")
 }
 
 // init registers the BuilderHerokuishPropertyTask with the task registry

--- a/tasks/builder_lambda_property_task.go
+++ b/tasks/builder_lambda_property_task.go
@@ -68,7 +68,12 @@ func (t BuilderLambdaPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the builder-lambda property
 func (t BuilderLambdaPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-lambda:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the BuilderLambdaPropertyTask would produce.
+func (t BuilderLambdaPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-lambda:set")
 }
 
 // init registers the BuilderLambdaPropertyTask with the task registry

--- a/tasks/builder_nixpacks_property_task.go
+++ b/tasks/builder_nixpacks_property_task.go
@@ -68,7 +68,12 @@ func (t BuilderNixpacksPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the builder-nixpacks property
 func (t BuilderNixpacksPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-nixpacks:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the BuilderNixpacksPropertyTask would produce.
+func (t BuilderNixpacksPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-nixpacks:set")
 }
 
 // init registers the BuilderNixpacksPropertyTask with the task registry

--- a/tasks/builder_pack_property_task.go
+++ b/tasks/builder_pack_property_task.go
@@ -68,7 +68,12 @@ func (t BuilderPackPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the builder-pack property
 func (t BuilderPackPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-pack:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the BuilderPackPropertyTask would produce.
+func (t BuilderPackPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-pack:set")
 }
 
 // init registers the BuilderPackPropertyTask with the task registry

--- a/tasks/builder_property_task.go
+++ b/tasks/builder_property_task.go
@@ -76,7 +76,12 @@ func (t BuilderPropertyTask) Examples() ([]Doc, error) {
 
 // Execute executes the builder configuration task
 func (t BuilderPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the BuilderPropertyTask would produce.
+func (t BuilderPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder:set")
 }
 
 // init registers the BuilderTask with the task registry

--- a/tasks/builder_railpack_property_task.go
+++ b/tasks/builder_railpack_property_task.go
@@ -68,7 +68,12 @@ func (t BuilderRailpackPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the builder-railpack property
 func (t BuilderRailpackPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-railpack:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the BuilderRailpackPropertyTask would produce.
+func (t BuilderRailpackPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-railpack:set")
 }
 
 // init registers the BuilderRailpackPropertyTask with the task registry

--- a/tasks/buildpacks_property_task.go
+++ b/tasks/buildpacks_property_task.go
@@ -68,7 +68,12 @@ func (t BuildpacksPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the buildpacks property
 func (t BuildpacksPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "buildpacks:set-property")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the BuildpacksPropertyTask would produce.
+func (t BuildpacksPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "buildpacks:set-property")
 }
 
 // init registers the BuildpacksPropertyTask with the task registry

--- a/tasks/buildpacks_task.go
+++ b/tasks/buildpacks_task.go
@@ -73,10 +73,135 @@ func (t BuildpacksTask) Examples() ([]Doc, error) {
 
 // Execute manages the buildpacks for a given app
 func (t BuildpacksTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return addBuildpacks(t) },
-		StateAbsent:  func() TaskOutputState { return removeBuildpacks(t) },
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the BuildpacksTask would produce.
+func (t BuildpacksTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return planBuildpacksAdd(t) },
+		StateAbsent:  func() PlanResult { return planBuildpacksRemove(t) },
 	})
+}
+
+func planBuildpacksAdd(t BuildpacksTask) PlanResult {
+	if t.App == "" {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+	}
+	if len(t.Buildpacks) == 0 {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'buildpacks' must not be empty for state 'present'")}
+	}
+	current, err := getBuildpacks(t.App)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	toAdd := []string{}
+	mutations := []string{}
+	for _, bp := range t.Buildpacks {
+		if !current[bp] {
+			toAdd = append(toAdd, bp)
+			mutations = append(mutations, "add "+bp)
+		}
+	}
+	if len(toAdd) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	status := PlanStatusModify
+	if len(current) == 0 {
+		status = PlanStatusCreate
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    status,
+		Reason:    fmt.Sprintf("%d buildpack(s) to add", len(toAdd)),
+		Mutations: mutations,
+		apply: func() TaskOutputState {
+			state := TaskOutputState{Changed: false, State: StateAbsent}
+			for _, bp := range toAdd {
+				result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+					Command: "dokku",
+					Args:    []string{"--quiet", "buildpacks:add", t.App, bp},
+				})
+				if err != nil {
+					return TaskOutputErrorFromExec(state, err, result)
+				}
+			}
+			state.Changed = true
+			state.State = StatePresent
+			return state
+		},
+	}
+}
+
+func planBuildpacksRemove(t BuildpacksTask) PlanResult {
+	if t.App == "" {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+	}
+	current, err := getBuildpacks(t.App)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	if len(t.Buildpacks) == 0 {
+		if len(current) == 0 {
+			return PlanResult{InSync: true, Status: PlanStatusOK}
+		}
+		mutations := make([]string, 0, len(current))
+		for bp := range current {
+			mutations = append(mutations, "remove "+bp)
+		}
+		app := t.App
+		return PlanResult{
+			InSync:    false,
+			Status:    PlanStatusDestroy,
+			Reason:    fmt.Sprintf("clear %d buildpack(s)", len(current)),
+			Mutations: mutations,
+			apply: func() TaskOutputState {
+				state := TaskOutputState{Changed: false, State: StatePresent}
+				result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+					Command: "dokku",
+					Args:    []string{"--quiet", "buildpacks:clear", app},
+				})
+				if err != nil {
+					return TaskOutputErrorFromExec(state, err, result)
+				}
+				state.Changed = true
+				state.State = StateAbsent
+				return state
+			},
+		}
+	}
+	toRemove := []string{}
+	mutations := []string{}
+	for _, bp := range t.Buildpacks {
+		if current[bp] {
+			toRemove = append(toRemove, bp)
+			mutations = append(mutations, "remove "+bp)
+		}
+	}
+	if len(toRemove) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    fmt.Sprintf("%d buildpack(s) to remove", len(toRemove)),
+		Mutations: mutations,
+		apply: func() TaskOutputState {
+			state := TaskOutputState{Changed: false, State: StatePresent}
+			for _, bp := range toRemove {
+				result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+					Command: "dokku",
+					Args:    []string{"--quiet", "buildpacks:remove", t.App, bp},
+				})
+				if err != nil {
+					return TaskOutputErrorFromExec(state, err, result)
+				}
+			}
+			state.Changed = true
+			state.State = StateAbsent
+			return state
+		},
+	}
 }
 
 // getBuildpacks fetches the current buildpacks list for an app
@@ -98,119 +223,6 @@ func getBuildpacks(app string) (map[string]bool, error) {
 		buildpacks[trimmed] = true
 	}
 	return buildpacks, nil
-}
-
-// addBuildpacks adds buildpacks to an app, skipping ones already present
-func addBuildpacks(t BuildpacksTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StateAbsent,
-	}
-
-	if t.App == "" {
-		state.Error = fmt.Errorf("'app' is required")
-		return state
-	}
-	if len(t.Buildpacks) == 0 {
-		state.Error = fmt.Errorf("'buildpacks' must not be empty for state 'present'")
-		return state
-	}
-
-	current, err := getBuildpacks(t.App)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	var toAdd []string
-	for _, bp := range t.Buildpacks {
-		if !current[bp] {
-			toAdd = append(toAdd, bp)
-		}
-	}
-
-	if len(toAdd) == 0 {
-		state.State = StatePresent
-		return state
-	}
-
-	for _, bp := range toAdd {
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    []string{"--quiet", "buildpacks:add", t.App, bp},
-		})
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-	}
-
-	state.Changed = true
-	state.State = StatePresent
-	return state
-}
-
-// removeBuildpacks removes buildpacks from an app, or clears all when none are specified
-func removeBuildpacks(t BuildpacksTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StatePresent,
-	}
-
-	if t.App == "" {
-		state.Error = fmt.Errorf("'app' is required")
-		return state
-	}
-
-	current, err := getBuildpacks(t.App)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	if len(t.Buildpacks) == 0 {
-		if len(current) == 0 {
-			state.State = StateAbsent
-			return state
-		}
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    []string{"--quiet", "buildpacks:clear", t.App},
-		})
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-		state.Changed = true
-		state.State = StateAbsent
-		return state
-	}
-
-	var toRemove []string
-	for _, bp := range t.Buildpacks {
-		if current[bp] {
-			toRemove = append(toRemove, bp)
-		}
-	}
-
-	if len(toRemove) == 0 {
-		state.State = StateAbsent
-		return state
-	}
-
-	for _, bp := range toRemove {
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    []string{"--quiet", "buildpacks:remove", t.App, bp},
-		})
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-	}
-
-	state.Changed = true
-	state.State = StateAbsent
-	return state
 }
 
 // init registers the BuildpacksTask with the task registry

--- a/tasks/caddy_property_task.go
+++ b/tasks/caddy_property_task.go
@@ -68,7 +68,12 @@ func (t CaddyPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the caddy property
 func (t CaddyPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "caddy:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the CaddyPropertyTask would produce.
+func (t CaddyPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "caddy:set")
 }
 
 // init registers the CaddyPropertyTask with the task registry

--- a/tasks/certs_task.go
+++ b/tasks/certs_task.go
@@ -83,9 +83,93 @@ func (t CertsTask) Examples() ([]Doc, error) {
 
 // Execute manages the SSL certificate
 func (t CertsTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return addCert(t) },
-		StateAbsent:  func() TaskOutputState { return removeCert(t) },
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the CertsTask would produce.
+func (t CertsTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if err := validateCertsTask(t); err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if t.Cert == "" || t.Key == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'cert' and 'key' are required when state is 'present'")}
+			}
+			enabled, err := certsEnabled(t)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if enabled {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			target := t.App
+			if t.Global {
+				target = "(global)"
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    "certificate not installed",
+				Mutations: []string{fmt.Sprintf("install certificate for %s", target)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					args := []string{"--quiet", "certs:add", t.App, t.Cert, t.Key}
+					if t.Global {
+						args = []string{"--quiet", "global-cert:set", t.Cert, t.Key}
+					}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			if err := validateCertsTask(t); err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			enabled, err := certsEnabled(t)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !enabled {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			target := t.App
+			if t.Global {
+				target = "(global)"
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "certificate present",
+				Mutations: []string{fmt.Sprintf("remove certificate for %s", target)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					args := []string{"--quiet", "certs:remove", t.App}
+					if t.Global {
+						args = []string{"--quiet", "global-cert:remove"}
+					}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
+			}
+		},
 	})
 }
 
@@ -116,92 +200,6 @@ func certsEnabled(t CertsTask) (bool, error) {
 	}
 
 	return strings.TrimSpace(result.StdoutContents()) == "true", nil
-}
-
-// addCert installs an SSL certificate for an app or globally
-func addCert(t CertsTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StateAbsent,
-	}
-
-	if err := validateCertsTask(t); err != nil {
-		state.Error = err
-		return state
-	}
-	if t.Cert == "" || t.Key == "" {
-		state.Error = fmt.Errorf("'cert' and 'key' are required when state is 'present'")
-		return state
-	}
-
-	enabled, err := certsEnabled(t)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-	if enabled {
-		state.State = StatePresent
-		return state
-	}
-
-	args := []string{"--quiet", "certs:add", t.App, t.Cert, t.Key}
-	if t.Global {
-		args = []string{"--quiet", "global-cert:set", t.Cert, t.Key}
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StatePresent
-	return state
-}
-
-// removeCert removes the SSL certificate for an app or globally
-func removeCert(t CertsTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StatePresent,
-	}
-
-	if err := validateCertsTask(t); err != nil {
-		state.Error = err
-		return state
-	}
-
-	enabled, err := certsEnabled(t)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-	if !enabled {
-		state.State = StateAbsent
-		return state
-	}
-
-	args := []string{"--quiet", "certs:remove", t.App}
-	if t.Global {
-		args = []string{"--quiet", "global-cert:remove"}
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StateAbsent
-	return state
 }
 
 // init registers the CertsTask with the task registry

--- a/tasks/checks_property_task.go
+++ b/tasks/checks_property_task.go
@@ -68,7 +68,12 @@ func (t ChecksPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the checks property
 func (t ChecksPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "checks:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the ChecksPropertyTask would produce.
+func (t ChecksPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "checks:set")
 }
 
 // init registers the ChecksPropertyTask with the task registry

--- a/tasks/checks_toggle_task.go
+++ b/tasks/checks_toggle_task.go
@@ -1,5 +1,33 @@
 package tasks
 
+import (
+	"strings"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// checksEnabled probes whether checks are enabled for an app via
+// `dokku --quiet checks:report <app> --checks-disabled`. The dokku-checks
+// plugin lists disabled process types here; an empty list or "none" means
+// every process has checks enabled.
+func checksEnabled(ctx ToggleContext) (bool, error) {
+	args := []string{"--quiet", "checks:report"}
+	if ctx.AllowGlobal && ctx.Global {
+		args = append(args, "--global", "--checks-disabled")
+	} else {
+		args = append(args, ctx.App, "--checks-disabled")
+	}
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		return false, err
+	}
+	disabled := strings.TrimSpace(result.StdoutContents())
+	return disabled == "" || disabled == "none", nil
+}
+
 // ChecksToggleTask enables or disables the checks plugin for a given dokku application
 type ChecksToggleTask struct {
 	// App is the name of the app
@@ -53,7 +81,12 @@ func (t ChecksToggleTask) Examples() ([]Doc, error) {
 
 // Execute enables or disables the checks plugin
 func (t ChecksToggleTask) Execute() TaskOutputState {
-	return executeToggle(t.State, t.App, t.Global, false, "checks:enable", "checks:disable")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the ChecksToggleTask would produce.
+func (t ChecksToggleTask) Plan() PlanResult {
+	return planToggle(t.State, t.App, t.Global, false, "checks:enable", "checks:disable", checksEnabled)
 }
 
 // init registers the ChecksToggleTask with the task registry

--- a/tasks/config_task.go
+++ b/tasks/config_task.go
@@ -69,10 +69,133 @@ func (t ConfigTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the configuration for a given dokku application
 func (t ConfigTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return setConfig(t) },
-		"absent":  func() TaskOutputState { return unsetConfig(t) },
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the ConfigTask would produce.
+func (t ConfigTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return planConfigSet(t) },
+		StateAbsent:  func() PlanResult { return planConfigUnset(t) },
 	})
+}
+
+// configKeysToSet returns keys whose desired value differs from the current value.
+func configKeysToSet(current, desired map[string]string) []string {
+	keys := []string{}
+	for k, v := range desired {
+		if cur, ok := current[k]; !ok || cur != v {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+// configKeysToUnset returns keys present in desired that exist in current.
+func configKeysToUnset(current, desired map[string]string) []string {
+	keys := []string{}
+	for k := range desired {
+		if _, ok := current[k]; ok {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+// planConfigSet probes current config once, computes the diff, and embeds
+// an apply closure that runs `dokku config:set` with only the changed keys.
+func planConfigSet(t ConfigTask) PlanResult {
+	currentConfig, err := getConfig(t)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	keys := configKeysToSet(currentConfig, t.Config)
+	if len(keys) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	mutations := make([]string, 0, len(keys))
+	status := PlanStatusModify
+	allNew := true
+	for _, k := range keys {
+		if _, ok := currentConfig[k]; ok {
+			mutations = append(mutations, fmt.Sprintf("set %s (was set)", k))
+			allNew = false
+		} else {
+			mutations = append(mutations, fmt.Sprintf("set %s (new)", k))
+		}
+	}
+	if allNew {
+		status = PlanStatusCreate
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    status,
+		Reason:    fmt.Sprintf("%d key(s) to set", len(keys)),
+		Mutations: mutations,
+		apply: func() TaskOutputState {
+			state := TaskOutputState{Changed: false, State: StateAbsent}
+			args := []string{"--quiet", "config:set", "--encoded"}
+			if !t.Restart {
+				args = append(args, "--no-restart")
+			}
+			args = append(args, t.App)
+			for _, k := range keys {
+				args = append(args, fmt.Sprintf("%s=%s", k, base64.StdEncoding.EncodeToString([]byte(t.Config[k]))))
+			}
+			result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+				Command: "dokku",
+				Args:    args,
+			})
+			if err != nil {
+				return TaskOutputErrorFromExec(state, err, result)
+			}
+			state.Changed = true
+			state.State = StatePresent
+			return state
+		},
+	}
+}
+
+// planConfigUnset probes current config once, computes the diff, and embeds
+// an apply closure that runs `dokku config:unset` with only existing keys.
+func planConfigUnset(t ConfigTask) PlanResult {
+	currentConfig, err := getConfig(t)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	keys := configKeysToUnset(currentConfig, t.Config)
+	if len(keys) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	mutations := make([]string, 0, len(keys))
+	for _, k := range keys {
+		mutations = append(mutations, fmt.Sprintf("unset %s", k))
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    fmt.Sprintf("%d key(s) to unset", len(keys)),
+		Mutations: mutations,
+		apply: func() TaskOutputState {
+			state := TaskOutputState{Changed: false, State: StatePresent}
+			args := []string{"--quiet", "config:unset"}
+			if !t.Restart {
+				args = append(args, "--no-restart")
+			}
+			args = append(args, t.App)
+			args = append(args, keys...)
+			result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+				Command: "dokku",
+				Args:    args,
+			})
+			if err != nil {
+				return TaskOutputErrorFromExec(state, err, result)
+			}
+			state.Changed = true
+			state.State = StateAbsent
+			return state
+		},
+	}
 }
 
 // getConfig retrieves the current configuration for a given dokku application
@@ -98,120 +221,6 @@ func getConfig(t ConfigTask) (map[string]string, error) {
 		return config, err
 	}
 	return config, nil
-}
-
-// setConfig sets the configuration for a given dokku application
-func setConfig(t ConfigTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
-
-	currentConfig, err := getConfig(t)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	desiredConfig := make(map[string]string)
-	for key, value := range t.Config {
-		if _, ok := currentConfig[key]; !ok {
-			desiredConfig[key] = value
-			continue
-		}
-		if currentConfig[key] != value {
-			desiredConfig[key] = value
-		}
-	}
-
-	if len(desiredConfig) == 0 {
-		state.State = "present"
-		return state
-	}
-
-	args := []string{
-		"--quiet",
-		"config:set",
-		"--encoded",
-	}
-
-	if !t.Restart {
-		// todo: rename no-restart to skip-deploy in dokku
-		args = append(args, "--no-restart")
-	}
-
-	args = append(args, t.App)
-
-	for key, value := range desiredConfig {
-		args = append(args, fmt.Sprintf("%s=%s", key, base64.StdEncoding.EncodeToString([]byte(value))))
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
-}
-
-// unsetConfig unsets the configuration for a given dokku application
-func unsetConfig(t ConfigTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "present",
-	}
-	currentConfig, err := getConfig(t)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	desiredConfig := make(map[string]bool)
-	for key := range t.Config {
-		if _, ok := currentConfig[key]; ok {
-			desiredConfig[key] = true
-		}
-	}
-
-	if len(desiredConfig) == 0 {
-		state.State = "absent"
-		return state
-	}
-
-	args := []string{
-		"--quiet",
-		"config:unset",
-	}
-
-	if !t.Restart {
-		// todo: rename no-restart to skip-deploy in dokku
-		args = append(args, "--no-restart")
-	}
-
-	args = append(args, t.App)
-
-	for key := range desiredConfig {
-		args = append(args, key)
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "absent"
-	return state
 }
 
 // init registers the ConfigTask with the task registry

--- a/tasks/cron_property_task.go
+++ b/tasks/cron_property_task.go
@@ -68,7 +68,12 @@ func (t CronPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the cron property
 func (t CronPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "cron:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the CronPropertyTask would produce.
+func (t CronPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "cron:set")
 }
 
 // init registers the CronPropertyTask with the task registry

--- a/tasks/dispatch.go
+++ b/tasks/dispatch.go
@@ -16,3 +16,65 @@ func DispatchState(state State, funcMap map[State]func() TaskOutputState) TaskOu
 	result.DesiredState = state
 	return result
 }
+
+// DispatchPlan looks up the given state in the funcMap, calls the matching
+// function, and returns an error PlanResult if the state is not found.
+// Mirrors DispatchState but for the read-only Plan() path.
+func DispatchPlan(state State, funcMap map[State]func() PlanResult) PlanResult {
+	fn, ok := funcMap[state]
+	if !ok {
+		return PlanResult{
+			Status: PlanStatusError,
+			Error:  fmt.Errorf("invalid state: %s", state),
+		}
+	}
+
+	result := fn()
+	result.DesiredState = state
+	return result
+}
+
+// ExecutePlan applies a PlanResult to the server. It is the canonical
+// implementation of Task.Execute(): each task's Execute body is
+// `return ExecutePlan(t.Plan())`. ExecutePlan ensures the existing
+// `state.State == state.DesiredState` contract that commands/apply.go
+// relies on.
+//
+// Three branches:
+//
+//  1. p.Error != nil  - probe failed; return TaskOutputState carrying the
+//     error and the desired state. The apply closure is not invoked.
+//  2. p.InSync        - no change needed; return State == DesiredState with
+//     Changed=false. The apply closure is not invoked.
+//  3. otherwise       - invoke p.apply (must be non-nil) and return its
+//     TaskOutputState verbatim. apply is responsible for setting Changed
+//     and a final State that matches DesiredState on success.
+func ExecutePlan(p PlanResult) TaskOutputState {
+	if p.Error != nil {
+		return TaskOutputState{
+			Error:        p.Error,
+			Message:      p.Error.Error(),
+			DesiredState: p.DesiredState,
+			State:        p.DesiredState,
+		}
+	}
+	if p.InSync {
+		return TaskOutputState{
+			Changed:      false,
+			State:        p.DesiredState,
+			DesiredState: p.DesiredState,
+		}
+	}
+	if p.apply == nil {
+		return TaskOutputState{
+			Error:        fmt.Errorf("plan reports drift but no apply function was provided"),
+			DesiredState: p.DesiredState,
+			State:        p.DesiredState,
+		}
+	}
+	out := p.apply()
+	if out.DesiredState == "" {
+		out.DesiredState = p.DesiredState
+	}
+	return out
+}

--- a/tasks/docker_options_task.go
+++ b/tasks/docker_options_task.go
@@ -67,9 +67,74 @@ func (t DockerOptionsTask) Examples() ([]Doc, error) {
 
 // Execute manages the docker option
 func (t DockerOptionsTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return addDockerOption(t) },
-		StateAbsent:  func() TaskOutputState { return removeDockerOption(t) },
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the DockerOptionsTask would produce.
+func (t DockerOptionsTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if err := validateDockerOptionsTask(t); err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			current, err := getDockerOptions(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if optionPresent(current[t.Phase], t.Option) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    fmt.Sprintf("missing on %s phase", t.Phase),
+				Mutations: []string{fmt.Sprintf("add %s option %q", t.Phase, t.Option)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "docker-options:add", t.App, t.Phase, t.Option},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			if err := validateDockerOptionsTask(t); err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			current, err := getDockerOptions(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !optionPresent(current[t.Phase], t.Option) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    fmt.Sprintf("present on %s phase", t.Phase),
+				Mutations: []string{fmt.Sprintf("remove %s option %q", t.Phase, t.Option)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "docker-options:remove", t.App, t.Phase, t.Option},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
+			}
+		},
 	})
 }
 
@@ -132,78 +197,6 @@ func optionPresent(existing, option string) bool {
 		}
 	}
 	return false
-}
-
-// addDockerOption adds a docker option to the specified phase
-func addDockerOption(t DockerOptionsTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StateAbsent,
-	}
-
-	if err := validateDockerOptionsTask(t); err != nil {
-		state.Error = err
-		return state
-	}
-
-	current, err := getDockerOptions(t.App)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-	if optionPresent(current[t.Phase], t.Option) {
-		state.State = StatePresent
-		return state
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    []string{"--quiet", "docker-options:add", t.App, t.Phase, t.Option},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StatePresent
-	return state
-}
-
-// removeDockerOption removes a docker option from the specified phase
-func removeDockerOption(t DockerOptionsTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StatePresent,
-	}
-
-	if err := validateDockerOptionsTask(t); err != nil {
-		state.Error = err
-		return state
-	}
-
-	current, err := getDockerOptions(t.App)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-	if !optionPresent(current[t.Phase], t.Option) {
-		state.State = StateAbsent
-		return state
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    []string{"--quiet", "docker-options:remove", t.App, t.Phase, t.Option},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StateAbsent
-	return state
 }
 
 // init registers the DockerOptionsTask with the task registry

--- a/tasks/domains_task.go
+++ b/tasks/domains_task.go
@@ -78,12 +78,185 @@ func (t DomainsTask) Examples() ([]Doc, error) {
 
 // Execute manages the domains
 func (t DomainsTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return addDomains(t) },
-		StateAbsent:  func() TaskOutputState { return removeDomains(t) },
-		StateSet:     func() TaskOutputState { return setDomains(t) },
-		StateClear:   func() TaskOutputState { return clearDomains(t) },
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the DomainsTask would produce.
+func (t DomainsTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return planDomainsPresent(t) },
+		StateAbsent:  func() PlanResult { return planDomainsAbsent(t) },
+		StateSet:     func() PlanResult { return planDomainsSet(t) },
+		StateClear:   func() PlanResult { return planDomainsClear(t) },
 	})
+}
+
+// planDomainsPresent reports drift for the present-state domain add.
+func planDomainsPresent(t DomainsTask) PlanResult {
+	if err := validateDomainsTask(t, true); err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	currentDomains, err := getDomains(t.App, t.Global)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	toAdd := []string{}
+	mutations := []string{}
+	for _, d := range t.Domains {
+		if !currentDomains[d] {
+			toAdd = append(toAdd, d)
+			mutations = append(mutations, fmt.Sprintf("add %s", d))
+		}
+	}
+	if len(toAdd) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	status := PlanStatusModify
+	if len(currentDomains) == 0 {
+		status = PlanStatusCreate
+	}
+	subcommand := "domains:add"
+	appName := t.App
+	if t.Global {
+		subcommand = "domains:add-global"
+		appName = "--global"
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    status,
+		Reason:    fmt.Sprintf("%d domain(s) to add", len(toAdd)),
+		Mutations: mutations,
+		apply:     applyDokkuArgs(subcommand, appName, toAdd, StatePresent, StateAbsent),
+	}
+}
+
+// planDomainsAbsent reports drift for the absent-state domain remove.
+func planDomainsAbsent(t DomainsTask) PlanResult {
+	if err := validateDomainsTask(t, true); err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	currentDomains, err := getDomains(t.App, t.Global)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	toRemove := []string{}
+	mutations := []string{}
+	for _, d := range t.Domains {
+		if currentDomains[d] {
+			toRemove = append(toRemove, d)
+			mutations = append(mutations, fmt.Sprintf("remove %s", d))
+		}
+	}
+	if len(toRemove) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	subcommand := "domains:remove"
+	appName := t.App
+	if t.Global {
+		subcommand = "domains:remove-global"
+		appName = "--global"
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    fmt.Sprintf("%d domain(s) to remove", len(toRemove)),
+		Mutations: mutations,
+		apply:     applyDokkuArgs(subcommand, appName, toRemove, StateAbsent, StatePresent),
+	}
+}
+
+// planDomainsSet reports drift for the set-state full replacement.
+func planDomainsSet(t DomainsTask) PlanResult {
+	if err := validateDomainsTask(t, true); err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	currentDomains, err := getDomains(t.App, t.Global)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	desired := map[string]bool{}
+	for _, d := range t.Domains {
+		desired[d] = true
+	}
+	mutations := []string{}
+	for d := range desired {
+		if !currentDomains[d] {
+			mutations = append(mutations, fmt.Sprintf("add %s", d))
+		}
+	}
+	for d := range currentDomains {
+		if !desired[d] {
+			mutations = append(mutations, fmt.Sprintf("remove %s", d))
+		}
+	}
+	if len(mutations) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	subcommand := "domains:set"
+	appName := t.App
+	if t.Global {
+		subcommand = "domains:set-global"
+		appName = "--global"
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusModify,
+		Reason:    fmt.Sprintf("%d domain change(s)", len(mutations)),
+		Mutations: mutations,
+		apply:     applyDokkuArgs(subcommand, appName, t.Domains, StateSet, StateAbsent),
+	}
+}
+
+// planDomainsClear reports drift for the clear-state operation.
+func planDomainsClear(t DomainsTask) PlanResult {
+	if err := validateDomainsTask(t, false); err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	currentDomains, err := getDomains(t.App, t.Global)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	if len(currentDomains) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	mutations := make([]string, 0, len(currentDomains))
+	for d := range currentDomains {
+		mutations = append(mutations, fmt.Sprintf("remove %s", d))
+	}
+	subcommand := "domains:clear"
+	appName := t.App
+	if t.Global {
+		subcommand = "domains:clear-global"
+		appName = "--global"
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    fmt.Sprintf("clear %d domain(s)", len(currentDomains)),
+		Mutations: mutations,
+		apply:     applyDokkuArgs(subcommand, appName, nil, StateClear, StatePresent),
+	}
+}
+
+// applyDokkuArgs returns a closure that runs `dokku --quiet <subcommand>
+// <target> <extra...>`. It is used by domains plan paths to share the
+// boilerplate around constructing the subprocess call.
+func applyDokkuArgs(subcommand, target string, extra []string, finalState State, errState State) func() TaskOutputState {
+	return func() TaskOutputState {
+		state := TaskOutputState{Changed: false, State: errState}
+		args := []string{"--quiet", subcommand, target}
+		args = append(args, extra...)
+		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    args,
+		})
+		if err != nil {
+			return TaskOutputErrorFromExec(state, err, result)
+		}
+		state.Changed = true
+		state.State = finalState
+		return state
+	}
 }
 
 // validateDomainsTask validates the domains task parameters
@@ -129,183 +302,6 @@ func getDomains(app string, global bool) (map[string]bool, error) {
 		domains[domain] = true
 	}
 	return domains, nil
-}
-
-// addDomains adds domains if they don't already exist
-func addDomains(t DomainsTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StateAbsent,
-	}
-
-	if err := validateDomainsTask(t, true); err != nil {
-		state.Error = err
-		return state
-	}
-
-	currentDomains, err := getDomains(t.App, t.Global)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	var newDomains []string
-	for _, domain := range t.Domains {
-		if !currentDomains[domain] {
-			newDomains = append(newDomains, domain)
-		}
-	}
-
-	if len(newDomains) == 0 {
-		state.State = StatePresent
-		return state
-	}
-
-	subcommand := "domains:add"
-	appName := t.App
-	if t.Global {
-		subcommand = "domains:add-global"
-		appName = "--global"
-	}
-
-	args := []string{"--quiet", subcommand, appName}
-	args = append(args, newDomains...)
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StatePresent
-	return state
-}
-
-// removeDomains removes domains if they exist
-func removeDomains(t DomainsTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StatePresent,
-	}
-
-	if err := validateDomainsTask(t, true); err != nil {
-		state.Error = err
-		return state
-	}
-
-	currentDomains, err := getDomains(t.App, t.Global)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	var domainsToRemove []string
-	for _, domain := range t.Domains {
-		if currentDomains[domain] {
-			domainsToRemove = append(domainsToRemove, domain)
-		}
-	}
-
-	if len(domainsToRemove) == 0 {
-		state.State = StateAbsent
-		return state
-	}
-
-	subcommand := "domains:remove"
-	appName := t.App
-	if t.Global {
-		subcommand = "domains:remove-global"
-		appName = "--global"
-	}
-
-	args := []string{"--quiet", subcommand, appName}
-	args = append(args, domainsToRemove...)
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StateAbsent
-	return state
-}
-
-// setDomains replaces all domains with the specified ones
-func setDomains(t DomainsTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StateAbsent,
-	}
-
-	if err := validateDomainsTask(t, true); err != nil {
-		state.Error = err
-		return state
-	}
-
-	subcommand := "domains:set"
-	appName := t.App
-	if t.Global {
-		subcommand = "domains:set-global"
-		appName = "--global"
-	}
-
-	args := []string{"--quiet", subcommand, appName}
-	args = append(args, t.Domains...)
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StateSet
-	return state
-}
-
-// clearDomains removes all domains
-func clearDomains(t DomainsTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   StatePresent,
-	}
-
-	if err := validateDomainsTask(t, false); err != nil {
-		state.Error = err
-		return state
-	}
-
-	subcommand := "domains:clear"
-	appName := t.App
-	if t.Global {
-		subcommand = "domains:clear-global"
-		appName = "--global"
-	}
-
-	args := []string{"--quiet", subcommand, appName}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = StateClear
-	return state
 }
 
 // init registers the DomainsTask with the task registry

--- a/tasks/domains_toggle_task.go
+++ b/tasks/domains_toggle_task.go
@@ -1,5 +1,31 @@
 package tasks
 
+import (
+	"strings"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// domainsEnabled probes whether the domains plugin is enabled for an app
+// via `dokku --quiet domains:report <app> --domains-app-enabled`, or for
+// the global scope via `--domains-global-enabled`.
+func domainsEnabled(ctx ToggleContext) (bool, error) {
+	args := []string{"--quiet", "domains:report"}
+	if ctx.AllowGlobal && ctx.Global {
+		args = append(args, "--global", "--domains-global-enabled")
+	} else {
+		args = append(args, ctx.App, "--domains-app-enabled")
+	}
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(result.StdoutContents()) == "true", nil
+}
+
 // DomainsToggleTask enables or disables the domains plugin for a given dokku application
 type DomainsToggleTask struct {
 	// App is the name of the app
@@ -38,7 +64,12 @@ func (t DomainsToggleTask) Examples() ([]Doc, error) {
 
 // Execute enables or disables the domains plugin
 func (t DomainsToggleTask) Execute() TaskOutputState {
-	return executeToggle(t.State, t.App, t.Global, false, "domains:enable", "domains:disable")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the DomainsToggleTask would produce.
+func (t DomainsToggleTask) Plan() PlanResult {
+	return planToggle(t.State, t.App, t.Global, false, "domains:enable", "domains:disable", domainsEnabled)
 }
 
 // init registers the DomainsToggleTask with the task registry

--- a/tasks/git_auth_task.go
+++ b/tasks/git_auth_task.go
@@ -69,9 +69,61 @@ func (t GitAuthTask) Examples() ([]Doc, error) {
 
 // Execute manages the netrc entry for a host
 func (t GitAuthTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return setGitAuth(t) },
-		StateAbsent:  func() TaskOutputState { return unsetGitAuth(t) },
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the GitAuthTask would produce. dokku has no public
+// way to query netrc state, so the plan reports drift unconditionally.
+func (t GitAuthTask) Plan() PlanResult {
+	if t.Host == "" {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'host' is required")}
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if t.Username == "" || t.Password == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'username' and 'password' are required when state is 'present'")}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    "netrc state not probed",
+				Mutations: []string{"git:auth " + t.Host + " " + t.Username + " ***"},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "git:auth", t.Host, t.Username, t.Password},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "netrc state not probed",
+				Mutations: []string{"git:auth " + t.Host + " (clear)"},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "git:auth", t.Host},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
+			}
+		},
 	})
 }
 

--- a/tasks/git_from_archive_task.go
+++ b/tasks/git_from_archive_task.go
@@ -73,8 +73,56 @@ var validGitFromArchiveTypes = map[string]bool{"tar": true, "tar.gz": true, "zip
 
 // Execute deploys a git repository from an archive URL
 func (t GitFromArchiveTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"deployed": func() TaskOutputState { return deployGitFromArchive(t) },
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the GitFromArchiveTask would produce.
+func (t GitFromArchiveTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StateDeployed: func() PlanResult {
+			if t.App == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+			}
+			if t.ArchiveURL == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'archive_url' is required")}
+			}
+			archiveType := t.ArchiveType
+			if archiveType == "" {
+				archiveType = "tar"
+			}
+			if !validGitFromArchiveTypes[archiveType] {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'archive_type' must be one of tar, tar.gz, zip")}
+			}
+			if (t.GitUsername == "") != (t.GitEmail == "") {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'git_username' and 'git_email' must be set together")}
+			}
+			if checkAppSourceArchive(t.App, archiveType, t.ArchiveURL) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    "archive source drift",
+				Mutations: []string{fmt.Sprintf("git:from-archive %s %s (%s)", t.App, t.ArchiveURL, archiveType)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: "undeployed"}
+					args := []string{"git:from-archive", "--archive-type", archiveType, t.App, t.ArchiveURL}
+					if t.GitUsername != "" {
+						args = append(args, t.GitUsername, t.GitEmail)
+					}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateDeployed
+					return state
+				},
+			}
+		},
 	})
 }
 
@@ -87,59 +135,6 @@ func checkAppSourceArchive(app, expectedType, expectedURL string) bool {
 		return false
 	}
 	return source.Source == expectedType && source.SourceMetadata == expectedURL
-}
-
-// deployGitFromArchive deploys a git repository from an archive URL
-func deployGitFromArchive(t GitFromArchiveTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "undeployed",
-	}
-
-	if t.App == "" {
-		state.Error = fmt.Errorf("'app' is required")
-		return state
-	}
-	if t.ArchiveURL == "" {
-		state.Error = fmt.Errorf("'archive_url' is required")
-		return state
-	}
-
-	archiveType := t.ArchiveType
-	if archiveType == "" {
-		archiveType = "tar"
-	}
-	if !validGitFromArchiveTypes[archiveType] {
-		state.Error = fmt.Errorf("'archive_type' must be one of tar, tar.gz, zip")
-		return state
-	}
-
-	if (t.GitUsername == "") != (t.GitEmail == "") {
-		state.Error = fmt.Errorf("'git_username' and 'git_email' must be set together")
-		return state
-	}
-
-	if checkAppSourceArchive(t.App, archiveType, t.ArchiveURL) {
-		state.State = "deployed"
-		return state
-	}
-
-	args := []string{"git:from-archive", "--archive-type", archiveType, t.App, t.ArchiveURL}
-	if t.GitUsername != "" {
-		args = append(args, t.GitUsername, t.GitEmail)
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "deployed"
-	return state
 }
 
 // init registers the GitFromArchiveTask with the task registry

--- a/tasks/git_from_image_task.go
+++ b/tasks/git_from_image_task.go
@@ -1,6 +1,8 @@
 package tasks
 
 import (
+	"fmt"
+
 	"github.com/dokku/docket/subprocess"
 )
 
@@ -53,8 +55,47 @@ func (t GitFromImageTask) Examples() ([]Doc, error) {
 
 // Execute deploys a git repository from a docker image
 func (t GitFromImageTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"deployed": func() TaskOutputState { return deployGitFromImage(t) },
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the GitFromImageTask would produce.
+func (t GitFromImageTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StateDeployed: func() PlanResult {
+			if checkAppSourceImage(t.App, t.Image) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    "image source drift",
+				Mutations: []string{fmt.Sprintf("git:from-image %s %s", t.App, t.Image)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: "undeployed"}
+					args := []string{"git:from-image"}
+					if t.BuildDir != "" {
+						args = append(args, "--build-dir", t.BuildDir)
+					}
+					args = append(args, t.App, t.Image)
+					if t.GitUsername != "" {
+						args = append(args, t.GitUsername)
+					}
+					if t.GitEmail != "" {
+						args = append(args, t.GitEmail)
+					}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateDeployed
+					return state
+				},
+			}
+		},
 	})
 }
 
@@ -66,48 +107,6 @@ func checkAppSourceImage(app, expectedImage string) bool {
 	}
 
 	return source.Source == "docker-image" && source.SourceMetadata == expectedImage
-}
-
-// deployGitFromImage deploys a git repository from a docker image
-func deployGitFromImage(t GitFromImageTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "undeployed",
-	}
-
-	if checkAppSourceImage(t.App, t.Image) {
-		state.Changed = false
-		state.State = "deployed"
-		return state
-	}
-
-	args := []string{
-		"git:from-image",
-	}
-	if t.BuildDir != "" {
-		args = append(args, "--build-dir", t.BuildDir)
-	}
-	args = append(args, t.App, t.Image)
-
-	// todo: ensure both the username and email are provided
-	if t.GitUsername != "" {
-		args = append(args, t.GitUsername)
-	}
-	if t.GitEmail != "" {
-		args = append(args, t.GitEmail)
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "deployed"
-	return state
 }
 
 // init registers the GitFromImageTask with the task registry

--- a/tasks/git_property_task.go
+++ b/tasks/git_property_task.go
@@ -76,7 +76,12 @@ func (t GitPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the git property
 func (t GitPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "git:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the GitPropertyTask would produce.
+func (t GitPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "git:set")
 }
 
 // init registers the GitPropertyTask with the task registry

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -72,8 +72,54 @@ func (t GitSyncTask) Examples() ([]Doc, error) {
 
 // Execute syncs a git repository to a dokku application
 func (t GitSyncTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return syncGitRepository(t) },
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the GitSyncTask would produce.
+func (t GitSyncTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if checkAppSyncState(t.App, t.Remote, t.GitRef) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			ref := t.GitRef
+			if ref == "" {
+				ref = "(default branch)"
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    "remote/ref drift",
+				Mutations: []string{fmt.Sprintf("git:sync %s %s %s", t.App, t.Remote, ref)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					args := []string{"git:sync"}
+					if t.Build {
+						args = append(args, "--build")
+					}
+					if t.BuildIfChanges {
+						args = append(args, "--build-if-changes")
+					}
+					if t.SkipDeployBranch {
+						args = append(args, "--skip-deploy-branch")
+					}
+					args = append(args, t.App, t.Remote)
+					if t.GitRef != "" {
+						args = append(args, t.GitRef)
+					}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
+			}
+		},
 	})
 }
 
@@ -86,51 +132,6 @@ func checkAppSyncState(app, expectedRemote, expectedRef string) bool {
 
 	expectedMetadata := fmt.Sprintf("%s#%s", expectedRemote, expectedRef)
 	return source.Source == "git-sync" && source.SourceMetadata == expectedMetadata
-}
-
-// syncGitRepository syncs a git repository to a dokku application
-func syncGitRepository(t GitSyncTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
-
-	if checkAppSyncState(t.App, t.Remote, t.GitRef) {
-		state.State = "present"
-		return state
-	}
-
-	args := []string{
-		"git:sync",
-	}
-
-	if t.Build {
-		args = append(args, "--build")
-	}
-	if t.BuildIfChanges {
-		args = append(args, "--build-if-changes")
-	}
-	if t.SkipDeployBranch {
-		args = append(args, "--skip-deploy-branch")
-	}
-
-	args = append(args, t.App, t.Remote)
-
-	if t.GitRef != "" {
-		args = append(args, t.GitRef)
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
 }
 
 // init registers the GitSyncTask with the task registry

--- a/tasks/haproxy_property_task.go
+++ b/tasks/haproxy_property_task.go
@@ -68,7 +68,12 @@ func (t HaproxyPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the haproxy property
 func (t HaproxyPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "haproxy:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the HaproxyPropertyTask would produce.
+func (t HaproxyPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "haproxy:set")
 }
 
 // init registers the HaproxyPropertyTask with the task registry

--- a/tasks/http_auth_task.go
+++ b/tasks/http_auth_task.go
@@ -63,20 +63,66 @@ func (t HttpAuthTask) Examples() ([]Doc, error) {
 
 // Execute enables or disables HTTP authentication for an app
 func (t HttpAuthTask) Execute() TaskOutputState {
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the HttpAuthTask would produce.
+func (t HttpAuthTask) Plan() PlanResult {
 	if t.State == StatePresent && t.Username == "" {
-		return TaskOutputState{
-			Error: fmt.Errorf("username is required when state is present"),
-		}
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("username is required when state is present")}
 	}
 	if t.State == StatePresent && t.Password == "" {
-		return TaskOutputState{
-			Error: fmt.Errorf("password is required when state is present"),
-		}
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("password is required when state is present")}
 	}
-
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return enableHttpAuth(t.App, t.Username, t.Password) },
-		"absent":  func() TaskOutputState { return disableHttpAuth(t.App) },
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if httpAuthEnabled(t.App) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    "http-auth disabled",
+				Mutations: []string{"http-auth:on " + t.App},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "http-auth:on", t.App, t.Username, t.Password},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			if !httpAuthEnabled(t.App) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "http-auth enabled",
+				Mutations: []string{"http-auth:off " + t.App},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "http-auth:off", t.App},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
+			}
+		},
 	})
 }
 

--- a/tasks/letsencrypt_property_task.go
+++ b/tasks/letsencrypt_property_task.go
@@ -76,7 +76,12 @@ func (t LetsencryptPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the letsencrypt property
 func (t LetsencryptPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "letsencrypt:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the LetsencryptPropertyTask would produce.
+func (t LetsencryptPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "letsencrypt:set")
 }
 
 // init registers the LetsencryptPropertyTask with the task registry

--- a/tasks/letsencrypt_task.go
+++ b/tasks/letsencrypt_task.go
@@ -56,9 +56,71 @@ func (t LetsencryptTask) Examples() ([]Doc, error) {
 
 // Execute enables or disables letsencrypt
 func (t LetsencryptTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return enableLetsencrypt(t.App) },
-		StateAbsent:  func() TaskOutputState { return disableLetsencrypt(t.App) },
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the LetsencryptTask would produce.
+func (t LetsencryptTask) Plan() PlanResult {
+	if t.App == "" {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			active, err := letsencryptActive(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if active {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    "letsencrypt not active",
+				Mutations: []string{"letsencrypt:enable " + t.App},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "letsencrypt:enable", t.App},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			active, err := letsencryptActive(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !active {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "letsencrypt active",
+				Mutations: []string{"letsencrypt:disable " + t.App},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "letsencrypt:disable", t.App},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
+			}
+		},
 	})
 }
 

--- a/tasks/logs_property_task.go
+++ b/tasks/logs_property_task.go
@@ -68,7 +68,12 @@ func (t LogsPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the logs property
 func (t LogsPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "logs:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the LogsPropertyTask would produce.
+func (t LogsPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "logs:set")
 }
 
 // init registers the LogsPropertyTask with the task registry

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -81,6 +81,57 @@ type TaskOutputState struct {
 	State State
 }
 
+// PlanStatus is the short marker that summarizes a planned change.
+type PlanStatus string
+
+const (
+	// PlanStatusOK indicates the task is in sync; no change would be made.
+	PlanStatusOK PlanStatus = "ok"
+	// PlanStatusModify indicates the task would modify existing state.
+	PlanStatusModify PlanStatus = "~"
+	// PlanStatusCreate indicates the task would create new state.
+	PlanStatusCreate PlanStatus = "+"
+	// PlanStatusDestroy indicates the task would remove existing state.
+	PlanStatusDestroy PlanStatus = "-"
+	// PlanStatusError indicates the read-state probe itself failed.
+	PlanStatusError PlanStatus = "error"
+)
+
+// PlanResult is the read-only drift report for a task.
+//
+// Plan() never mutates server state. The unexported apply closure carries
+// any state probed during planning so the apply path does not re-probe;
+// ExecutePlan is the only consumer. When InSync is true, apply is nil.
+type PlanResult struct {
+	// InSync is true when the task would not change anything.
+	InSync bool
+
+	// Status is the short marker for the drift kind.
+	Status PlanStatus
+
+	// Reason is human-readable detail (e.g. "ref drift", "2 keys to set").
+	Reason string
+
+	// Mutations optionally itemizes per-mutation drift for tasks that
+	// perform multiple operations (e.g. config setting and unsetting
+	// individual keys). One entry per atomic change.
+	Mutations []string
+
+	// DesiredState mirrors TaskOutputState.DesiredState so plan output can
+	// render the same context as apply output.
+	DesiredState State
+
+	// Error is non-nil when the read-state probe itself failed. A non-nil
+	// Error implies Status == PlanStatusError.
+	Error error
+
+	// apply, when non-nil, is the closure ExecutePlan invokes to mutate
+	// server state. nil when InSync. Captures any probed state needed for
+	// the mutation so the apply path does not re-probe. Unexported so
+	// formatters and JSON consumers cannot accidentally invoke it.
+	apply func() TaskOutputState
+}
+
 // Task represents a task
 type Task interface {
 	// Doc returns the docblock for the task
@@ -89,7 +140,13 @@ type Task interface {
 	// Examples returns the examples for the task
 	Examples() ([]Doc, error)
 
-	// Execute executes the task
+	// Plan reports the drift the task would produce against the live server,
+	// without mutating it. Plan must never call mutating dokku commands.
+	Plan() PlanResult
+
+	// Execute executes the task. Conventionally implemented as
+	// ExecutePlan(t.Plan()) so probing happens once and the per-state
+	// mutation logic lives only in Plan().
 	Execute() TaskOutputState
 }
 

--- a/tasks/network_property_task.go
+++ b/tasks/network_property_task.go
@@ -76,7 +76,12 @@ func (t NetworkPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the network property
 func (t NetworkPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "network:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the NetworkPropertyTask would produce.
+func (t NetworkPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "network:set")
 }
 
 // init registers the NetworkPropertyTask with the task registry

--- a/tasks/network_task.go
+++ b/tasks/network_task.go
@@ -53,9 +53,60 @@ func (t NetworkTask) Examples() ([]Doc, error) {
 
 // Execute creates or destroys a Docker network
 func (t NetworkTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return createNetwork(t.Name) },
-		"absent":  func() TaskOutputState { return destroyNetwork(t.Name) },
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the NetworkTask would produce.
+func (t NetworkTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if networkExists(t.Name) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    "network missing",
+				Mutations: []string{"create network " + t.Name},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "network:create", t.Name},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			if !networkExists(t.Name) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "network present",
+				Mutations: []string{"destroy network " + t.Name},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "--force", "network:destroy", t.Name},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
+			}
+		},
 	})
 }
 
@@ -76,60 +127,23 @@ func networkExists(name string) bool {
 	return result.ExitCode == 0
 }
 
-// createNetwork creates a Docker network
-func createNetwork(name string) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
-	if networkExists(name) {
-		state.State = "present"
-		return state
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			"network:create",
-			name,
-		},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
-}
-
-// destroyNetwork destroys a Docker network
+// destroyNetwork is retained as an integration-test helper. It runs the
+// destroy-network apply path synchronously.
 func destroyNetwork(name string) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "present",
-	}
+	state := TaskOutputState{Changed: false, State: StatePresent}
 	if !networkExists(name) {
-		state.State = "absent"
+		state.State = StateAbsent
 		return state
 	}
-
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			"--force",
-			"network:destroy",
-			name,
-		},
+		Args:    []string{"--quiet", "--force", "network:destroy", name},
 	})
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}
-
 	state.Changed = true
-	state.State = "absent"
+	state.State = StateAbsent
 	return state
 }
 

--- a/tasks/nginx_property_task.go
+++ b/tasks/nginx_property_task.go
@@ -76,7 +76,12 @@ func (t NginxPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the nginx property
 func (t NginxPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "nginx:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the NginxPropertyTask would produce.
+func (t NginxPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "nginx:set")
 }
 
 // init registers the NginxPropertyTask with the task registry

--- a/tasks/openresty_property_task.go
+++ b/tasks/openresty_property_task.go
@@ -76,7 +76,12 @@ func (t OpenrestyPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the openresty property
 func (t OpenrestyPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "openresty:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the OpenrestyPropertyTask would produce.
+func (t OpenrestyPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "openresty:set")
 }
 
 // init registers the OpenrestyPropertyTask with the task registry

--- a/tasks/ordered_map_test.go
+++ b/tasks/ordered_map_test.go
@@ -12,6 +12,7 @@ type mockTask struct {
 
 func (m mockTask) Doc() string              { return "" }
 func (m mockTask) Examples() ([]Doc, error) { return nil, nil }
+func (m mockTask) Plan() PlanResult         { return PlanResult{InSync: true, Status: PlanStatusOK} }
 func (m mockTask) Execute() TaskOutputState { return TaskOutputState{State: m.state} }
 
 func TestOrderedStringTaskMapSetAndGet(t *testing.T) {

--- a/tasks/plan_integration_test.go
+++ b/tasks/plan_integration_test.go
@@ -1,0 +1,131 @@
+package tasks
+
+import (
+	"testing"
+)
+
+// TestIntegrationPlanDetectsMissingApp asserts Plan() reports drift for a
+// dokku_app task when the target app does not exist.
+func TestIntegrationPlanDetectsMissingApp(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-plan-detect"
+	destroyApp(appName)
+	defer destroyApp(appName)
+
+	task := AppTask{App: appName, State: StatePresent}
+
+	plan := task.Plan()
+	if plan.Error != nil {
+		t.Fatalf("Plan() errored: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Errorf("expected drift on missing app, got InSync=true")
+	}
+	if plan.Status != PlanStatusCreate {
+		t.Errorf("expected status=%q, got %q", PlanStatusCreate, plan.Status)
+	}
+}
+
+// TestIntegrationPlanInSyncAfterApply applies a single dokku_app task then
+// verifies Plan() reports InSync. This is the round-trip property: every
+// apply followed by an immediate plan must report clean.
+func TestIntegrationPlanInSyncAfterApply(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-plan-roundtrip"
+	destroyApp(appName)
+	defer destroyApp(appName)
+
+	task := AppTask{App: appName, State: StatePresent}
+	if state := task.Execute(); state.Error != nil {
+		t.Fatalf("apply errored: %v", state.Error)
+	}
+
+	plan := task.Plan()
+	if plan.Error != nil {
+		t.Fatalf("plan errored after apply: %v", plan.Error)
+	}
+	if !plan.InSync {
+		t.Errorf("expected InSync after apply, got %+v", plan)
+	}
+}
+
+// TestIntegrationPlanDoesNotMutate is the safety contract for plan: it must
+// never create, modify, or destroy server state.
+func TestIntegrationPlanDoesNotMutate(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-plan-no-mutate"
+	destroyApp(appName)
+	defer destroyApp(appName)
+
+	task := AppTask{App: appName, State: StatePresent}
+	_ = task.Plan()
+
+	if appExists(appName) {
+		t.Errorf("Plan() unexpectedly created %s", appName)
+	}
+}
+
+// TestIntegrationPlanConfigItemizes asserts the per-key Mutations contract
+// for multi-mutation tasks against a real Dokku.
+func TestIntegrationPlanConfigItemizes(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-plan-config"
+	destroyApp(appName)
+	defer destroyApp(appName)
+
+	if state := (AppTask{App: appName, State: StatePresent}).Execute(); state.Error != nil {
+		t.Fatalf("setup apps:create failed: %v", state.Error)
+	}
+
+	task := ConfigTask{
+		App:     appName,
+		Restart: false,
+		Config:  map[string]string{"DOCKET_TEST_KEY_A": "1", "DOCKET_TEST_KEY_B": "2"},
+		State:   StatePresent,
+	}
+
+	plan := task.Plan()
+	if plan.Error != nil {
+		t.Fatalf("plan errored: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Fatal("expected drift, got InSync=true")
+	}
+	if len(plan.Mutations) != 2 {
+		t.Errorf("expected 2 mutations (one per key), got %d: %v", len(plan.Mutations), plan.Mutations)
+	}
+}
+
+// TestIntegrationExecuteIdempotent asserts the property the new design
+// guarantees: a second Execute() on a task that just ran reports
+// Changed=false (because the apply closure short-circuits inside Plan via
+// the InSync check). This is the user-visible payoff of the refactor.
+func TestIntegrationExecuteIdempotent(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-plan-idempotent"
+	destroyApp(appName)
+	defer destroyApp(appName)
+
+	task := AppTask{App: appName, State: StatePresent}
+
+	first := task.Execute()
+	if first.Error != nil {
+		t.Fatalf("first apply errored: %v", first.Error)
+	}
+	if !first.Changed {
+		t.Error("first apply should report Changed=true (app was missing)")
+	}
+
+	second := task.Execute()
+	if second.Error != nil {
+		t.Fatalf("second apply errored: %v", second.Error)
+	}
+	if second.Changed {
+		t.Error("second apply should report Changed=false (app already present)")
+	}
+}

--- a/tasks/plan_test.go
+++ b/tasks/plan_test.go
@@ -1,0 +1,215 @@
+package tasks
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestAllTasksImplementPlan asserts every registered task type satisfies the
+// Task interface (which now requires Plan()). The interface assignment is a
+// compile-time guarantee, but this test fails loudly if a future refactor
+// loosens the contract or registers a task that does not implement Plan.
+func TestAllTasksImplementPlan(t *testing.T) {
+	if len(RegisteredTasks) == 0 {
+		t.Fatal("no tasks registered; init() side effects didn't run")
+	}
+	for name, task := range RegisteredTasks {
+		var _ Task = task
+		if name == "" {
+			t.Errorf("task with empty name: %T", task)
+		}
+	}
+}
+
+// TestDispatchPlanInvalidState verifies that DispatchPlan returns an error
+// PlanResult when the requested state has no handler, mirroring DispatchState.
+func TestDispatchPlanInvalidState(t *testing.T) {
+	result := DispatchPlan(State("nonsense"), map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return PlanResult{InSync: true} },
+	})
+	if result.Error == nil {
+		t.Fatal("DispatchPlan with unknown state should set Error")
+	}
+	if result.Status != PlanStatusError {
+		t.Errorf("expected PlanStatusError, got %q", result.Status)
+	}
+}
+
+// TestDispatchPlanSetsDesiredState verifies DispatchPlan propagates the
+// requested state onto the returned PlanResult.
+func TestDispatchPlanSetsDesiredState(t *testing.T) {
+	result := DispatchPlan(StatePresent, map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return PlanResult{InSync: true, Status: PlanStatusOK} },
+	})
+	if result.DesiredState != StatePresent {
+		t.Errorf("expected DesiredState=%q, got %q", StatePresent, result.DesiredState)
+	}
+	if !result.InSync {
+		t.Error("expected handler's InSync to propagate")
+	}
+}
+
+// TestExecutePlanInSyncSkipsApply verifies that ExecutePlan does not invoke
+// the apply closure when the plan reports InSync. This is the critical
+// invariant that makes apply idempotent for the post-#198 design.
+func TestExecutePlanInSyncSkipsApply(t *testing.T) {
+	called := false
+	result := ExecutePlan(PlanResult{
+		InSync:       true,
+		Status:       PlanStatusOK,
+		DesiredState: StatePresent,
+		apply: func() TaskOutputState {
+			called = true
+			return TaskOutputState{}
+		},
+	})
+	if called {
+		t.Fatal("ExecutePlan invoked apply on InSync result")
+	}
+	if result.Changed {
+		t.Error("InSync result should report Changed=false")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected State=%q, got %q", StatePresent, result.State)
+	}
+	if result.DesiredState != StatePresent {
+		t.Errorf("expected DesiredState=%q, got %q", StatePresent, result.DesiredState)
+	}
+}
+
+// TestExecutePlanErrorSkipsApply verifies that ExecutePlan does not invoke
+// the apply closure when the plan reports an error.
+func TestExecutePlanErrorSkipsApply(t *testing.T) {
+	called := false
+	probeErr := errors.New("probe failed")
+	result := ExecutePlan(PlanResult{
+		Status:       PlanStatusError,
+		Error:        probeErr,
+		DesiredState: StatePresent,
+		apply: func() TaskOutputState {
+			called = true
+			return TaskOutputState{}
+		},
+	})
+	if called {
+		t.Fatal("ExecutePlan invoked apply on error result")
+	}
+	if !errors.Is(result.Error, probeErr) {
+		t.Errorf("expected Error to be probeErr, got %v", result.Error)
+	}
+}
+
+// TestExecutePlanInvokesApplyOnDrift verifies that ExecutePlan does invoke
+// the apply closure when the plan reports drift (the canonical path).
+func TestExecutePlanInvokesApplyOnDrift(t *testing.T) {
+	called := false
+	result := ExecutePlan(PlanResult{
+		InSync:       false,
+		Status:       PlanStatusModify,
+		DesiredState: StatePresent,
+		apply: func() TaskOutputState {
+			called = true
+			return TaskOutputState{Changed: true, State: StatePresent}
+		},
+	})
+	if !called {
+		t.Fatal("ExecutePlan did not invoke apply on drift result")
+	}
+	if !result.Changed {
+		t.Error("apply returned Changed=true; ExecutePlan must propagate it")
+	}
+	if result.DesiredState != StatePresent {
+		t.Errorf("ExecutePlan should fill in DesiredState; got %q", result.DesiredState)
+	}
+}
+
+// TestExecutePlanMissingApplyIsError verifies that a drift PlanResult
+// without an apply closure surfaces a clear error rather than silently
+// no-opping. Catches refactor mistakes where Plan() forgets to set apply.
+func TestExecutePlanMissingApplyIsError(t *testing.T) {
+	result := ExecutePlan(PlanResult{
+		InSync:       false,
+		Status:       PlanStatusModify,
+		DesiredState: StatePresent,
+		// apply intentionally nil
+	})
+	if result.Error == nil {
+		t.Fatal("ExecutePlan with drift but no apply should error")
+	}
+}
+
+// TestPlanResultStatusConstants documents the canonical status values used
+// across the codebase. If a refactor renames or removes one, this test
+// fails so the plan output formatter and JSON consumers can be updated.
+func TestPlanResultStatusConstants(t *testing.T) {
+	cases := map[PlanStatus]string{
+		PlanStatusOK:      "ok",
+		PlanStatusModify:  "~",
+		PlanStatusCreate:  "+",
+		PlanStatusDestroy: "-",
+		PlanStatusError:   "error",
+	}
+	for got, want := range cases {
+		if string(got) != want {
+			t.Errorf("status %q has unexpected string %q", want, string(got))
+		}
+	}
+}
+
+// TestPlanConfigSetItemizesKeys exercises the per-key diff helper used by
+// config_task.Plan to ensure the right keys are flagged. Plan-level
+// integration with subprocess is covered by integration tests; this is a
+// pure-data test that does not touch dokku.
+func TestPlanConfigSetItemizesKeys(t *testing.T) {
+	current := map[string]string{
+		"EXISTING": "old",
+		"KEEP":     "same",
+	}
+	desired := map[string]string{
+		"EXISTING": "new",
+		"KEEP":     "same",
+		"NEW":      "value",
+	}
+
+	keys := configKeysToSet(current, desired)
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 keys to set, got %d: %v", len(keys), keys)
+	}
+	got := map[string]bool{}
+	for _, k := range keys {
+		got[k] = true
+	}
+	if !got["EXISTING"] || !got["NEW"] {
+		t.Errorf("expected EXISTING and NEW; got %v", keys)
+	}
+	if got["KEEP"] {
+		t.Error("KEEP should not be in keys to set (value matches)")
+	}
+}
+
+// TestPlanConfigUnsetItemizesKeys checks that the unset path itemizes only
+// keys that currently exist on the server.
+func TestPlanConfigUnsetItemizesKeys(t *testing.T) {
+	current := map[string]string{"PRESENT": "v"}
+	desired := map[string]string{"PRESENT": "", "MISSING": ""}
+	keys := configKeysToUnset(current, desired)
+	if len(keys) != 1 || keys[0] != "PRESENT" {
+		t.Errorf("expected only PRESENT; got %v", keys)
+	}
+}
+
+// TestPluginFromSubcommand exercises the plugin extraction used by the
+// generic property probe.
+func TestPluginFromSubcommand(t *testing.T) {
+	cases := map[string]string{
+		"nginx:set":                  "nginx",
+		"app-json:set":               "app-json",
+		"buildpacks:set-property":    "buildpacks",
+		"scheduler-docker-local:set": "scheduler-docker-local",
+	}
+	for input, want := range cases {
+		if got := pluginFromSubcommand(input); got != want {
+			t.Errorf("pluginFromSubcommand(%q) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -63,19 +63,93 @@ func (t PortsTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the ports
 func (t PortsTask) Execute() TaskOutputState {
-	// todo: add port mapping validation
-	if len(t.PortMappings) == 0 {
-		return TaskOutputState{
-			Changed: false,
-			State:   "absent",
-			Error:   errors.New("no port mappings provided"),
-			Message: "no port mappings provided",
-		}
-	}
+	return ExecutePlan(t.Plan())
+}
 
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return setPorts(t.App, t.PortMappings) },
-		"absent":  func() TaskOutputState { return unsetPorts(t.App, t.PortMappings) },
+// Plan reports the drift the PortsTask would produce.
+func (t PortsTask) Plan() PlanResult {
+	if len(t.PortMappings) == 0 {
+		return PlanResult{Status: PlanStatusError, Error: errors.New("no port mappings provided")}
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			currentPorts := getPorts(t.App)
+			toAdd := []PortMapping{}
+			mutations := []string{}
+			for _, pm := range t.PortMappings {
+				if _, ok := currentPorts[pm.String()]; !ok {
+					toAdd = append(toAdd, pm)
+					mutations = append(mutations, fmt.Sprintf("add %s", pm.String()))
+				}
+			}
+			if len(toAdd) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			status := PlanStatusModify
+			if len(currentPorts) == 0 {
+				status = PlanStatusCreate
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    status,
+				Reason:    fmt.Sprintf("%d port mapping(s) to add", len(toAdd)),
+				Mutations: mutations,
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					args := []string{"--quiet", "ports:add", t.App}
+					for _, pm := range toAdd {
+						args = append(args, pm.String())
+					}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			currentPorts := getPorts(t.App)
+			toRemove := []PortMapping{}
+			mutations := []string{}
+			for _, pm := range t.PortMappings {
+				if _, ok := currentPorts[pm.String()]; ok {
+					toRemove = append(toRemove, pm)
+					mutations = append(mutations, fmt.Sprintf("remove %s", pm.String()))
+				}
+			}
+			if len(toRemove) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    fmt.Sprintf("%d port mapping(s) to remove", len(toRemove)),
+				Mutations: mutations,
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					args := []string{"--quiet", "ports:remove", t.App}
+					for _, pm := range toRemove {
+						args = append(args, pm.String())
+					}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
+			}
+		},
 	})
 }
 
@@ -121,92 +195,6 @@ func getPorts(appName string) map[string]PortMapping {
 	}
 
 	return portMappings
-}
-
-// setPorts sets the ports for a given app
-func setPorts(appName string, portMappings []PortMapping) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
-
-	currentPorts := getPorts(appName)
-	newPorts := map[string]PortMapping{}
-	for _, portMapping := range portMappings {
-		if _, ok := currentPorts[portMapping.String()]; !ok {
-			newPorts[portMapping.String()] = portMapping
-		}
-	}
-
-	if len(newPorts) == 0 {
-		state.State = "present"
-		return state
-	}
-
-	args := []string{
-		"--quiet",
-		"ports:add",
-		appName,
-	}
-
-	for _, portMapping := range newPorts {
-		args = append(args, portMapping.String())
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
-}
-
-// unsetPorts unsets the ports for a given app
-func unsetPorts(appName string, portMappings []PortMapping) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "present",
-	}
-
-	currentPorts := getPorts(appName)
-	removedPorts := map[string]PortMapping{}
-	for _, portMapping := range portMappings {
-		if _, ok := currentPorts[portMapping.String()]; ok {
-			removedPorts[portMapping.String()] = portMapping
-		}
-	}
-
-	if len(removedPorts) == 0 {
-		state.State = "absent"
-		return state
-	}
-
-	args := []string{
-		"--quiet",
-		"ports:remove",
-		appName,
-	}
-
-	for _, portMapping := range removedPorts {
-		args = append(args, portMapping.String())
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "absent"
-	return state
 }
 
 // init registers the PortsTask with the task registry

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -3,6 +3,8 @@ package tasks
 import (
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/dokku/docket/subprocess"
 )
 
@@ -21,107 +23,165 @@ type PropertyContext struct {
 	Value string `required:"false" yaml:"value"`
 }
 
-// executeProperty is a shared Execute implementation for property tasks.
-func executeProperty(state State, app string, global bool, property, value, subcommand string) TaskOutputState {
+// pluginFromSubcommand returns the plugin component of a colon-separated
+// subcommand. For example, "nginx:set" -> "nginx", "buildpacks:set-property" ->
+// "buildpacks", "app-json:set" -> "app-json".
+func pluginFromSubcommand(subcommand string) string {
+	return strings.SplitN(subcommand, ":", 2)[0]
+}
+
+// getProperty reads the current value of a property via
+// `dokku <plugin>:report <target> --<plugin>-<property>`. Returns the
+// trimmed string value on success. When the report subcommand or property
+// flag is not supported by the plugin, returns a non-nil error and callers
+// fall back to an unconditional set/unset (matches the pre-probe behavior).
+func getProperty(subcommand, app string, global bool, property string) (string, error) {
+	plugin := pluginFromSubcommand(subcommand)
+	reportSubcommand := plugin + ":report"
+	reportFlag := "--" + plugin + "-" + property
+
+	args := []string{"--quiet", reportSubcommand}
+	if global {
+		args = append(args, "--global", reportFlag)
+	} else {
+		args = append(args, app, reportFlag)
+	}
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(result.StdoutContents()), nil
+}
+
+// planProperty is the shared Plan() implementation for property tasks. It
+// probes the current value via getProperty, returns InSync when current
+// matches desired, and otherwise embeds an apply closure that runs the
+// underlying `dokku <subcommand>` call. ExecutePlan is the only invoker.
+//
+// When the report subcommand or property flag is missing, the probe error
+// is swallowed and the apply closure runs the set/unset unconditionally,
+// matching the pre-probe behavior of property tasks.
+func planProperty(state State, app string, global bool, property, value, subcommand string) PlanResult {
 	if !global && app == "" {
-		return TaskOutputState{
-			Error: errors.New("app is required when global is false"),
+		return PlanResult{
+			Status: PlanStatusError,
+			Error:  errors.New("app is required when global is false"),
+		}
+	}
+	if global && app != "" {
+		return PlanResult{
+			Status: PlanStatusError,
+			Error:  fmt.Errorf("'app' must not be set when 'global' is set to true"),
 		}
 	}
 
-	ctx := PropertyContext{
-		App:      app,
-		Global:   global,
-		Property: property,
-		Value:    value,
+	target := app
+	if global {
+		target = "--global"
 	}
-	return DispatchState(state, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return setProperty(subcommand, ctx) },
-		"absent":  func() TaskOutputState { return unsetProperty(subcommand, ctx) },
+
+	return DispatchPlan(state, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if value == "" {
+				return PlanResult{
+					Status: PlanStatusError,
+					Error:  fmt.Errorf("setting a state of 'present' is invalid without a value for 'value'"),
+				}
+			}
+
+			// Probe; treat probe failure as "drift, must mutate".
+			current, probeErr := getProperty(subcommand, app, global, property)
+			if probeErr == nil && current == value {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+
+			status := PlanStatusModify
+			reason := fmt.Sprintf("would set %s on %s", property, target)
+			if probeErr != nil {
+				reason = fmt.Sprintf("would set %s on %s (probe failed: %v)", property, target, probeErr)
+			} else if current == "" {
+				status = PlanStatusCreate
+				reason = fmt.Sprintf("%s missing on %s", property, target)
+			} else {
+				reason = fmt.Sprintf("%s drift on %s (was %q)", property, target, current)
+			}
+
+			return PlanResult{
+				InSync:    false,
+				Status:    status,
+				Reason:    reason,
+				Mutations: []string{fmt.Sprintf("set %s=%s", property, value)},
+				apply:     applyPropertySet(subcommand, target, property, value),
+			}
+		},
+		StateAbsent: func() PlanResult {
+			if value != "" {
+				return PlanResult{
+					Status: PlanStatusError,
+					Error:  fmt.Errorf("setting a state of 'absent' is invalid with a value for 'value'"),
+				}
+			}
+
+			current, probeErr := getProperty(subcommand, app, global, property)
+			if probeErr == nil && current == "" {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+
+			reason := fmt.Sprintf("would unset %s on %s", property, target)
+			if probeErr != nil {
+				reason = fmt.Sprintf("would unset %s on %s (probe failed: %v)", property, target, probeErr)
+			} else {
+				reason = fmt.Sprintf("would unset %s on %s (was %q)", property, target, current)
+			}
+
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    reason,
+				Mutations: []string{fmt.Sprintf("unset %s", property)},
+				apply:     applyPropertyUnset(subcommand, target, property),
+			}
+		},
 	})
 }
 
-// setProperty sets a property for a given app
-func setProperty(subcommand string, pctx PropertyContext) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
-
-	if pctx.Global && pctx.App != "" {
-		state.Error = fmt.Errorf("'app' must not be set when 'global' is set to true")
+// applyPropertySet returns a closure that runs `dokku <subcommand> <target>
+// <property> <value>` and converts the result into a TaskOutputState.
+func applyPropertySet(subcommand, target, property, value string) func() TaskOutputState {
+	return func() TaskOutputState {
+		state := TaskOutputState{Changed: false, State: StateAbsent}
+		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", subcommand, target, property, value},
+		})
+		if err != nil {
+			return TaskOutputErrorFromExec(state, err, result)
+		}
+		state.Changed = true
+		state.State = StatePresent
 		return state
 	}
-
-	appName := "--global"
-	if pctx.App != "" {
-		appName = pctx.App
-	}
-
-	if pctx.Value == "" {
-		state.Error = fmt.Errorf("setting a state of 'present' is invalid without a value for 'value'")
-		return state
-	}
-
-	// todo: validate that the value isn't already set
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			subcommand,
-			appName,
-			pctx.Property,
-			pctx.Value,
-		},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
 }
 
-// unsetProperty unsets a property for a given app
-func unsetProperty(subcommand string, pctx PropertyContext) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "present",
-	}
-
-	if pctx.Global && pctx.App != "" {
-		state.Error = fmt.Errorf("'app' must not be set when 'global' is set to true")
+// applyPropertyUnset returns a closure that runs `dokku <subcommand> <target>
+// <property>` (no value, which dokku interprets as unset) and converts the
+// result into a TaskOutputState.
+func applyPropertyUnset(subcommand, target, property string) func() TaskOutputState {
+	return func() TaskOutputState {
+		state := TaskOutputState{Changed: false, State: StatePresent}
+		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", subcommand, target, property},
+		})
+		if err != nil {
+			return TaskOutputErrorFromExec(state, err, result)
+		}
+		state.Changed = true
+		state.State = StateAbsent
 		return state
 	}
-
-	appName := "--global"
-	if pctx.App != "" {
-		appName = pctx.App
-	}
-
-	if pctx.Value != "" {
-		state.Error = fmt.Errorf("setting a state of 'absent' is invalid with a value for 'value'")
-		return state
-	}
-
-	// todo: validate that the value isn't already unset
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			subcommand,
-			appName,
-			pctx.Property,
-		},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "absent"
-	return state
 }

--- a/tasks/proxy_toggle_task.go
+++ b/tasks/proxy_toggle_task.go
@@ -1,5 +1,30 @@
 package tasks
 
+import (
+	"strings"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// proxyEnabled probes whether the proxy is enabled for an app via
+// `dokku --quiet proxy:report <app> --proxy-enabled`. Output is "true"/"false".
+func proxyEnabled(ctx ToggleContext) (bool, error) {
+	args := []string{"--quiet", "proxy:report"}
+	if ctx.AllowGlobal && ctx.Global {
+		args = append(args, "--global", "--proxy-enabled")
+	} else {
+		args = append(args, ctx.App, "--proxy-enabled")
+	}
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(result.StdoutContents()) == "true", nil
+}
+
 // ProxyToggleTask manages the proxy for a given dokku application
 type ProxyToggleTask struct {
 	// App is the name of the app
@@ -38,7 +63,12 @@ func (t ProxyToggleTask) Examples() ([]Doc, error) {
 
 // Execute enables or disables the proxy
 func (t ProxyToggleTask) Execute() TaskOutputState {
-	return executeToggle(t.State, t.App, t.Global, false, "proxy:enable", "proxy:disable")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the ProxyToggleTask would produce.
+func (t ProxyToggleTask) Plan() PlanResult {
+	return planToggle(t.State, t.App, t.Global, false, "proxy:enable", "proxy:disable", proxyEnabled)
 }
 
 // init registers the ProxyToggleTask with the task registry

--- a/tasks/ps_property_task.go
+++ b/tasks/ps_property_task.go
@@ -68,7 +68,12 @@ func (t PsPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the ps property
 func (t PsPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "ps:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the PsPropertyTask would produce.
+func (t PsPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "ps:set")
 }
 
 // init registers the PsPropertyTask with the task registry

--- a/tasks/ps_scale_task.go
+++ b/tasks/ps_scale_task.go
@@ -70,14 +70,62 @@ func (t PsScaleTask) Examples() ([]Doc, error) {
 
 // Execute sets the process scale for a given dokku application
 func (t PsScaleTask) Execute() TaskOutputState {
-	if t.State == StatePresent && len(t.Scale) == 0 {
-		return TaskOutputState{
-			Error: fmt.Errorf("scale must be specified when state is present"),
-		}
-	}
+	return ExecutePlan(t.Plan())
+}
 
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return setPsScale(t) },
+// Plan reports the drift the PsScaleTask would produce.
+func (t PsScaleTask) Plan() PlanResult {
+	if t.State == StatePresent && len(t.Scale) == 0 {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("scale must be specified when state is present")}
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			existing, err := getPsScale(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			toScale := []string{}
+			mutations := []string{}
+			for proctype, qty := range t.Scale {
+				if cur, ok := existing[proctype]; ok && cur == qty {
+					continue
+				}
+				toScale = append(toScale, fmt.Sprintf("%s=%d", proctype, qty))
+				if cur, ok := existing[proctype]; ok {
+					mutations = append(mutations, fmt.Sprintf("scale %s=%d (was %d)", proctype, qty, cur))
+				} else {
+					mutations = append(mutations, fmt.Sprintf("scale %s=%d (new)", proctype, qty))
+				}
+			}
+			if len(toScale) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    fmt.Sprintf("%d process scale change(s)", len(mutations)),
+				Mutations: mutations,
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					args := []string{"ps:scale"}
+					if t.SkipDeploy {
+						args = append(args, "--skip-deploy")
+					}
+					args = append(args, t.App)
+					args = append(args, toScale...)
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
+			}
+		},
 	})
 }
 
@@ -109,57 +157,6 @@ func getPsScale(app string) (map[string]int, error) {
 		scale[parts[0]] = qty
 	}
 	return scale, nil
-}
-
-// setPsScale sets the process scale for a given dokku application
-func setPsScale(t PsScaleTask) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
-
-	existing, err := getPsScale(t.App)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
-	}
-
-	var proctypesToScale []string
-	for proctype, qty := range t.Scale {
-		if existingQty, ok := existing[proctype]; ok && existingQty == qty {
-			continue
-		}
-		proctypesToScale = append(proctypesToScale, fmt.Sprintf("%s=%d", proctype, qty))
-	}
-
-	if len(proctypesToScale) == 0 {
-		state.State = "present"
-		return state
-	}
-
-	args := []string{
-		"ps:scale",
-	}
-
-	if t.SkipDeploy {
-		args = append(args, "--skip-deploy")
-	}
-
-	args = append(args, t.App)
-	args = append(args, proctypesToScale...)
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
 }
 
 // init registers the PsScaleTask with the task registry

--- a/tasks/registry_auth_task.go
+++ b/tasks/registry_auth_task.go
@@ -90,9 +90,81 @@ func (t RegistryAuthTask) Examples() ([]Doc, error) {
 
 // Execute manages the registry authentication
 func (t RegistryAuthTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		StatePresent: func() TaskOutputState { return registryLogin(t) },
-		StateAbsent:  func() TaskOutputState { return registryLogout(t) },
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the RegistryAuthTask would produce. dokku registry
+// plugins do not expose a probe for current login state, so the plan
+// reports drift unconditionally.
+func (t RegistryAuthTask) Plan() PlanResult {
+	if err := validateRegistryAuthTask(t); err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	target := t.App
+	if t.Global {
+		target = "(global)"
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if t.Username == "" || t.Password == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'username' and 'password' are required when state is 'present'")}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    "registry login state not probed",
+				Mutations: []string{fmt.Sprintf("registry:login %s %s as %s", target, t.Server, t.Username)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					args := []string{"--quiet", "registry:login", "--password-stdin"}
+					if t.Global {
+						args = append(args, "--global")
+					} else {
+						args = append(args, t.App)
+					}
+					args = append(args, t.Server, t.Username)
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+						Stdin:   strings.NewReader(t.Password),
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "registry login state not probed",
+				Mutations: []string{fmt.Sprintf("registry:logout %s %s", target, t.Server)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					args := []string{"--quiet", "registry:logout"}
+					if t.Global {
+						args = append(args, "--global")
+					} else {
+						args = append(args, t.App)
+					}
+					args = append(args, t.Server)
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    args,
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
+			}
+		},
 	})
 }
 

--- a/tasks/registry_property_task.go
+++ b/tasks/registry_property_task.go
@@ -76,7 +76,12 @@ func (t RegistryPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the registry property
 func (t RegistryPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "registry:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the RegistryPropertyTask would produce.
+func (t RegistryPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "registry:set")
 }
 
 // init registers the RegistryPropertyTask with the task registry

--- a/tasks/resource_limit_task.go
+++ b/tasks/resource_limit_task.go
@@ -72,7 +72,12 @@ func (t ResourceLimitTask) Examples() ([]Doc, error) {
 
 // Execute sets or clears the resource limits for a given dokku application
 func (t ResourceLimitTask) Execute() TaskOutputState {
-	return executeResource(t.State, t.App, t.ProcessType, t.Resources, t.ClearBefore, "resource:limit")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the ResourceLimitTask would produce.
+func (t ResourceLimitTask) Plan() PlanResult {
+	return planResource(t.State, t.App, t.ProcessType, t.Resources, t.ClearBefore, "resource:limit")
 }
 
 // init registers the ResourceLimitTask with the task registry

--- a/tasks/resource_reserve_task.go
+++ b/tasks/resource_reserve_task.go
@@ -72,7 +72,12 @@ func (t ResourceReserveTask) Examples() ([]Doc, error) {
 
 // Execute sets or clears the resource reservations for a given dokku application
 func (t ResourceReserveTask) Execute() TaskOutputState {
-	return executeResource(t.State, t.App, t.ProcessType, t.Resources, t.ClearBefore, "resource:reserve")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the ResourceReserveTask would produce.
+func (t ResourceReserveTask) Plan() PlanResult {
+	return planResource(t.State, t.App, t.ProcessType, t.Resources, t.ClearBefore, "resource:reserve")
 }
 
 // init registers the ResourceReserveTask with the task registry

--- a/tasks/resources.go
+++ b/tasks/resources.go
@@ -3,8 +3,9 @@ package tasks
 import (
 	"errors"
 	"fmt"
-	"github.com/dokku/docket/subprocess"
 	"strings"
+
+	"github.com/dokku/docket/subprocess"
 )
 
 // ResourceContext represents the context for a resource operation
@@ -20,27 +21,6 @@ type ResourceContext struct {
 
 	// ClearBefore clears all resources before applying new ones
 	ClearBefore bool
-}
-
-// executeResource is a shared Execute implementation for resource tasks.
-func executeResource(state State, app, processType string, resources map[string]string, clearBefore bool, subcommand string) TaskOutputState {
-	if state == StatePresent && len(resources) == 0 {
-		return TaskOutputState{
-			Error:   errors.New("resources are required when state is present"),
-			Message: "resources are required when state is present",
-		}
-	}
-
-	rctx := ResourceContext{
-		App:         app,
-		ProcessType: processType,
-		Resources:   resources,
-		ClearBefore: clearBefore,
-	}
-	return DispatchState(state, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return setResource(subcommand, rctx) },
-		"absent":  func() TaskOutputState { return clearResource(subcommand, rctx) },
-	})
 }
 
 // getResources retrieves the current resources for a given dokku application
@@ -82,93 +62,72 @@ func getResources(subcommand string, rctx ResourceContext) (map[string]string, e
 	return resources, nil
 }
 
-// setResource sets the resources for a given dokku application
-func setResource(subcommand string, rctx ResourceContext) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
-
-	if rctx.ClearBefore {
-		err := execResourceClear(subcommand, rctx)
-		if err != nil {
-			state.Error = err
-			state.Message = err.Error()
-			return state
-		}
-		state.Changed = true
-	}
-
-	if !rctx.ClearBefore {
-		currentResources, err := getResources(subcommand, rctx)
-		if err != nil {
-			state.Error = err
-			state.Message = err.Error()
-			return state
-		}
-
-		// validate that all requested resources exist
-		for k := range rctx.Resources {
-			if _, ok := currentResources[k]; !ok {
-				state.Error = fmt.Errorf("unknown resource %s, valid resources: %v", k, mapKeys(currentResources))
-				state.Message = state.Error.Error()
-				return state
-			}
-		}
-
-		hasChanged := false
-		for k, v := range rctx.Resources {
-			if currentResources[k] != v {
-				hasChanged = true
-				break
-			}
-		}
-
-		if !hasChanged {
-			state.State = "present"
-			return state
+// planResource is the shared Plan() implementation for resource tasks. The
+// probe runs once; the apply closure consumes the diff.
+func planResource(state State, app, processType string, resources map[string]string, clearBefore bool, subcommand string) PlanResult {
+	if state == StatePresent && len(resources) == 0 {
+		return PlanResult{
+			Status: PlanStatusError,
+			Error:  errors.New("resources are required when state is present"),
 		}
 	}
 
-	args := []string{
-		subcommand,
+	rctx := ResourceContext{
+		App:         app,
+		ProcessType: processType,
+		Resources:   resources,
+		ClearBefore: clearBefore,
 	}
 
-	for key, value := range rctx.Resources {
-		args = append(args, fmt.Sprintf("--%s", key), value)
-	}
-
-	if rctx.ProcessType != "" {
-		args = append(args, "--process-type", rctx.ProcessType)
-	}
-
-	args = append(args, rctx.App)
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
+	return DispatchPlan(state, map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return planSetResource(subcommand, rctx) },
+		StateAbsent:  func() PlanResult { return planClearResource(subcommand, rctx) },
 	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
 }
 
-// clearResource clears the resources for a given dokku application
-func clearResource(subcommand string, rctx ResourceContext) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "present",
-	}
-
+// planSetResource reports drift for a present-state resource set.
+func planSetResource(subcommand string, rctx ResourceContext) PlanResult {
 	currentResources, err := getResources(subcommand, rctx)
 	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
-		return state
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+
+	for k := range rctx.Resources {
+		if _, ok := currentResources[k]; !ok {
+			return PlanResult{
+				Status: PlanStatusError,
+				Error:  fmt.Errorf("unknown resource %s, valid resources: %v", k, mapKeys(currentResources)),
+			}
+		}
+	}
+
+	mutations := []string{}
+	if rctx.ClearBefore {
+		mutations = append(mutations, "clear before set")
+	}
+	for k, v := range rctx.Resources {
+		if currentResources[k] != v {
+			mutations = append(mutations, fmt.Sprintf("set %s=%s (was %q)", k, v, currentResources[k]))
+		}
+	}
+
+	if len(mutations) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusModify,
+		Reason:    fmt.Sprintf("%d resource(s) to set", len(mutations)),
+		Mutations: mutations,
+		apply:     applyResourceSet(subcommand, rctx),
+	}
+}
+
+// planClearResource reports drift for an absent-state resource clear.
+func planClearResource(subcommand string, rctx ResourceContext) PlanResult {
+	currentResources, err := getResources(subcommand, rctx)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
 	}
 
 	hasResources := false
@@ -180,20 +139,67 @@ func clearResource(subcommand string, rctx ResourceContext) TaskOutputState {
 	}
 
 	if !hasResources {
-		state.State = "absent"
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    "would clear all resources",
+		Mutations: []string{fmt.Sprintf("clear resources via %s-clear", subcommand)},
+		apply:     applyResourceClear(subcommand, rctx),
+	}
+}
+
+// applyResourceSet returns a closure that runs the underlying resource
+// set command. ClearBefore is honored by clearing before setting.
+func applyResourceSet(subcommand string, rctx ResourceContext) func() TaskOutputState {
+	return func() TaskOutputState {
+		state := TaskOutputState{Changed: false, State: StateAbsent}
+		if rctx.ClearBefore {
+			if err := execResourceClear(subcommand, rctx); err != nil {
+				state.Error = err
+				state.Message = err.Error()
+				return state
+			}
+			state.Changed = true
+		}
+
+		args := []string{subcommand}
+		for key, value := range rctx.Resources {
+			args = append(args, fmt.Sprintf("--%s", key), value)
+		}
+		if rctx.ProcessType != "" {
+			args = append(args, "--process-type", rctx.ProcessType)
+		}
+		args = append(args, rctx.App)
+
+		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    args,
+		})
+		if err != nil {
+			return TaskOutputErrorFromExec(state, err, result)
+		}
+		state.Changed = true
+		state.State = StatePresent
 		return state
 	}
+}
 
-	err = execResourceClear(subcommand, rctx)
-	if err != nil {
-		state.Error = err
-		state.Message = err.Error()
+// applyResourceClear returns a closure that runs the underlying resource
+// clear command (subcommand + "-clear").
+func applyResourceClear(subcommand string, rctx ResourceContext) func() TaskOutputState {
+	return func() TaskOutputState {
+		state := TaskOutputState{Changed: false, State: StatePresent}
+		if err := execResourceClear(subcommand, rctx); err != nil {
+			state.Error = err
+			state.Message = err.Error()
+			return state
+		}
+		state.Changed = true
+		state.State = StateAbsent
 		return state
 	}
-
-	state.Changed = true
-	state.State = "absent"
-	return state
 }
 
 // execResourceClear executes the dokku resource clear command

--- a/tasks/scheduler_docker_local_property_task.go
+++ b/tasks/scheduler_docker_local_property_task.go
@@ -65,7 +65,12 @@ func (t SchedulerDockerLocalPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the scheduler-docker-local property
 func (t SchedulerDockerLocalPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, false, t.Property, t.Value, "scheduler-docker-local:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the SchedulerDockerLocalPropertyTask would produce.
+func (t SchedulerDockerLocalPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, false, t.Property, t.Value, "scheduler-docker-local:set")
 }
 
 // init registers the SchedulerDockerLocalPropertyTask with the task registry

--- a/tasks/scheduler_k3s_property_task.go
+++ b/tasks/scheduler_k3s_property_task.go
@@ -76,7 +76,12 @@ func (t SchedulerK3sPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the scheduler-k3s property
 func (t SchedulerK3sPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "scheduler-k3s:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the SchedulerK3sPropertyTask would produce.
+func (t SchedulerK3sPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "scheduler-k3s:set")
 }
 
 // init registers the SchedulerK3sPropertyTask with the task registry

--- a/tasks/scheduler_property_task.go
+++ b/tasks/scheduler_property_task.go
@@ -68,7 +68,12 @@ func (t SchedulerPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the scheduler property
 func (t SchedulerPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "scheduler:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the SchedulerPropertyTask would produce.
+func (t SchedulerPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "scheduler:set")
 }
 
 // init registers the SchedulerPropertyTask with the task registry

--- a/tasks/service_create_task.go
+++ b/tasks/service_create_task.go
@@ -66,9 +66,60 @@ func (t ServiceCreateTask) Examples() ([]Doc, error) {
 
 // Execute creates or destroys a dokku service
 func (t ServiceCreateTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return createService(t.Service, t.Name) },
-		"absent":  func() TaskOutputState { return destroyService(t.Service, t.Name) },
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the ServiceCreateTask would produce.
+func (t ServiceCreateTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if serviceExists(t.Service, t.Name) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    fmt.Sprintf("%s service %s missing", t.Service, t.Name),
+				Mutations: []string{fmt.Sprintf("%s:create %s", t.Service, t.Name)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", fmt.Sprintf("%s:create", t.Service), t.Name},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			if !serviceExists(t.Service, t.Name) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    fmt.Sprintf("%s service %s present", t.Service, t.Name),
+				Mutations: []string{fmt.Sprintf("%s:destroy %s", t.Service, t.Name)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "--force", fmt.Sprintf("%s:destroy", t.Service), t.Name},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
+			}
+		},
 	})
 }
 

--- a/tasks/service_link_task.go
+++ b/tasks/service_link_task.go
@@ -72,9 +72,72 @@ func (t ServiceLinkTask) Examples() ([]Doc, error) {
 
 // Execute links or unlinks a dokku service to an app
 func (t ServiceLinkTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return linkService(t.Service, t.Name, t.App) },
-		"absent":  func() TaskOutputState { return unlinkService(t.Service, t.Name, t.App) },
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the ServiceLinkTask would produce.
+func (t ServiceLinkTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if !serviceExists(t.Service, t.Name) {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("service %s %s does not exist", t.Service, t.Name)}
+			}
+			if !appExists(t.App) {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("app %s does not exist", t.App)}
+			}
+			if serviceLinked(t.Service, t.Name, t.App) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    fmt.Sprintf("%s service %s not linked to %s", t.Service, t.Name, t.App),
+				Mutations: []string{fmt.Sprintf("%s:link %s %s", t.Service, t.Name, t.App)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", fmt.Sprintf("%s:link", t.Service), t.Name, t.App},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			if !serviceExists(t.Service, t.Name) {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("service %s %s does not exist", t.Service, t.Name)}
+			}
+			if !appExists(t.App) {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("app %s does not exist", t.App)}
+			}
+			if !serviceLinked(t.Service, t.Name, t.App) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    fmt.Sprintf("%s service %s linked to %s", t.Service, t.Name, t.App),
+				Mutations: []string{fmt.Sprintf("%s:unlink %s %s", t.Service, t.Name, t.App)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", fmt.Sprintf("%s:unlink", t.Service), t.Name, t.App},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
+			}
+		},
 	})
 }
 

--- a/tasks/storage_ensure_task.go
+++ b/tasks/storage_ensure_task.go
@@ -43,61 +43,45 @@ func (t StorageEnsureTask) Examples() ([]Doc, error) {
 
 // Execute ensures the storage for a given app
 func (t StorageEnsureTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return ensureStorage(t.App, t.Chown) },
-		"absent":  func() TaskOutputState { return removeStorage(t.App, t.Chown) },
-	})
+	return ExecutePlan(t.Plan())
 }
 
-// ensureStorage ensures the storage for a given app
-func ensureStorage(app, chown string) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
-
-	// ensure chown is a valid value
+// Plan reports the drift the StorageEnsureTask would produce. dokku does
+// not expose a probe for storage:ensure-directory, so the plan reports
+// drift unconditionally.
+func (t StorageEnsureTask) Plan() PlanResult {
 	chownValues := map[string]bool{
-		"heroku":    true,
-		"herokuish": true,
-		"paketo":    true,
-		"root":      true,
-		"false":     true,
+		"heroku": true, "herokuish": true, "paketo": true, "root": true, "false": true,
 	}
-	if !chownValues[chown] {
-		state.Error = errors.New("invalid chown value specified")
-		return state
-	}
-
-	// todo: implement a check to see if the folder exists?
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			"storage:ensure-directory",
-			"--chown",
-			chown,
-			app,
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if !chownValues[t.Chown] {
+				return PlanResult{Status: PlanStatusError, Error: errors.New("invalid chown value specified")}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    "directory presence not probed",
+				Mutations: []string{"storage:ensure-directory --chown " + t.Chown + " " + t.App},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "storage:ensure-directory", "--chown", t.Chown, t.App},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			return PlanResult{Status: PlanStatusError, Error: errors.New("the absent state is not supported for storage:ensure")}
 		},
 	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
-}
-
-// removeStorage removes the storage for a given app
-func removeStorage(app, chown string) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
-
-	state.Error = errors.New("the absent state is not supported for storage:ensure")
-	return state
 }
 
 // init registers the StorageEnsureTask with the task registry

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -47,9 +47,61 @@ func (t StorageMountTask) Examples() ([]Doc, error) {
 
 // Execute mounts or unmounts the storage for a given app
 func (t StorageMountTask) Execute() TaskOutputState {
-	return DispatchState(t.State, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return mountStorage(t.App, t.HostDir, t.ContainerDir) },
-		"absent":  func() TaskOutputState { return unmountStorage(t.App, t.HostDir, t.ContainerDir) },
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the StorageMountTask would produce.
+func (t StorageMountTask) Plan() PlanResult {
+	mountSpec := fmt.Sprintf("%s:%s", t.HostDir, t.ContainerDir)
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if mountExists(t.App, t.HostDir, t.ContainerDir) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    "mount missing",
+				Mutations: []string{fmt.Sprintf("mount %s on %s", mountSpec, t.App)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StateAbsent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "storage:mount", t.App, mountSpec},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StatePresent
+					return state
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			if !mountExists(t.App, t.HostDir, t.ContainerDir) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "mount present",
+				Mutations: []string{fmt.Sprintf("unmount %s on %s", mountSpec, t.App)},
+				apply: func() TaskOutputState {
+					state := TaskOutputState{Changed: false, State: StatePresent}
+					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+						Command: "dokku",
+						Args:    []string{"--quiet", "storage:unmount", t.App, mountSpec},
+					})
+					if err != nil {
+						return TaskOutputErrorFromExec(state, err, result)
+					}
+					state.Changed = true
+					state.State = StateAbsent
+					return state
+				},
+			}
+		},
 	})
 }
 
@@ -85,68 +137,6 @@ func mountExists(app, hostDir, containerDir string) bool {
 		}
 	}
 	return false
-}
-
-// mountStorage mounts the storage for a given app
-func mountStorage(app, hostDir, containerDir string) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "present",
-	}
-
-	// check if the mount already exists
-	if mountExists(app, hostDir, containerDir) {
-		state.Changed = false
-		state.State = "present"
-		return state
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			"storage:mount",
-			app,
-			fmt.Sprintf("%s:%s", hostDir, containerDir),
-		},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "present"
-	return state
-}
-
-// unmountStorage unmounts the storage for a given app
-func unmountStorage(app, hostDir, containerDir string) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "present",
-	}
-	if !mountExists(app, hostDir, containerDir) {
-		state.Changed = false
-		state.State = "absent"
-		return state
-	}
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			"storage:unmount",
-			app,
-			fmt.Sprintf("%s:%s", hostDir, containerDir),
-		},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "absent"
-	return state
 }
 
 // init registers the StorageMountTask with the task registry

--- a/tasks/toggle.go
+++ b/tasks/toggle.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"fmt"
+
 	"github.com/dokku/docket/subprocess"
 )
 
@@ -17,87 +18,80 @@ type ToggleContext struct {
 	AllowGlobal bool `required:"false" yaml:"allow_global"`
 }
 
-// enablePlugin executes the enable state for a plugin
-func enablePlugin(subcommand string, pctx ToggleContext) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "absent",
-	}
+// ToggleProbe returns whether the toggle is currently in the "enabled"
+// (state: present) position. nil from a probe (or a non-nil error) is
+// treated as "drift, must mutate" so we still run the underlying command.
+type ToggleProbe func(ctx ToggleContext) (enabled bool, err error)
 
-	appName := pctx.App
-	if pctx.AllowGlobal {
-		if pctx.Global && pctx.App != "" {
-			state.Error = fmt.Errorf("'app' must not be set when 'global' is set to true")
-			return state
+// planToggle is the shared Plan() implementation for toggle tasks. The
+// probe reports whether the underlying plugin is currently in the
+// "enabled" position; when probe is nil or fails, planToggle reports drift
+// and the apply closure runs the underlying enable/disable command.
+func planToggle(state State, app string, global bool, allowGlobal bool, enableCmd, disableCmd string, probe ToggleProbe) PlanResult {
+	if allowGlobal && global && app != "" {
+		return PlanResult{
+			Status: PlanStatusError,
+			Error:  fmt.Errorf("'app' must not be set when 'global' is set to true"),
 		}
-		if pctx.Global {
-			appName = "--global"
-		}
 	}
 
-	// todo: validate that the plugin isn't already enabled
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			subcommand,
-			appName,
-		},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
+	target := app
+	if allowGlobal && global {
+		target = "--global"
 	}
 
-	state.Changed = true
-	state.State = "present"
-	return state
-}
-
-// executeToggle is a shared Execute implementation for toggle tasks.
-func executeToggle(state State, app string, global bool, allowGlobal bool, enableCmd, disableCmd string) TaskOutputState {
 	ctx := ToggleContext{
 		AllowGlobal: allowGlobal,
 		App:         app,
 		Global:      global,
 	}
-	return DispatchState(state, map[State]func() TaskOutputState{
-		"present": func() TaskOutputState { return enablePlugin(enableCmd, ctx) },
-		"absent":  func() TaskOutputState { return disablePlugin(disableCmd, ctx) },
+
+	return DispatchPlan(state, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if probe != nil {
+				if enabled, err := probe(ctx); err == nil && enabled {
+					return PlanResult{InSync: true, Status: PlanStatusOK}
+				}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    fmt.Sprintf("would run %s on %s", enableCmd, target),
+				Mutations: []string{fmt.Sprintf("%s %s", enableCmd, target)},
+				apply:     applyToggle(enableCmd, target, StatePresent),
+			}
+		},
+		StateAbsent: func() PlanResult {
+			if probe != nil {
+				if enabled, err := probe(ctx); err == nil && !enabled {
+					return PlanResult{InSync: true, Status: PlanStatusOK}
+				}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    fmt.Sprintf("would run %s on %s", disableCmd, target),
+				Mutations: []string{fmt.Sprintf("%s %s", disableCmd, target)},
+				apply:     applyToggle(disableCmd, target, StateAbsent),
+			}
+		},
 	})
 }
 
-// disablePlugin executes the disable state for a plugin
-func disablePlugin(subcommand string, pctx ToggleContext) TaskOutputState {
-	state := TaskOutputState{
-		Changed: false,
-		State:   "present",
-	}
-
-	appName := pctx.App
-	if pctx.AllowGlobal {
-		if pctx.Global && pctx.App != "" {
-			state.Error = fmt.Errorf("'app' must not be set when 'global' is set to true")
-			return state
+// applyToggle returns a closure that runs `dokku <subcommand> <target>` and
+// reports the resulting state.
+func applyToggle(subcommand, target string, finalState State) func() TaskOutputState {
+	return func() TaskOutputState {
+		state := TaskOutputState{Changed: false, State: finalState}
+		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", subcommand, target},
+		})
+		if err != nil {
+			return TaskOutputErrorFromExec(state, err, result)
 		}
-		if pctx.Global {
-			appName = "--global"
-		}
+		state.Changed = true
+		state.State = finalState
+		return state
 	}
-
-	// todo: validate that the plugin isn't already disabled
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			subcommand,
-			appName,
-		},
-	})
-	if err != nil {
-		return TaskOutputErrorFromExec(state, err, result)
-	}
-
-	state.Changed = true
-	state.State = "absent"
-	return state
 }

--- a/tasks/traefik_property_task.go
+++ b/tasks/traefik_property_task.go
@@ -68,7 +68,12 @@ func (t TraefikPropertyTask) Examples() ([]Doc, error) {
 
 // Execute sets or unsets the traefik property
 func (t TraefikPropertyTask) Execute() TaskOutputState {
-	return executeProperty(t.State, t.App, t.Global, t.Property, t.Value, "traefik:set")
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the TraefikPropertyTask would produce.
+func (t TraefikPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "traefik:set")
 }
 
 // init registers the TraefikPropertyTask with the task registry

--- a/tests/bats/README.md
+++ b/tests/bats/README.md
@@ -1,0 +1,42 @@
+# bats tests
+
+End-to-end tests for the `docket` CLI, exercised against a real Dokku
+installation. These complement the Go unit tests under `tasks/*_test.go`
+(which mock subprocess) and the Go integration tests under
+`tasks/*_integration_test.go` (which exercise the task layer against a real
+Dokku).
+
+## Layout
+
+- `test_helper.bash` - shared helpers for building the binary, writing
+  per-test `tasks.yml` fixtures, and cleaning up apps in setup/teardown.
+- `*.bats` - one file per CLI subcommand or feature.
+
+## Running locally
+
+The tests need:
+
+- `bats-core` (`bats` on PATH)
+- `bats-support` and `bats-assert` (loaded from `/usr/lib/bats/*` or
+  `/usr/lib/bats-support/`, `/usr/lib/bats-assert/`)
+- A Dokku installation reachable via the `dokku` CLI
+
+On Debian / Ubuntu:
+
+```bash
+sudo apt-get install -y bats bats-support bats-assert
+```
+
+Run from the repo root:
+
+```bash
+bats tests/bats/
+```
+
+Tests skip themselves when `dokku` is not available, so the suite is safe
+to run on a developer laptop without a local Dokku.
+
+## CI
+
+`.github/workflows/test.yml` defines a `bats-test` job that installs Dokku
+and the bats helpers, builds the docket binary, and runs the suite.

--- a/tests/bats/plan.bats
+++ b/tests/bats/plan.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  require_dokku
+  docket_build
+  dokku_clean_app docket-test-plan
+}
+
+teardown() {
+  dokku_clean_app docket-test-plan
+}
+
+@test "docket plan reports drift on a missing app" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-plan
+      dokku_app:
+        app: docket-test-plan
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "[+]"
+  assert_output --partial "Plan:"
+  assert_output --partial "1 would change"
+}
+
+@test "docket plan does not mutate state" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-plan
+      dokku_app:
+        app: docket-test-plan
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  run dokku apps:exists docket-test-plan
+  # apps:exists returns non-zero when the app does not exist.
+  assert_failure
+}
+
+@test "docket plan reports in sync after apply" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-plan
+      dokku_app:
+        app: docket-test-plan
+EOF
+  "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "[ok]"
+  assert_output --partial "in sync"
+  assert_output --partial "0 would change"
+}
+
+@test "docket plan itemizes config keys to set" {
+  write_tasks_file setup.yml <<EOF
+---
+- tasks:
+    - dokku_app:
+        app: docket-test-plan
+EOF
+  "$(docket_bin)" apply --tasks "$TASKS_FILE"
+
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: configure
+      dokku_config:
+        app: docket-test-plan
+        restart: false
+        config:
+          KEY_ONE: value-one
+          KEY_TWO: value-two
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "2 key(s) to set"
+  assert_output --partial "set KEY_ONE"
+  assert_output --partial "set KEY_TWO"
+}
+
+@test "docket apply is idempotent on second run" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-plan
+      dokku_app:
+        app: docket-test-plan
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  run dokku apps:exists docket-test-plan
+  assert_success
+
+  # Second apply must not report any error and must not destroy the app.
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  run dokku apps:exists docket-test-plan
+  assert_success
+}

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Shared helpers for docket bats tests.
+#
+# Bats and the bats-support / bats-assert helper libraries are expected to be
+# installed system-wide via apt; the tests load them from /usr/lib/bats/*.
+# See .github/workflows/test.yml for CI install steps and
+# tests/bats/README.md for local developer setup.
+
+set -euo pipefail
+
+# Load bats-support / bats-assert from the standard package paths.
+load_bats_libraries() {
+  local lib
+  for lib in /usr/lib/bats/bats-support/load.bash /usr/lib/bats-support/load.bash; do
+    if [ -f "$lib" ]; then
+      # shellcheck disable=SC1090
+      source "$lib"
+      break
+    fi
+  done
+  for lib in /usr/lib/bats/bats-assert/load.bash /usr/lib/bats-assert/load.bash; do
+    if [ -f "$lib" ]; then
+      # shellcheck disable=SC1090
+      source "$lib"
+      break
+    fi
+  done
+}
+
+load_bats_libraries
+
+# Resolve the docket binary. Prefer the in-tree build at ./docket so a local
+# `go build` tests the working tree; fall back to PATH otherwise.
+docket_bin() {
+  if [ -n "${DOCKET_BIN:-}" ]; then
+    echo "$DOCKET_BIN"
+    return
+  fi
+  local repo_root
+  repo_root="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  if [ -x "$repo_root/docket" ]; then
+    echo "$repo_root/docket"
+    return
+  fi
+  command -v docket
+}
+
+# docket_build builds the binary at the repo root. Subsequent calls in the
+# same bats run skip the rebuild because Go caches incremental builds.
+docket_build() {
+  local repo_root
+  repo_root="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  (cd "$repo_root" && go build -o docket .)
+  export DOCKET_BIN="$repo_root/docket"
+}
+
+# write_tasks_file writes its stdin to "$BATS_TEST_TMPDIR/<name>" (default:
+# tasks.yml) and exports TASKS_FILE so tests can pass --tasks "$TASKS_FILE".
+write_tasks_file() {
+  local name="${1:-tasks.yml}"
+  TASKS_FILE="$BATS_TEST_TMPDIR/$name"
+  cat >"$TASKS_FILE"
+  export TASKS_FILE
+}
+
+# dokku_clean_app destroys an app if it exists. Used in setup/teardown so
+# tests are idempotent on shared CI hosts.
+dokku_clean_app() {
+  local app="$1"
+  if ! command -v dokku >/dev/null 2>&1; then
+    return 0
+  fi
+  if dokku apps:exists "$app" >/dev/null 2>&1; then
+    dokku --force apps:destroy "$app" >/dev/null 2>&1 || true
+  fi
+}
+
+# require_dokku skips the current test when no dokku binary is installed.
+require_dokku() {
+  if ! command -v dokku >/dev/null 2>&1; then
+    skip "dokku not available"
+  fi
+}


### PR DESCRIPTION
## Summary

Adds a `Plan()` method to the `Task` interface alongside `Execute()`, and wires every task's `Execute()` to be a thin wrapper around `ExecutePlan(t.Plan())`. The probe runs once per task per apply; the per-state mutation logic lives in exactly one place; `apply` is properly idempotent for every task family including the ones that previously lacked probes (properties, toggles).

Replaces #213. PR #213 added Plan() with Plan and Execute each running the probe and decision logic independently. This PR ships the cleaner Plan-drives-Execute architecture from the start, without the intermediate "probe runs twice" state.

## Architecture

```go
type PlanResult struct {
    InSync       bool
    Status       PlanStatus
    Reason       string
    Mutations    []string
    DesiredState State
    Error        error

    // apply, when non-nil, is the closure ExecutePlan invokes to mutate
    // server state. nil when InSync. Captures any probed state so the apply
    // path does not re-probe. Unexported so JSON formatters cannot
    // accidentally invoke it.
    apply func() TaskOutputState
}

type Task interface {
    Doc() string
    Examples() ([]Doc, error)
    Plan() PlanResult       // probes + decides; never mutates
    Execute() TaskOutputState  // = ExecutePlan(t.Plan())
}
```

`ExecutePlan` is the canonical Execute body. Three branches: error → propagate; InSync → return `Changed=false`; drift → invoke the embedded apply closure. Every task's `Execute()` is now exactly `return ExecutePlan(t.Plan())`.

## What lands

- `tasks/main.go` adds `PlanResult` (with private `apply` field), `PlanStatus` constants, and `Plan()` on the `Task` interface.
- `tasks/dispatch.go` adds `DispatchPlan` (mirrors `DispatchState`) and the `ExecutePlan` helper.
- `tasks/properties.go` carries a generic `getProperty` probe via `dokku <plugin>:report --<plugin>-<property>`. Probe failure falls through to an unconditional set/unset, matching the pre-probe behavior of property tasks.
- `tasks/toggle.go` accepts a `ToggleProbe` callback. Three toggle tasks (proxy, domains, checks) supply per-plugin probes (`proxy:report --proxy-enabled`, `domains:report --domains-app-enabled`, `checks:report --checks-disabled`).
- `tasks/resources.go` probes once and itemizes per-resource diff in `Mutations`.
- Every `tasks/*_task.go` (50+ files) now has `Plan()` returning a `PlanResult` with an `apply` closure, and `Execute()` is a 1-line wrapper. Per-state functions (`createApp`, `setConfig`, `addDomains`, etc.) collapse into closures inside `Plan()`.
- `commands/plan.go` is the `docket plan` subcommand; iterates the parsed recipe and calls `Plan()` per task, printing one line each plus a final summary.
- `tests/bats/` introduces the bats test scaffolding (helper + plan.bats + README); `.github/workflows/test.yml` adds a `bats-test` job mirroring `integration-test`.
- `README.md` documents the plan output, plan markers, and the Plan/Execute template for new tasks.

## Test coverage

| Layer | What's covered |
|-------|----------------|
| Unit (`tasks/plan_test.go`) | ExecutePlan invariants (InSync skips apply, error skips apply, drift invokes apply, missing apply errors); registry walk asserting every task implements `Plan()`; per-key diff helpers for config; `pluginFromSubcommand` extraction |
| Unit (`commands/plan_test.go`) | Plan subcommand metadata, examples, FlagSet doesn't panic without tasks.yml, interface contract |
| Integration (`tasks/plan_integration_test.go`, gated by `skipIfNoDokkuT`) | Plan reports drift on missing app; Plan reports InSync after apply (round-trip); Plan does not mutate; per-key Mutations against real dokku; **apply-then-apply idempotency** (the user-visible payoff: second apply returns `Changed=false`) |
| Bats (`tests/bats/plan.bats`) | Plan reports drift, doesn't mutate, reports in-sync after apply, itemizes config keys, **`docket apply` is idempotent on a second run** |

## Notes for reviewers

- The `apply` field is unexported and tagged `json:"-"` (implicit via lowercase). Only `ExecutePlan` reads it. JSON output of PlanResult, validate output, and any future formatter cannot accidentally invoke it.
- A handful of tasks (`git_auth`, `registry_auth`, `storage_ensure`) still report drift unconditionally because dokku itself does not expose a probe for them. Their plan output calls this out with `(... not probed)` in the reason. Adding real probes is per-plugin follow-up work upstream.
- Multi-mutation tasks (config, ports, domains, docker_options, buildpacks, ps_scale, acl_app, acl_service, resources) populate `Mutations[]` with one entry per key/port/domain/etc. so plan output itemizes the diff.