### PR TITLE
feat: add fmt subcommand for canonical tasks.yml formatting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: run unit tests
-        run: go test -v -count=1 . ./tasks/ ./subprocess/
+        run: go test -v -count=1 . ./commands/ ./tasks/ ./subprocess/
 
   integration-test:
     name: integration-test

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Run it:
 docket apply
 ```
 
-Running `docket` with no subcommand prints the available commands. Use `docket init` to scaffold a starter `tasks.yml`, `docket apply` to execute a task file, `docket plan` to preview the changes a task file would make without mutating any state, `docket validate` to check a task file's schema and templates without contacting the server, or `docket version` to print the binary's version.
+Running `docket` with no subcommand prints the available commands. Use `docket init` to scaffold a starter `tasks.yml`, `docket apply` to execute a task file, `docket fmt` to canonically format a task file, `docket plan` to preview the changes a task file would make without mutating any state, `docket validate` to check a task file's schema and templates without contacting the server, or `docket version` to print the binary's version.
 
 ### Scaffolding with `init`
 
@@ -61,6 +61,36 @@ The flags are:
 | `--name <name>` | Override the play and `app` input default (defaults to the cwd basename) |
 | `--repo <url>` | Override the `repo` input default (defaults to `remote.origin.url` in `./.git/config`, if present) |
 | `--minimal` | One-task example with no `inputs:` block |
+
+### Formatting recipes with `fmt`
+
+`docket fmt` is a canonical formatter for `tasks.yml`, in the spirit of `gofmt`. It parses with `gopkg.in/yaml.v3`'s `Node` API so head, line, and foot comments round-trip; reorders task envelope and play keys into a stable order; normalises indentation to a 2-space step; and inserts blank lines between top-level plays and between top-level task entries. The default rewrites `./tasks.yml` in place; `--check` and `--diff` are read-only modes. The CLI flags compose, modeled after `black` / `ruff format`.
+
+```shell
+# Rewrite ./tasks.yml in place.
+docket fmt
+
+# CI gate: print the diff and exit 1 if anything is not canonical.
+docket fmt --check --diff
+
+# Read from stdin, write canonical to stdout.
+cat tasks.yml | docket fmt -
+```
+
+The flags are:
+
+| Flag | Effect |
+|------|--------|
+| (default) | Format `./tasks.yml` in place; no-op (mtime preserved) when already canonical |
+| `--check` | Exit 1 if any file is not canonical; no writes. Composes with `--diff` |
+| `--diff` | Print a GNU unified diff against canonical; no writes. Composes with `--check` |
+| `--color <when>` | When to colorize the diff: `auto` (default; on if stdout is a TTY and `NO_COLOR` is unset), `always`, `never` |
+| `-` | Read from stdin, write canonical to stdout |
+| `<path...>` | Format the named files; each argument is expanded as a glob and rewritten in place |
+
+The diff output is GNU unified diff with `--- <path>` / `+++ <path>` / `@@` headers and is consumable by `git apply` and `patch -p0` once colors are stripped.
+
+Before writing, `fmt` re-parses its canonical output and aborts if the round-tripped AST does not match the input AST - a guard against `yaml.v3` emitter edge cases (notably anchors and complex flow scalars). On a parse error or round-trip mismatch the file is not touched and `fmt` exits 1.
 
 ### Previewing changes with `plan`
 

--- a/commands/fmt.go
+++ b/commands/fmt.go
@@ -1,0 +1,344 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/dokku/docket/tasks"
+
+	udiff "github.com/aymanbagabas/go-udiff"
+	"github.com/fatih/color"
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/mattn/go-isatty"
+	"github.com/posener/complete"
+	flag "github.com/spf13/pflag"
+)
+
+// FmtCommand canonicalises tasks.yml files in place. CLI semantics are
+// modeled after black / ruff format: --check controls exit-code-on-
+// mismatch, --diff controls whether the unified diff is printed, the
+// two flags compose. Default (no flags) writes each file in place.
+//
+// fmt is offline by contract: it never opens a subprocess and never
+// contacts the Dokku server.
+type FmtCommand struct {
+	command.Meta
+
+	check bool
+	diff  bool
+	color string
+}
+
+func (c *FmtCommand) Name() string {
+	return "fmt"
+}
+
+func (c *FmtCommand) Synopsis() string {
+	return "Formats a tasks.yml file canonically"
+}
+
+func (c *FmtCommand) Help() string {
+	return command.CommandHelp(c)
+}
+
+func (c *FmtCommand) Examples() map[string]string {
+	appName := os.Getenv("CLI_APP_NAME")
+	return map[string]string{
+		"Format ./tasks.yml in place":         fmt.Sprintf("%s %s", appName, c.Name()),
+		"Check whether files are canonical":   fmt.Sprintf("%s %s --check", appName, c.Name()),
+		"Print the diff without writing":      fmt.Sprintf("%s %s --diff", appName, c.Name()),
+		"CI gate: print diff and fail on bad": fmt.Sprintf("%s %s --check --diff", appName, c.Name()),
+		"Read from stdin, write to stdout":    fmt.Sprintf("cat tasks.yml | %s %s -", appName, c.Name()),
+		"Format every yaml under recipes/":    fmt.Sprintf("%s %s 'recipes/*.yml'", appName, c.Name()),
+		"Force colorized diff in a pipe":      fmt.Sprintf("%s %s --diff --color always", appName, c.Name()),
+	}
+}
+
+func (c *FmtCommand) Arguments() []command.Argument {
+	return []command.Argument{}
+}
+
+func (c *FmtCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictFiles("*.yml")
+}
+
+func (c *FmtCommand) ParsedArguments(args []string) (map[string]command.Argument, error) {
+	return command.ParseArguments(args, c.Arguments())
+}
+
+func (c *FmtCommand) FlagSet() *flag.FlagSet {
+	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
+	f.BoolVar(&c.check, "check", false, "exit non-zero if any file is not canonically formatted; do not write")
+	f.BoolVar(&c.diff, "diff", false, "print a unified diff for any file that is not canonically formatted; do not write")
+	f.StringVar(&c.color, "color", "auto", "when to colorize diff output: auto, always, never")
+	return f
+}
+
+func (c *FmtCommand) AutocompleteFlags() complete.Flags {
+	return command.MergeAutocompleteFlags(
+		c.Meta.AutocompleteFlags(command.FlagSetClient),
+		complete.Flags{
+			"--check": complete.PredictNothing,
+			"--diff":  complete.PredictNothing,
+			"--color": complete.PredictSet("auto", "always", "never"),
+		},
+	)
+}
+
+// Run executes fmt against the resolved file list and reports per-file
+// outcomes. Exit codes:
+//
+//	0 - every file is canonical (or was successfully formatted in place)
+//	1 - flag parse error, IO error, parse / round-trip failure, or
+//	    --check mismatch on at least one file
+func (c *FmtCommand) Run(args []string) int {
+	flags := c.FlagSet()
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	if err := flags.Parse(args); err != nil {
+		c.Ui.Error(err.Error())
+		c.Ui.Error(command.CommandErrorText(c))
+		return 1
+	}
+
+	if err := applyColorMode(c.color); err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	positional := flags.Args()
+	if len(positional) == 1 && positional[0] == "-" {
+		return c.runStdin()
+	}
+
+	paths, err := expandPaths(positional)
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	exit := 0
+	for _, path := range paths {
+		if status := c.formatPath(path); status > exit {
+			exit = status
+		}
+	}
+	return exit
+}
+
+// runStdin reads stdin, formats it, and writes the result to stdout in
+// the default mode. With --diff the diff goes to stdout; with --check
+// the exit code reflects whether the input was canonical.
+func (c *FmtCommand) runStdin() int {
+	src, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("read stdin: %v", err))
+		return 1
+	}
+	formatted, err := tasks.Format(src)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("format error: %v", err))
+		return 1
+	}
+
+	changed := !bytesEqual(src, formatted)
+
+	if c.diff && changed {
+		_, _ = os.Stdout.WriteString(renderDiff("<stdin>", string(src), string(formatted)))
+	}
+
+	if c.check {
+		if changed {
+			c.Ui.Error("[error]   stdin is not canonically formatted")
+			return 1
+		}
+		return 0
+	}
+
+	if c.diff {
+		// --diff alone: never write, even on stdin.
+		return 0
+	}
+
+	if _, err := os.Stdout.Write(formatted); err != nil {
+		c.Ui.Error(fmt.Sprintf("write stdout: %v", err))
+		return 1
+	}
+	return 0
+}
+
+// formatPath formats a single file. Returns 0 on success, 1 on any
+// error or --check mismatch. Errors are reported via c.Ui and the
+// caller picks the worst-of exit code across all paths.
+func (c *FmtCommand) formatPath(path string) int {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("read %s: %v", path, err))
+		return 1
+	}
+
+	formatted, err := tasks.Format(src)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("%s: %v", path, err))
+		return 1
+	}
+
+	changed := !bytesEqual(src, formatted)
+
+	if c.diff && changed {
+		_, _ = os.Stdout.WriteString(renderDiff(path, string(src), string(formatted)))
+	}
+
+	if c.check {
+		if changed {
+			c.Ui.Error(fmt.Sprintf("[error]   %s is not canonically formatted", path))
+			c.Ui.Error(fmt.Sprintf("          run: %s fmt %s", appName(), path))
+			return 1
+		}
+		return 0
+	}
+
+	if c.diff {
+		return 0
+	}
+
+	if !changed {
+		// no-op preservation: leave the file untouched so mtime
+		// stays clean for make / file-watchers.
+		return 0
+	}
+
+	if err := os.WriteFile(path, formatted, 0o644); err != nil {
+		c.Ui.Error(fmt.Sprintf("write %s: %v", path, err))
+		return 1
+	}
+	c.Ui.Output(fmt.Sprintf("==> Formatted %s", path))
+	return 0
+}
+
+// expandPaths resolves the positional arguments to a sorted, deduped
+// list of file paths. An empty argument list expands to "tasks.yml".
+// Each argument is passed through filepath.Glob; literal paths that
+// do not match the glob syntax flow through unchanged.
+func expandPaths(args []string) ([]string, error) {
+	if len(args) == 0 {
+		return []string{"tasks.yml"}, nil
+	}
+
+	seen := map[string]bool{}
+	var paths []string
+	for _, arg := range args {
+		matches, err := filepath.Glob(arg)
+		if err != nil {
+			return nil, fmt.Errorf("invalid glob %q: %w", arg, err)
+		}
+		if len(matches) == 0 {
+			// A literal path with no glob metacharacters that does
+			// not exist still flows through to the read step so
+			// the user gets a clean "no such file" error.
+			matches = []string{arg}
+		}
+		for _, m := range matches {
+			if !seen[m] {
+				seen[m] = true
+				paths = append(paths, m)
+			}
+		}
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+// applyColorMode resolves the --color flag value into the global
+// fatih/color state. auto delegates to the library's TTY / NO_COLOR
+// detection; always forces colors on; never forces colors off.
+func applyColorMode(mode string) error {
+	switch mode {
+	case "auto":
+		// Default behaviour: respect TTY and NO_COLOR. fatih/color
+		// already does this when color.NoColor is left at its
+		// package-default value. Re-derive the default explicitly
+		// so a previous --color always/never invocation in the same
+		// process (i.e. tests) does not leak state.
+		color.NoColor = noColorDefault()
+	case "always":
+		color.NoColor = false
+	case "never":
+		color.NoColor = true
+	default:
+		return fmt.Errorf("invalid --color value %q (allowed: auto, always, never)", mode)
+	}
+	return nil
+}
+
+// noColorDefault matches fatih/color's own default detection: colors
+// on when stdout is a terminal AND NO_COLOR is unset.
+func noColorDefault() bool {
+	if _, ok := os.LookupEnv("NO_COLOR"); ok {
+		return true
+	}
+	return !isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd())
+}
+
+// renderDiff produces a colorized GNU unified diff between original
+// and formatted with file path on both header lines (no a/ b/ prefix,
+// matching gofmt / black). The output round-trips through patch -p0
+// once colors are stripped.
+func renderDiff(path, original, formatted string) string {
+	raw, err := udiff.ToUnified(path, path, original, udiff.Strings(original, formatted), udiff.DefaultContextLines)
+	if err != nil {
+		return fmt.Sprintf("[error]   diff failed for %s: %v\n", path, err)
+	}
+	if raw == "" {
+		return ""
+	}
+	return colorizeDiff(raw)
+}
+
+var (
+	diffRemoveLine = color.New(color.FgRed)
+	diffAddLine    = color.New(color.FgGreen)
+	diffHunk       = color.New(color.FgCyan)
+	diffFileHeader = color.New(color.Bold)
+)
+
+// colorizeDiff walks the unified diff output line by line and applies
+// ANSI colors. fatih/color is a no-op when color.NoColor is true (set
+// by --color never, NO_COLOR, or non-TTY auto), so the same code
+// produces plain output in CI / pipes.
+func colorizeDiff(raw string) string {
+	var b strings.Builder
+	for _, line := range strings.SplitAfter(raw, "\n") {
+		if line == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "--- ") || strings.HasPrefix(line, "+++ "):
+			b.WriteString(diffFileHeader.Sprint(line))
+		case strings.HasPrefix(line, "@@"):
+			b.WriteString(diffHunk.Sprint(line))
+		case strings.HasPrefix(line, "-"):
+			b.WriteString(diffRemoveLine.Sprint(line))
+		case strings.HasPrefix(line, "+"):
+			b.WriteString(diffAddLine.Sprint(line))
+		default:
+			b.WriteString(line)
+		}
+	}
+	return b.String()
+}
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/commands/fmt_integration_test.go
+++ b/commands/fmt_integration_test.go
@@ -1,0 +1,39 @@
+package commands
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestFmtDoesNotImportSubprocess is a guard that the fmt code path stays
+// offline. It parses fmt.go's import block and asserts that the
+// subprocess package is not referenced. The issue's acceptance criteria
+// state that fmt must not contact any subprocess; the package import
+// graph is the ground truth.
+func TestFmtDoesNotImportSubprocess(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+	path := filepath.Join(wd, "fmt.go")
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+	if err != nil {
+		t.Fatalf("parser.ParseFile: %v", err)
+	}
+
+	for _, imp := range f.Imports {
+		p := strings.Trim(imp.Path.Value, `"`)
+		if strings.HasSuffix(p, "/subprocess") || p == "github.com/dokku/docket/subprocess" {
+			t.Errorf("fmt.go must not import subprocess (offline contract); found import %q", p)
+		}
+		if p == "os/exec" {
+			t.Errorf("fmt.go must not import os/exec (offline contract); found import %q", p)
+		}
+	}
+}

--- a/commands/fmt_test.go
+++ b/commands/fmt_test.go
@@ -1,0 +1,395 @@
+package commands
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/mitchellh/cli"
+)
+
+const messyTasksYAML = `---
+- tasks:
+        - dokku_app:
+              app: web
+          name: configure web
+`
+
+const canonicalTasksYAML = `---
+- tasks:
+    - name: configure web
+      dokku_app:
+        app: web
+`
+
+func TestFmtCommandMetadata(t *testing.T) {
+	c := &FmtCommand{}
+	if c.Name() != "fmt" {
+		t.Errorf("Name = %q, want %q", c.Name(), "fmt")
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis must not be empty")
+	}
+}
+
+func TestFmtCommandExamples(t *testing.T) {
+	c := &FmtCommand{}
+	examples := c.Examples()
+	if len(examples) == 0 {
+		t.Fatal("expected at least one example")
+	}
+	for label, example := range examples {
+		if example == "" {
+			t.Errorf("example %q is empty", label)
+		}
+	}
+}
+
+func TestFmtCommandHelpDoesNotPanic(t *testing.T) {
+	c := &FmtCommand{}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("FlagSet panicked: %v", r)
+		}
+	}()
+	_ = c.FlagSet()
+}
+
+func TestFmtRewritesNonCanonicalInPlace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(path, []byte(messyTasksYAML), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	c := newTestFmtCommand()
+	if exit := c.Run([]string{path}); exit != 0 {
+		t.Errorf("exit = %d, want 0", exit)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != canonicalTasksYAML {
+		t.Errorf("file not canonicalised:\n%s", got)
+	}
+}
+
+func TestFmtNoOpPreservesMtime(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(path, []byte(canonicalTasksYAML), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	// Backdate so a no-op write would produce a clearly different mtime.
+	older := time.Now().Add(-1 * time.Hour)
+	if err := os.Chtimes(path, older, older); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat before: %v", err)
+	}
+
+	c := newTestFmtCommand()
+	if exit := c.Run([]string{path}); exit != 0 {
+		t.Errorf("exit = %d, want 0", exit)
+	}
+
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Errorf("mtime should be preserved on no-op format; before=%v after=%v", before.ModTime(), after.ModTime())
+	}
+}
+
+func TestFmtCheckExitsNonZeroOnNonCanonical(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(path, []byte(messyTasksYAML), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	c := newTestFmtCommand()
+	if exit := c.Run([]string{"--check", path}); exit != 1 {
+		t.Errorf("exit = %d, want 1", exit)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != messyTasksYAML {
+		t.Error("--check must not write")
+	}
+}
+
+func TestFmtCheckExitsZeroOnCanonical(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(path, []byte(canonicalTasksYAML), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	c := newTestFmtCommand()
+	if exit := c.Run([]string{"--check", path}); exit != 0 {
+		t.Errorf("exit = %d, want 0", exit)
+	}
+}
+
+func TestFmtCheckAloneEmitsNoDiff(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(path, []byte(messyTasksYAML), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	captured, exit := captureStdout(t, func() int {
+		c := newTestFmtCommand()
+		return c.Run([]string{"--check", "--color", "never", path})
+	})
+	if exit != 1 {
+		t.Errorf("exit = %d, want 1", exit)
+	}
+	if strings.Contains(captured, "@@") || strings.Contains(captured, "+++") {
+		t.Errorf("--check alone should not emit a unified diff body:\n%s", captured)
+	}
+}
+
+func TestFmtDiffPrintsDiffAndDoesNotWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(path, []byte(messyTasksYAML), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	captured, exit := captureStdout(t, func() int {
+		c := newTestFmtCommand()
+		return c.Run([]string{"--diff", "--color", "never", path})
+	})
+	if exit != 0 {
+		t.Errorf("exit = %d, want 0 for --diff alone on mismatch", exit)
+	}
+	for _, want := range []string{"--- " + path, "+++ " + path, "@@", "-              app: web", "+        app: web"} {
+		if !strings.Contains(captured, want) {
+			t.Errorf("diff output missing %q:\n%s", want, captured)
+		}
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != messyTasksYAML {
+		t.Error("--diff must not write")
+	}
+}
+
+func TestFmtCheckDiffComposes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(path, []byte(messyTasksYAML), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	captured, exit := captureStdout(t, func() int {
+		c := newTestFmtCommand()
+		return c.Run([]string{"--check", "--diff", "--color", "never", path})
+	})
+	if exit != 1 {
+		t.Errorf("exit = %d, want 1 for --check --diff on mismatch", exit)
+	}
+	if !strings.Contains(captured, "@@") {
+		t.Errorf("--check --diff should emit hunk headers:\n%s", captured)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != messyTasksYAML {
+		t.Error("--check --diff must not write")
+	}
+}
+
+func TestFmtColorNeverProducesPlainOutput(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(path, []byte(messyTasksYAML), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	captured, _ := captureStdout(t, func() int {
+		c := newTestFmtCommand()
+		return c.Run([]string{"--diff", "--color", "never", path})
+	})
+	if strings.Contains(captured, "\x1b[") {
+		t.Errorf("--color never should suppress ANSI escapes:\n%q", captured)
+	}
+}
+
+func TestFmtColorAlwaysProducesAnsiEvenInPipe(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(path, []byte(messyTasksYAML), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	captured, _ := captureStdout(t, func() int {
+		c := newTestFmtCommand()
+		return c.Run([]string{"--diff", "--color", "always", path})
+	})
+	if !strings.Contains(captured, "\x1b[") {
+		t.Errorf("--color always should force ANSI escapes:\n%q", captured)
+	}
+	// Restore default so other tests are not affected.
+	color.NoColor = true
+}
+
+func TestFmtColorInvalidValueFails(t *testing.T) {
+	c := newTestFmtCommand()
+	if exit := c.Run([]string{"--color", "rainbow", "tasks.yml"}); exit != 1 {
+		t.Errorf("invalid --color exit = %d, want 1", exit)
+	}
+}
+
+func TestFmtStdinReadsAndWritesStdout(t *testing.T) {
+	captured, exit := withStdinAndStdout(t, messyTasksYAML, func() int {
+		c := newTestFmtCommand()
+		return c.Run([]string{"-"})
+	})
+	if exit != 0 {
+		t.Errorf("exit = %d, want 0", exit)
+	}
+	if captured != canonicalTasksYAML {
+		t.Errorf("stdin->stdout output mismatch:\nwant:\n%s\ngot:\n%s", canonicalTasksYAML, captured)
+	}
+}
+
+func TestFmtGlobExpandsMatches(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"a.yml", "b.yml", "c.yaml"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(messyTasksYAML), 0o644); err != nil {
+			t.Fatalf("seed write: %v", err)
+		}
+	}
+
+	c := newTestFmtCommand()
+	if exit := c.Run([]string{filepath.Join(dir, "*.yml")}); exit != 0 {
+		t.Errorf("exit = %d, want 0", exit)
+	}
+	for _, name := range []string{"a.yml", "b.yml"} {
+		got, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if string(got) != canonicalTasksYAML {
+			t.Errorf("%s not canonicalised:\n%s", name, got)
+		}
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "c.yaml"))
+	if err != nil {
+		t.Fatalf("read c.yaml: %v", err)
+	}
+	if string(got) != messyTasksYAML {
+		t.Error("*.yml glob must not match c.yaml")
+	}
+}
+
+func TestFmtMultiFilePerFileErrorsDoNotAbort(t *testing.T) {
+	dir := t.TempDir()
+	good := filepath.Join(dir, "good.yml")
+	bad := filepath.Join(dir, "missing.yml")
+	if err := os.WriteFile(good, []byte(messyTasksYAML), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	c := newTestFmtCommand()
+	exit := c.Run([]string{bad, good})
+	if exit != 1 {
+		t.Errorf("exit = %d, want 1 (worst-of)", exit)
+	}
+	got, err := os.ReadFile(good)
+	if err != nil {
+		t.Fatalf("read good: %v", err)
+	}
+	if string(got) != canonicalTasksYAML {
+		t.Errorf("good.yml should still be formatted despite missing.yml error:\n%s", got)
+	}
+}
+
+func TestFmtParseErrorReturnsExit1(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(path, []byte("- a: [b\n"), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	c := newTestFmtCommand()
+	exit := c.Run([]string{path})
+	if exit != 1 {
+		t.Errorf("exit = %d, want 1", exit)
+	}
+}
+
+// newTestFmtCommand wires up a Meta backed by cli.MockUi so c.Ui.* calls
+// don't nil-panic during Run. Tests assert via the file system or
+// captured stdout; the MockUi error/output buffers are inspected only
+// when needed.
+func newTestFmtCommand() *FmtCommand {
+	c := &FmtCommand{}
+	c.Meta = command.Meta{Ui: cli.NewMockUi()}
+	return c
+}
+
+// captureStdout swaps os.Stdout for a pipe, runs fn, and returns the
+// captured output. Used to assert on diff output.
+func captureStdout(t *testing.T, fn func() int) (string, int) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	origStdout := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	exitCh := make(chan int, 1)
+	go func() {
+		exit := fn()
+		w.Close()
+		exitCh <- exit
+	}()
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	return buf.String(), <-exitCh
+}
+
+// withStdinAndStdout pipes the given input to os.Stdin and captures
+// os.Stdout while fn runs. Returns the captured stdout.
+func withStdinAndStdout(t *testing.T, input string, fn func() int) (string, int) {
+	t.Helper()
+
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	origStdin := os.Stdin
+	os.Stdin = stdinR
+	t.Cleanup(func() { os.Stdin = origStdin })
+
+	go func() {
+		_, _ = stdinW.WriteString(input)
+		stdinW.Close()
+	}()
+
+	return captureStdout(t, fn)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,12 @@ go 1.25.0
 
 require (
 	github.com/alexellis/go-execute/v2 v2.2.1
+	github.com/aymanbagabas/go-udiff v0.4.1
 	github.com/fatih/color v1.19.0
 	github.com/gliderlabs/sigil v0.12.0
 	github.com/gobuffalo/flect v1.0.3
 	github.com/josegonzalez/cli-skeleton v0.23.0
+	github.com/mattn/go-isatty v0.0.20
 	github.com/mcuadros/go-defaults v1.2.0
 	github.com/mitchellh/cli v1.1.5
 	github.com/posener/complete v1.2.3
@@ -32,7 +34,6 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mgood/go-posix v0.0.0-20150821180505-948c005421f5 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/alexellis/go-execute/v2 v2.2.1/go.mod h1:FMdRnUTiFAmYXcv23txrp3VYZfLo
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ12Gv5o=
+github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=

--- a/main.go
+++ b/main.go
@@ -41,6 +41,9 @@ func Commands(ctx context.Context, meta command.Meta) map[string]cli.CommandFact
 		"apply": func() (cli.Command, error) {
 			return &commands.ApplyCommand{Meta: meta}, nil
 		},
+		"fmt": func() (cli.Command, error) {
+			return &commands.FmtCommand{Meta: meta}, nil
+		},
 		"init": func() (cli.Command, error) {
 			return &commands.InitCommand{Meta: meta}, nil
 		},

--- a/tasks/format.go
+++ b/tasks/format.go
@@ -1,0 +1,391 @@
+package tasks
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// canonicalPlayKeys is the canonical key order inside a play mapping.
+// Keys not in this list keep their relative order, appended after the
+// canonical keys.
+var canonicalPlayKeys = []string{"name", "tags", "when", "inputs", "tasks"}
+
+// canonicalEnvelopeKeys is the canonical key order inside a task entry's
+// envelope. The task-type key (e.g. dokku_app) sorts after every envelope
+// key. Keys not in this list keep their relative order, appended after
+// the canonical envelope keys but before the task-type key.
+//
+// Most envelope keys are reserved for activation in #205, #210, #211,
+// #212; encoding the order today means recipes formatted now will still
+// be canonical once those issues land.
+var canonicalEnvelopeKeys = []string{
+	"name",
+	"tags",
+	"when",
+	"loop",
+	"register",
+	"changed_when",
+	"failed_when",
+	"ignore_errors",
+}
+
+// envelopeKeySet is canonicalEnvelopeKeys as a lookup set.
+var envelopeKeySet = func() map[string]bool {
+	m := make(map[string]bool, len(canonicalEnvelopeKeys))
+	for _, k := range canonicalEnvelopeKeys {
+		m[k] = true
+	}
+	return m
+}()
+
+// Format returns the canonical form of data. err is non-nil only on a
+// yaml.v3 parse error or when the round-trip equivalence guard fails.
+//
+// The formatter:
+//
+//   - Uses yaml.v3's Node API so head/line/foot comments survive.
+//   - Indents with 2 spaces.
+//   - Reorders task envelope keys per canonicalEnvelopeKeys (task-type
+//     key last) and play keys per canonicalPlayKeys.
+//   - Inserts a blank line between top-level plays and between top-level
+//     task entries inside a play's tasks: list.
+//   - Strips trailing whitespace and forces LF line endings.
+//   - Re-parses the canonical output and aborts unless the original and
+//     canonical AST trees are structurally equivalent (defends against
+//     yaml.v3 emitter edge cases with anchors / complex flow scalars).
+func Format(data []byte) ([]byte, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("yaml parse error: %w", err)
+	}
+
+	doc := documentBody(&root)
+	if doc != nil && doc.Kind == yaml.SequenceNode {
+		canonicalizeRecipe(doc)
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&root); err != nil {
+		_ = enc.Close()
+		return nil, fmt.Errorf("yaml encode error: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("yaml encode close error: %w", err)
+	}
+
+	out := postProcess(buf.Bytes())
+
+	if hasDocumentMarker(data) && !hasDocumentMarker(out) {
+		out = append([]byte("---\n"), out...)
+	}
+
+	// Round-trip equivalence guard: re-parse the canonical output and
+	// require structural equivalence to the input. Catches yaml.v3
+	// emitter edge cases before the caller writes anything to disk.
+	var roundTrip yaml.Node
+	if err := yaml.Unmarshal(out, &roundTrip); err != nil {
+		return nil, fmt.Errorf("round-trip parse error: %w", err)
+	}
+	if !equivalentNodes(documentBody(&root), documentBody(&roundTrip)) {
+		return nil, fmt.Errorf("round-trip equivalence check failed; refusing to write")
+	}
+
+	return out, nil
+}
+
+// canonicalizeRecipe reorders the keys inside each play mapping and each
+// task entry mapping under the play's tasks: sequence.
+func canonicalizeRecipe(recipe *yaml.Node) {
+	for _, play := range recipe.Content {
+		if play.Kind != yaml.MappingNode {
+			continue
+		}
+		reorderMapping(play, canonicalPlayKeys)
+
+		tasksNode := mappingValue(play, "tasks")
+		if tasksNode == nil || tasksNode.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, task := range tasksNode.Content {
+			if task.Kind != yaml.MappingNode {
+				continue
+			}
+			reorderTaskEnvelope(task)
+		}
+	}
+}
+
+// reorderMapping rebuilds node.Content so keys appear in the order given
+// by priority, with any unrecognised keys appended in their original
+// relative order.
+func reorderMapping(node *yaml.Node, priority []string) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return
+	}
+	pairs := mappingPairs(node)
+	out := make([]*yaml.Node, 0, len(pairs)*2)
+	used := make(map[int]bool, len(pairs))
+
+	for _, key := range priority {
+		for i, pair := range pairs {
+			if used[i] {
+				continue
+			}
+			if pair.key.Value == key {
+				out = append(out, pair.key, pair.value)
+				used[i] = true
+				break
+			}
+		}
+	}
+	for i, pair := range pairs {
+		if used[i] {
+			continue
+		}
+		out = append(out, pair.key, pair.value)
+	}
+	node.Content = out
+}
+
+// reorderTaskEnvelope reorders a task entry mapping so the task-type key
+// (the single non-envelope key) comes last, with envelope keys ahead in
+// the order canonicalEnvelopeKeys defines.
+func reorderTaskEnvelope(node *yaml.Node) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return
+	}
+	pairs := mappingPairs(node)
+	out := make([]*yaml.Node, 0, len(pairs)*2)
+	used := make(map[int]bool, len(pairs))
+
+	for _, key := range canonicalEnvelopeKeys {
+		for i, pair := range pairs {
+			if used[i] {
+				continue
+			}
+			if pair.key.Value == key {
+				out = append(out, pair.key, pair.value)
+				used[i] = true
+				break
+			}
+		}
+	}
+	// Any remaining envelope-recognised keys (none today, but
+	// future-proof) keep relative order before the task-type key.
+	for i, pair := range pairs {
+		if used[i] {
+			continue
+		}
+		if envelopeKeySet[pair.key.Value] {
+			out = append(out, pair.key, pair.value)
+			used[i] = true
+		}
+	}
+	// Everything else (the task-type key plus any unrecognised keys)
+	// goes last, in original relative order.
+	for i, pair := range pairs {
+		if used[i] {
+			continue
+		}
+		out = append(out, pair.key, pair.value)
+	}
+	node.Content = out
+}
+
+// mappingKV is a single (key, value) pair from a mapping node.
+type mappingKV struct {
+	key   *yaml.Node
+	value *yaml.Node
+}
+
+// mappingPairs lifts a mapping's flat content slice into (key, value)
+// pairs for easier reordering. yaml.v3 stores mappings as
+// [k1, v1, k2, v2, ...].
+func mappingPairs(node *yaml.Node) []mappingKV {
+	pairs := make([]mappingKV, 0, len(node.Content)/2)
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		pairs = append(pairs, mappingKV{key: node.Content[i], value: node.Content[i+1]})
+	}
+	return pairs
+}
+
+// postProcess applies the byte-level canonicalization rules yaml.v3's
+// emitter does not control: trailing-whitespace strip, LF endings,
+// blank lines between top-level plays, and blank lines between
+// top-level task entries in each play.
+func postProcess(data []byte) []byte {
+	lines := strings.Split(string(data), "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, " \t\r")
+	}
+
+	// Drop the trailing empty entry produced by Split when the input
+	// ends with a newline; it is re-added below.
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	lines = insertBlankLinesBetweenSequenceEntries(lines)
+
+	out := strings.Join(lines, "\n")
+	out = strings.TrimRight(out, "\n") + "\n"
+	return []byte(out)
+}
+
+// insertBlankLinesBetweenSequenceEntries walks the canonicalized lines
+// and inserts a single blank line between top-level plays (sibling
+// sequence entries at column 0) and between top-level task entries
+// (sibling sequence entries at column 4) inside a play's tasks: block.
+// yaml.v3's emitter does not preserve inter-entry blank lines, so we
+// add them back here.
+//
+// yaml.v3 with SetIndent(2) emits the recipe sequence at column 0
+// ("- "), the per-play tasks: key at column 2 ("  tasks:"), and each
+// task entry at column 4 ("    - "). Anything deeper is a list inside
+// a task body and is not blank-line separated.
+func insertBlankLinesBetweenSequenceEntries(lines []string) []string {
+	out := make([]string, 0, len(lines))
+	seenTopDash := false
+	seenTaskDash := false
+	inTasksBlock := false
+
+	for _, line := range lines {
+		switch {
+		case strings.HasPrefix(line, "- "):
+			if seenTopDash {
+				out = append(out, "")
+			}
+			seenTopDash = true
+			seenTaskDash = false
+			// yaml.v3 inlines the first key of a sequence-element
+			// mapping onto the dash line, so a play whose only key
+			// is "tasks" emits as "- tasks:". Detect this so the
+			// subsequent task entries get blank-line separation.
+			inTasksBlock = line == "- tasks:"
+			out = append(out, line)
+			continue
+		case line == "  tasks:":
+			inTasksBlock = true
+			seenTaskDash = false
+			out = append(out, line)
+			continue
+		case strings.HasPrefix(line, "    - ") && inTasksBlock:
+			if seenTaskDash {
+				out = append(out, "")
+			}
+			seenTaskDash = true
+			out = append(out, line)
+			continue
+		case strings.HasPrefix(line, "  ") && !strings.HasPrefix(line, "   "):
+			// A line at exactly 2-space indent that is not part of
+			// the tasks: sequence (handled above) is a sibling key
+			// of tasks within the play - it closes the tasks block.
+			inTasksBlock = false
+		case len(line) > 0 && !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "-"):
+			// A top-level non-list line (like "---") resets the
+			// "seen" trackers so a recipe with a leading document
+			// marker still gets its blank-line behaviour.
+			seenTopDash = false
+			seenTaskDash = false
+			inTasksBlock = false
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+// equivalentNodes compares two YAML AST trees structurally. Mapping
+// keys are compared as a set (canonicalisation reorders them by
+// design); sequences are compared in order; scalars compare on Value
+// (and Tag when set explicitly).
+//
+// Comments do not contribute to equivalence: they are preserved by the
+// emitter but a comment-only edit to a node should not flag the round-
+// trip guard.
+func equivalentNodes(a, b *yaml.Node) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if a.Kind != b.Kind {
+		return false
+	}
+	if !tagsEquivalent(a, b) {
+		return false
+	}
+
+	switch a.Kind {
+	case yaml.ScalarNode:
+		return a.Value == b.Value
+	case yaml.SequenceNode:
+		if len(a.Content) != len(b.Content) {
+			return false
+		}
+		for i := range a.Content {
+			if !equivalentNodes(a.Content[i], b.Content[i]) {
+				return false
+			}
+		}
+		return true
+	case yaml.MappingNode:
+		if len(a.Content) != len(b.Content) {
+			return false
+		}
+		bIdx := make(map[string]*yaml.Node, len(b.Content)/2)
+		for i := 0; i+1 < len(b.Content); i += 2 {
+			bIdx[b.Content[i].Value] = b.Content[i+1]
+		}
+		for i := 0; i+1 < len(a.Content); i += 2 {
+			key := a.Content[i].Value
+			bVal, ok := bIdx[key]
+			if !ok {
+				return false
+			}
+			if !equivalentNodes(a.Content[i+1], bVal) {
+				return false
+			}
+		}
+		return true
+	case yaml.DocumentNode, yaml.AliasNode:
+		if len(a.Content) != len(b.Content) {
+			return false
+		}
+		for i := range a.Content {
+			if !equivalentNodes(a.Content[i], b.Content[i]) {
+				return false
+			}
+		}
+		return true
+	}
+	return true
+}
+
+// hasDocumentMarker reports whether the byte slice begins with a YAML
+// document-start marker, optionally preceded by whitespace or a BOM.
+// yaml.v3's encoder does not emit the marker by default, so a recipe
+// that opened with "---" needs it re-prepended for round-trip parity.
+func hasDocumentMarker(data []byte) bool {
+	s := string(data)
+	s = strings.TrimLeft(s, " \t\r\n\ufeff")
+	return strings.HasPrefix(s, "---\n") || s == "---" || strings.HasPrefix(s, "---\r")
+}
+
+// tagsEquivalent returns true when two nodes' explicit tags are
+// compatible. Empty / default tags compare equal to each other.
+func tagsEquivalent(a, b *yaml.Node) bool {
+	at, bt := a.Tag, b.Tag
+	if at == "" || at == "!" {
+		at = ""
+	}
+	if bt == "" || bt == "!" {
+		bt = ""
+	}
+	return at == bt
+}

--- a/tasks/format_test.go
+++ b/tasks/format_test.go
@@ -1,0 +1,274 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+func TestFormatNormalizesIndent(t *testing.T) {
+	in := `---
+- tasks:
+            - dokku_app:
+                  app: x
+`
+	out, err := Format([]byte(in))
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	body := string(out)
+	// yaml.v3's SetIndent(2) renders the recipe sequence at column 0,
+	// the per-play tasks: key at column 2, and each task entry at
+	// column 4 - the indent step is 2, the visual offset for nested
+	// sequence-of-mappings is twice that.
+	wantLines := []string{
+		"- tasks:",
+		"    - dokku_app:",
+		"        app: x",
+	}
+	for _, want := range wantLines {
+		if !strings.Contains(body, want+"\n") && !strings.HasSuffix(body, want) {
+			t.Errorf("expected canonical line %q in output:\n%s", want, body)
+		}
+	}
+}
+
+func TestFormatReordersEnvelopeKeys(t *testing.T) {
+	in := `---
+- tasks:
+    - dokku_app:
+        app: web
+      name: configure web
+`
+	out, err := Format([]byte(in))
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	body := string(out)
+	idxName := strings.Index(body, "name:")
+	idxType := strings.Index(body, "dokku_app:")
+	if idxName < 0 || idxType < 0 {
+		t.Fatalf("missing expected keys:\n%s", body)
+	}
+	if !(idxName < idxType) {
+		t.Errorf("name should sort before task-type key:\n%s", body)
+	}
+}
+
+func TestFormatReordersPlayKeys(t *testing.T) {
+	in := `---
+- tasks:
+    - dokku_app:
+        app: web
+  inputs:
+    - name: app
+      default: web
+`
+	out, err := Format([]byte(in))
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	body := string(out)
+	idxInputs := strings.Index(body, "inputs:")
+	idxTasks := strings.Index(body, "tasks:")
+	if idxInputs < 0 || idxTasks < 0 {
+		t.Fatalf("missing expected keys:\n%s", body)
+	}
+	if !(idxInputs < idxTasks) {
+		t.Errorf("inputs should sort before tasks:\n%s", body)
+	}
+}
+
+func TestFormatPreservesHeadComment(t *testing.T) {
+	in := `---
+- tasks:
+    # a comment about the next task
+    - dokku_app:
+        app: web
+`
+	out, err := Format([]byte(in))
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	body := string(out)
+	if !strings.Contains(body, "# a comment about the next task") {
+		t.Errorf("head comment not preserved:\n%s", body)
+	}
+}
+
+func TestFormatPreservesLineComment(t *testing.T) {
+	in := `---
+- tasks:
+    - dokku_app:
+        app: web # inline note
+`
+	out, err := Format([]byte(in))
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	body := string(out)
+	if !strings.Contains(body, "# inline note") {
+		t.Errorf("line comment not preserved:\n%s", body)
+	}
+}
+
+func TestFormatAlreadyCanonicalIsByteIdentical(t *testing.T) {
+	canonical := mustFormat(t, `---
+- inputs:
+    - name: app
+      default: web
+  tasks:
+    - name: configure web
+      dokku_app:
+        app: web
+`)
+	out, err := Format(canonical)
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	if string(out) != string(canonical) {
+		t.Errorf("already-canonical input changed on second Format pass:\nbefore:\n%s\nafter:\n%s", canonical, out)
+	}
+}
+
+func TestFormatStripsTrailingWhitespace(t *testing.T) {
+	in := "---\n- tasks:   \n    - dokku_app:\n        app: x   \n"
+	out, err := Format([]byte(in))
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	for i, line := range strings.Split(string(out), "\n") {
+		if strings.HasSuffix(line, " ") || strings.HasSuffix(line, "\t") {
+			t.Errorf("line %d has trailing whitespace: %q", i, line)
+		}
+	}
+}
+
+func TestFormatEnsuresTrailingNewline(t *testing.T) {
+	in := "---\n- tasks:\n    - dokku_app:\n        app: x"
+	out, err := Format([]byte(in))
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	if !strings.HasSuffix(string(out), "\n") {
+		t.Errorf("output missing trailing newline:\n%q", out)
+	}
+	if strings.HasSuffix(string(out), "\n\n") {
+		t.Errorf("output ends with multiple newlines:\n%q", out)
+	}
+}
+
+func TestFormatBlankLineBetweenPlays(t *testing.T) {
+	in := `---
+- tasks:
+    - dokku_app:
+        app: a
+- tasks:
+    - dokku_app:
+        app: b
+`
+	out, err := Format([]byte(in))
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	body := string(out)
+	// Find both top-level "- tasks:" lines and confirm at least one
+	// blank line separates them.
+	if !strings.Contains(body, "- tasks:\n\n- tasks:") &&
+		!strings.Contains(body, "        app: a\n\n- tasks:") {
+		t.Errorf("expected blank line between top-level plays:\n%s", body)
+	}
+}
+
+func TestFormatBlankLineBetweenTasks(t *testing.T) {
+	in := `---
+- tasks:
+    - dokku_app:
+        app: a
+    - dokku_config:
+        app: a
+        config:
+          KEY: value
+`
+	out, err := Format([]byte(in))
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	body := string(out)
+	if !strings.Contains(body, "\n\n    - dokku_config:") {
+		t.Errorf("expected blank line between top-level task entries:\n%s", body)
+	}
+}
+
+func TestEquivalentNodesEqual(t *testing.T) {
+	a := mustParse(t, "{a: 1, b: [x, y]}")
+	b := mustParse(t, "{b: [x, y], a: 1}")
+	if !equivalentNodes(documentBody(a), documentBody(b)) {
+		t.Error("expected mappings with same key set to be equivalent regardless of order")
+	}
+}
+
+func TestEquivalentNodesDifferentValue(t *testing.T) {
+	a := mustParse(t, "{a: 1, b: [x, y]}")
+	b := mustParse(t, "{a: 1, b: [x, z]}")
+	if equivalentNodes(documentBody(a), documentBody(b)) {
+		t.Error("sequences with different elements should not be equivalent")
+	}
+}
+
+func TestEquivalentNodesDifferentKeys(t *testing.T) {
+	a := mustParse(t, "{a: 1, b: 2}")
+	b := mustParse(t, "{a: 1, c: 2}")
+	if equivalentNodes(documentBody(a), documentBody(b)) {
+		t.Error("mappings with different key sets should not be equivalent")
+	}
+}
+
+func TestFormatRoundTripStaysValidatable(t *testing.T) {
+	in := `---
+- inputs:
+    - name: app
+      required: true
+  tasks:
+    - dokku_app:
+        app: "{{ .app }}"
+`
+	formatted, err := Format([]byte(in))
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	// re-format must converge: the second pass equals the first.
+	again, err := Format(formatted)
+	if err != nil {
+		t.Fatalf("Format (second pass): %v", err)
+	}
+	if string(again) != string(formatted) {
+		t.Errorf("formatter is not idempotent:\nfirst:\n%s\nsecond:\n%s", formatted, again)
+	}
+}
+
+func TestFormatRejectsBrokenYAML(t *testing.T) {
+	_, err := Format([]byte("- a: [b\n"))
+	if err == nil {
+		t.Error("expected parse error on malformed YAML")
+	}
+}
+
+func mustFormat(t *testing.T, in string) []byte {
+	t.Helper()
+	out, err := Format([]byte(in))
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	return out
+}
+
+func mustParse(t *testing.T, in string) *yaml.Node {
+	t.Helper()
+	var n yaml.Node
+	if err := yaml.Unmarshal([]byte(in), &n); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	return &n
+}

--- a/tests/bats/fmt.bats
+++ b/tests/bats/fmt.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  docket_build
+}
+
+@test "docket fmt rewrites a non-canonical file in place" {
+  cd "$BATS_TEST_TMPDIR"
+  cat >tasks.yml <<'EOF'
+---
+- tasks:
+        - dokku_app:
+              app: x
+EOF
+  run "$(docket_bin)" fmt
+  assert_success
+  run grep -c "^        - " tasks.yml
+  assert_output "0"
+  assert [ -f tasks.yml ]
+}
+
+@test "docket fmt --check exits 1 on non-canonical" {
+  cd "$BATS_TEST_TMPDIR"
+  cat >tasks.yml <<'EOF'
+---
+- tasks:
+        - dokku_app:
+              app: x
+EOF
+  run "$(docket_bin)" fmt --check
+  assert_failure
+  assert_output --partial "not canonically formatted"
+}
+
+@test "docket fmt --check exits 0 on canonical" {
+  cd "$BATS_TEST_TMPDIR"
+  "$(docket_bin)" init
+  run "$(docket_bin)" fmt --check
+  assert_success
+}
+
+@test "docket fmt --diff prints unified diff and does not write" {
+  cd "$BATS_TEST_TMPDIR"
+  cat >tasks.yml <<'EOF'
+---
+- tasks:
+        - dokku_app:
+              app: x
+EOF
+  before=$(cat tasks.yml)
+  run "$(docket_bin)" fmt --diff --color never
+  assert_success
+  assert_output --partial "---"
+  assert_output --partial "+++"
+  assert_output --partial "@@"
+  assert [ "$(cat tasks.yml)" = "$before" ]
+}
+
+@test "docket fmt --check --diff prints diff and exits 1" {
+  cd "$BATS_TEST_TMPDIR"
+  cat >tasks.yml <<'EOF'
+---
+- tasks:
+        - dokku_app:
+              app: x
+EOF
+  run "$(docket_bin)" fmt --check --diff --color never
+  assert_failure
+  assert_output --partial "@@"
+  assert_output --partial "not canonically formatted"
+}
+
+@test "docket fmt - reads stdin and writes stdout" {
+  cd "$BATS_TEST_TMPDIR"
+  cat >input.yml <<'EOF'
+---
+- tasks:
+        - dokku_app:
+              app: x
+EOF
+  run bash -c "\"$(docket_bin)\" fmt - <input.yml"
+  assert_success
+  assert_output --partial "    - dokku_app:"
+  assert [ ! -f tasks.yml ]
+}
+
+@test "docket fmt preserves comments" {
+  cd "$BATS_TEST_TMPDIR"
+  cat >tasks.yml <<'EOF'
+---
+- tasks:
+    # this is a comment
+    - dokku_app:
+        app: x
+EOF
+  "$(docket_bin)" fmt
+  run grep -c "this is a comment" tasks.yml
+  assert_output "1"
+}
+
+@test "docket fmt is a no-op on already-canonical input (mtime preserved)" {
+  cd "$BATS_TEST_TMPDIR"
+  "$(docket_bin)" init
+  before_mtime=$(stat -f "%m" tasks.yml 2>/dev/null || stat -c "%Y" tasks.yml)
+  sleep 1
+  run "$(docket_bin)" fmt
+  assert_success
+  after_mtime=$(stat -f "%m" tasks.yml 2>/dev/null || stat -c "%Y" tasks.yml)
+  assert [ "$before_mtime" = "$after_mtime" ]
+}
+
+@test "docket fmt --diff --color never round-trips through patch -p0" {
+  cd "$BATS_TEST_TMPDIR"
+  cat >tasks.yml <<'EOF'
+---
+- tasks:
+        - dokku_app:
+              app: x
+EOF
+  cp tasks.yml tasks.orig
+
+  "$(docket_bin)" fmt --diff --color never tasks.yml >tasks.diff
+  assert [ -s tasks.diff ]
+  patch -p0 <tasks.diff
+
+  "$(docket_bin)" fmt - <tasks.orig >tasks.expected
+  cmp tasks.yml tasks.expected
+}


### PR DESCRIPTION
## Summary

Adds a `docket fmt` canonical formatter for `tasks.yml`, in the spirit of `gofmt`. Built on `yaml.v3`'s `Node` API so head / line / foot comments and ordering round-trip; reorders play and task envelope keys into a stable order; normalises indentation to a 2-space step; inserts blank lines between top-level plays and between top-level task entries; strips trailing whitespace and forces LF endings. CLI semantics are modeled after `black` / `ruff format`: `--check` and `--diff` compose, default rewrites in place. The unified diff is GNU format via `github.com/aymanbagabas/go-udiff`, colorized on TTY via `fatih/color` with `--color auto|always|never` (also honors `NO_COLOR`).

Before writing, `fmt` re-parses its canonical output and aborts unless the resulting AST structurally matches the input - the round-trip equivalence guard the issue calls out, defending against `yaml.v3` emitter edge cases with anchors and complex flow scalars. The diff round-trips through `patch -p0` once colors are stripped.

Closes #201.