### PR TITLE
feat: mask sensitive values via struct tags and inputs

### DIFF
--- a/commands/apply.go
+++ b/commands/apply.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/dokku/docket/subprocess"
 	"github.com/dokku/docket/tasks"
 
 	"github.com/josegonzalez/cli-skeleton/command"
@@ -57,7 +58,7 @@ func (c *ApplyCommand) ParsedArguments(args []string) (map[string]command.Argume
 func (c *ApplyCommand) FlagSet() *flag.FlagSet {
 	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
 	f.StringVar(&c.tasksFile, "tasks", "tasks.yml", "a yaml file containing a task list")
-	f.BoolVar(&c.verbose, "verbose", false, "echo the resolved dokku command for each task as a continuation line (commands are not masked; avoid on recipes that pass secrets via task arguments)")
+	f.BoolVar(&c.verbose, "verbose", false, "echo the resolved dokku command for each task as a continuation line. Values from inputs declared `sensitive: true` and from task struct fields tagged `sensitive:\"true\"` are masked as `***`")
 
 	taskFile := getTaskYamlFilename(os.Args)
 	data, err := os.ReadFile(taskFile)
@@ -100,12 +101,18 @@ func (c *ApplyCommand) Run(args []string) int {
 	}
 
 	context := make(map[string]interface{})
+	var sensitiveValues []string
 	for name, argument := range c.arguments {
 		if argument.Required && !argument.HasValue() {
 			c.Ui.Error(fmt.Sprintf("Missing flag '--%s'", name))
 			return 1
 		}
 		context[name] = argument.GetValue()
+		if argument.Sensitive {
+			if v := argument.StringValue(); v != "" {
+				sensitiveValues = append(sensitiveValues, v)
+			}
+		}
 	}
 
 	taskList, err := tasks.GetTasks(data, context)
@@ -113,6 +120,10 @@ func (c *ApplyCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("task error: %v", err))
 		return 1
 	}
+
+	sensitiveValues = append(sensitiveValues, tasks.CollectSensitiveValues(taskList)...)
+	subprocess.SetGlobalSensitive(sensitiveValues)
+	defer subprocess.SetGlobalSensitive(nil)
 
 	formatter := NewFormatter(c.Ui, c.verbose)
 	formatter.PlayHeader("tasks")

--- a/commands/apply_args.go
+++ b/commands/apply_args.go
@@ -15,6 +15,7 @@ import (
 
 type Argument struct {
 	Required    bool
+	Sensitive   bool
 	boolValue   *bool
 	floatValue  *float64
 	intValue    *int
@@ -36,6 +37,35 @@ func (c Argument) GetValue() interface{} {
 
 func (c Argument) HasValue() bool {
 	return c.GetValue() != nil
+}
+
+// StringValue returns the argument's value formatted as the same string sigil
+// will substitute into the rendered YAML. Returns "" when no value is set.
+// Used to register sensitive input values with the subprocess masker.
+func (c Argument) StringValue() string {
+	switch v := c.GetValue().(type) {
+	case *string:
+		if v == nil {
+			return ""
+		}
+		return *v
+	case *int:
+		if v == nil {
+			return ""
+		}
+		return strconv.Itoa(*v)
+	case *float64:
+		if v == nil {
+			return ""
+		}
+		return strconv.FormatFloat(*v, 'g', -1, 64)
+	case *bool:
+		if v == nil {
+			return ""
+		}
+		return strconv.FormatBool(*v)
+	}
+	return ""
 }
 
 func (c *Argument) SetBoolValue(ptr *bool) {
@@ -119,7 +149,7 @@ func registerInputFlags(f *flag.FlagSet, data []byte) (map[string]*Argument, err
 		if input.Name == "tasks" {
 			continue
 		}
-		arg := &Argument{Required: input.Required}
+		arg := &Argument{Required: input.Required, Sensitive: input.Sensitive}
 		switch input.Type {
 		case "string", "":
 			arg.SetStringValue(f.String(input.Name, input.Default, input.Description))

--- a/commands/output.go
+++ b/commands/output.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dokku/docket/subprocess"
 	"github.com/fatih/color"
 	"github.com/mitchellh/cli"
 )
@@ -108,12 +109,14 @@ func (f *Formatter) PlayHeader(name string) {
 // appended after two spaces (matching the legacy plan-line layout).
 //
 // Errored task lines are routed through Ui.Error so they land on stderr
-// and inherit the cli-skeleton error styling.
+// and inherit the cli-skeleton error styling. The suffix is masked
+// against the global sensitive value set so error contexts that include
+// stderr can't leak secrets.
 func (f *Formatter) TaskLine(m Marker, name, suffix string) {
 	marker := f.paintMarker(m)
 	line := marker + name
 	if suffix != "" {
-		line = line + "  " + suffix
+		line = line + "  " + subprocess.MaskString(suffix)
 	}
 	if m == MarkerError || m == MarkerProbeError {
 		f.ui.Error(line)
@@ -126,11 +129,13 @@ func (f *Formatter) TaskLine(m Marker, name, suffix string) {
 // recent task line. prefix is the leading rune (`!` for errors,
 // `→` for the verbose command echo, `-` for plan mutation items).
 // Each line of `body` is emitted as its own continuation so multi-line
-// stderr renders cleanly under the marker column.
+// stderr renders cleanly under the marker column. The body is masked
+// against the global sensitive value set before output.
 func (f *Formatter) Continuation(prefix rune, body string) {
 	if body == "" {
 		return
 	}
+	body = subprocess.MaskString(body)
 	for _, line := range strings.Split(strings.TrimRight(body, "\n"), "\n") {
 		out := fmt.Sprintf("%s%c %s", continuationIndent, prefix, line)
 		f.ui.Output(out)

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/dokku/docket/subprocess"
 	"github.com/dokku/docket/tasks"
 
 	"github.com/josegonzalez/cli-skeleton/command"
@@ -107,12 +108,18 @@ func (c *PlanCommand) Run(args []string) int {
 	}
 
 	context := make(map[string]interface{})
+	var sensitiveValues []string
 	for name, argument := range c.arguments {
 		if argument.Required && !argument.HasValue() {
 			c.Ui.Error(fmt.Sprintf("Missing flag '--%s'", name))
 			return 1
 		}
 		context[name] = argument.GetValue()
+		if argument.Sensitive {
+			if v := argument.StringValue(); v != "" {
+				sensitiveValues = append(sensitiveValues, v)
+			}
+		}
 	}
 
 	taskList, err := tasks.GetTasks(data, context)
@@ -120,6 +127,10 @@ func (c *PlanCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("task error: %v", err))
 		return 1
 	}
+
+	sensitiveValues = append(sensitiveValues, tasks.CollectSensitiveValues(taskList)...)
+	subprocess.SetGlobalSensitive(sensitiveValues)
+	defer subprocess.SetGlobalSensitive(nil)
 
 	formatter := NewFormatter(c.Ui, false)
 	formatter.PlayHeader("tasks")

--- a/subprocess/exec.go
+++ b/subprocess/exec.go
@@ -152,7 +152,7 @@ func CallExecCommandWithContext(ctx context.Context, input ExecCommandInput) (Ex
 		if len(cmd.Args) > 0 {
 			argsSt = strings.Join(cmd.Args, " ")
 		}
-		log.Printf("exec: %s %s", cmd.Command, argsSt)
+		log.Printf("exec: %s %s", MaskString(cmd.Command), MaskString(argsSt))
 	}
 
 	if input.Stdin != nil {
@@ -181,6 +181,7 @@ func CallExecCommandWithContext(ctx context.Context, input ExecCommandInput) (Ex
 	if len(commandArgs) > 0 {
 		resolved = command + " " + strings.Join(commandArgs, " ")
 	}
+	resolved = MaskString(resolved)
 
 	res, err := cmd.Execute(ctx)
 	if err != nil {

--- a/subprocess/exec_test.go
+++ b/subprocess/exec_test.go
@@ -3,6 +3,7 @@ package subprocess
 import (
 	"bytes"
 	"context"
+	"log"
 	"strings"
 	"testing"
 	"time"
@@ -142,3 +143,68 @@ func TestCallExecCommandWithContext(t *testing.T) {
 		t.Fatal("expected error from cancelled context")
 	}
 }
+
+func TestCallExecCommandResponseCommandIsMasked(t *testing.T) {
+	SetGlobalSensitive([]string{"topsecret123"})
+	defer SetGlobalSensitive(nil)
+
+	resp, err := CallExecCommand(ExecCommandInput{
+		Command: "echo",
+		Args:    []string{"login", "topsecret123"},
+	})
+	if err != nil {
+		t.Fatalf("CallExecCommand failed: %v", err)
+	}
+	if strings.Contains(resp.Command, "topsecret123") {
+		t.Errorf("response.Command leaked secret: %q", resp.Command)
+	}
+	if !strings.Contains(resp.Command, "***") {
+		t.Errorf("response.Command did not mask: %q", resp.Command)
+	}
+	// Stdout still contains the actual value because the subprocess
+	// receives the unmasked args - masking only applies to display.
+	if !strings.Contains(resp.StdoutContents(), "topsecret123") {
+		t.Errorf("subprocess should have received unmasked args; stdout = %q", resp.StdoutContents())
+	}
+}
+
+func TestCallExecCommandTraceLogIsMasked(t *testing.T) {
+	t.Setenv("DOKKU_TRACE", "1")
+	SetGlobalSensitive([]string{"topsecret123"})
+	defer SetGlobalSensitive(nil)
+
+	var buf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(prev)
+
+	if _, err := CallExecCommand(ExecCommandInput{
+		Command: "echo",
+		Args:    []string{"login", "topsecret123"},
+	}); err != nil {
+		t.Fatalf("CallExecCommand failed: %v", err)
+	}
+	got := buf.String()
+	if strings.Contains(got, "topsecret123") {
+		t.Errorf("DOKKU_TRACE log leaked secret: %q", got)
+	}
+	if !strings.Contains(got, "***") {
+		t.Errorf("DOKKU_TRACE log did not mask: %q", got)
+	}
+}
+
+func TestCallExecCommandResponseCommandUnmaskedWhenNoSecrets(t *testing.T) {
+	SetGlobalSensitive(nil)
+
+	resp, err := CallExecCommand(ExecCommandInput{
+		Command: "echo",
+		Args:    []string{"hello", "world"},
+	})
+	if err != nil {
+		t.Fatalf("CallExecCommand failed: %v", err)
+	}
+	if !strings.Contains(resp.Command, "hello") || !strings.Contains(resp.Command, "world") {
+		t.Errorf("response.Command unexpectedly altered: %q", resp.Command)
+	}
+}
+

--- a/subprocess/mask.go
+++ b/subprocess/mask.go
@@ -1,0 +1,86 @@
+package subprocess
+
+import (
+	"sort"
+	"strings"
+	"sync"
+)
+
+// maskPlaceholder is what every sensitive value is replaced with in user-facing
+// output. Length is intentionally fixed at three asterisks so masked output
+// reveals nothing about the original value (no length, prefix, or suffix).
+const maskPlaceholder = "***"
+
+var (
+	sensitiveMu     sync.RWMutex
+	sensitiveValues []string
+)
+
+// SetGlobalSensitive registers the set of literal string values that must be
+// masked anywhere they appear in user-facing output. Pass nil or an empty
+// slice to clear the registry. Empty entries in values are dropped (matching
+// every empty substring would otherwise mask everything).
+//
+// Callers (typically commands/apply.go and commands/plan.go) collect this set
+// from input values declared `sensitive: true` and from task struct fields
+// tagged `sensitive:"true"` before any subprocess runs, then defer a clear.
+func SetGlobalSensitive(values []string) {
+	cleaned := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, v := range values {
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		cleaned = append(cleaned, v)
+	}
+	// Sort by length descending so longer matches are masked before any
+	// shorter substring of them would be.
+	sort.SliceStable(cleaned, func(i, j int) bool {
+		return len(cleaned[i]) > len(cleaned[j])
+	})
+
+	sensitiveMu.Lock()
+	defer sensitiveMu.Unlock()
+	if len(cleaned) == 0 {
+		sensitiveValues = nil
+		return
+	}
+	sensitiveValues = cleaned
+}
+
+// GlobalSensitive returns a snapshot of the current sensitive value set.
+func GlobalSensitive() []string {
+	sensitiveMu.RLock()
+	defer sensitiveMu.RUnlock()
+	if len(sensitiveValues) == 0 {
+		return nil
+	}
+	out := make([]string, len(sensitiveValues))
+	copy(out, sensitiveValues)
+	return out
+}
+
+// MaskString replaces every occurrence of any registered sensitive value in s
+// with `***`. Returns s unchanged when the registry is empty.
+func MaskString(s string) string {
+	if s == "" {
+		return s
+	}
+	sensitiveMu.RLock()
+	values := sensitiveValues
+	sensitiveMu.RUnlock()
+	if len(values) == 0 {
+		return s
+	}
+	for _, v := range values {
+		if v == "" {
+			continue
+		}
+		s = strings.ReplaceAll(s, v, maskPlaceholder)
+	}
+	return s
+}

--- a/subprocess/mask_test.go
+++ b/subprocess/mask_test.go
@@ -1,0 +1,108 @@
+package subprocess
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestMaskStringNoGlobalSet(t *testing.T) {
+	SetGlobalSensitive(nil)
+	defer SetGlobalSensitive(nil)
+
+	if got := MaskString("hello world"); got != "hello world" {
+		t.Errorf("MaskString with no global set = %q, want input unchanged", got)
+	}
+}
+
+func TestMaskStringReplacesAllOccurrences(t *testing.T) {
+	SetGlobalSensitive([]string{"secret"})
+	defer SetGlobalSensitive(nil)
+
+	got := MaskString("a secret and another secret")
+	want := "a *** and another ***"
+	if got != want {
+		t.Errorf("MaskString = %q, want %q", got, want)
+	}
+}
+
+func TestMaskStringEmptyEntriesSkipped(t *testing.T) {
+	SetGlobalSensitive([]string{"", "tok"})
+	defer SetGlobalSensitive(nil)
+
+	got := MaskString("xtoky")
+	if got != "x***y" {
+		t.Errorf("MaskString = %q, want %q", got, "x***y")
+	}
+	// Verify the empty entry didn't cause every character to mask.
+	if strings.Contains(MaskString("abc"), "***") && !strings.Contains("abc", "tok") {
+		t.Errorf("empty entry caused unintended masking")
+	}
+}
+
+func TestMaskStringLongerBeforeShorter(t *testing.T) {
+	// "ab" is a substring of "abcdef"; the longer one must be masked first
+	// so we don't see "***cdef" instead of a single "***".
+	SetGlobalSensitive([]string{"ab", "abcdef"})
+	defer SetGlobalSensitive(nil)
+
+	got := MaskString("xabcdefy")
+	if got != "x***y" {
+		t.Errorf("MaskString = %q, want %q (longer match first)", got, "x***y")
+	}
+}
+
+func TestSetGlobalSensitiveDeduplicates(t *testing.T) {
+	SetGlobalSensitive([]string{"a", "a", "b"})
+	defer SetGlobalSensitive(nil)
+
+	values := GlobalSensitive()
+	count := 0
+	for _, v := range values {
+		if v == "a" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("duplicates not removed: got %d copies of 'a' in %v", count, values)
+	}
+}
+
+func TestSetGlobalSensitiveClear(t *testing.T) {
+	SetGlobalSensitive([]string{"x"})
+	SetGlobalSensitive(nil)
+	if got := MaskString("xyz"); got != "xyz" {
+		t.Errorf("MaskString after clear = %q, want %q", got, "xyz")
+	}
+}
+
+func TestMaskStringConcurrent(t *testing.T) {
+	SetGlobalSensitive([]string{"secret"})
+	defer SetGlobalSensitive(nil)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			SetGlobalSensitive([]string{"secret", "token"})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = MaskString("a secret token here")
+		}()
+	}
+	wg.Wait()
+}
+
+func TestGlobalSensitiveReturnsCopy(t *testing.T) {
+	SetGlobalSensitive([]string{"a"})
+	defer SetGlobalSensitive(nil)
+
+	values := GlobalSensitive()
+	values[0] = "mutated"
+	again := GlobalSensitive()
+	if again[0] != "a" {
+		t.Errorf("GlobalSensitive returned shared slice; mutation leaked: %v", again)
+	}
+}

--- a/tasks/certs_task.go
+++ b/tasks/certs_task.go
@@ -17,10 +17,10 @@ type CertsTask struct {
 	Global bool `required:"false" yaml:"global,omitempty"`
 
 	// Cert is the path on the dokku server to the SSL certificate file
-	Cert string `required:"false" yaml:"cert,omitempty"`
+	Cert string `required:"false" sensitive:"true" yaml:"cert,omitempty"`
 
 	// Key is the path on the dokku server to the SSL certificate key file
-	Key string `required:"false" yaml:"key,omitempty"`
+	Key string `required:"false" sensitive:"true" yaml:"key,omitempty"`
 
 	// State is the desired state of the SSL configuration
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`

--- a/tasks/config_task.go
+++ b/tasks/config_task.go
@@ -72,6 +72,23 @@ func (t ConfigTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// SensitiveValues returns every non-empty value in the Config map together
+// with its base64 encoding. The base64 form is included because the apply
+// path passes config values to `dokku config:set --encoded` as
+// `KEY=<base64(value)>`, so the literal value never appears on argv but the
+// encoded form does. Masking both means the verbose command echo and the
+// DOKKU_TRACE log scrub the secret in either representation.
+func (t ConfigTask) SensitiveValues() []string {
+	out := make([]string, 0, 2*len(t.Config))
+	for _, v := range t.Config {
+		if v == "" {
+			continue
+		}
+		out = append(out, v, base64.StdEncoding.EncodeToString([]byte(v)))
+	}
+	return out
+}
+
 // Plan reports the drift the ConfigTask would produce.
 func (t ConfigTask) Plan() PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{

--- a/tasks/git_auth_task.go
+++ b/tasks/git_auth_task.go
@@ -21,7 +21,7 @@ type GitAuthTask struct {
 	Username string `required:"false" yaml:"username,omitempty"`
 
 	// Password is the netrc password. Required when state is present.
-	Password string `required:"false" yaml:"password,omitempty"`
+	Password string `required:"false" sensitive:"true" yaml:"password,omitempty"`
 
 	// State is the desired state of the netrc entry
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
@@ -87,7 +87,7 @@ func (t GitAuthTask) Plan() PlanResult {
 				InSync:    false,
 				Status:    PlanStatusModify,
 				Reason:    "netrc state not probed",
-				Mutations: []string{"git:auth " + t.Host + " " + t.Username + " ***"},
+				Mutations: []string{"git:auth " + t.Host + " " + t.Username + " " + t.Password},
 				apply: func() TaskOutputState {
 					state := TaskOutputState{Changed: false, State: StateAbsent}
 					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{

--- a/tasks/git_from_archive_task.go
+++ b/tasks/git_from_archive_task.go
@@ -11,8 +11,9 @@ type GitFromArchiveTask struct {
 	// App is the name of the app
 	App string `required:"true" yaml:"app"`
 
-	// ArchiveURL is the URL of the archive to deploy
-	ArchiveURL string `required:"true" yaml:"archive_url"`
+	// ArchiveURL is the URL of the archive to deploy. Tagged sensitive
+	// because URLs can embed credentials (e.g. https://user:token@host/path).
+	ArchiveURL string `required:"true" sensitive:"true" yaml:"archive_url"`
 
 	// ArchiveType is the format of the archive
 	ArchiveType string `required:"false" yaml:"archive_type,omitempty" default:"tar" options:"tar,tar.gz,zip"`

--- a/tasks/git_from_image_task.go
+++ b/tasks/git_from_image_task.go
@@ -13,8 +13,9 @@ type GitFromImageTask struct {
 	// App is the name of the app
 	App string `required:"true" yaml:"app"`
 
-	// Image is the docker image to deploy
-	Image string `required:"true" yaml:"image"`
+	// Image is the docker image to deploy. Tagged sensitive because image
+	// references can embed registry credentials (e.g. user:token@host/repo).
+	Image string `required:"true" sensitive:"true" yaml:"image"`
 
 	// BuildDir is the directory to build the git repository
 	BuildDir string `required:"false" yaml:"build_dir"`

--- a/tasks/http_auth_task.go
+++ b/tasks/http_auth_task.go
@@ -15,7 +15,7 @@ type HttpAuthTask struct {
 	Username string `required:"false" yaml:"username,omitempty"`
 
 	// Password is the HTTP auth password
-	Password string `required:"false" yaml:"password,omitempty"`
+	Password string `required:"false" sensitive:"true" yaml:"password,omitempty"`
 
 	// State is the state of the HTTP auth
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`

--- a/tasks/letsencrypt_property_task.go
+++ b/tasks/letsencrypt_property_task.go
@@ -11,8 +11,10 @@ type LetsencryptPropertyTask struct {
 	// Property is the name of the letsencrypt property to set
 	Property string `required:"true" yaml:"property"`
 
-	// Value is the value to set for the letsencrypt property
-	Value string `required:"false" yaml:"value,omitempty"`
+	// Value is the value to set for the letsencrypt property. Tagged sensitive
+	// because some letsencrypt properties carry DNS-API credentials; benign
+	// property values get masked too, which is preferable to leaking secrets.
+	Value string `required:"false" sensitive:"true" yaml:"value,omitempty"`
 
 	// State is the desired state of the letsencrypt configuration
 	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -53,6 +53,12 @@ type Input struct {
 	// Required is a flag indicating if the input is required
 	Required bool `yaml:"required"`
 
+	// Sensitive marks the input's resolved value as a secret. When true,
+	// the value is masked as `***` anywhere it would otherwise appear in
+	// user-facing output (apply --verbose echoes, plan output, error
+	// messages, and the DOKKU_TRACE debug log).
+	Sensitive bool `yaml:"sensitive"`
+
 	// Type is the type of the input
 	Type string `yaml:"type"`
 

--- a/tasks/registry_auth_task.go
+++ b/tasks/registry_auth_task.go
@@ -23,7 +23,7 @@ type RegistryAuthTask struct {
 
 	// Password is the registry password (required when state is present)
 	// The value is fed to dokku via --password-stdin and never appears on argv
-	Password string `required:"false" yaml:"password,omitempty"`
+	Password string `required:"false" sensitive:"true" yaml:"password,omitempty"`
 
 	// State is the desired state of the registry credential
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`

--- a/tasks/sensitive.go
+++ b/tasks/sensitive.go
@@ -1,0 +1,129 @@
+package tasks
+
+import (
+	"reflect"
+)
+
+// SensitiveOverride is implemented by tasks whose sensitive values cannot be
+// declared with a struct tag - typically because the secret lives in the
+// values of an arbitrary map (e.g. dokku_config's `config:` field where every
+// value is a secret regardless of key).
+//
+// SensitiveValues returns the literal string values from this task instance
+// that must be masked in any user-facing logging output. The tag-based walker
+// runs in addition to this method; both contribute to the final masked set.
+type SensitiveOverride interface {
+	SensitiveValues() []string
+}
+
+// CollectSensitiveValues walks every task in tasks and returns the union of
+// values that must be masked in user-facing output. A value is included when
+// either:
+//
+//   - it lives in a struct field carrying the `sensitive:"true"` struct tag, or
+//   - the task implements SensitiveOverride and the method returns it.
+//
+// String, []string, and map[string]string fields are supported. Nested
+// structs and pointers are walked recursively. Empty values are dropped by
+// the subprocess masker, not here.
+func CollectSensitiveValues(tasks OrderedStringTaskMap) []string {
+	var out []string
+	for _, name := range tasks.Keys() {
+		t := tasks.Get(name)
+		out = append(out, sensitiveValuesFromTask(t)...)
+	}
+	return out
+}
+
+// sensitiveValuesFromTask returns the masked-value set for a single task.
+func sensitiveValuesFromTask(t Task) []string {
+	var out []string
+	if override, ok := t.(SensitiveOverride); ok {
+		out = append(out, override.SensitiveValues()...)
+	}
+	out = append(out, walkSensitiveTags(reflect.ValueOf(t))...)
+	return out
+}
+
+// walkSensitiveTags recursively walks v and returns the value of any field
+// whose `sensitive:"true"` struct tag is set. Pointers and embedded structs
+// are followed; everything else is leaf-evaluated.
+func walkSensitiveTags(v reflect.Value) []string {
+	for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return nil
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return nil
+	}
+	t := v.Type()
+
+	var out []string
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		fv := v.Field(i)
+		if field.Tag.Get("sensitive") == "true" {
+			out = append(out, sensitiveLeafValues(fv)...)
+			continue
+		}
+		// Recurse into nested structs and struct pointers regardless of tag
+		// so deeply nested sensitive fields surface too.
+		switch {
+		case fv.Kind() == reflect.Struct:
+			out = append(out, walkSensitiveTags(fv)...)
+		case fv.Kind() == reflect.Ptr && !fv.IsNil() && fv.Elem().Kind() == reflect.Struct:
+			out = append(out, walkSensitiveTags(fv)...)
+		}
+	}
+	return out
+}
+
+// sensitiveLeafValues extracts string values from a sensitive-tagged field.
+// Supports string, []string, and map[string]string. For other types, returns
+// empty (the field can't safely be string-masked).
+func sensitiveLeafValues(v reflect.Value) []string {
+	for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return nil
+		}
+		v = v.Elem()
+	}
+	switch v.Kind() {
+	case reflect.String:
+		s := v.String()
+		if s == "" {
+			return nil
+		}
+		return []string{s}
+	case reflect.Slice, reflect.Array:
+		if v.Type().Elem().Kind() != reflect.String {
+			return nil
+		}
+		out := make([]string, 0, v.Len())
+		for i := 0; i < v.Len(); i++ {
+			s := v.Index(i).String()
+			if s == "" {
+				continue
+			}
+			out = append(out, s)
+		}
+		return out
+	case reflect.Map:
+		if v.Type().Elem().Kind() != reflect.String {
+			return nil
+		}
+		out := make([]string, 0, v.Len())
+		iter := v.MapRange()
+		for iter.Next() {
+			s := iter.Value().String()
+			if s == "" {
+				continue
+			}
+			out = append(out, s)
+		}
+		return out
+	}
+	return nil
+}

--- a/tasks/sensitive_test.go
+++ b/tasks/sensitive_test.go
@@ -1,0 +1,184 @@
+package tasks
+
+import (
+	"sort"
+	"testing"
+)
+
+// fakeTask is a minimal Task implementation that lets unit tests construct
+// arbitrary structs and exercise the sensitive value walker without needing
+// any real Dokku side effect.
+type fakeTask struct {
+	Public    string `yaml:"public"`
+	Secret    string `sensitive:"true" yaml:"secret"`
+	SecretMap map[string]string
+}
+
+func (f *fakeTask) Doc() string                  { return "" }
+func (f *fakeTask) Examples() ([]Doc, error)     { return nil, nil }
+func (f *fakeTask) Plan() PlanResult             { return PlanResult{} }
+func (f *fakeTask) Execute() TaskOutputState     { return TaskOutputState{} }
+
+type taggedSliceTask struct {
+	Tokens []string `sensitive:"true"`
+}
+
+func (t *taggedSliceTask) Doc() string              { return "" }
+func (t *taggedSliceTask) Examples() ([]Doc, error) { return nil, nil }
+func (t *taggedSliceTask) Plan() PlanResult         { return PlanResult{} }
+func (t *taggedSliceTask) Execute() TaskOutputState { return TaskOutputState{} }
+
+type taggedMapTask struct {
+	Headers map[string]string `sensitive:"true"`
+}
+
+func (t *taggedMapTask) Doc() string              { return "" }
+func (t *taggedMapTask) Examples() ([]Doc, error) { return nil, nil }
+func (t *taggedMapTask) Plan() PlanResult         { return PlanResult{} }
+func (t *taggedMapTask) Execute() TaskOutputState { return TaskOutputState{} }
+
+type nestedTask struct {
+	Outer struct {
+		Inner string `sensitive:"true"`
+	}
+}
+
+func (n *nestedTask) Doc() string              { return "" }
+func (n *nestedTask) Examples() ([]Doc, error) { return nil, nil }
+func (n *nestedTask) Plan() PlanResult         { return PlanResult{} }
+func (n *nestedTask) Execute() TaskOutputState { return TaskOutputState{} }
+
+type overrideTask struct {
+	Field string `sensitive:"true"`
+	Map   map[string]string
+}
+
+func (o *overrideTask) Doc() string                { return "" }
+func (o *overrideTask) Examples() ([]Doc, error)   { return nil, nil }
+func (o *overrideTask) Plan() PlanResult           { return PlanResult{} }
+func (o *overrideTask) Execute() TaskOutputState   { return TaskOutputState{} }
+func (o *overrideTask) SensitiveValues() []string {
+	out := make([]string, 0, len(o.Map))
+	for _, v := range o.Map {
+		out = append(out, v)
+	}
+	return out
+}
+
+func sortedEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	x := append([]string(nil), a...)
+	y := append([]string(nil), b...)
+	sort.Strings(x)
+	sort.Strings(y)
+	for i := range x {
+		if x[i] != y[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestSensitiveValuesFromTaggedString(t *testing.T) {
+	got := sensitiveValuesFromTask(&fakeTask{Public: "p", Secret: "s"})
+	if !sortedEqual(got, []string{"s"}) {
+		t.Errorf("got %v, want [s]", got)
+	}
+}
+
+func TestSensitiveValuesEmptyForUntaggedStruct(t *testing.T) {
+	type plain struct {
+		A string
+		B int
+	}
+	type plainTask struct {
+		fakeTask
+		Plain plain
+	}
+	pt := &plainTask{fakeTask: fakeTask{Public: "x"}}
+	got := sensitiveValuesFromTask(pt)
+	for _, v := range got {
+		if v == "x" {
+			t.Errorf("untagged field surfaced: %v", got)
+		}
+	}
+}
+
+func TestSensitiveValuesFromTaggedSlice(t *testing.T) {
+	got := sensitiveValuesFromTask(&taggedSliceTask{Tokens: []string{"a", "", "b"}})
+	if !sortedEqual(got, []string{"a", "b"}) {
+		t.Errorf("got %v, want [a b]", got)
+	}
+}
+
+func TestSensitiveValuesFromTaggedMap(t *testing.T) {
+	got := sensitiveValuesFromTask(&taggedMapTask{Headers: map[string]string{
+		"X-Token":  "secret123",
+		"X-Public": "",
+		"X-Other":  "more",
+	}})
+	if !sortedEqual(got, []string{"secret123", "more"}) {
+		t.Errorf("got %v, want [secret123 more]", got)
+	}
+}
+
+func TestSensitiveValuesNestedStruct(t *testing.T) {
+	n := &nestedTask{}
+	n.Outer.Inner = "hidden"
+	got := sensitiveValuesFromTask(n)
+	if !sortedEqual(got, []string{"hidden"}) {
+		t.Errorf("got %v, want [hidden]", got)
+	}
+}
+
+func TestSensitiveValuesOverrideMergesWithTags(t *testing.T) {
+	o := &overrideTask{
+		Field: "tagged",
+		Map:   map[string]string{"k1": "viaOverride", "k2": "alsoOverride"},
+	}
+	got := sensitiveValuesFromTask(o)
+	if !sortedEqual(got, []string{"tagged", "viaOverride", "alsoOverride"}) {
+		t.Errorf("got %v, want all three values", got)
+	}
+}
+
+func TestCollectSensitiveValuesAcrossTasks(t *testing.T) {
+	m := OrderedStringTaskMap{}
+	m.Set("a", &fakeTask{Secret: "s1"})
+	m.Set("b", &taggedSliceTask{Tokens: []string{"s2"}})
+	got := CollectSensitiveValues(m)
+	if !sortedEqual(got, []string{"s1", "s2"}) {
+		t.Errorf("got %v, want [s1 s2]", got)
+	}
+}
+
+func TestConfigTaskSensitiveValuesReturnsMapValuesAndBase64(t *testing.T) {
+	ct := &ConfigTask{
+		App:    "myapp",
+		Config: map[string]string{"DATABASE_URL": "postgres://x", "EMPTY": "", "TOKEN": "abc"},
+	}
+	got := ct.SensitiveValues()
+	// Each non-empty value contributes its raw form plus base64 (the form
+	// the apply path puts on argv via `config:set --encoded`).
+	want := []string{
+		"postgres://x", "cG9zdGdyZXM6Ly94", // base64("postgres://x")
+		"abc", "YWJj", // base64("abc")
+	}
+	if !sortedEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestRegistryAuthTaskPasswordIsCollected(t *testing.T) {
+	rt := &RegistryAuthTask{
+		Server:   "ghcr.io",
+		Username: "alice",
+		Password: "topsecret",
+	}
+	got := sensitiveValuesFromTask(rt)
+	if !sortedEqual(got, []string{"topsecret"}) {
+		t.Errorf("got %v, want [topsecret]", got)
+	}
+}

--- a/tests/bats/masking.bats
+++ b/tests/bats/masking.bats
@@ -75,12 +75,21 @@ EOF
 }
 
 @test "docket plan output never echoes dokku_config map values" {
-  write_tasks_file <<'EOF'
+  # Create the app first so the dokku_config plan probe succeeds; otherwise
+  # the missing-app probe error short-circuits the test before the masking
+  # path is exercised.
+  write_tasks_file create.yml <<'EOF'
 ---
 - tasks:
     - name: ensure docket-test-mask
       dokku_app:
         app: docket-test-mask
+EOF
+  "$(docket_bin)" apply --tasks "$TASKS_FILE"
+
+  write_tasks_file plan.yml <<'EOF'
+---
+- tasks:
     - name: set a literal config value
       dokku_config:
         app: docket-test-mask

--- a/tests/bats/masking.bats
+++ b/tests/bats/masking.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  require_dokku
+  docket_build
+  dokku_clean_app docket-test-mask
+}
+
+teardown() {
+  dokku_clean_app docket-test-mask
+}
+
+@test "docket apply --verbose masks an input declared sensitive" {
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - name: ensure docket-test-mask
+      dokku_app:
+        app: docket-test-mask
+    - name: set the secret
+      dokku_config:
+        app: docket-test-mask
+        config:
+          MY_SECRET: "{{ .secret_value }}"
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --secret_value=topsecret123 --verbose
+  assert_success
+  refute_output --partial "topsecret123"
+  assert_output --partial "***"
+}
+
+@test "docket apply --verbose masks dokku_config map values" {
+  write_tasks_file <<'EOF'
+---
+- tasks:
+    - name: ensure docket-test-mask
+      dokku_app:
+        app: docket-test-mask
+    - name: set a literal config value
+      dokku_config:
+        app: docket-test-mask
+        config:
+          MY_LITERAL: literal-value-zzz
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --verbose
+  assert_success
+  refute_output --partial "literal-value-zzz"
+  # base64 of literal-value-zzz is bGl0ZXJhbC12YWx1ZS16eno=, also masked.
+  refute_output --partial "bGl0ZXJhbC12YWx1ZS16eno"
+  assert_output --partial "***"
+}
+
+@test "DOKKU_TRACE masks values from inputs declared sensitive" {
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - name: ensure docket-test-mask
+      dokku_app:
+        app: docket-test-mask
+    - name: set the secret
+      dokku_config:
+        app: docket-test-mask
+        config:
+          MY_SECRET: "{{ .secret_value }}"
+EOF
+  DOKKU_TRACE=1 run "$(docket_bin)" apply --tasks "$TASKS_FILE" --secret_value=tracesecretzzz
+  assert_success
+  refute_output --partial "tracesecretzzz"
+}
+
+@test "docket plan output never echoes dokku_config map values" {
+  write_tasks_file <<'EOF'
+---
+- tasks:
+    - name: ensure docket-test-mask
+      dokku_app:
+        app: docket-test-mask
+    - name: set a literal config value
+      dokku_config:
+        app: docket-test-mask
+        config:
+          MY_LITERAL: literal-value-zzz
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  refute_output --partial "literal-value-zzz"
+}


### PR DESCRIPTION
Adds explicit, struct-tag-driven masking of sensitive values in every user-facing logging path: the `apply --verbose` command echo, the `DOKKU_TRACE=1` log, plan mutations, and any error message that surfaces a resolved Dokku command. Inputs gain a `sensitive: true` flag and task struct fields gain a `sensitive:"true"` tag; matching values are replaced with `***` before output. `dokku_config.config` map values are always masked via a `SensitiveOverride` interface because the secret lives in the value, not the key. The `config:set --encoded` base64 form is masked alongside the raw value so the encoded argv form does not leak the secret either.

Closes #203.