### PR TITLE
feat: add init subcommand to scaffold a starter tasks.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,30 @@ Run it:
 docket apply
 ```
 
-Running `docket` with no subcommand prints the available commands. Use `docket apply` to execute a task file, `docket plan` to preview the changes a task file would make without mutating any state, `docket validate` to check a task file's schema and templates without contacting the server, or `docket version` to print the binary's version.
+Running `docket` with no subcommand prints the available commands. Use `docket init` to scaffold a starter `tasks.yml`, `docket apply` to execute a task file, `docket plan` to preview the changes a task file would make without mutating any state, `docket validate` to check a task file's schema and templates without contacting the server, or `docket version` to print the binary's version.
+
+### Scaffolding with `init`
+
+`docket init` writes a starter `tasks.yml` from an embedded template. It is offline only: no Dokku server contact, no `git` subprocess. The default scaffold ships four tasks (`dokku_app`, `dokku_config`, `dokku_domains`, `dokku_git_sync`) wrapped in a single play with `app` and `repo` inputs, and round-trips cleanly through `docket validate`.
+
+```shell
+# Use cwd basename as the app and remote.origin.url from ./.git/config as the repo
+docket init
+
+# Stream the rendered YAML to stdout for piping
+docket init --output -
+```
+
+The flags are:
+
+| Flag | Effect |
+|------|--------|
+| (default) | Write `./tasks.yml`; refuse if the file exists |
+| `--output <path>` | Write to a specific path; `-` writes to stdout |
+| `--force` | Overwrite an existing file |
+| `--name <name>` | Override the play and `app` input default (defaults to the cwd basename) |
+| `--repo <url>` | Override the `repo` input default (defaults to `remote.origin.url` in `./.git/config`, if present) |
+| `--minimal` | One-task example with no `inputs:` block |
 
 ### Previewing changes with `plan`
 

--- a/commands/init.go
+++ b/commands/init.go
@@ -1,0 +1,285 @@
+package commands
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/dokku/docket/commands/templates"
+	"github.com/dokku/docket/tasks"
+
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/posener/complete"
+	flag "github.com/spf13/pflag"
+	yaml "gopkg.in/yaml.v3"
+)
+
+// InitCommand scaffolds a starter tasks.yml from an embedded template.
+//
+// init is offline by contract: it never opens a subprocess and never
+// contacts the Dokku server. All defaults are derived from the working
+// directory (cwd basename for --name, ./.git/config for --repo).
+type InitCommand struct {
+	command.Meta
+
+	output  string
+	name    string
+	repo    string
+	force   bool
+	minimal bool
+}
+
+func (c *InitCommand) Name() string {
+	return "init"
+}
+
+func (c *InitCommand) Synopsis() string {
+	return "Scaffolds a starter tasks.yml from an embedded template"
+}
+
+func (c *InitCommand) Help() string {
+	return command.CommandHelp(c)
+}
+
+func (c *InitCommand) Examples() map[string]string {
+	appName := os.Getenv("CLI_APP_NAME")
+	return map[string]string{
+		"Scaffold tasks.yml using cwd defaults": fmt.Sprintf("%s %s", appName, c.Name()),
+		"Write a minimal one-task scaffold":     fmt.Sprintf("%s %s --minimal", appName, c.Name()),
+		"Override the play and app name":        fmt.Sprintf("%s %s --name web", appName, c.Name()),
+		"Override the git repository URL":       fmt.Sprintf("%s %s --repo git@example.com:owner/repo.git", appName, c.Name()),
+		"Write to a specific path":              fmt.Sprintf("%s %s --output path/to/tasks.yml", appName, c.Name()),
+		"Stream the rendered YAML to stdout":    fmt.Sprintf("%s %s --output -", appName, c.Name()),
+		"Overwrite an existing file":            fmt.Sprintf("%s %s --force", appName, c.Name()),
+	}
+}
+
+func (c *InitCommand) Arguments() []command.Argument {
+	return []command.Argument{}
+}
+
+func (c *InitCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *InitCommand) ParsedArguments(args []string) (map[string]command.Argument, error) {
+	return command.ParseArguments(args, c.Arguments())
+}
+
+func (c *InitCommand) FlagSet() *flag.FlagSet {
+	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	f.StringVar(&c.output, "output", "tasks.yml", "path to write the scaffold to; pass - to write to stdout")
+	f.BoolVar(&c.force, "force", false, "overwrite an existing output file")
+	f.BoolVar(&c.minimal, "minimal", false, "emit a minimal one-task scaffold without an inputs block")
+	f.StringVar(&c.name, "name", defaultName(), "play name and default app input value")
+	f.StringVar(&c.repo, "repo", defaultRepo(), "git repository URL used as the default for the repo input")
+	return f
+}
+
+func (c *InitCommand) AutocompleteFlags() complete.Flags {
+	return command.MergeAutocompleteFlags(
+		c.Meta.AutocompleteFlags(command.FlagSetClient),
+		complete.Flags{
+			"--output":  complete.PredictFiles("*.yml"),
+			"--force":   complete.PredictNothing,
+			"--minimal": complete.PredictNothing,
+			"--name":    complete.PredictNothing,
+			"--repo":    complete.PredictNothing,
+		},
+	)
+}
+
+// Run renders the scaffold and writes it. Exit codes:
+//
+//	0 - scaffold written
+//	1 - flag parse error, output file already exists without --force,
+//	    template render error, IO error
+func (c *InitCommand) Run(args []string) int {
+	flags := c.FlagSet()
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(err.Error())
+		c.Ui.Error(command.CommandErrorText(c))
+		return 1
+	}
+
+	toStdout := c.output == "-"
+
+	if !toStdout {
+		if _, err := os.Stat(c.output); err == nil {
+			if !c.force {
+				c.Ui.Error(fmt.Sprintf("file %s already exists; pass --force to overwrite", c.output))
+				return 1
+			}
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			c.Ui.Error(fmt.Sprintf("stat error: %v", err))
+			return 1
+		}
+	}
+
+	rendered, err := renderInit(initOptions{
+		Name:    c.name,
+		Repo:    c.repo,
+		Minimal: c.minimal,
+	})
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	if toStdout {
+		if _, err := os.Stdout.Write(rendered); err != nil {
+			c.Ui.Error(fmt.Sprintf("write error: %v", err))
+			return 1
+		}
+		return 0
+	}
+
+	if err := os.WriteFile(c.output, rendered, 0o644); err != nil {
+		c.Ui.Error(fmt.Sprintf("write error: %v", err))
+		return 1
+	}
+
+	taskCount, err := countTasks(rendered)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("internal error: rendered scaffold did not parse: %v", err))
+		return 1
+	}
+
+	c.Ui.Output(fmt.Sprintf("==> Created %s (%s, 1 play)", c.output, pluralize(taskCount, "task")))
+	c.Ui.Output("")
+	c.Ui.Output("Next steps:")
+	c.Ui.Output(fmt.Sprintf("  $ %s validate          # offline check", appName()))
+	c.Ui.Output(fmt.Sprintf("  $ %s plan              # preview against the server", appName()))
+	c.Ui.Output(fmt.Sprintf("  $ %s apply             # apply", appName()))
+	return 0
+}
+
+// initOptions is the substitution data passed to the embedded templates.
+type initOptions struct {
+	Name    string
+	Repo    string
+	Minimal bool
+}
+
+// renderInit reads the right embedded template, parses it with custom
+// delimiters so sigil syntax in the body survives untouched, and returns
+// the rendered bytes (including the leading `---\n` document marker).
+//
+// Exposed at package scope so unit tests can drive it directly without
+// going through the cli-skeleton UI plumbing.
+func renderInit(opts initOptions) ([]byte, error) {
+	name := strings.TrimSpace(opts.Name)
+	if name == "" {
+		name = "app"
+	}
+
+	templateName := "default.yml.tmpl"
+	if opts.Minimal {
+		templateName = "minimal.yml.tmpl"
+	}
+
+	raw, err := templates.FS.ReadFile(templateName)
+	if err != nil {
+		return nil, fmt.Errorf("read template %s: %w", templateName, err)
+	}
+
+	tmpl, err := template.New(templateName).Delims("<<", ">>").Parse(string(raw))
+	if err != nil {
+		return nil, fmt.Errorf("parse template %s: %w", templateName, err)
+	}
+
+	var body bytes.Buffer
+	if err := tmpl.Execute(&body, struct {
+		Name string
+		Repo string
+	}{Name: name, Repo: opts.Repo}); err != nil {
+		return nil, fmt.Errorf("render template %s: %w", templateName, err)
+	}
+
+	var out bytes.Buffer
+	out.WriteString("---\n")
+	out.Write(body.Bytes())
+	return out.Bytes(), nil
+}
+
+// defaultName returns the basename of the working directory, or "app" if
+// the cwd cannot be derived to a usable name.
+func defaultName() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "app"
+	}
+	base := filepath.Base(cwd)
+	if base == "" || base == "." || base == string(filepath.Separator) {
+		return "app"
+	}
+	return base
+}
+
+// defaultRepo reads ./.git/config and returns the value of the `url` key
+// inside the `[remote "origin"]` section. Returns "" when the file does
+// not exist, when there is no origin section, or on any parse error.
+func defaultRepo() string {
+	f, err := os.Open(".git/config")
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	inOrigin := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			inOrigin = strings.EqualFold(line, `[remote "origin"]`)
+			continue
+		}
+		if !inOrigin {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(key) == "url" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+// countTasks parses rendered YAML and returns the total number of tasks
+// across all plays. Used for the "==> Created tasks.yml (N tasks, 1 play)"
+// summary line.
+func countTasks(data []byte) (int, error) {
+	var recipe tasks.Recipe
+	if err := yaml.Unmarshal(data, &recipe); err != nil {
+		return 0, err
+	}
+	total := 0
+	for _, play := range recipe {
+		total += len(play.Tasks)
+	}
+	return total, nil
+}
+
+func pluralize(n int, word string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, word)
+	}
+	return fmt.Sprintf("%d %ss", n, word)
+}
+
+func appName() string {
+	if name := os.Getenv("CLI_APP_NAME"); name != "" {
+		return name
+	}
+	return "docket"
+}

--- a/commands/init_integration_test.go
+++ b/commands/init_integration_test.go
@@ -1,0 +1,39 @@
+package commands
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestInitDoesNotImportSubprocess is a guard that the init code path stays
+// offline. It parses init.go's import block and asserts that the
+// subprocess package is not referenced. The issue's acceptance criteria
+// state that init must not contact any subprocess; the package import
+// graph is the ground truth.
+func TestInitDoesNotImportSubprocess(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+	path := filepath.Join(wd, "init.go")
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+	if err != nil {
+		t.Fatalf("parser.ParseFile: %v", err)
+	}
+
+	for _, imp := range f.Imports {
+		p := strings.Trim(imp.Path.Value, `"`)
+		if strings.HasSuffix(p, "/subprocess") || p == "github.com/dokku/docket/subprocess" {
+			t.Errorf("init.go must not import subprocess (offline contract); found import %q", p)
+		}
+		if p == "os/exec" {
+			t.Errorf("init.go must not import os/exec (offline contract); found import %q", p)
+		}
+	}
+}

--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -1,0 +1,375 @@
+package commands
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dokku/docket/tasks"
+
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/mitchellh/cli"
+	yaml "gopkg.in/yaml.v3"
+)
+
+func TestInitCommandMetadata(t *testing.T) {
+	c := &InitCommand{}
+	if c.Name() != "init" {
+		t.Errorf("Name = %q, want %q", c.Name(), "init")
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis must not be empty")
+	}
+}
+
+func TestInitCommandExamples(t *testing.T) {
+	c := &InitCommand{}
+	examples := c.Examples()
+	if len(examples) == 0 {
+		t.Fatal("expected at least one example")
+	}
+	for label, example := range examples {
+		if example == "" {
+			t.Errorf("example %q is empty", label)
+		}
+	}
+}
+
+func TestInitCommandHelpDoesNotPanic(t *testing.T) {
+	c := &InitCommand{}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("FlagSet panicked: %v", r)
+		}
+	}()
+	_ = c.FlagSet()
+}
+
+func TestInitRendersDefaultTemplate(t *testing.T) {
+	out, err := renderInit(initOptions{Name: "demo"})
+	if err != nil {
+		t.Fatalf("renderInit: %v", err)
+	}
+	body := string(out)
+	for _, want := range []string{"dokku_app", "dokku_config", "dokku_domains", "dokku_git_sync", "default: demo"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("output missing %q\n%s", want, body)
+		}
+	}
+	// dokku_git_sync is documented as last so build/deploy follows the
+	// app/config/domains setup.
+	idxApp := strings.Index(body, "dokku_app")
+	idxConfig := strings.Index(body, "dokku_config")
+	idxDomains := strings.Index(body, "dokku_domains")
+	idxSync := strings.Index(body, "dokku_git_sync")
+	if !(idxApp < idxConfig && idxConfig < idxDomains && idxDomains < idxSync) {
+		t.Errorf("ordering wrong: app=%d config=%d domains=%d sync=%d", idxApp, idxConfig, idxDomains, idxSync)
+	}
+}
+
+func TestInitRendersMinimalTemplate(t *testing.T) {
+	out, err := renderInit(initOptions{Name: "demo", Minimal: true})
+	if err != nil {
+		t.Fatalf("renderInit: %v", err)
+	}
+	body := string(out)
+	if !strings.Contains(body, "dokku_app") {
+		t.Errorf("minimal output missing dokku_app: %s", body)
+	}
+	for _, unwanted := range []string{"dokku_config", "dokku_domains", "dokku_git_sync", "inputs:"} {
+		if strings.Contains(body, unwanted) {
+			t.Errorf("minimal output unexpectedly contains %q\n%s", unwanted, body)
+		}
+	}
+	// Hard-substituted app value, not a sigil expression.
+	if !strings.Contains(body, "app: demo") {
+		t.Errorf("minimal output missing literal `app: demo` substitution: %s", body)
+	}
+}
+
+func TestInitRefusesToOverwriteWithoutForce(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(path, []byte("preserved\n"), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	c := newTestInitCommand()
+	if exit := c.Run([]string{"--output", path, "--name", "demo"}); exit != 1 {
+		t.Errorf("exit = %d, want 1", exit)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "preserved\n" {
+		t.Errorf("file was overwritten without --force: %q", got)
+	}
+}
+
+func TestInitForceOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(path, []byte("preserved\n"), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	c := newTestInitCommand()
+	if exit := c.Run([]string{"--output", path, "--force", "--name", "demo"}); exit != 0 {
+		t.Errorf("exit = %d, want 0", exit)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(got), "dokku_app") {
+		t.Errorf("file was not overwritten: %q", got)
+	}
+}
+
+func TestInitWritesDefaultTemplateToDisk(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+
+	c := newTestInitCommand()
+	if exit := c.Run([]string{"--output", path, "--name", "demo"}); exit != 0 {
+		t.Errorf("exit = %d, want 0", exit)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(got), "dokku_git_sync") {
+		t.Errorf("file missing dokku_git_sync:\n%s", got)
+	}
+}
+
+func TestInitNameFlagSetsAppDefault(t *testing.T) {
+	out, err := renderInit(initOptions{Name: "billing"})
+	if err != nil {
+		t.Fatalf("renderInit: %v", err)
+	}
+	if !strings.Contains(string(out), "default: billing") {
+		t.Errorf("--name not propagated to app input default:\n%s", out)
+	}
+}
+
+func TestInitRepoFlagSetsRepoDefault(t *testing.T) {
+	out, err := renderInit(initOptions{Name: "demo", Repo: "git@github.com:foo/bar.git"})
+	if err != nil {
+		t.Fatalf("renderInit: %v", err)
+	}
+	body := string(out)
+	if !strings.Contains(body, `default: "git@github.com:foo/bar.git"`) {
+		t.Errorf("--repo not propagated to repo input default:\n%s", body)
+	}
+	if strings.Contains(body, "required: true") {
+		t.Errorf("repo input still marked required despite --repo:\n%s", body)
+	}
+}
+
+func TestInitRepoEmptyKeepsRepoRequired(t *testing.T) {
+	out, err := renderInit(initOptions{Name: "demo"})
+	if err != nil {
+		t.Fatalf("renderInit: %v", err)
+	}
+	body := string(out)
+	if !strings.Contains(body, "required: true") {
+		t.Errorf("empty --repo should keep repo input required:\n%s", body)
+	}
+}
+
+func TestInitDefaultNameFromCwd(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "widget-svc")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Chdir(dir)
+
+	if got := defaultName(); got != "widget-svc" {
+		t.Errorf("defaultName() = %q, want %q", got, "widget-svc")
+	}
+}
+
+func TestInitDefaultRepoFromGitConfig(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfg := "[core]\n" +
+		"\trepositoryformatversion = 0\n" +
+		"[remote \"origin\"]\n" +
+		"\turl = git@example.com:owner/repo.git\n" +
+		"\tfetch = +refs/heads/*:refs/remotes/origin/*\n"
+	if err := os.WriteFile(filepath.Join(dir, ".git", "config"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write git config: %v", err)
+	}
+	t.Chdir(dir)
+
+	if got := defaultRepo(); got != "git@example.com:owner/repo.git" {
+		t.Errorf("defaultRepo() = %q, want git@example.com:owner/repo.git", got)
+	}
+}
+
+func TestInitNoGitConfigYieldsEmptyRepo(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if got := defaultRepo(); got != "" {
+		t.Errorf("defaultRepo() with no .git/config = %q, want empty", got)
+	}
+}
+
+func TestInitGitConfigWithoutOriginYieldsEmptyRepo(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfg := "[core]\n\trepositoryformatversion = 0\n[remote \"upstream\"]\n\turl = git@example.com:upstream/repo.git\n"
+	if err := os.WriteFile(filepath.Join(dir, ".git", "config"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write git config: %v", err)
+	}
+	t.Chdir(dir)
+
+	if got := defaultRepo(); got != "" {
+		t.Errorf("defaultRepo() with no origin = %q, want empty", got)
+	}
+}
+
+func TestInitDefaultPassesValidate(t *testing.T) {
+	out, err := renderInit(initOptions{Name: "demo"})
+	if err != nil {
+		t.Fatalf("renderInit: %v", err)
+	}
+	problems := tasks.Validate(out, tasks.ValidateOptions{})
+	if len(problems) != 0 {
+		t.Fatalf("default scaffold should pass validate, got %+v", problems)
+	}
+
+	out2, err := renderInit(initOptions{Name: "demo", Repo: "git@example.com:foo/bar.git"})
+	if err != nil {
+		t.Fatalf("renderInit: %v", err)
+	}
+	if problems := tasks.Validate(out2, tasks.ValidateOptions{}); len(problems) != 0 {
+		t.Fatalf("default scaffold with --repo should pass validate, got %+v", problems)
+	}
+}
+
+func TestInitMinimalPassesValidate(t *testing.T) {
+	out, err := renderInit(initOptions{Name: "demo", Minimal: true})
+	if err != nil {
+		t.Fatalf("renderInit: %v", err)
+	}
+	if problems := tasks.Validate(out, tasks.ValidateOptions{}); len(problems) != 0 {
+		t.Fatalf("minimal scaffold should pass validate, got %+v", problems)
+	}
+}
+
+func TestInitDefaultParsesAsRecipe(t *testing.T) {
+	out, err := renderInit(initOptions{Name: "api"})
+	if err != nil {
+		t.Fatalf("renderInit: %v", err)
+	}
+	taskList, err := tasks.GetTasks(out, map[string]interface{}{
+		"app":  "api",
+		"repo": "https://example.com/repo.git",
+	})
+	if err != nil {
+		t.Fatalf("tasks.GetTasks: %v", err)
+	}
+	if got := len(taskList.Keys()); got != 4 {
+		t.Errorf("default scaffold = %d tasks, want 4", got)
+	}
+}
+
+func TestInitDefaultRecipeShape(t *testing.T) {
+	out, err := renderInit(initOptions{Name: "billing", Repo: "git@example.com:foo/bar.git"})
+	if err != nil {
+		t.Fatalf("renderInit: %v", err)
+	}
+	var recipe tasks.Recipe
+	if err := yaml.Unmarshal(out, &recipe); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if len(recipe) != 1 {
+		t.Fatalf("recipe has %d plays, want 1", len(recipe))
+	}
+	play := recipe[0]
+	if len(play.Inputs) != 2 {
+		t.Errorf("play has %d inputs, want 2", len(play.Inputs))
+	}
+	var appInput, repoInput *tasks.Input
+	for i := range play.Inputs {
+		switch play.Inputs[i].Name {
+		case "app":
+			appInput = &play.Inputs[i]
+		case "repo":
+			repoInput = &play.Inputs[i]
+		}
+	}
+	if appInput == nil || appInput.Default != "billing" {
+		t.Errorf("app input default = %+v, want billing", appInput)
+	}
+	if repoInput == nil || repoInput.Default != "git@example.com:foo/bar.git" {
+		t.Errorf("repo input default = %+v, want git@example.com:foo/bar.git", repoInput)
+	}
+	if repoInput != nil && repoInput.Required {
+		t.Errorf("repo input should not be required when --repo is set")
+	}
+}
+
+func TestInitOutputDashWritesToStdout(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	origStdout := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = origStdout }()
+
+	c := newTestInitCommand()
+	exitCh := make(chan int, 1)
+	go func() {
+		exitCh <- c.Run([]string{"--output", "-", "--name", "demo"})
+		w.Close()
+	}()
+
+	captured, err := readAllString(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	if exit := <-exitCh; exit != 0 {
+		t.Errorf("exit = %d, want 0", exit)
+	}
+
+	if !strings.HasPrefix(captured, "---\n") {
+		t.Errorf("stdout missing leading ---:\n%s", captured)
+	}
+	if !strings.Contains(captured, "dokku_app") {
+		t.Errorf("stdout missing dokku_app:\n%s", captured)
+	}
+	if strings.Contains(captured, "==> Created") {
+		t.Errorf("stdout contains success block (should be suppressed):\n%s", captured)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "tasks.yml")); err == nil {
+		t.Errorf("--output - should not create tasks.yml on disk")
+	}
+}
+
+// newTestInitCommand wires up a Meta backed by cli.MockUi so c.Ui.* calls
+// don't nil-panic during Run. Tests assert via the file system or stdout
+// capture; MockUi's buffers are ignored.
+func newTestInitCommand() *InitCommand {
+	c := &InitCommand{}
+	c.Meta = command.Meta{Ui: cli.NewMockUi()}
+	return c
+}
+
+func readAllString(r io.Reader) (string, error) {
+	b, err := io.ReadAll(r)
+	return string(b), err
+}

--- a/commands/templates/default.yml.tmpl
+++ b/commands/templates/default.yml.tmpl
@@ -1,0 +1,30 @@
+- inputs:
+    - name: app
+      default: <<.Name>>
+      description: "Application name"
+    - name: repo
+      <<if .Repo>>default: "<<.Repo>>"<<else>>required: true<<end>>
+      description: "Git repository URL"
+  tasks:
+    - name: create app
+      dokku_app:
+        app: "{{ .app }}"
+        state: present
+
+    - name: configure env vars
+      dokku_config:
+        app: "{{ .app }}"
+        config:
+          APP_ENV: production
+          LOG_LEVEL: info
+
+    - name: configure domains
+      dokku_domains:
+        app: "{{ .app }}"
+        domains: ["{{ .app }}.example.com"]
+        state: set
+
+    - name: sync git repository
+      dokku_git_sync:
+        app: "{{ .app }}"
+        remote: "{{ .repo }}"

--- a/commands/templates/minimal.yml.tmpl
+++ b/commands/templates/minimal.yml.tmpl
@@ -1,0 +1,5 @@
+- tasks:
+    - name: create app
+      dokku_app:
+        app: <<.Name>>
+        state: present

--- a/commands/templates/templates.go
+++ b/commands/templates/templates.go
@@ -1,0 +1,11 @@
+// Package templates ships the embedded scaffolds used by `docket init`.
+//
+// The init command reads these files from the embedded FS, renders them
+// through text/template (with custom delimiters so sigil syntax in the
+// body is preserved), and writes the result to disk.
+package templates
+
+import "embed"
+
+//go:embed *.yml.tmpl
+var FS embed.FS

--- a/main.go
+++ b/main.go
@@ -41,6 +41,9 @@ func Commands(ctx context.Context, meta command.Meta) map[string]cli.CommandFact
 		"apply": func() (cli.Command, error) {
 			return &commands.ApplyCommand{Meta: meta}, nil
 		},
+		"init": func() (cli.Command, error) {
+			return &commands.InitCommand{Meta: meta}, nil
+		},
 		"plan": func() (cli.Command, error) {
 			return &commands.PlanCommand{Meta: meta}, nil
 		},

--- a/tests/bats/init.bats
+++ b/tests/bats/init.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  docket_build
+}
+
+@test "docket init writes tasks.yml" {
+  cd "$BATS_TEST_TMPDIR"
+  run "$(docket_bin)" init
+  assert_success
+  assert [ -f tasks.yml ]
+  assert_output --partial "Created tasks.yml"
+}
+
+@test "docket init refuses to overwrite without --force" {
+  cd "$BATS_TEST_TMPDIR"
+  echo "preserved" >tasks.yml
+  run "$(docket_bin)" init
+  assert_failure
+  assert_output --partial "already exists"
+  run cat tasks.yml
+  assert_output "preserved"
+}
+
+@test "docket init --force overwrites" {
+  cd "$BATS_TEST_TMPDIR"
+  echo "preserved" >tasks.yml
+  run "$(docket_bin)" init --force
+  assert_success
+  run cat tasks.yml
+  refute_output "preserved"
+  assert_output --partial "dokku_app"
+}
+
+@test "docket init --name uses the supplied name" {
+  cd "$BATS_TEST_TMPDIR"
+  run "$(docket_bin)" init --name billing
+  assert_success
+  run cat tasks.yml
+  assert_output --partial "default: billing"
+}
+
+@test "docket init --repo uses the supplied url" {
+  cd "$BATS_TEST_TMPDIR"
+  run "$(docket_bin)" init --repo "git@example.com:foo/bar.git"
+  assert_success
+  run cat tasks.yml
+  assert_output --partial 'default: "git@example.com:foo/bar.git"'
+  refute_output --partial "required: true"
+}
+
+@test "docket init defaults the play name to the cwd basename" {
+  mkdir -p "$BATS_TEST_TMPDIR/widget-svc"
+  cd "$BATS_TEST_TMPDIR/widget-svc"
+  run "$(docket_bin)" init
+  assert_success
+  run cat tasks.yml
+  assert_output --partial "default: widget-svc"
+}
+
+@test "docket init picks up remote.origin.url from .git/config" {
+  cd "$BATS_TEST_TMPDIR"
+  mkdir -p .git
+  cat >.git/config <<CFG
+[core]
+	repositoryformatversion = 0
+[remote "origin"]
+	url = git@example.com:owner/repo.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+CFG
+  run "$(docket_bin)" init
+  assert_success
+  run cat tasks.yml
+  assert_output --partial 'default: "git@example.com:owner/repo.git"'
+}
+
+@test "docket init --output - writes to stdout and creates no file" {
+  cd "$BATS_TEST_TMPDIR"
+  run "$(docket_bin)" init --output -
+  assert_success
+  assert_output --partial "dokku_app"
+  refute_output --partial "Created"
+  assert [ ! -f tasks.yml ]
+}
+
+@test "docket init output validates" {
+  cd "$BATS_TEST_TMPDIR"
+  "$(docket_bin)" init
+  run "$(docket_bin)" validate
+  assert_success
+  assert_output --partial "is valid"
+}
+
+@test "docket init --minimal writes minimal scaffold" {
+  cd "$BATS_TEST_TMPDIR"
+  run "$(docket_bin)" init --minimal
+  assert_success
+  run cat tasks.yml
+  assert_output --partial "dokku_app"
+  refute_output --partial "dokku_git_sync"
+  refute_output --partial "inputs:"
+}


### PR DESCRIPTION
## Summary

`docket init` writes an embedded scaffold to `tasks.yml`, lowering the
bar between "I installed the binary" and "here is a working `tasks.yml`."
The scaffold ships four tasks (`dokku_app`, `dokku_config`,
`dokku_domains`, `dokku_git_sync`) and round-trips cleanly through
`docket validate`.

Defaults are derived from the working directory: the play's `app` input
default is the cwd basename, and the `repo` input default is harvested
from `remote.origin.url` in `./.git/config` when present (a pure file
read, no `git` subprocess). `--name` and `--repo` override either.

`--output -` streams the rendered YAML to stdout for piping; `--minimal`
emits a one-task scaffold with no `inputs:` block; `--force` overwrites
an existing file.

Closes #200.