### PR TITLE
feat: structured per-task output and end-of-run summary for apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,15 @@ The flags are:
 | Flag | Effect |
 |------|--------|
 | `--tasks <path>` | Use a specific task file (default `./tasks.yml`) |
-| `--verbose` | After each task line, echo the resolved Dokku command on a `→`-prefixed continuation line. Commands are not masked - avoid on recipes that pass secrets via task arguments. |
+| `--verbose` | After each task line, echo every resolved Dokku command the task ran on a `→`-prefixed continuation line, in invocation order. Tasks that loop over inputs (e.g. `dokku_buildpacks` adding several URLs) emit one continuation per call. Commands are not masked - avoid on recipes that pass secrets via task arguments. |
+
+For example, a multi-command task renders one continuation per invocation:
+
+```text
+[changed] add buildpacks
+          → dokku --quiet buildpacks:add app https://github.com/heroku/heroku-buildpack-nodejs.git
+          → dokku --quiet buildpacks:add app https://github.com/heroku/heroku-buildpack-nginx.git
+```
 
 Color output respects [`NO_COLOR`](https://no-color.org/): set `NO_COLOR=1` to disable ANSI escapes, or pipe to a non-TTY (output is plain in that case automatically).
 

--- a/README.md
+++ b/README.md
@@ -92,9 +92,41 @@ The diff output is GNU unified diff with `--- <path>` / `+++ <path>` / `@@` head
 
 Before writing, `fmt` re-parses its canonical output and aborts if the round-tripped AST does not match the input AST - a guard against `yaml.v3` emitter edge cases (notably anchors and complex flow scalars). On a parse error or round-trip mismatch the file is not touched and `fmt` exits 1.
 
+### Applying recipes with `apply`
+
+`docket apply` runs every task in the recipe, mutating the live dokku server as needed. Each task line is prefixed with a status marker padded to a fixed column:
+
+| Marker | Meaning |
+|--------|---------|
+| `[ok]` | Task ran, no change |
+| `[changed]` | Task ran, mutated state |
+| `[skipped]` | Task was filtered out (tags, `when:`, `--start-at-task`) |
+| `[error]` | Task errored; the run aborts |
+
+A play header (`==> Play: tasks`) precedes the per-task lines, and an end-of-run summary line follows them:
+
+```text
+==> Play: tasks
+[changed] dokku apps:create api
+[ok]      dokku config:set api KEY=value
+
+Summary: 2 tasks · 1 changed · 1 ok · 0 skipped · 0 errors  (took 0.8s)
+```
+
+On error, the failing task's error message is printed as a `!`-prefixed continuation line and the run aborts with exit 1. The summary still prints with the partial counts before exit.
+
+The flags are:
+
+| Flag | Effect |
+|------|--------|
+| `--tasks <path>` | Use a specific task file (default `./tasks.yml`) |
+| `--verbose` | After each task line, echo the resolved Dokku command on a `→`-prefixed continuation line. Commands are not masked - avoid on recipes that pass secrets via task arguments. |
+
+Color output respects [`NO_COLOR`](https://no-color.org/): set `NO_COLOR=1` to disable ANSI escapes, or pipe to a non-TTY (output is plain in that case automatically).
+
 ### Previewing changes with `plan`
 
-`docket plan` reads each task's current state from the live dokku server and reports what `apply` would change, without invoking any mutating dokku command. Each task line is prefixed with a marker:
+`docket plan` reads each task's current state from the live dokku server and reports what `apply` would change, without invoking any mutating dokku command. The output uses the same play header and column layout as `apply`, with a different marker set:
 
 | Marker | Meaning |
 |--------|---------|
@@ -107,6 +139,7 @@ Before writing, `fmt` re-parses its canonical output and aborts if the round-tri
 Tasks that perform multiple operations (e.g. `dokku_config` setting several keys) report each individual mutation under the task line:
 
 ```text
+==> Play: tasks
 [~]       configure  (2 key(s) to set)
           - set KEY_ONE (new)
           - set KEY_TWO (was set)

--- a/commands/apply.go
+++ b/commands/apply.go
@@ -130,8 +130,10 @@ func (c *ApplyCommand) Run(args []string) int {
 			counts.Errors++
 			formatter.TaskLine(MarkerError, name, "")
 			formatter.Continuation('!', state.Error.Error())
-			if c.verbose && state.Command != "" {
-				formatter.Continuation('\u2192', state.Command)
+			if c.verbose {
+				for _, cmd := range state.Commands {
+					formatter.Continuation('\u2192', cmd)
+				}
 			}
 			formatter.ApplySummary(counts, time.Since(start))
 			return 1
@@ -143,8 +145,10 @@ func (c *ApplyCommand) Run(args []string) int {
 			formatter.TaskLine(MarkerOK, name, "")
 		}
 
-		if c.verbose && state.Command != "" {
-			formatter.Continuation('\u2192', state.Command)
+		if c.verbose {
+			for _, cmd := range state.Commands {
+				formatter.Continuation('\u2192', cmd)
+			}
 		}
 
 		if state.State != state.DesiredState {

--- a/commands/apply.go
+++ b/commands/apply.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/dokku/docket/tasks"
 
@@ -15,6 +16,7 @@ type ApplyCommand struct {
 	command.Meta
 
 	tasksFile string
+	verbose   bool
 	arguments map[string]*Argument
 }
 
@@ -55,6 +57,7 @@ func (c *ApplyCommand) ParsedArguments(args []string) (map[string]command.Argume
 func (c *ApplyCommand) FlagSet() *flag.FlagSet {
 	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
 	f.StringVar(&c.tasksFile, "tasks", "tasks.yml", "a yaml file containing a task list")
+	f.BoolVar(&c.verbose, "verbose", false, "echo the resolved dokku command for each task as a continuation line (commands are not masked; avoid on recipes that pass secrets via task arguments)")
 
 	taskFile := getTaskYamlFilename(os.Args)
 	data, err := os.ReadFile(taskFile)
@@ -75,7 +78,8 @@ func (c *ApplyCommand) AutocompleteFlags() complete.Flags {
 	return command.MergeAutocompleteFlags(
 		c.Meta.AutocompleteFlags(command.FlagSetClient),
 		complete.Flags{
-			"--tasks": complete.PredictFiles("*.yml"),
+			"--tasks":   complete.PredictFiles("*.yml"),
+			"--verbose": complete.PredictNothing,
 		},
 	)
 }
@@ -110,20 +114,48 @@ func (c *ApplyCommand) Run(args []string) int {
 		return 1
 	}
 
+	formatter := NewFormatter(c.Ui, c.verbose)
+	formatter.PlayHeader("tasks")
+
+	start := time.Now()
+	counts := ApplyCounts{}
+
 	for _, name := range taskList.Keys() {
 		task := taskList.Get(name)
-		c.Ui.Info(fmt.Sprintf("executing %s", name))
 		state := task.Execute()
-		if state.Error != nil {
-			c.Ui.Error(fmt.Sprintf("execute error: %v", state.Error))
+		counts.Tasks++
+
+		switch {
+		case state.Error != nil:
+			counts.Errors++
+			formatter.TaskLine(MarkerError, name, "")
+			formatter.Continuation('!', state.Error.Error())
+			if c.verbose && state.Command != "" {
+				formatter.Continuation('\u2192', state.Command)
+			}
+			formatter.ApplySummary(counts, time.Since(start))
 			return 1
+		case state.Changed:
+			counts.Changed++
+			formatter.TaskLine(MarkerChanged, name, "")
+		default:
+			counts.OK++
+			formatter.TaskLine(MarkerOK, name, "")
+		}
+
+		if c.verbose && state.Command != "" {
+			formatter.Continuation('\u2192', state.Command)
 		}
 
 		if state.State != state.DesiredState {
-			c.Ui.Error(fmt.Sprintf("Invalid state found, expected=%v actual=%v", state.DesiredState, state.State))
+			counts.Errors++
+			formatter.TaskLine(MarkerError, name, "")
+			formatter.Continuation('!', fmt.Sprintf("invalid state: expected=%v actual=%v", state.DesiredState, state.State))
+			formatter.ApplySummary(counts, time.Since(start))
 			return 1
 		}
 	}
 
+	formatter.ApplySummary(counts, time.Since(start))
 	return 0
 }

--- a/commands/output.go
+++ b/commands/output.go
@@ -1,0 +1,186 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/mitchellh/cli"
+)
+
+// Marker is the bracketed status marker that prefixes a task line. The
+// concrete strings (without brackets) match the conventions documented
+// in issue #202: apply uses ok/changed/skipped/error, plan uses
+// ok/+/~/-/!.
+type Marker string
+
+const (
+	// Apply markers
+	MarkerOK      Marker = "ok"
+	MarkerChanged Marker = "changed"
+	MarkerSkipped Marker = "skipped"
+	MarkerError   Marker = "error"
+
+	// Plan markers (PlanStatusOK reuses MarkerOK)
+	MarkerCreate     Marker = "+"
+	MarkerModify     Marker = "~"
+	MarkerDestroy    Marker = "-"
+	MarkerProbeError Marker = "!"
+)
+
+// markerWidth is the fixed column width that every bracketed marker is
+// padded to. Wide enough for the longest marker `[changed]` (9 chars)
+// plus a trailing space.
+const markerWidth = 10
+
+// continuationIndent matches markerWidth so continuation lines align
+// under the task name column.
+var continuationIndent = strings.Repeat(" ", markerWidth)
+
+// ApplyCounts holds the running totals printed by the apply summary
+// line.
+type ApplyCounts struct {
+	Tasks   int
+	Changed int
+	OK      int
+	Skipped int
+	Errors  int
+}
+
+// PlanCounts holds the running totals printed by the plan summary line.
+type PlanCounts struct {
+	Tasks       int
+	WouldChange int
+	InSync      int
+	Errors      int
+}
+
+// Formatter renders the structured per-task output for `apply` and
+// `plan`. It owns marker padding, color decisions, and the play /
+// summary line shapes so both subcommands stay visually consistent.
+//
+// Color is resolved once at construction and honours NO_COLOR plus
+// stdout-isatty, matching fatih/color's defaults. When the active Ui
+// is not the real terminal Ui (e.g. cli.MockUi in tests), color is
+// also forced off so test assertions stay stable.
+type Formatter struct {
+	ui      cli.Ui
+	verbose bool
+	color   bool
+	paint   map[Marker]*color.Color
+}
+
+// NewFormatter constructs a Formatter bound to the given Ui. verbose
+// controls whether `→`-prefixed continuation lines are emitted under
+// each task line in apply mode.
+func NewFormatter(ui cli.Ui, verbose bool) *Formatter {
+	useColor := !noColorDefault()
+	return &Formatter{
+		ui:      ui,
+		verbose: verbose,
+		color:   useColor,
+		paint: map[Marker]*color.Color{
+			MarkerOK:         color.New(color.FgGreen),
+			MarkerChanged:    color.New(color.FgYellow),
+			MarkerSkipped:    color.New(color.Faint),
+			MarkerError:      color.New(color.FgRed),
+			MarkerCreate:     color.New(color.FgGreen),
+			MarkerModify:     color.New(color.FgYellow),
+			MarkerDestroy:    color.New(color.FgRed),
+			MarkerProbeError: color.New(color.FgRed),
+		},
+	}
+}
+
+// Verbose reports whether the formatter is in verbose mode.
+func (f *Formatter) Verbose() bool { return f.verbose }
+
+// PlayHeader emits a `==> Play: <name>` line above the per-task
+// listing. Used once per play; until #208 lands, callers emit one
+// header per run.
+func (f *Formatter) PlayHeader(name string) {
+	f.ui.Output(fmt.Sprintf("==> Play: %s", name))
+}
+
+// TaskLine emits one structured task line: a colored, bracketed,
+// padded marker followed by the task name. suffix, when non-empty, is
+// appended after two spaces (matching the legacy plan-line layout).
+//
+// Errored task lines are routed through Ui.Error so they land on stderr
+// and inherit the cli-skeleton error styling.
+func (f *Formatter) TaskLine(m Marker, name, suffix string) {
+	marker := f.paintMarker(m)
+	line := marker + name
+	if suffix != "" {
+		line = line + "  " + suffix
+	}
+	if m == MarkerError || m == MarkerProbeError {
+		f.ui.Error(line)
+		return
+	}
+	f.ui.Output(line)
+}
+
+// Continuation emits an indented continuation line under the most
+// recent task line. prefix is the leading rune (`!` for errors,
+// `→` for the verbose command echo, `-` for plan mutation items).
+// Each line of `body` is emitted as its own continuation so multi-line
+// stderr renders cleanly under the marker column.
+func (f *Formatter) Continuation(prefix rune, body string) {
+	if body == "" {
+		return
+	}
+	for _, line := range strings.Split(strings.TrimRight(body, "\n"), "\n") {
+		out := fmt.Sprintf("%s%c %s", continuationIndent, prefix, line)
+		f.ui.Output(out)
+	}
+}
+
+// ApplySummary emits the blank line and `Summary: ...` footer that
+// follows an apply run. elapsed is rendered with one decimal of
+// seconds, matching the spec in issue #202.
+func (f *Formatter) ApplySummary(c ApplyCounts, elapsed time.Duration) {
+	errWord := "errors"
+	if c.Errors == 1 {
+		errWord = "error"
+	}
+	f.ui.Output("")
+	f.ui.Output(fmt.Sprintf(
+		"Summary: %d tasks · %d changed · %d ok · %d skipped · %d %s  (took %.1fs)",
+		c.Tasks, c.Changed, c.OK, c.Skipped, c.Errors, errWord, elapsed.Seconds(),
+	))
+}
+
+// PlanSummary emits the blank line and `Plan: ...` footer that
+// follows a plan run. The format intentionally matches the legacy
+// shape so existing CI consumers (and the bats partial-match
+// assertions in tests/bats/plan.bats) keep working.
+func (f *Formatter) PlanSummary(c PlanCounts) {
+	f.ui.Output("")
+	f.ui.Output(fmt.Sprintf(
+		"Plan: %d task(s); %d would change, %d in sync, %d error(s).",
+		c.Tasks, c.WouldChange, c.InSync, c.Errors,
+	))
+}
+
+// paintMarker pads the bracketed marker text to markerWidth and applies
+// color when enabled.
+func (f *Formatter) paintMarker(m Marker) string {
+	text := fmt.Sprintf("[%s]", string(m))
+	pad := markerWidth - len(text)
+	if pad < 1 {
+		pad = 1
+	}
+	padded := text + strings.Repeat(" ", pad)
+	if !f.color {
+		return padded
+	}
+	if c, ok := f.paint[m]; ok {
+		// Only color the bracketed text; keep trailing whitespace
+		// uncolored so the indent is unaffected by ANSI resets.
+		return c.Sprint(text) + strings.Repeat(" ", pad)
+	}
+	return padded
+}
+

--- a/commands/output_test.go
+++ b/commands/output_test.go
@@ -1,0 +1,209 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/mitchellh/cli"
+)
+
+// newTestFormatter returns a formatter wired to a fresh MockUi with
+// color forced off. Tests that need colored output set f.color = true
+// explicitly.
+func newTestFormatter(verbose bool) (*Formatter, *cli.MockUi) {
+	ui := cli.NewMockUi()
+	f := NewFormatter(ui, verbose)
+	f.color = false
+	return f, ui
+}
+
+func TestFormatterPlayHeader(t *testing.T) {
+	f, ui := newTestFormatter(false)
+	f.PlayHeader("tasks")
+	got := ui.OutputWriter.String()
+	want := "==> Play: tasks\n"
+	if got != want {
+		t.Errorf("PlayHeader output mismatch\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestFormatterTaskLineMarkerPadding(t *testing.T) {
+	cases := []struct {
+		marker Marker
+		want   string
+	}{
+		{MarkerOK, "[ok]      task-name\n"},
+		{MarkerChanged, "[changed] task-name\n"},
+		{MarkerSkipped, "[skipped] task-name\n"},
+		{MarkerCreate, "[+]       task-name\n"},
+		{MarkerModify, "[~]       task-name\n"},
+		{MarkerDestroy, "[-]       task-name\n"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.marker), func(t *testing.T) {
+			f, ui := newTestFormatter(false)
+			f.TaskLine(tc.marker, "task-name", "")
+			got := ui.OutputWriter.String()
+			if got != tc.want {
+				t.Errorf("marker %q\nwant: %q\ngot:  %q", tc.marker, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestFormatterTaskLineWithSuffix(t *testing.T) {
+	f, ui := newTestFormatter(false)
+	f.TaskLine(MarkerOK, "configure", "(in sync)")
+	got := ui.OutputWriter.String()
+	want := "[ok]      configure  (in sync)\n"
+	if got != want {
+		t.Errorf("TaskLine with suffix\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestFormatterTaskLineErrorRoutesToStderr(t *testing.T) {
+	f, ui := newTestFormatter(false)
+	f.TaskLine(MarkerError, "task-name", "")
+	if got := ui.OutputWriter.String(); got != "" {
+		t.Errorf("error marker should not write to stdout, got %q", got)
+	}
+	want := "[error]   task-name\n"
+	if got := ui.ErrorWriter.String(); got != want {
+		t.Errorf("error marker stderr\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestFormatterTaskLineProbeErrorRoutesToStderr(t *testing.T) {
+	f, ui := newTestFormatter(false)
+	f.TaskLine(MarkerProbeError, "task-name", "(probe failed)")
+	if got := ui.OutputWriter.String(); got != "" {
+		t.Errorf("probe-error marker should not write to stdout, got %q", got)
+	}
+	want := "[!]       task-name  (probe failed)\n"
+	if got := ui.ErrorWriter.String(); got != want {
+		t.Errorf("probe-error stderr\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestFormatterContinuationBangPrefix(t *testing.T) {
+	f, ui := newTestFormatter(false)
+	f.Continuation('!', "app foo does not exist")
+	got := ui.OutputWriter.String()
+	want := "          ! app foo does not exist\n"
+	if got != want {
+		t.Errorf("Continuation\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestFormatterContinuationVerboseArrow(t *testing.T) {
+	f, ui := newTestFormatter(true)
+	f.Continuation('\u2192', "dokku --quiet apps:create foo")
+	got := ui.OutputWriter.String()
+	want := "          \u2192 dokku --quiet apps:create foo\n"
+	if got != want {
+		t.Errorf("verbose continuation\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestFormatterContinuationSkipsEmpty(t *testing.T) {
+	f, ui := newTestFormatter(false)
+	f.Continuation('!', "")
+	if got := ui.OutputWriter.String(); got != "" {
+		t.Errorf("empty body should produce no output, got %q", got)
+	}
+}
+
+func TestFormatterContinuationMultiLine(t *testing.T) {
+	f, ui := newTestFormatter(false)
+	f.Continuation('!', "line one\nline two")
+	got := ui.OutputWriter.String()
+	want := "          ! line one\n          ! line two\n"
+	if got != want {
+		t.Errorf("multi-line continuation\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestFormatterApplySummary(t *testing.T) {
+	f, ui := newTestFormatter(false)
+	f.ApplySummary(ApplyCounts{Tasks: 3, Changed: 1, OK: 2}, 3200*time.Millisecond)
+	got := ui.OutputWriter.String()
+	wantContains := []string{
+		"Summary: 3 tasks · 1 changed · 2 ok · 0 skipped · 0 errors",
+		"(took 3.2s)",
+	}
+	for _, want := range wantContains {
+		if !strings.Contains(got, want) {
+			t.Errorf("ApplySummary missing %q in:\n%s", want, got)
+		}
+	}
+	if !strings.HasPrefix(got, "\n") {
+		t.Errorf("ApplySummary should start with a blank line; got:\n%s", got)
+	}
+}
+
+func TestFormatterApplySummaryErrorWord(t *testing.T) {
+	f, ui := newTestFormatter(false)
+	f.ApplySummary(ApplyCounts{Tasks: 1, Errors: 1}, time.Second)
+	got := ui.OutputWriter.String()
+	if !strings.Contains(got, "1 error  ") {
+		t.Errorf("singular `1 error`, got:\n%s", got)
+	}
+
+	f2, ui2 := newTestFormatter(false)
+	f2.ApplySummary(ApplyCounts{Tasks: 2, Errors: 2}, time.Second)
+	got2 := ui2.OutputWriter.String()
+	if !strings.Contains(got2, "2 errors") {
+		t.Errorf("plural `2 errors`, got:\n%s", got2)
+	}
+}
+
+func TestFormatterPlanSummary(t *testing.T) {
+	f, ui := newTestFormatter(false)
+	f.PlanSummary(PlanCounts{Tasks: 3, WouldChange: 2, InSync: 1, Errors: 0})
+	got := ui.OutputWriter.String()
+	want := "Plan: 3 task(s); 2 would change, 1 in sync, 0 error(s)."
+	if !strings.Contains(got, want) {
+		t.Errorf("PlanSummary missing %q in:\n%s", want, got)
+	}
+}
+
+func TestFormatterColorOffProducesPlainOutput(t *testing.T) {
+	f, ui := newTestFormatter(false) // color forced off
+	f.TaskLine(MarkerChanged, "task", "")
+	got := ui.OutputWriter.String()
+	if strings.Contains(got, "\x1b[") {
+		t.Errorf("color off should not emit ANSI escapes, got %q", got)
+	}
+}
+
+func TestFormatterColorOnEmitsAnsi(t *testing.T) {
+	// Force color on regardless of TTY/NO_COLOR detection.
+	prev := color.NoColor
+	color.NoColor = false
+	t.Cleanup(func() { color.NoColor = prev })
+
+	ui := cli.NewMockUi()
+	f := NewFormatter(ui, false)
+	f.color = true
+	f.TaskLine(MarkerChanged, "task", "")
+	got := ui.OutputWriter.String()
+	if !strings.Contains(got, "\x1b[") {
+		t.Errorf("color on should emit ANSI escapes, got %q", got)
+	}
+	if !strings.Contains(got, "[changed]") {
+		t.Errorf("colored output should still contain marker text, got %q", got)
+	}
+}
+
+func TestFormatterVerboseAccessor(t *testing.T) {
+	f, _ := newTestFormatter(true)
+	if !f.Verbose() {
+		t.Error("Verbose() should be true when constructed with verbose=true")
+	}
+	f2, _ := newTestFormatter(false)
+	if f2.Verbose() {
+		t.Error("Verbose() should be false when constructed with verbose=false")
+	}
+}

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -121,49 +121,43 @@ func (c *PlanCommand) Run(args []string) int {
 		return 1
 	}
 
-	totals := struct {
-		tasks       int
-		wouldChange int
-		inSync      int
-		errors      int
-	}{}
+	formatter := NewFormatter(c.Ui, false)
+	formatter.PlayHeader("tasks")
+
+	counts := PlanCounts{}
 	hasError := false
 
 	for _, name := range taskList.Keys() {
 		task := taskList.Get(name)
 		result := task.Plan()
-		totals.tasks++
+		counts.Tasks++
 
 		switch {
 		case result.Error != nil:
-			totals.errors++
+			counts.Errors++
 			hasError = true
-			c.Ui.Error(fmt.Sprintf("[%s]       %s  (%v)", tasks.PlanStatusError, name, result.Error))
+			formatter.TaskLine(MarkerProbeError, name, fmt.Sprintf("(%v)", result.Error))
 		case result.InSync:
-			totals.inSync++
-			c.Ui.Info(fmt.Sprintf("[ok]      %s  (in sync)", name))
+			counts.InSync++
+			formatter.TaskLine(MarkerOK, name, "(in sync)")
 		default:
-			totals.wouldChange++
-			marker := string(result.Status)
+			counts.WouldChange++
+			marker := Marker(result.Status)
 			if marker == "" {
-				marker = string(tasks.PlanStatusModify)
+				marker = Marker(tasks.PlanStatusModify)
 			}
-			line := fmt.Sprintf("[%s]       %s", marker, name)
+			suffix := ""
 			if result.Reason != "" {
-				line = fmt.Sprintf("[%s]       %s  (%s)", marker, name, result.Reason)
+				suffix = "(" + result.Reason + ")"
 			}
-			c.Ui.Info(line)
+			formatter.TaskLine(marker, name, suffix)
 			for _, m := range result.Mutations {
-				c.Ui.Info(fmt.Sprintf("          - %s", m))
+				formatter.Continuation('-', m)
 			}
 		}
 	}
 
-	c.Ui.Info("")
-	c.Ui.Info(fmt.Sprintf(
-		"Plan: %d task(s); %d would change, %d in sync, %d error(s).",
-		totals.tasks, totals.wouldChange, totals.inSync, totals.errors,
-	))
+	formatter.PlanSummary(counts)
 
 	if hasError {
 		return 1

--- a/subprocess/exec.go
+++ b/subprocess/exec.go
@@ -58,6 +58,11 @@ type ExecCommandInput struct {
 
 // ExecCommandResponse is the response for the ExecCommand function
 type ExecCommandResponse struct {
+	// Command is the resolved command line that was executed, including
+	// any sudo wrapping and joined arguments. Used by callers that surface
+	// the command in user-facing output (e.g. `docket apply --verbose`).
+	Command string
+
 	// Stdout is the stdout of the command
 	Stdout string
 
@@ -172,9 +177,15 @@ func CallExecCommandWithContext(ctx context.Context, input ExecCommandInput) (Ex
 		cmd.StdErrWriter = input.StderrWriter
 	}
 
+	resolved := command
+	if len(commandArgs) > 0 {
+		resolved = command + " " + strings.Join(commandArgs, " ")
+	}
+
 	res, err := cmd.Execute(ctx)
 	if err != nil {
 		return ExecCommandResponse{
+			Command:   resolved,
 			Stdout:    res.Stdout,
 			Stderr:    res.Stderr,
 			ExitCode:  res.ExitCode,
@@ -184,6 +195,7 @@ func CallExecCommandWithContext(ctx context.Context, input ExecCommandInput) (Ex
 
 	if res.ExitCode != 0 {
 		return ExecCommandResponse{
+			Command:   resolved,
 			Stdout:    res.Stdout,
 			Stderr:    res.Stderr,
 			ExitCode:  res.ExitCode,
@@ -192,6 +204,7 @@ func CallExecCommandWithContext(ctx context.Context, input ExecCommandInput) (Ex
 	}
 
 	return ExecCommandResponse{
+		Command:   resolved,
 		Stdout:    res.Stdout,
 		Stderr:    res.Stderr,
 		ExitCode:  res.ExitCode,

--- a/tasks/acl_app_task.go
+++ b/tasks/acl_app_task.go
@@ -108,6 +108,7 @@ func (t AclAppTask) Plan() PlanResult {
 							Command: "dokku",
 							Args:    []string{"--quiet", "acl:add", t.App, u},
 						})
+						state.Command = result.Command
 						if err != nil {
 							return TaskOutputErrorFromExec(state, err, result)
 						}
@@ -153,6 +154,7 @@ func (t AclAppTask) Plan() PlanResult {
 							Command: "dokku",
 							Args:    []string{"--quiet", "acl:remove", t.App, u},
 						})
+						state.Command = result.Command
 						if err != nil {
 							return TaskOutputErrorFromExec(state, err, result)
 						}

--- a/tasks/acl_app_task.go
+++ b/tasks/acl_app_task.go
@@ -108,7 +108,7 @@ func (t AclAppTask) Plan() PlanResult {
 							Command: "dokku",
 							Args:    []string{"--quiet", "acl:add", t.App, u},
 						})
-						state.Command = result.Command
+						state.Commands = append(state.Commands, result.Command)
 						if err != nil {
 							return TaskOutputErrorFromExec(state, err, result)
 						}
@@ -154,7 +154,7 @@ func (t AclAppTask) Plan() PlanResult {
 							Command: "dokku",
 							Args:    []string{"--quiet", "acl:remove", t.App, u},
 						})
-						state.Command = result.Command
+						state.Commands = append(state.Commands, result.Command)
 						if err != nil {
 							return TaskOutputErrorFromExec(state, err, result)
 						}

--- a/tasks/acl_service_task.go
+++ b/tasks/acl_service_task.go
@@ -114,7 +114,7 @@ func (t AclServiceTask) Plan() PlanResult {
 							Command: "dokku",
 							Args:    []string{"--quiet", "acl:add-service", t.Type, t.Service, u},
 						})
-						state.Command = result.Command
+						state.Commands = append(state.Commands, result.Command)
 						if err != nil {
 							return TaskOutputErrorFromExec(state, err, result)
 						}
@@ -160,7 +160,7 @@ func (t AclServiceTask) Plan() PlanResult {
 							Command: "dokku",
 							Args:    []string{"--quiet", "acl:remove-service", t.Type, t.Service, u},
 						})
-						state.Command = result.Command
+						state.Commands = append(state.Commands, result.Command)
 						if err != nil {
 							return TaskOutputErrorFromExec(state, err, result)
 						}

--- a/tasks/acl_service_task.go
+++ b/tasks/acl_service_task.go
@@ -114,6 +114,7 @@ func (t AclServiceTask) Plan() PlanResult {
 							Command: "dokku",
 							Args:    []string{"--quiet", "acl:add-service", t.Type, t.Service, u},
 						})
+						state.Command = result.Command
 						if err != nil {
 							return TaskOutputErrorFromExec(state, err, result)
 						}
@@ -159,6 +160,7 @@ func (t AclServiceTask) Plan() PlanResult {
 							Command: "dokku",
 							Args:    []string{"--quiet", "acl:remove-service", t.Type, t.Service, u},
 						})
+						state.Command = result.Command
 						if err != nil {
 							return TaskOutputErrorFromExec(state, err, result)
 						}

--- a/tasks/app_clone_task.go
+++ b/tasks/app_clone_task.go
@@ -95,7 +95,7 @@ func (t AppCloneTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    args,
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/app_clone_task.go
+++ b/tasks/app_clone_task.go
@@ -95,6 +95,7 @@ func (t AppCloneTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    args,
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/app_lock_task.go
+++ b/tasks/app_lock_task.go
@@ -79,6 +79,7 @@ func (t AppLockTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "apps:lock", t.App},
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -103,6 +104,7 @@ func (t AppLockTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "apps:unlock", t.App},
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/app_lock_task.go
+++ b/tasks/app_lock_task.go
@@ -79,7 +79,7 @@ func (t AppLockTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "apps:lock", t.App},
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -104,7 +104,7 @@ func (t AppLockTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "apps:unlock", t.App},
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/app_task.go
+++ b/tasks/app_task.go
@@ -111,7 +111,7 @@ func applyCreateApp(app string) func() TaskOutputState {
 			Command: "dokku",
 			Args:    []string{"--quiet", "apps:create", app},
 		})
-		state.Command = result.Command
+		state.Commands = append(state.Commands, result.Command)
 		if err != nil {
 			return TaskOutputErrorFromExec(state, err, result)
 		}
@@ -129,7 +129,7 @@ func applyDestroyApp(app string) func() TaskOutputState {
 			Command: "dokku",
 			Args:    []string{"--quiet", "--force", "apps:destroy", app},
 		})
-		state.Command = result.Command
+		state.Commands = append(state.Commands, result.Command)
 		if err != nil {
 			return TaskOutputErrorFromExec(state, err, result)
 		}

--- a/tasks/app_task.go
+++ b/tasks/app_task.go
@@ -111,6 +111,7 @@ func applyCreateApp(app string) func() TaskOutputState {
 			Command: "dokku",
 			Args:    []string{"--quiet", "apps:create", app},
 		})
+		state.Command = result.Command
 		if err != nil {
 			return TaskOutputErrorFromExec(state, err, result)
 		}
@@ -128,6 +129,7 @@ func applyDestroyApp(app string) func() TaskOutputState {
 			Command: "dokku",
 			Args:    []string{"--quiet", "--force", "apps:destroy", app},
 		})
+		state.Command = result.Command
 		if err != nil {
 			return TaskOutputErrorFromExec(state, err, result)
 		}

--- a/tasks/buildpacks_task.go
+++ b/tasks/buildpacks_task.go
@@ -122,7 +122,7 @@ func planBuildpacksAdd(t BuildpacksTask) PlanResult {
 					Command: "dokku",
 					Args:    []string{"--quiet", "buildpacks:add", t.App, bp},
 				})
-				state.Command = result.Command
+				state.Commands = append(state.Commands, result.Command)
 				if err != nil {
 					return TaskOutputErrorFromExec(state, err, result)
 				}
@@ -162,7 +162,7 @@ func planBuildpacksRemove(t BuildpacksTask) PlanResult {
 					Command: "dokku",
 					Args:    []string{"--quiet", "buildpacks:clear", app},
 				})
-				state.Command = result.Command
+				state.Commands = append(state.Commands, result.Command)
 				if err != nil {
 					return TaskOutputErrorFromExec(state, err, result)
 				}
@@ -195,7 +195,7 @@ func planBuildpacksRemove(t BuildpacksTask) PlanResult {
 					Command: "dokku",
 					Args:    []string{"--quiet", "buildpacks:remove", t.App, bp},
 				})
-				state.Command = result.Command
+				state.Commands = append(state.Commands, result.Command)
 				if err != nil {
 					return TaskOutputErrorFromExec(state, err, result)
 				}

--- a/tasks/buildpacks_task.go
+++ b/tasks/buildpacks_task.go
@@ -122,6 +122,7 @@ func planBuildpacksAdd(t BuildpacksTask) PlanResult {
 					Command: "dokku",
 					Args:    []string{"--quiet", "buildpacks:add", t.App, bp},
 				})
+				state.Command = result.Command
 				if err != nil {
 					return TaskOutputErrorFromExec(state, err, result)
 				}
@@ -161,6 +162,7 @@ func planBuildpacksRemove(t BuildpacksTask) PlanResult {
 					Command: "dokku",
 					Args:    []string{"--quiet", "buildpacks:clear", app},
 				})
+				state.Command = result.Command
 				if err != nil {
 					return TaskOutputErrorFromExec(state, err, result)
 				}
@@ -193,6 +195,7 @@ func planBuildpacksRemove(t BuildpacksTask) PlanResult {
 					Command: "dokku",
 					Args:    []string{"--quiet", "buildpacks:remove", t.App, bp},
 				})
+				state.Command = result.Command
 				if err != nil {
 					return TaskOutputErrorFromExec(state, err, result)
 				}

--- a/tasks/certs_task.go
+++ b/tasks/certs_task.go
@@ -122,7 +122,7 @@ func (t CertsTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    args,
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -162,7 +162,7 @@ func (t CertsTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    args,
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/certs_task.go
+++ b/tasks/certs_task.go
@@ -122,6 +122,7 @@ func (t CertsTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    args,
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -161,6 +162,7 @@ func (t CertsTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    args,
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/config_task.go
+++ b/tasks/config_task.go
@@ -146,7 +146,7 @@ func planConfigSet(t ConfigTask) PlanResult {
 				Command: "dokku",
 				Args:    args,
 			})
-			state.Command = result.Command
+			state.Commands = append(state.Commands, result.Command)
 			if err != nil {
 				return TaskOutputErrorFromExec(state, err, result)
 			}
@@ -189,7 +189,7 @@ func planConfigUnset(t ConfigTask) PlanResult {
 				Command: "dokku",
 				Args:    args,
 			})
-			state.Command = result.Command
+			state.Commands = append(state.Commands, result.Command)
 			if err != nil {
 				return TaskOutputErrorFromExec(state, err, result)
 			}

--- a/tasks/config_task.go
+++ b/tasks/config_task.go
@@ -146,6 +146,7 @@ func planConfigSet(t ConfigTask) PlanResult {
 				Command: "dokku",
 				Args:    args,
 			})
+			state.Command = result.Command
 			if err != nil {
 				return TaskOutputErrorFromExec(state, err, result)
 			}
@@ -188,6 +189,7 @@ func planConfigUnset(t ConfigTask) PlanResult {
 				Command: "dokku",
 				Args:    args,
 			})
+			state.Command = result.Command
 			if err != nil {
 				return TaskOutputErrorFromExec(state, err, result)
 			}

--- a/tasks/docker_options_task.go
+++ b/tasks/docker_options_task.go
@@ -95,7 +95,7 @@ func (t DockerOptionsTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "docker-options:add", t.App, t.Phase, t.Option},
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -127,7 +127,7 @@ func (t DockerOptionsTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "docker-options:remove", t.App, t.Phase, t.Option},
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/docker_options_task.go
+++ b/tasks/docker_options_task.go
@@ -95,6 +95,7 @@ func (t DockerOptionsTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "docker-options:add", t.App, t.Phase, t.Option},
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -126,6 +127,7 @@ func (t DockerOptionsTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "docker-options:remove", t.App, t.Phase, t.Option},
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/domains_task.go
+++ b/tasks/domains_task.go
@@ -250,7 +250,7 @@ func applyDokkuArgs(subcommand, target string, extra []string, finalState State,
 			Command: "dokku",
 			Args:    args,
 		})
-		state.Command = result.Command
+		state.Commands = append(state.Commands, result.Command)
 		if err != nil {
 			return TaskOutputErrorFromExec(state, err, result)
 		}

--- a/tasks/domains_task.go
+++ b/tasks/domains_task.go
@@ -250,6 +250,7 @@ func applyDokkuArgs(subcommand, target string, extra []string, finalState State,
 			Command: "dokku",
 			Args:    args,
 		})
+		state.Command = result.Command
 		if err != nil {
 			return TaskOutputErrorFromExec(state, err, result)
 		}

--- a/tasks/errors.go
+++ b/tasks/errors.go
@@ -2,14 +2,19 @@ package tasks
 
 import "github.com/dokku/docket/subprocess"
 
-// TaskOutputErrorFromExec sets Error, Message, and Command on the given state
-// from an exec result. Returns the modified state for convenient use with
-// early returns.
+// TaskOutputErrorFromExec sets Error and Message on the given state from an
+// exec result, and ensures the failing invocation is recorded in
+// state.Commands so it surfaces under `--verbose`. Idempotent against the
+// per-task pre-error-check append pattern: when the failing command is
+// already the most recent entry it is not appended again. Returns the
+// modified state for convenient use with early returns.
 func TaskOutputErrorFromExec(state TaskOutputState, err error, result subprocess.ExecCommandResponse) TaskOutputState {
 	state.Error = err
 	state.Message = result.StderrContents()
 	if result.Command != "" {
-		state.Command = result.Command
+		if n := len(state.Commands); n == 0 || state.Commands[n-1] != result.Command {
+			state.Commands = append(state.Commands, result.Command)
+		}
 	}
 	return state
 }

--- a/tasks/errors.go
+++ b/tasks/errors.go
@@ -2,10 +2,14 @@ package tasks
 
 import "github.com/dokku/docket/subprocess"
 
-// TaskOutputErrorFromExec sets Error and Message on the given state from an exec result.
-// Returns the modified state for convenient use with early returns.
+// TaskOutputErrorFromExec sets Error, Message, and Command on the given state
+// from an exec result. Returns the modified state for convenient use with
+// early returns.
 func TaskOutputErrorFromExec(state TaskOutputState, err error, result subprocess.ExecCommandResponse) TaskOutputState {
 	state.Error = err
 	state.Message = result.StderrContents()
+	if result.Command != "" {
+		state.Command = result.Command
+	}
 	return state
 }

--- a/tasks/git_auth_task.go
+++ b/tasks/git_auth_task.go
@@ -94,6 +94,7 @@ func (t GitAuthTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "git:auth", t.Host, t.Username, t.Password},
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -115,6 +116,7 @@ func (t GitAuthTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "git:auth", t.Host},
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -147,6 +149,7 @@ func setGitAuth(t GitAuthTask) TaskOutputState {
 		Command: "dokku",
 		Args:    []string{"--quiet", "git:auth", t.Host, t.Username, t.Password},
 	})
+	state.Command = result.Command
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}
@@ -172,6 +175,7 @@ func unsetGitAuth(t GitAuthTask) TaskOutputState {
 		Command: "dokku",
 		Args:    []string{"--quiet", "git:auth", t.Host},
 	})
+	state.Command = result.Command
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}

--- a/tasks/git_auth_task.go
+++ b/tasks/git_auth_task.go
@@ -94,7 +94,7 @@ func (t GitAuthTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "git:auth", t.Host, t.Username, t.Password},
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -116,7 +116,7 @@ func (t GitAuthTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "git:auth", t.Host},
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -149,7 +149,7 @@ func setGitAuth(t GitAuthTask) TaskOutputState {
 		Command: "dokku",
 		Args:    []string{"--quiet", "git:auth", t.Host, t.Username, t.Password},
 	})
-	state.Command = result.Command
+	state.Commands = append(state.Commands, result.Command)
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}
@@ -175,7 +175,7 @@ func unsetGitAuth(t GitAuthTask) TaskOutputState {
 		Command: "dokku",
 		Args:    []string{"--quiet", "git:auth", t.Host},
 	})
-	state.Command = result.Command
+	state.Commands = append(state.Commands, result.Command)
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}

--- a/tasks/git_from_archive_task.go
+++ b/tasks/git_from_archive_task.go
@@ -114,6 +114,7 @@ func (t GitFromArchiveTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    args,
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/git_from_archive_task.go
+++ b/tasks/git_from_archive_task.go
@@ -114,7 +114,7 @@ func (t GitFromArchiveTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    args,
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/git_from_image_task.go
+++ b/tasks/git_from_image_task.go
@@ -87,7 +87,7 @@ func (t GitFromImageTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    args,
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/git_from_image_task.go
+++ b/tasks/git_from_image_task.go
@@ -87,6 +87,7 @@ func (t GitFromImageTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    args,
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -111,7 +111,7 @@ func (t GitSyncTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    args,
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -111,6 +111,7 @@ func (t GitSyncTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    args,
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/http_auth_task.go
+++ b/tasks/http_auth_task.go
@@ -90,6 +90,7 @@ func (t HttpAuthTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "http-auth:on", t.App, t.Username, t.Password},
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -114,6 +115,7 @@ func (t HttpAuthTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "http-auth:off", t.App},
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -174,6 +176,7 @@ func enableHttpAuth(app, username, password string) TaskOutputState {
 			password,
 		},
 	})
+	state.Command = result.Command
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}
@@ -202,6 +205,7 @@ func disableHttpAuth(app string) TaskOutputState {
 			app,
 		},
 	})
+	state.Command = result.Command
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}

--- a/tasks/http_auth_task.go
+++ b/tasks/http_auth_task.go
@@ -90,7 +90,7 @@ func (t HttpAuthTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "http-auth:on", t.App, t.Username, t.Password},
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -115,7 +115,7 @@ func (t HttpAuthTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "http-auth:off", t.App},
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -176,7 +176,7 @@ func enableHttpAuth(app, username, password string) TaskOutputState {
 			password,
 		},
 	})
-	state.Command = result.Command
+	state.Commands = append(state.Commands, result.Command)
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}
@@ -205,7 +205,7 @@ func disableHttpAuth(app string) TaskOutputState {
 			app,
 		},
 	})
-	state.Command = result.Command
+	state.Commands = append(state.Commands, result.Command)
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}

--- a/tasks/letsencrypt_task.go
+++ b/tasks/letsencrypt_task.go
@@ -84,7 +84,7 @@ func (t LetsencryptTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "letsencrypt:enable", t.App},
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -113,7 +113,7 @@ func (t LetsencryptTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "letsencrypt:disable", t.App},
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -166,7 +166,7 @@ func enableLetsencrypt(app string) TaskOutputState {
 		Command: "dokku",
 		Args:    []string{"--quiet", "letsencrypt:enable", app},
 	})
-	state.Command = result.Command
+	state.Commands = append(state.Commands, result.Command)
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}
@@ -203,7 +203,7 @@ func disableLetsencrypt(app string) TaskOutputState {
 		Command: "dokku",
 		Args:    []string{"--quiet", "letsencrypt:disable", app},
 	})
-	state.Command = result.Command
+	state.Commands = append(state.Commands, result.Command)
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}

--- a/tasks/letsencrypt_task.go
+++ b/tasks/letsencrypt_task.go
@@ -84,6 +84,7 @@ func (t LetsencryptTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "letsencrypt:enable", t.App},
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -112,6 +113,7 @@ func (t LetsencryptTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "letsencrypt:disable", t.App},
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -164,6 +166,7 @@ func enableLetsencrypt(app string) TaskOutputState {
 		Command: "dokku",
 		Args:    []string{"--quiet", "letsencrypt:enable", app},
 	})
+	state.Command = result.Command
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}
@@ -200,6 +203,7 @@ func disableLetsencrypt(app string) TaskOutputState {
 		Command: "dokku",
 		Args:    []string{"--quiet", "letsencrypt:disable", app},
 	})
+	state.Command = result.Command
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -65,6 +65,12 @@ type TaskOutputState struct {
 	// Changed is a flag indicating if the task was changed
 	Changed bool
 
+	// Command is the resolved Dokku subprocess command line that the
+	// task's apply path executed, used by `docket apply --verbose`. When
+	// a task runs multiple subprocess commands, this records the last
+	// command executed.
+	Command string
+
 	// DesiredState is the desired state of the task
 	DesiredState State
 

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -65,11 +65,11 @@ type TaskOutputState struct {
 	// Changed is a flag indicating if the task was changed
 	Changed bool
 
-	// Command is the resolved Dokku subprocess command line that the
-	// task's apply path executed, used by `docket apply --verbose`. When
-	// a task runs multiple subprocess commands, this records the last
-	// command executed.
-	Command string
+	// Commands records every resolved Dokku subprocess command line the
+	// task's apply path executed, in invocation order. Used by
+	// `docket apply --verbose` to echo one `→` continuation line per
+	// command. Empty for tasks that did not invoke any subprocess.
+	Commands []string
 
 	// DesiredState is the desired state of the task
 	DesiredState State

--- a/tasks/network_task.go
+++ b/tasks/network_task.go
@@ -74,7 +74,7 @@ func (t NetworkTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "network:create", t.Name},
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -99,7 +99,7 @@ func (t NetworkTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "--force", "network:destroy", t.Name},
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -141,7 +141,7 @@ func destroyNetwork(name string) TaskOutputState {
 		Command: "dokku",
 		Args:    []string{"--quiet", "--force", "network:destroy", name},
 	})
-	state.Command = result.Command
+	state.Commands = append(state.Commands, result.Command)
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}

--- a/tasks/network_task.go
+++ b/tasks/network_task.go
@@ -74,6 +74,7 @@ func (t NetworkTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "network:create", t.Name},
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -98,6 +99,7 @@ func (t NetworkTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "--force", "network:destroy", t.Name},
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -139,6 +141,7 @@ func destroyNetwork(name string) TaskOutputState {
 		Command: "dokku",
 		Args:    []string{"--quiet", "--force", "network:destroy", name},
 	})
+	state.Command = result.Command
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -104,6 +104,7 @@ func (t PortsTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    args,
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -141,6 +142,7 @@ func (t PortsTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    args,
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -104,7 +104,7 @@ func (t PortsTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    args,
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -142,7 +142,7 @@ func (t PortsTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    args,
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -158,7 +158,7 @@ func applyPropertySet(subcommand, target, property, value string) func() TaskOut
 			Command: "dokku",
 			Args:    []string{"--quiet", subcommand, target, property, value},
 		})
-		state.Command = result.Command
+		state.Commands = append(state.Commands, result.Command)
 		if err != nil {
 			return TaskOutputErrorFromExec(state, err, result)
 		}
@@ -178,7 +178,7 @@ func applyPropertyUnset(subcommand, target, property string) func() TaskOutputSt
 			Command: "dokku",
 			Args:    []string{"--quiet", subcommand, target, property},
 		})
-		state.Command = result.Command
+		state.Commands = append(state.Commands, result.Command)
 		if err != nil {
 			return TaskOutputErrorFromExec(state, err, result)
 		}

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -158,6 +158,7 @@ func applyPropertySet(subcommand, target, property, value string) func() TaskOut
 			Command: "dokku",
 			Args:    []string{"--quiet", subcommand, target, property, value},
 		})
+		state.Command = result.Command
 		if err != nil {
 			return TaskOutputErrorFromExec(state, err, result)
 		}
@@ -177,6 +178,7 @@ func applyPropertyUnset(subcommand, target, property string) func() TaskOutputSt
 			Command: "dokku",
 			Args:    []string{"--quiet", subcommand, target, property},
 		})
+		state.Command = result.Command
 		if err != nil {
 			return TaskOutputErrorFromExec(state, err, result)
 		}

--- a/tasks/ps_scale_task.go
+++ b/tasks/ps_scale_task.go
@@ -117,7 +117,7 @@ func (t PsScaleTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    args,
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/ps_scale_task.go
+++ b/tasks/ps_scale_task.go
@@ -117,6 +117,7 @@ func (t PsScaleTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    args,
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/registry_auth_task.go
+++ b/tasks/registry_auth_task.go
@@ -128,6 +128,7 @@ func (t RegistryAuthTask) Plan() PlanResult {
 						Args:    args,
 						Stdin:   strings.NewReader(t.Password),
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -156,6 +157,7 @@ func (t RegistryAuthTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    args,
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -212,6 +214,7 @@ func registryLogin(t RegistryAuthTask) TaskOutputState {
 		Args:    args,
 		Stdin:   strings.NewReader(t.Password),
 	})
+	state.Command = result.Command
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}
@@ -245,6 +248,7 @@ func registryLogout(t RegistryAuthTask) TaskOutputState {
 		Command: "dokku",
 		Args:    args,
 	})
+	state.Command = result.Command
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}

--- a/tasks/registry_auth_task.go
+++ b/tasks/registry_auth_task.go
@@ -128,7 +128,7 @@ func (t RegistryAuthTask) Plan() PlanResult {
 						Args:    args,
 						Stdin:   strings.NewReader(t.Password),
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -157,7 +157,7 @@ func (t RegistryAuthTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    args,
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -214,7 +214,7 @@ func registryLogin(t RegistryAuthTask) TaskOutputState {
 		Args:    args,
 		Stdin:   strings.NewReader(t.Password),
 	})
-	state.Command = result.Command
+	state.Commands = append(state.Commands, result.Command)
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}
@@ -248,7 +248,7 @@ func registryLogout(t RegistryAuthTask) TaskOutputState {
 		Command: "dokku",
 		Args:    args,
 	})
-	state.Command = result.Command
+	state.Commands = append(state.Commands, result.Command)
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}

--- a/tasks/resources.go
+++ b/tasks/resources.go
@@ -177,7 +177,7 @@ func applyResourceSet(subcommand string, rctx ResourceContext) func() TaskOutput
 			Command: "dokku",
 			Args:    args,
 		})
-		state.Command = result.Command
+		state.Commands = append(state.Commands, result.Command)
 		if err != nil {
 			return TaskOutputErrorFromExec(state, err, result)
 		}

--- a/tasks/resources.go
+++ b/tasks/resources.go
@@ -177,6 +177,7 @@ func applyResourceSet(subcommand string, rctx ResourceContext) func() TaskOutput
 			Command: "dokku",
 			Args:    args,
 		})
+		state.Command = result.Command
 		if err != nil {
 			return TaskOutputErrorFromExec(state, err, result)
 		}

--- a/tasks/service_create_task.go
+++ b/tasks/service_create_task.go
@@ -87,7 +87,7 @@ func (t ServiceCreateTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", fmt.Sprintf("%s:create", t.Service), t.Name},
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -112,7 +112,7 @@ func (t ServiceCreateTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "--force", fmt.Sprintf("%s:destroy", t.Service), t.Name},
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -161,7 +161,7 @@ func createService(service, name string) TaskOutputState {
 			name,
 		},
 	})
-	state.Command = result.Command
+	state.Commands = append(state.Commands, result.Command)
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}
@@ -191,7 +191,7 @@ func destroyService(service, name string) TaskOutputState {
 			name,
 		},
 	})
-	state.Command = result.Command
+	state.Commands = append(state.Commands, result.Command)
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}

--- a/tasks/service_create_task.go
+++ b/tasks/service_create_task.go
@@ -87,6 +87,7 @@ func (t ServiceCreateTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", fmt.Sprintf("%s:create", t.Service), t.Name},
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -111,6 +112,7 @@ func (t ServiceCreateTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "--force", fmt.Sprintf("%s:destroy", t.Service), t.Name},
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -159,6 +161,7 @@ func createService(service, name string) TaskOutputState {
 			name,
 		},
 	})
+	state.Command = result.Command
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}
@@ -188,6 +191,7 @@ func destroyService(service, name string) TaskOutputState {
 			name,
 		},
 	})
+	state.Command = result.Command
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}

--- a/tasks/service_link_task.go
+++ b/tasks/service_link_task.go
@@ -99,7 +99,7 @@ func (t ServiceLinkTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", fmt.Sprintf("%s:link", t.Service), t.Name, t.App},
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -130,7 +130,7 @@ func (t ServiceLinkTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", fmt.Sprintf("%s:unlink", t.Service), t.Name, t.App},
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -192,7 +192,7 @@ func linkService(service, name, app string) TaskOutputState {
 			app,
 		},
 	})
-	state.Command = result.Command
+	state.Commands = append(state.Commands, result.Command)
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}
@@ -233,7 +233,7 @@ func unlinkService(service, name, app string) TaskOutputState {
 			app,
 		},
 	})
-	state.Command = result.Command
+	state.Commands = append(state.Commands, result.Command)
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}

--- a/tasks/service_link_task.go
+++ b/tasks/service_link_task.go
@@ -99,6 +99,7 @@ func (t ServiceLinkTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", fmt.Sprintf("%s:link", t.Service), t.Name, t.App},
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -129,6 +130,7 @@ func (t ServiceLinkTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", fmt.Sprintf("%s:unlink", t.Service), t.Name, t.App},
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -190,6 +192,7 @@ func linkService(service, name, app string) TaskOutputState {
 			app,
 		},
 	})
+	state.Command = result.Command
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}
@@ -230,6 +233,7 @@ func unlinkService(service, name, app string) TaskOutputState {
 			app,
 		},
 	})
+	state.Command = result.Command
 	if err != nil {
 		return TaskOutputErrorFromExec(state, err, result)
 	}

--- a/tasks/storage_ensure_task.go
+++ b/tasks/storage_ensure_task.go
@@ -69,7 +69,7 @@ func (t StorageEnsureTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "storage:ensure-directory", "--chown", t.Chown, t.App},
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/storage_ensure_task.go
+++ b/tasks/storage_ensure_task.go
@@ -69,6 +69,7 @@ func (t StorageEnsureTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "storage:ensure-directory", "--chown", t.Chown, t.App},
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -69,6 +69,7 @@ func (t StorageMountTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "storage:mount", t.App, mountSpec},
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -93,6 +94,7 @@ func (t StorageMountTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "storage:unmount", t.App, mountSpec},
 					})
+					state.Command = result.Command
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -69,7 +69,7 @@ func (t StorageMountTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "storage:mount", t.App, mountSpec},
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}
@@ -94,7 +94,7 @@ func (t StorageMountTask) Plan() PlanResult {
 						Command: "dokku",
 						Args:    []string{"--quiet", "storage:unmount", t.App, mountSpec},
 					})
-					state.Command = result.Command
+					state.Commands = append(state.Commands, result.Command)
 					if err != nil {
 						return TaskOutputErrorFromExec(state, err, result)
 					}

--- a/tasks/toggle.go
+++ b/tasks/toggle.go
@@ -87,7 +87,7 @@ func applyToggle(subcommand, target string, finalState State) func() TaskOutputS
 			Command: "dokku",
 			Args:    []string{"--quiet", subcommand, target},
 		})
-		state.Command = result.Command
+		state.Commands = append(state.Commands, result.Command)
 		if err != nil {
 			return TaskOutputErrorFromExec(state, err, result)
 		}

--- a/tasks/toggle.go
+++ b/tasks/toggle.go
@@ -87,6 +87,7 @@ func applyToggle(subcommand, target string, finalState State) func() TaskOutputS
 			Command: "dokku",
 			Args:    []string{"--quiet", subcommand, target},
 		})
+		state.Command = result.Command
 		if err != nil {
 			return TaskOutputErrorFromExec(state, err, result)
 		}

--- a/tests/bats/output.bats
+++ b/tests/bats/output.bats
@@ -58,6 +58,38 @@ EOF
   assert_output --partial "apps:create"
 }
 
+@test "docket apply --verbose echoes every command for multi-command tasks" {
+  # dokku_buildpacks invokes `dokku buildpacks:add` once per buildpack URL,
+  # which exercises the per-task multi-command append path. The URLs are
+  # only recorded in the buildpacks file (no network fetch happens at
+  # add-time) so this stays a pure docket+dokku test.
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-output
+      dokku_app:
+        app: docket-test-output
+    - name: add buildpacks
+      dokku_buildpacks:
+        app: docket-test-output
+        buildpacks:
+          - https://github.com/heroku/heroku-buildpack-nodejs.git
+          - https://github.com/heroku/heroku-buildpack-nginx.git
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --verbose
+  assert_success
+  assert_output --partial "→ dokku"
+  assert_output --partial "buildpacks:add"
+  assert_output --partial "heroku-buildpack-nodejs"
+  assert_output --partial "heroku-buildpack-nginx"
+  # One -> line per buildpack add.
+  local arrow_count
+  arrow_count="$(printf '%s\n' "${output}" | grep -c "→ dokku.*buildpacks:add" || true)"
+  if [ "${arrow_count}" -lt 2 ]; then
+    fail "expected at least 2 '→ dokku ... buildpacks:add' continuation lines, got ${arrow_count} in:${output}"
+  fi
+}
+
 @test "docket apply on error surfaces the failure" {
   write_tasks_file <<EOF
 ---

--- a/tests/bats/output.bats
+++ b/tests/bats/output.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  require_dokku
+  docket_build
+  dokku_clean_app docket-test-output
+}
+
+teardown() {
+  dokku_clean_app docket-test-output
+}
+
+@test "docket apply prints structured per-task output" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-output
+      dokku_app:
+        app: docket-test-output
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "==> Play: tasks"
+  assert_output --partial "[changed] "
+  assert_output --partial "Summary:"
+  assert_output --regexp "took [0-9]+\.[0-9]+s"
+}
+
+@test "docket apply on second run reports ok" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-output
+      dokku_app:
+        app: docket-test-output
+EOF
+  "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "[ok]"
+  refute_output --partial "[changed]"
+  assert_output --partial "0 changed"
+}
+
+@test "docket apply --verbose echoes resolved commands" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-output
+      dokku_app:
+        app: docket-test-output
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --verbose
+  assert_success
+  assert_output --partial "→ dokku"
+  assert_output --partial "apps:create"
+}
+
+@test "docket apply on error surfaces the failure" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: add ports to a missing app
+      dokku_ports:
+        app: docket-test-output-missing
+        port_mappings:
+          - { scheme: http, host_port: 80, container_port: 5000 }
+        state: present
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "[error]"
+  assert_output --partial "          !"
+  assert_output --partial "1 error"
+}
+
+@test "docket apply respects NO_COLOR" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-output
+      dokku_app:
+        app: docket-test-output
+EOF
+  NO_COLOR=1 run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  refute_output --partial $'\x1b['
+}

--- a/tests/bats/plan.bats
+++ b/tests/bats/plan.bats
@@ -22,6 +22,7 @@ teardown() {
 EOF
   run "$(docket_bin)" plan --tasks "$TASKS_FILE"
   assert_success
+  assert_output --partial "==> Play: tasks"
   assert_output --partial "[+]"
   assert_output --partial "Plan:"
   assert_output --partial "1 would change"


### PR DESCRIPTION
## Summary

Closes #202.

Replaces the bare `executing <task>` line in `apply` with bracketed status markers (`[ok]`, `[changed]`, `[error]`), a `==> Play: tasks` header, and a `Summary: ...` end-of-run line. Failing tasks surface their error message as a `!`-prefixed continuation line and the run aborts with exit 1 (fail-fast preserved). Adds a `--verbose` flag that echoes every resolved Dokku command the task ran on `→`-prefixed continuation lines, in invocation order - so multi-command tasks (e.g. `dokku_buildpacks` adding several URLs) emit one continuation per call. Sourced from new `Command` field on `subprocess.ExecCommandResponse` and `Commands []string` on `tasks.TaskOutputState`. The same shared formatter in `commands/output.go` powers `plan`, which keeps its existing exit codes. Color decisions live in the formatter and respect the `NO_COLOR` de-facto standard.

The verbose echo is unmasked until #203 ships sensitive value masking; the help text for `--verbose` notes that. Stderr surfacing as a separate `stderr:` continuation is deferred to #209 (the formatter only prints `state.Error.Error()` today).