### PR TITLE
feat: add validate subcommand for offline schema and template checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Run it:
 docket apply
 ```
 
-Running `docket` with no subcommand prints the available commands. Use `docket apply` to execute a task file, `docket plan` to preview the changes a task file would make without mutating any state, or `docket version` to print the binary's version.
+Running `docket` with no subcommand prints the available commands. Use `docket apply` to execute a task file, `docket plan` to preview the changes a task file would make without mutating any state, `docket validate` to check a task file's schema and templates without contacting the server, or `docket version` to print the binary's version.
 
 ### Previewing changes with `plan`
 
@@ -64,6 +64,21 @@ Plan: 1 task(s); 1 would change, 0 in sync, 0 error(s).
 `Plan()` results drive `apply`: every task probes the server once, and `apply` reuses that probe to decide whether to mutate. `apply` on an already-converged server reports `Changed=false` for every task; back-to-back applies are no-ops by design.
 
 A handful of tasks (notably `dokku_git_auth`, `dokku_registry_auth`, and `dokku_storage_ensure`) cannot probe their current state without invoking the corresponding dokku command, so their plan output reports drift unconditionally with `(... not probed)` in the reason.
+
+### Validating recipes with `validate`
+
+`docket validate` performs offline schema and template checks against a `tasks.yml` without contacting any Dokku server, suitable for CI lint jobs that need to reject broken recipes before deploy.
+
+The shipping checks cover: YAML parses, recipe shape (top-level list of plays with `inputs`/`tasks`), task entry shape (envelope keys plus exactly one task-type key), task type registered (with a "did you mean" suggestion for typos), required fields decode, and sigil templates render against input defaults.
+
+```shell
+docket validate --tasks path/to/tasks.yml
+```
+
+Exit codes are `0` when no problems are found and `1` otherwise. Two flags are available:
+
+- `--json` emits one JSON-lines event per problem with a stable `version: 1` schema (`{"type":"validate_problem","code":"unknown_task_type", ...}`), suitable for piping into a CI annotator.
+- `--strict` additionally flags any input declared `required: true` that has no `default` and no value supplied via a CLI flag - useful in CI to ensure the recipe can be applied without runtime overrides.
 
 A task file can also be specified via flag, and may be a file retrieved via http:
 

--- a/commands/validate.go
+++ b/commands/validate.go
@@ -1,0 +1,244 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/dokku/docket/tasks"
+
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/posener/complete"
+	flag "github.com/spf13/pflag"
+)
+
+// ValidateCommand performs offline schema and template checks against a
+// docket recipe without contacting a Dokku server.
+type ValidateCommand struct {
+	command.Meta
+
+	tasksFile string
+	json      bool
+	strict    bool
+	arguments map[string]*Argument
+}
+
+func (c *ValidateCommand) Name() string {
+	return "validate"
+}
+
+func (c *ValidateCommand) Synopsis() string {
+	return "Performs offline schema and template checks on a docket task file"
+}
+
+func (c *ValidateCommand) Help() string {
+	return command.CommandHelp(c)
+}
+
+func (c *ValidateCommand) Examples() map[string]string {
+	appName := os.Getenv("CLI_APP_NAME")
+	return map[string]string{
+		"Validate the default tasks.yml":           fmt.Sprintf("%s %s", appName, c.Name()),
+		"Validate a specific file":                 fmt.Sprintf("%s %s --tasks path/to/task.yml", appName, c.Name()),
+		"Emit JSON-lines problem events":           fmt.Sprintf("%s %s --json", appName, c.Name()),
+		"Flag required inputs without an override": fmt.Sprintf("%s %s --strict", appName, c.Name()),
+	}
+}
+
+func (c *ValidateCommand) Arguments() []command.Argument {
+	return []command.Argument{}
+}
+
+func (c *ValidateCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *ValidateCommand) ParsedArguments(args []string) (map[string]command.Argument, error) {
+	return command.ParseArguments(args, c.Arguments())
+}
+
+func (c *ValidateCommand) FlagSet() *flag.FlagSet {
+	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	f.StringVar(&c.tasksFile, "tasks", "tasks.yml", "a yaml file containing a task list")
+	f.BoolVar(&c.json, "json", false, "emit one JSON-lines problem event per finding")
+	f.BoolVar(&c.strict, "strict", false, "additionally flag required inputs that have no default and no CLI override")
+
+	taskFile := getTaskYamlFilename(os.Args)
+	data, err := os.ReadFile(taskFile)
+	if err != nil {
+		return f
+	}
+
+	arguments, err := registerInputFlags(f, data)
+	if err != nil {
+		return f
+	}
+	c.arguments = arguments
+
+	return f
+}
+
+func (c *ValidateCommand) AutocompleteFlags() complete.Flags {
+	return command.MergeAutocompleteFlags(
+		c.Meta.AutocompleteFlags(command.FlagSetClient),
+		complete.Flags{
+			"--tasks":  complete.PredictFiles("*.yml"),
+			"--json":   complete.PredictNothing,
+			"--strict": complete.PredictNothing,
+		},
+	)
+}
+
+// Run loads the tasks file and reports every problem the validator finds.
+//
+// Exit codes:
+//
+//	0 - no problems found
+//	1 - file read failed, or the validator returned at least one problem
+func (c *ValidateCommand) Run(args []string) int {
+	flags := c.FlagSet()
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(err.Error())
+		c.Ui.Error(command.CommandErrorText(c))
+		return 1
+	}
+
+	data, err := os.ReadFile(c.tasksFile)
+	if err != nil {
+		if c.json {
+			c.emitJSONProblem(tasks.Problem{
+				Code:    "read_error",
+				Message: err.Error(),
+			})
+		} else {
+			c.Ui.Error(fmt.Sprintf("read error: %v", err))
+		}
+		return 1
+	}
+
+	overrides := map[string]bool{}
+	for name, argument := range c.arguments {
+		if argument.HasValue() {
+			overrides[name] = true
+		}
+	}
+
+	problems := tasks.Validate(data, tasks.ValidateOptions{
+		Strict:         c.strict,
+		InputOverrides: overrides,
+	})
+
+	if c.json {
+		for _, p := range problems {
+			c.emitJSONProblem(p)
+		}
+		if len(problems) > 0 {
+			return 1
+		}
+		return 0
+	}
+
+	if len(problems) == 0 {
+		c.Ui.Info(fmt.Sprintf("==> Validating %s", c.tasksFile))
+		c.Ui.Info("")
+		c.Ui.Info(fmt.Sprintf("[ok]      %s is valid", c.tasksFile))
+		return 0
+	}
+
+	c.renderHumanProblems(problems)
+	return 1
+}
+
+// emitJSONProblem prints a single JSON-lines event. The version field is
+// pinned at 1 so consumers can branch on schema changes.
+func (c *ValidateCommand) emitJSONProblem(p tasks.Problem) {
+	event := map[string]interface{}{
+		"version": 1,
+		"type":    "validate_problem",
+		"code":    p.Code,
+		"message": p.Message,
+	}
+	if p.Play != "" {
+		event["play"] = p.Play
+	}
+	if p.Task != "" {
+		event["task"] = p.Task
+	}
+	if p.Line > 0 {
+		event["line"] = p.Line
+	}
+	if p.Column > 0 {
+		event["column"] = p.Column
+	}
+	if p.Hint != "" {
+		event["hint"] = p.Hint
+	}
+	b, err := json.Marshal(event)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("json marshal error: %v", err))
+		return
+	}
+	c.Ui.Output(string(b))
+}
+
+// renderHumanProblems prints problems grouped by play, mirroring the issue's
+// example output. Play and task headers are emitted only when they change so
+// the output stays compact.
+func (c *ValidateCommand) renderHumanProblems(problems []tasks.Problem) {
+	c.Ui.Info(fmt.Sprintf("==> Validating %s", c.tasksFile))
+	c.Ui.Info("")
+	c.Ui.Info(fmt.Sprintf("[error]   %d problem(s):", len(problems)))
+	c.Ui.Info("")
+
+	grouped := map[string][]tasks.Problem{}
+	playOrder := []string{}
+	for _, p := range problems {
+		key := p.Play
+		if _, ok := grouped[key]; !ok {
+			playOrder = append(playOrder, key)
+		}
+		grouped[key] = append(grouped[key], p)
+	}
+	sort.SliceStable(playOrder, func(i, j int) bool {
+		return playOrder[i] < playOrder[j]
+	})
+
+	for _, play := range playOrder {
+		if play != "" {
+			c.Ui.Info(fmt.Sprintf("  %s", play))
+		}
+		for _, p := range grouped[play] {
+			c.Ui.Info(fmt.Sprintf("    ! %s", formatProblem(p)))
+		}
+		c.Ui.Info("")
+	}
+}
+
+func formatProblem(p tasks.Problem) string {
+	var b strings.Builder
+	if p.Task != "" {
+		b.WriteString(p.Task)
+		if p.Line > 0 {
+			fmt.Fprintf(&b, " (line %d", p.Line)
+			if p.Column > 0 {
+				fmt.Fprintf(&b, ":%d", p.Column)
+			}
+			b.WriteString(")")
+		}
+		b.WriteString(": ")
+	} else if p.Line > 0 {
+		fmt.Fprintf(&b, "line %d", p.Line)
+		if p.Column > 0 {
+			fmt.Fprintf(&b, ":%d", p.Column)
+		}
+		b.WriteString(": ")
+	}
+	b.WriteString(p.Message)
+	if p.Hint != "" {
+		fmt.Fprintf(&b, " - %s", p.Hint)
+	}
+	return b.String()
+}

--- a/commands/validate_test.go
+++ b/commands/validate_test.go
@@ -1,0 +1,126 @@
+package commands
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/dokku/docket/tasks"
+)
+
+func TestValidateCommandMetadata(t *testing.T) {
+	c := &ValidateCommand{}
+	if c.Name() != "validate" {
+		t.Errorf("Name = %q, want \"validate\"", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis must not be empty")
+	}
+}
+
+func TestValidateCommandExamples(t *testing.T) {
+	c := &ValidateCommand{}
+	examples := c.Examples()
+	if len(examples) == 0 {
+		t.Fatal("expected at least one example")
+	}
+	for label, example := range examples {
+		if example == "" {
+			t.Errorf("example %q is empty", label)
+		}
+	}
+}
+
+func TestValidateCommandHelpDoesNotPanic(t *testing.T) {
+	c := &ValidateCommand{}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("FlagSet panicked without tasks.yml on disk: %v", r)
+		}
+	}()
+	_ = c.FlagSet()
+}
+
+// TestFormatProblemHumanOutput exercises the human formatter end-to-end so
+// the issue's example output (line N column M, "did you mean" hint) keeps
+// rendering as documented.
+func TestFormatProblemHumanOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		p    tasks.Problem
+		want []string
+	}{
+		{
+			name: "task with line/column",
+			p: tasks.Problem{
+				Task:    "task #2",
+				Line:    8,
+				Column:  7,
+				Message: "unknown task type \"dokku_appp\"",
+				Hint:    "did you mean \"dokku_app\"?",
+			},
+			want: []string{"task #2", "line 8:7", "unknown task type", "did you mean"},
+		},
+		{
+			name: "play-level problem with no task",
+			p: tasks.Problem{
+				Line:    3,
+				Column:  7,
+				Message: "input \"app\" is required",
+			},
+			want: []string{"line 3:7", "is required"},
+		},
+		{
+			name: "no position info",
+			p: tasks.Problem{
+				Code:    "yaml_parse",
+				Message: "broken",
+			},
+			want: []string{"broken"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatProblem(tt.p)
+			for _, fragment := range tt.want {
+				if !strings.Contains(got, fragment) {
+					t.Errorf("formatProblem output missing %q\nfull: %q", fragment, got)
+				}
+			}
+		})
+	}
+}
+
+// TestValidateJSONEventShape constructs a Problem and round-trips it through
+// the JSON encoder used by --json output to confirm that consumers can rely
+// on the documented fields.
+func TestValidateJSONEventShape(t *testing.T) {
+	event := map[string]interface{}{
+		"version": 1,
+		"type":    "validate_problem",
+		"code":    "unknown_task_type",
+		"message": "unknown task type \"dokku_appp\"",
+		"play":    "play #1",
+		"task":    "task #2",
+		"line":    8,
+		"column":  7,
+		"hint":    "did you mean \"dokku_app\"?",
+	}
+	b, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if v, ok := decoded["version"].(float64); !ok || int(v) != 1 {
+		t.Errorf("expected version=1, got %v", decoded["version"])
+	}
+	if decoded["type"] != "validate_problem" {
+		t.Errorf("expected type=validate_problem, got %v", decoded["type"])
+	}
+	if decoded["code"] != "unknown_task_type" {
+		t.Errorf("expected code=unknown_task_type, got %v", decoded["code"])
+	}
+}

--- a/main.go
+++ b/main.go
@@ -44,6 +44,9 @@ func Commands(ctx context.Context, meta command.Meta) map[string]cli.CommandFact
 		"plan": func() (cli.Command, error) {
 			return &commands.PlanCommand{Meta: meta}, nil
 		},
+		"validate": func() (cli.Command, error) {
+			return &commands.ValidateCommand{Meta: meta}, nil
+		},
 		"version": func() (cli.Command, error) {
 			return &command.VersionCommand{Meta: meta}, nil
 		},

--- a/tasks/validate.go
+++ b/tasks/validate.go
@@ -1,0 +1,671 @@
+package tasks
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+
+	sigil "github.com/gliderlabs/sigil"
+	defaults "github.com/mcuadros/go-defaults"
+	yaml "gopkg.in/yaml.v3"
+)
+
+// Problem is a single validation finding emitted by Validate.
+//
+// Code is a stable machine-readable identifier so JSON consumers (and the
+// follow-on issues that activate the placeholder checks) can branch without
+// matching on free-form Message text. Line/Column are 1-based and 0 when the
+// position cannot be derived from yaml.v3 anchors or the underlying parser.
+type Problem struct {
+	Code    string
+	Play    string
+	Task    string
+	Line    int
+	Column  int
+	Message string
+	Hint    string
+}
+
+// ValidateOptions controls optional checks. Strict turns on the input-resolution
+// audit; InputOverrides is the set of input names whose values were supplied on
+// the CLI (the same map registerInputFlags fills in for apply/plan).
+type ValidateOptions struct {
+	Strict         bool
+	InputOverrides map[string]bool
+}
+
+// validatePlaceholder is substituted for any input that has no default during
+// the sigil-render check. It is unique enough that no real recipe would
+// produce it accidentally; downstream type-decoding sees it as a normal
+// string, which is the right behaviour for offline validation since we do
+// not know what the runtime value will be.
+const validatePlaceholder = "__docket_validate_placeholder__"
+
+// reservedEnvelopeKeys lists the per-task keys that are recognised at the
+// envelope level but not yet activated. They live here so a typo in a real
+// task-type name (e.g. dokku_appp) is reported as "unknown task type" rather
+// than getting silently swallowed by an envelope allowlist.
+var reservedEnvelopeKeys = map[string]string{
+	"block":    "#211",
+	"rescue":   "#211",
+	"always":   "#211",
+	"when":     "#205",
+	"loop":     "#205",
+	"register": "#210",
+	"tags":     "#212",
+}
+
+// Validate parses data as a docket recipe and returns every problem it finds.
+// It is offline by contract: the implementation must never invoke
+// subprocess.CallExecCommand.
+//
+// The validator first parses the raw bytes to extract input definitions, then
+// renders the recipe through sigil with a context built from those defaults
+// (plus a placeholder for any required input without a default) so structural
+// checks operate on the same form `apply` would see. yaml.v3 line/column
+// anchors from the rendered tree are used for error reporting. Source line
+// numbers align with rendered line numbers as long as templates render
+// inline, which is the case for typical recipes.
+func Validate(data []byte, opts ValidateOptions) []Problem {
+	if opts.InputOverrides == nil {
+		opts.InputOverrides = map[string]bool{}
+	}
+
+	// Sigil renders templates, so a malformed `{{ .x` is caught here even
+	// when the rest of the file is otherwise unparseable as YAML (the YAML
+	// parser would otherwise misread `{{` as a broken flow mapping). The
+	// initial render uses an empty context so input-default substitution is
+	// not yet applied; text/template's `missingkey=default` mode renders
+	// missing keys as `<no value>` rather than failing, so this pass only
+	// surfaces real template syntax errors.
+	if _, renderProblem := renderForValidate(data, map[string]interface{}{}); renderProblem != nil {
+		return []Problem{*renderProblem}
+	}
+
+	var rawRoot yaml.Node
+	if err := yaml.Unmarshal(data, &rawRoot); err != nil {
+		line, col := parseYAMLErrorPosition(err.Error())
+		return []Problem{{
+			Code:    "yaml_parse",
+			Line:    line,
+			Column:  col,
+			Message: err.Error(),
+		}}
+	}
+
+	rawDoc := documentBody(&rawRoot)
+	if rawDoc == nil {
+		return []Problem{{
+			Code:    "recipe_shape",
+			Message: "no recipe found in tasks file",
+		}}
+	}
+	if rawDoc.Kind != yaml.SequenceNode {
+		return []Problem{{
+			Code:    "recipe_shape",
+			Line:    rawDoc.Line,
+			Column:  rawDoc.Column,
+			Message: "recipe must be a yaml list of plays",
+		}}
+	}
+
+	playsInputs := extractPlayInputs(rawDoc)
+	context := buildSigilContext(playsInputs)
+
+	rendered, renderProblem := renderForValidate(data, context)
+	if renderProblem != nil {
+		// Without rendered bytes the structural walk cannot run; return the
+		// template error alongside whatever input-strict findings can still
+		// be derived from the raw tree.
+		problems := []Problem{*renderProblem}
+		if opts.Strict {
+			for i, inputs := range playsInputs {
+				label := fmt.Sprintf("play #%d", i+1)
+				problems = append(problems, validateStrictInputs(inputs, opts.InputOverrides, label)...)
+			}
+		}
+		return problems
+	}
+
+	var renderedRoot yaml.Node
+	if err := yaml.Unmarshal(rendered, &renderedRoot); err != nil {
+		line, col := parseYAMLErrorPosition(err.Error())
+		return []Problem{{
+			Code:    "yaml_parse",
+			Line:    line,
+			Column:  col,
+			Message: fmt.Sprintf("rendered recipe parse error: %v", err),
+		}}
+	}
+
+	doc := documentBody(&renderedRoot)
+	if doc == nil || doc.Kind != yaml.SequenceNode {
+		return []Problem{{
+			Code:    "recipe_shape",
+			Message: "rendered recipe is not a yaml list of plays",
+		}}
+	}
+
+	var problems []Problem
+	for i, play := range doc.Content {
+		label := fmt.Sprintf("play #%d", i+1)
+		var inputs []inputWithNode
+		if i < len(playsInputs) {
+			inputs = playsInputs[i]
+		}
+		problems = append(problems, validatePlay(play, label, inputs, opts)...)
+	}
+
+	return problems
+}
+
+// validatePlay walks one play (one MappingNode within the recipe sequence).
+func validatePlay(play *yaml.Node, label string, inputs []inputWithNode, opts ValidateOptions) []Problem {
+	var problems []Problem
+
+	if play.Kind != yaml.MappingNode {
+		return append(problems, Problem{
+			Code:    "recipe_shape",
+			Play:    label,
+			Line:    play.Line,
+			Column:  play.Column,
+			Message: "play must be a yaml mapping with inputs and/or tasks",
+		})
+	}
+
+	tasksNode := mappingValue(play, "tasks")
+
+	for i := 0; i < len(play.Content); i += 2 {
+		key := play.Content[i].Value
+		if key != "inputs" && key != "tasks" {
+			problems = append(problems, Problem{
+				Code:    "recipe_shape",
+				Play:    label,
+				Line:    play.Content[i].Line,
+				Column:  play.Content[i].Column,
+				Message: fmt.Sprintf("unexpected play key %q (expected: inputs, tasks)", key),
+			})
+		}
+	}
+
+	if opts.Strict {
+		problems = append(problems, validateStrictInputs(inputs, opts.InputOverrides, label)...)
+	}
+
+	// Stub checks: present so future PRs (#205/#208/#210/#211/#212) can wire
+	// real bodies without touching the call site.
+	problems = append(problems, validateBlockStructure(tasksNode, label)...)
+	problems = append(problems, validateExprPredicates(tasksNode, label)...)
+	problems = append(problems, validateRegisterReferences(tasksNode, label)...)
+	problems = append(problems, validateTargetReferences(tasksNode, label)...)
+
+	if tasksNode == nil {
+		return problems
+	}
+	if tasksNode.Kind != yaml.SequenceNode {
+		return append(problems, Problem{
+			Code:    "recipe_shape",
+			Play:    label,
+			Line:    tasksNode.Line,
+			Column:  tasksNode.Column,
+			Message: "tasks must be a yaml list",
+		})
+	}
+
+	for i, task := range tasksNode.Content {
+		problems = append(problems, validateTaskEntry(task, label, i+1)...)
+	}
+
+	return problems
+}
+
+// validateTaskEntry covers checks 3-5: envelope shape, registered task type,
+// and required-field decode.
+func validateTaskEntry(task *yaml.Node, playLabel string, idx int) []Problem {
+	var problems []Problem
+	taskLabel := fmt.Sprintf("task #%d", idx)
+
+	if task.Kind != yaml.MappingNode {
+		return []Problem{{
+			Code:    "task_entry_shape",
+			Play:    playLabel,
+			Task:    taskLabel,
+			Line:    task.Line,
+			Column:  task.Column,
+			Message: "task entry must be a yaml mapping",
+		}}
+	}
+
+	var (
+		taskTypeKey  string
+		taskTypeNode *yaml.Node
+		taskBodyNode *yaml.Node
+		taskTypeKeys []string
+		nameValue    string
+	)
+
+	for i := 0; i < len(task.Content); i += 2 {
+		keyNode := task.Content[i]
+		valueNode := task.Content[i+1]
+		key := keyNode.Value
+
+		if key == "name" {
+			if valueNode.Kind == yaml.ScalarNode {
+				nameValue = valueNode.Value
+			}
+			continue
+		}
+
+		if dependentIssue, reserved := reservedEnvelopeKeys[key]; reserved {
+			problems = append(problems, Problem{
+				Code:    "envelope_key_unsupported",
+				Play:    playLabel,
+				Task:    taskLabel,
+				Line:    keyNode.Line,
+				Column:  keyNode.Column,
+				Message: fmt.Sprintf("envelope key %q is reserved but not yet supported", key),
+				Hint:    fmt.Sprintf("activates with %s", dependentIssue),
+			})
+			continue
+		}
+
+		taskTypeKeys = append(taskTypeKeys, key)
+		taskTypeKey = key
+		taskTypeNode = keyNode
+		taskBodyNode = valueNode
+	}
+
+	if nameValue != "" {
+		taskLabel = fmt.Sprintf("task #%d %q", idx, nameValue)
+	}
+
+	if len(taskTypeKeys) == 0 {
+		return append(problems, Problem{
+			Code:    "task_entry_shape",
+			Play:    playLabel,
+			Task:    taskLabel,
+			Line:    task.Line,
+			Column:  task.Column,
+			Message: "task entry must contain exactly one task-type key",
+		})
+	}
+	if len(taskTypeKeys) > 1 {
+		return append(problems, Problem{
+			Code:    "task_entry_shape",
+			Play:    playLabel,
+			Task:    taskLabel,
+			Line:    task.Line,
+			Column:  task.Column,
+			Message: fmt.Sprintf("task entry has %d task-type keys (%s); exactly one is allowed", len(taskTypeKeys), strings.Join(taskTypeKeys, ", ")),
+		})
+	}
+
+	registered, ok := RegisteredTasks[taskTypeKey]
+	if !ok {
+		hint := ""
+		if suggestion := nearestTaskName(taskTypeKey); suggestion != "" {
+			hint = fmt.Sprintf("did you mean %q?", suggestion)
+		}
+		return append(problems, Problem{
+			Code:    "unknown_task_type",
+			Play:    playLabel,
+			Task:    taskLabel,
+			Line:    taskTypeNode.Line,
+			Column:  taskTypeNode.Column,
+			Message: fmt.Sprintf("unknown task type %q", taskTypeKey),
+			Hint:    hint,
+		})
+	}
+
+	problems = append(problems, validateTaskBody(registered, taskTypeKey, taskBodyNode, playLabel, taskLabel)...)
+	return problems
+}
+
+// validateTaskBody decodes the task body into the registered struct, applies
+// defaults, and reports any required:"true" field whose value is still the
+// zero value of its type.
+func validateTaskBody(registered Task, typeName string, body *yaml.Node, playLabel, taskLabel string) []Problem {
+	var problems []Problem
+
+	marshaled, err := yaml.Marshal(body)
+	if err != nil {
+		return append(problems, Problem{
+			Code:    "task_body_decode",
+			Play:    playLabel,
+			Task:    taskLabel,
+			Line:    body.Line,
+			Column:  body.Column,
+			Message: fmt.Sprintf("failed to re-marshal task body: %v", err),
+		})
+	}
+
+	v := reflect.New(reflect.TypeOf(registered).Elem())
+	if err := yaml.Unmarshal(marshaled, v.Interface()); err != nil {
+		return append(problems, Problem{
+			Code:    "task_body_decode",
+			Play:    playLabel,
+			Task:    taskLabel,
+			Line:    body.Line,
+			Column:  body.Column,
+			Message: fmt.Sprintf("failed to decode body to %s: %v", typeName, err),
+		})
+	}
+
+	defaults.SetDefaults(v.Interface())
+
+	elem := v.Elem()
+	t := elem.Type()
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.Tag.Get("required") != "true" {
+			continue
+		}
+		// The placeholder string used for required-no-default inputs at
+		// render time looks like a real value to the field zero-check, so
+		// any field whose only value came from a placeholder substitution
+		// is considered satisfied — the actual missing value will surface
+		// at runtime as a missing CLI flag, which apply already enforces.
+		if !elem.Field(i).IsZero() {
+			continue
+		}
+		yamlName := field.Tag.Get("yaml")
+		if comma := strings.Index(yamlName, ","); comma >= 0 {
+			yamlName = yamlName[:comma]
+		}
+		if yamlName == "" {
+			yamlName = strings.ToLower(field.Name)
+		}
+		problems = append(problems, Problem{
+			Code:    "missing_required_field",
+			Play:    playLabel,
+			Task:    taskLabel,
+			Line:    body.Line,
+			Column:  body.Column,
+			Message: fmt.Sprintf("missing required field %q on %s", yamlName, typeName),
+		})
+	}
+
+	return problems
+}
+
+// renderForValidate runs the recipe through sigil with the given context and
+// returns the rendered bytes. A non-nil Problem return signals a render
+// failure; the caller is responsible for surfacing it.
+func renderForValidate(data []byte, context map[string]interface{}) ([]byte, *Problem) {
+	rendered, err := sigil.Execute(data, context, "tasks.yml")
+	if err != nil {
+		line, col := parseSigilErrorPosition(err.Error())
+		return nil, &Problem{
+			Code:    "template_render",
+			Line:    line,
+			Column:  col,
+			Message: fmt.Sprintf("template render error: %v", err),
+		}
+	}
+	out, err := io.ReadAll(&rendered)
+	if err != nil {
+		return nil, &Problem{
+			Code:    "template_render",
+			Message: fmt.Sprintf("template render read error: %v", err),
+		}
+	}
+	return out, nil
+}
+
+func validateStrictInputs(inputs []inputWithNode, overrides map[string]bool, label string) []Problem {
+	var problems []Problem
+	for _, in := range inputs {
+		if !in.Required {
+			continue
+		}
+		if in.Default != "" {
+			continue
+		}
+		if overrides[in.Name] {
+			continue
+		}
+		problems = append(problems, Problem{
+			Code:    "input_missing",
+			Play:    label,
+			Line:    in.Line,
+			Column:  in.Column,
+			Message: fmt.Sprintf("input %q is required and has no default; pass --%s to override", in.Name, in.Name),
+		})
+	}
+	return problems
+}
+
+// validateBlockStructure is a stub. #211 will populate it with checks that
+// block:/rescue:/always: children are valid task entries.
+func validateBlockStructure(_ *yaml.Node, _ string) []Problem {
+	// TODO(#211): walk block/rescue/always children once they are activated.
+	return nil
+}
+
+// validateExprPredicates is a stub. #205 will populate it with checks that
+// when:/changed_when:/failed_when: and list-form loop: parse as expr.
+func validateExprPredicates(_ *yaml.Node, _ string) []Problem {
+	// TODO(#205): compile expr predicates once envelope-level expr lands.
+	return nil
+}
+
+// validateRegisterReferences is a stub. #210 will populate it with checks
+// that anything referencing .registered.foo has a prior register: foo.
+func validateRegisterReferences(_ *yaml.Node, _ string) []Problem {
+	// TODO(#210): resolve register references once the registry is wired.
+	return nil
+}
+
+// validateTargetReferences is a stub. #205/#208/#212 will populate it with
+// checks that --start-at-task / --play / --tags references actually exist
+// in the file.
+func validateTargetReferences(_ *yaml.Node, _ string) []Problem {
+	// TODO(#205/#208/#212): resolve target references once they exist.
+	return nil
+}
+
+// inputWithNode is the validate-time projection of an Input that also carries
+// the source position of the input's mapping node so strict-mode problems can
+// anchor at the right line.
+type inputWithNode struct {
+	Name     string
+	Default  string
+	Required bool
+	Type     string
+	Line     int
+	Column   int
+}
+
+// extractPlayInputs walks the raw recipe and returns the input definitions
+// for each play (slice index = play index). Inputs do not contain templates,
+// so the source positions on inputWithNode are reliable.
+func extractPlayInputs(recipe *yaml.Node) [][]inputWithNode {
+	plays := make([][]inputWithNode, 0, len(recipe.Content))
+	for _, play := range recipe.Content {
+		if play.Kind != yaml.MappingNode {
+			plays = append(plays, nil)
+			continue
+		}
+		inputsNode := mappingValue(play, "inputs")
+		if inputsNode == nil || inputsNode.Kind != yaml.SequenceNode {
+			plays = append(plays, nil)
+			continue
+		}
+		var inputs []inputWithNode
+		for _, node := range inputsNode.Content {
+			if node.Kind != yaml.MappingNode {
+				continue
+			}
+			in := inputWithNode{Line: node.Line, Column: node.Column}
+			in.Name = scalarChild(node, "name")
+			in.Default = scalarChild(node, "default")
+			in.Type = scalarChild(node, "type")
+			if reqStr := scalarChild(node, "required"); reqStr != "" {
+				if v, err := strconv.ParseBool(reqStr); err == nil {
+					in.Required = v
+				}
+			}
+			inputs = append(inputs, in)
+		}
+		plays = append(plays, inputs)
+	}
+	return plays
+}
+
+// buildSigilContext assembles the variable map sigil renders against. Inputs
+// with a non-empty Default contribute their default value; inputs without a
+// default contribute validatePlaceholder so the render does not error on
+// missing keys. Names collide cleanly across plays since sigil receives a
+// single flat namespace.
+func buildSigilContext(plays [][]inputWithNode) map[string]interface{} {
+	context := map[string]interface{}{}
+	for _, inputs := range plays {
+		for _, in := range inputs {
+			if in.Name == "" {
+				continue
+			}
+			if in.Default != "" {
+				context[in.Name] = in.Default
+			} else if _, ok := context[in.Name]; !ok {
+				context[in.Name] = validatePlaceholder
+			}
+		}
+	}
+	return context
+}
+
+// documentBody returns the inner content node when root is a DocumentNode,
+// or root itself otherwise. nil when the document is empty.
+func documentBody(root *yaml.Node) *yaml.Node {
+	if root == nil || root.Kind == 0 || len(root.Content) == 0 {
+		return nil
+	}
+	if root.Kind == yaml.DocumentNode {
+		return root.Content[0]
+	}
+	return root
+}
+
+// mappingValue returns the value node for the given key in a MappingNode, or
+// nil if absent. Mapping content is laid out as [k1, v1, k2, v2, ...].
+func mappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// scalarChild returns the scalar string at node[key], or "" if the key is
+// absent or the value is not a scalar.
+func scalarChild(node *yaml.Node, key string) string {
+	v := mappingValue(node, key)
+	if v == nil || v.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return v.Value
+}
+
+// nearestTaskName returns the registered task name with the lowest Levenshtein
+// distance to candidate, but only if that distance is at most 2. Returning ""
+// means "no useful suggestion".
+func nearestTaskName(candidate string) string {
+	best := ""
+	bestDist := 3
+	for name := range RegisteredTasks {
+		d := levenshtein(candidate, name)
+		if d < bestDist {
+			bestDist = d
+			best = name
+		}
+	}
+	if bestDist <= 2 {
+		return best
+	}
+	return ""
+}
+
+// levenshtein returns the edit distance between a and b. Small strings only;
+// a 2D allocation is fine.
+func levenshtein(a, b string) int {
+	if a == b {
+		return 0
+	}
+	la, lb := len(a), len(b)
+	if la == 0 {
+		return lb
+	}
+	if lb == 0 {
+		return la
+	}
+	prev := make([]int, lb+1)
+	curr := make([]int, lb+1)
+	for j := 0; j <= lb; j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= la; i++ {
+		curr[0] = i
+		for j := 1; j <= lb; j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min3(prev[j]+1, curr[j-1]+1, prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[lb]
+}
+
+func min3(a, b, c int) int {
+	m := a
+	if b < m {
+		m = b
+	}
+	if c < m {
+		m = c
+	}
+	return m
+}
+
+// yamlPositionRe matches the "line N: ..." style errors yaml.v3 emits. The
+// optional "column M" group is only present in some templates so we capture
+// what we can and leave 0 otherwise.
+var yamlPositionRe = regexp.MustCompile(`line (\d+)(?::|, column (\d+))`)
+
+func parseYAMLErrorPosition(msg string) (int, int) {
+	m := yamlPositionRe.FindStringSubmatch(msg)
+	if m == nil {
+		return 0, 0
+	}
+	line, _ := strconv.Atoi(m[1])
+	col := 0
+	if m[2] != "" {
+		col, _ = strconv.Atoi(m[2])
+	}
+	return line, col
+}
+
+// sigilPositionRe matches the "template: name:LINE:COL" prefix emitted by
+// text/template (which sigil delegates to).
+var sigilPositionRe = regexp.MustCompile(`template:\s*[^:]+:(\d+)(?::(\d+))?`)
+
+func parseSigilErrorPosition(msg string) (int, int) {
+	m := sigilPositionRe.FindStringSubmatch(msg)
+	if m == nil {
+		return 0, 0
+	}
+	line, _ := strconv.Atoi(m[1])
+	col := 0
+	if len(m) > 2 && m[2] != "" {
+		col, _ = strconv.Atoi(m[2])
+	}
+	return line, col
+}

--- a/tasks/validate_integration_test.go
+++ b/tasks/validate_integration_test.go
@@ -1,0 +1,78 @@
+package tasks
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestValidateDoesNotImportSubprocess is an integration-style guard that the
+// validate code path stays offline. It parses validate.go's import block and
+// asserts that the subprocess package is not referenced. If a future change
+// pulls subprocess in (directly or transitively via a helper added to the
+// tasks package), this test fails loudly.
+//
+// This is preferred over a runtime PATH-stripping check because Go's import
+// graph is the ground truth: if subprocess is not in the import set,
+// CallExecCommand cannot be invoked from within Validate.
+func TestValidateDoesNotImportSubprocess(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+	path := filepath.Join(wd, "validate.go")
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+	if err != nil {
+		t.Fatalf("parser.ParseFile: %v", err)
+	}
+
+	for _, imp := range f.Imports {
+		p := strings.Trim(imp.Path.Value, `"`)
+		if strings.HasSuffix(p, "/subprocess") || p == "github.com/dokku/docket/subprocess" {
+			t.Errorf("validate.go must not import subprocess (offline contract); found import %q", p)
+		}
+	}
+}
+
+// TestIntegrationValidateRunsOffline runs Validate against a multi-task
+// fixture with PATH cleared so any accidental call to a `dokku` binary
+// would fail and the validator must continue to succeed. This complements
+// the import-graph guard above by exercising the actual function at
+// runtime.
+func TestIntegrationValidateRunsOffline(t *testing.T) {
+	original := os.Getenv("PATH")
+	if err := os.Setenv("PATH", ""); err != nil {
+		t.Fatalf("os.Setenv: %v", err)
+	}
+	defer os.Setenv("PATH", original)
+
+	data := []byte(`---
+- inputs:
+    - name: app
+      default: docket-validate-offline
+  tasks:
+    - name: create app
+      dokku_app:
+        app: {{ .app | default "" }}
+    - name: set config
+      dokku_config:
+        app: {{ .app | default "" }}
+        restart: false
+        config:
+          KEY: value
+    - name: ensure storage
+      dokku_storage_ensure:
+        app: {{ .app | default "" }}
+        chown: herokuish
+`)
+
+	problems := Validate(data, ValidateOptions{})
+	if len(problems) != 0 {
+		t.Fatalf("expected no problems with empty PATH, got: %+v", problems)
+	}
+}

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -1,0 +1,373 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+
+	_ "github.com/gliderlabs/sigil/builtin"
+)
+
+// findProblem returns the first problem whose Code matches code, or nil.
+func findProblem(problems []Problem, code string) *Problem {
+	for i := range problems {
+		if problems[i].Code == code {
+			return &problems[i]
+		}
+	}
+	return nil
+}
+
+// countProblems returns the number of problems with the given code.
+func countProblems(problems []Problem, code string) int {
+	n := 0
+	for _, p := range problems {
+		if p.Code == code {
+			n++
+		}
+	}
+	return n
+}
+
+func TestValidateValidRecipe(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: create app
+      dokku_app:
+        app: my-app
+`)
+	problems := Validate(data, ValidateOptions{})
+	if len(problems) != 0 {
+		t.Fatalf("expected no problems, got: %+v", problems)
+	}
+}
+
+func TestValidateYAMLParseError(t *testing.T) {
+	// `app: [unclosed` is a non-template parse error so sigil renders fine
+	// and the yaml parser is the one that complains.
+	data := []byte(`---
+- tasks:
+    - dokku_app:
+        app: [unclosed
+`)
+	problems := Validate(data, ValidateOptions{})
+	if p := findProblem(problems, "yaml_parse"); p == nil {
+		t.Fatalf("expected yaml_parse problem, got: %+v", problems)
+	}
+}
+
+func TestValidateRecipeShapeBareScalar(t *testing.T) {
+	data := []byte("foo\n")
+	problems := Validate(data, ValidateOptions{})
+	if p := findProblem(problems, "recipe_shape"); p == nil {
+		t.Fatalf("expected recipe_shape problem, got: %+v", problems)
+	}
+}
+
+func TestValidateTaskEntryShapeNoTaskType(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: nothing-here
+`)
+	problems := Validate(data, ValidateOptions{})
+	if p := findProblem(problems, "task_entry_shape"); p == nil {
+		t.Fatalf("expected task_entry_shape problem, got: %+v", problems)
+	}
+}
+
+func TestValidateTaskEntryShapeMultipleTaskTypes(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - dokku_app:
+        app: a
+      dokku_config:
+        app: a
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "task_entry_shape")
+	if p == nil {
+		t.Fatalf("expected task_entry_shape problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, "exactly one is allowed") {
+		t.Errorf("expected message to mention exactly-one constraint, got: %q", p.Message)
+	}
+}
+
+func TestValidateUnknownTaskTypeWithSuggestion(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - dokku_appp:
+        app: my-app
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "unknown_task_type")
+	if p == nil {
+		t.Fatalf("expected unknown_task_type problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Hint, "dokku_app") {
+		t.Errorf("expected hint to suggest dokku_app, got: %q", p.Hint)
+	}
+	if p.Line == 0 {
+		t.Errorf("expected non-zero line, got: %d", p.Line)
+	}
+}
+
+func TestValidateUnknownTaskTypeNoSuggestion(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - completely_unrelated_task:
+        foo: bar
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "unknown_task_type")
+	if p == nil {
+		t.Fatalf("expected unknown_task_type problem, got: %+v", problems)
+	}
+	if p.Hint != "" {
+		t.Errorf("expected no suggestion, got hint: %q", p.Hint)
+	}
+}
+
+func TestValidateMissingRequiredField(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - dokku_config:
+        restart: false
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "missing_required_field")
+	if p == nil {
+		t.Fatalf("expected missing_required_field problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, `"app"`) {
+		t.Errorf("expected message to mention app, got: %q", p.Message)
+	}
+}
+
+func TestValidateRequiredFieldPresent(t *testing.T) {
+	// The body provides app; defaults fill State; nothing should flag.
+	data := []byte(`---
+- tasks:
+    - dokku_app:
+        app: my-app
+`)
+	problems := Validate(data, ValidateOptions{})
+	if n := countProblems(problems, "missing_required_field"); n != 0 {
+		t.Errorf("expected no missing_required_field problems, got %d: %+v", n, problems)
+	}
+}
+
+func TestValidateSigilRenderBrokenTemplate(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - dokku_app:
+        app: {{ .broken
+`)
+	problems := Validate(data, ValidateOptions{})
+	if p := findProblem(problems, "template_render"); p == nil {
+		t.Fatalf("expected template_render problem, got: %+v", problems)
+	}
+}
+
+func TestValidateSigilRenderWithDefault(t *testing.T) {
+	// `default ""` makes missing keys safe; render must succeed.
+	data := []byte(`---
+- inputs:
+    - name: app
+      default: foo
+  tasks:
+    - dokku_app:
+        app: {{ .app | default "" }}
+`)
+	problems := Validate(data, ValidateOptions{})
+	if len(problems) != 0 {
+		t.Fatalf("expected no problems, got: %+v", problems)
+	}
+}
+
+func TestValidateInputsStrictMissing(t *testing.T) {
+	data := []byte(`---
+- inputs:
+    - name: app
+      required: true
+  tasks:
+    - dokku_app:
+        app: {{ .app | default "" }}
+`)
+	// Without strict: no problems.
+	if problems := Validate(data, ValidateOptions{}); len(problems) != 0 {
+		t.Fatalf("expected no problems without strict, got: %+v", problems)
+	}
+	// With strict: input_missing.
+	problems := Validate(data, ValidateOptions{Strict: true})
+	if p := findProblem(problems, "input_missing"); p == nil {
+		t.Fatalf("expected input_missing problem with strict, got: %+v", problems)
+	}
+}
+
+func TestValidateInputsStrictWithDefault(t *testing.T) {
+	data := []byte(`---
+- inputs:
+    - name: app
+      required: true
+      default: my-app
+  tasks:
+    - dokku_app:
+        app: {{ .app | default "" }}
+`)
+	problems := Validate(data, ValidateOptions{Strict: true})
+	if n := countProblems(problems, "input_missing"); n != 0 {
+		t.Errorf("expected no input_missing with default, got %d: %+v", n, problems)
+	}
+}
+
+func TestValidateInputsStrictWithOverride(t *testing.T) {
+	data := []byte(`---
+- inputs:
+    - name: app
+      required: true
+  tasks:
+    - dokku_app:
+        app: {{ .app | default "" }}
+`)
+	problems := Validate(data, ValidateOptions{
+		Strict:         true,
+		InputOverrides: map[string]bool{"app": true},
+	})
+	if n := countProblems(problems, "input_missing"); n != 0 {
+		t.Errorf("expected no input_missing with override, got %d: %+v", n, problems)
+	}
+}
+
+func TestValidateMultipleProblemsCollected(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - dokku_appp:
+        app: my-app
+    - dokku_config:
+        restart: false
+`)
+	problems := Validate(data, ValidateOptions{})
+	if countProblems(problems, "unknown_task_type") != 1 {
+		t.Errorf("expected exactly one unknown_task_type, got: %+v", problems)
+	}
+	if countProblems(problems, "missing_required_field") < 1 {
+		t.Errorf("expected at least one missing_required_field, got: %+v", problems)
+	}
+}
+
+func TestValidateNearestTaskName(t *testing.T) {
+	tests := []struct {
+		input  string
+		expect string
+	}{
+		{"dokku_appp", "dokku_app"},
+		{"dokku_app", "dokku_app"}, // exact match returns same name
+		{"completely_unrelated", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := nearestTaskName(tt.input)
+			if got != tt.expect {
+				t.Errorf("nearestTaskName(%q) = %q, want %q", tt.input, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestValidateLevenshtein(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"abc", "abc", 0},
+		{"abc", "abd", 1},
+		{"abc", "abcd", 1},
+		{"abc", "", 3},
+		{"", "abc", 3},
+		{"kitten", "sitting", 3},
+	}
+	for _, tt := range tests {
+		got := levenshtein(tt.a, tt.b)
+		if got != tt.want {
+			t.Errorf("levenshtein(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestValidateReservedEnvelopeKeyFlagged(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - dokku_app:
+        app: my-app
+      when: "true"
+`)
+	problems := Validate(data, ValidateOptions{})
+	if p := findProblem(problems, "envelope_key_unsupported"); p == nil {
+		t.Fatalf("expected envelope_key_unsupported problem, got: %+v", problems)
+	}
+}
+
+func TestValidateUnexpectedPlayKey(t *testing.T) {
+	data := []byte(`---
+- foo: bar
+  tasks: []
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "recipe_shape")
+	if p == nil {
+		t.Fatalf("expected recipe_shape problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, `"foo"`) {
+		t.Errorf("expected message to mention foo, got: %q", p.Message)
+	}
+}
+
+func TestValidateLineColumnAnchored(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - dokku_appp:
+        app: my-app
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "unknown_task_type")
+	if p == nil {
+		t.Fatalf("expected unknown_task_type problem")
+	}
+	if p.Line != 3 {
+		t.Errorf("expected Line=3, got %d", p.Line)
+	}
+	if p.Column == 0 {
+		t.Errorf("expected non-zero Column, got %d", p.Column)
+	}
+}
+
+func TestParseYAMLErrorPosition(t *testing.T) {
+	tests := []struct {
+		msg  string
+		line int
+		col  int
+	}{
+		{"yaml: line 5: did not find expected key", 5, 0},
+		{"yaml: line 12, column 7: foo", 12, 7},
+		{"some unrelated error", 0, 0},
+	}
+	for _, tt := range tests {
+		gotLine, gotCol := parseYAMLErrorPosition(tt.msg)
+		if gotLine != tt.line || gotCol != tt.col {
+			t.Errorf("parseYAMLErrorPosition(%q) = (%d, %d), want (%d, %d)", tt.msg, gotLine, gotCol, tt.line, tt.col)
+		}
+	}
+}
+
+func TestParseSigilErrorPosition(t *testing.T) {
+	msg := "template: tasks.yml:5: unclosed action started at tasks.yml:4"
+	line, col := parseSigilErrorPosition(msg)
+	if line != 5 {
+		t.Errorf("expected line 5, got %d", line)
+	}
+	if col != 0 {
+		t.Errorf("expected col 0, got %d", col)
+	}
+}

--- a/tests/bats/validate.bats
+++ b/tests/bats/validate.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  docket_build
+}
+
+@test "docket validate exits 0 on a valid tasks.yml" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_app:
+        app: docket-test-validate
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "is valid"
+}
+
+@test "docket validate exits 1 on unknown task type" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_appp:
+        app: docket-test-validate
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "unknown task type"
+  assert_output --partial "did you mean"
+}
+
+@test "docket validate exits 1 on missing required field" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_config:
+        restart: false
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial 'missing required field "app"'
+}
+
+@test "docket validate exits 1 on broken sigil template" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_app:
+        app: {{ .broken
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "template render error"
+}
+
+@test "docket validate --json emits structured problems" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_appp:
+        app: x
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE" --json
+  assert_failure
+  assert_output --partial '"type":"validate_problem"'
+  assert_output --partial '"code":"unknown_task_type"'
+  assert_output --partial '"version":1'
+}
+
+@test "docket validate --strict flags required input without default" {
+  write_tasks_file <<EOF
+---
+- inputs:
+    - name: app
+      required: true
+  tasks:
+    - dokku_app:
+        app: {{ .app | default "" }}
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_success
+
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE" --strict
+  assert_failure
+  assert_output --partial 'input "app" is required'
+}
+
+@test "docket validate --strict passes when input has CLI override" {
+  write_tasks_file <<EOF
+---
+- inputs:
+    - name: app
+      required: true
+  tasks:
+    - dokku_app:
+        app: {{ .app | default "" }}
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE" --strict --app docket-test
+  assert_success
+  assert_output --partial "is valid"
+}


### PR DESCRIPTION
## Summary

Adds `docket validate`, an offline lint that catches structural problems in `tasks.yml` (typos, missing required fields, broken sigil templates) before `apply` ever contacts the server. Ships the seven shipping checks called out in #199 plus four stub handlers ready for the dependent issues to populate.

Closes #199.

## Approach

- `tasks/validate.go` walks the recipe via `yaml.v3`'s `*yaml.Node` API so every problem can be anchored to a `line:column` in the source file. Sigil runs once first (with an empty context) so template parse errors surface as `template_render` rather than the misleading YAML flow-mapping error the parser would otherwise emit; a second render uses input defaults plus a placeholder for required-no-default inputs to reach the structural walk.
- The `--strict` check compares each play's `required: true` inputs against the resolved CLI argument set, mirroring how `apply` resolves overrides today. `--vars-file` is left for a future PR.
- Unknown task types receive a "did you mean" hint via Levenshtein distance against `tasks.RegisteredTasks`.
- The four placeholder cross-checks (#205, #208, #210, #211, #212) live as empty handler functions with `TODO(#NNN)` comments so future PRs can fill them in without touching the call site.
- An import-graph guard test (`TestValidateDoesNotImportSubprocess`) plus a runtime `PATH=""` test enforce the offline contract.

## Tests

- `tasks/validate_test.go` - 19 unit tests covering each shipping check (passing + failing fixtures), the Levenshtein helper, error-position parsers, and multi-problem collection.
- `tasks/validate_integration_test.go` - import-graph guard + offline runtime check.
- `commands/validate_test.go` - command metadata, FlagSet panic guard, human formatter table tests, JSON event shape.
- `tests/bats/validate.bats` - 7 end-to-end cases against the compiled binary; runs in the existing `bats-test` job (no Dokku install needed since validate is offline).