### PR TITLE
feat: route dokku invocations over ssh when DOKKU_HOST is set

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,5 +87,26 @@ jobs:
         run: sudo apt-get install -qq -y bats bats-support bats-assert
       - name: build docket
         run: go build -o docket .
+      - name: setup ssh to localhost for ssh transport tests
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          ssh-keygen -t ed25519 -N '' -f ~/.ssh/id_ed25519
+          cat ~/.ssh/id_ed25519.pub >> ~/.ssh/authorized_keys
+          chmod 600 ~/.ssh/authorized_keys
+          ssh-keyscan -H localhost >> ~/.ssh/known_hosts
+          ssh-keyscan -H 127.0.0.1 >> ~/.ssh/known_hosts
+          ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new "$USER@localhost" 'echo ssh-ok'
+          # Mirror the developer's SSH setup into the root user that bats
+          # runs as via sudo, so DOKKU_HOST=$USER@localhost works under
+          # `sudo --preserve-env=PATH`.
+          sudo mkdir -p /root/.ssh
+          sudo chmod 700 /root/.ssh
+          sudo cp ~/.ssh/id_ed25519 /root/.ssh/id_ed25519
+          sudo cp ~/.ssh/id_ed25519.pub /root/.ssh/id_ed25519.pub
+          sudo cp ~/.ssh/known_hosts /root/.ssh/known_hosts
+          sudo chmod 600 /root/.ssh/id_ed25519
+      - name: export remote host fixture
+        run: echo "DOCKET_TEST_REMOTE_HOST=$USER@localhost" >> $GITHUB_ENV
       - name: run bats tests
-        run: sudo --preserve-env=PATH bats tests/bats/
+        run: sudo --preserve-env=PATH,DOCKET_TEST_REMOTE_HOST bats tests/bats/

--- a/README.md
+++ b/README.md
@@ -132,6 +132,42 @@ For example, a multi-command task renders one continuation per invocation:
 
 Color output respects [`NO_COLOR`](https://no-color.org/): set `NO_COLOR=1` to disable ANSI escapes, or pipe to a non-TTY (output is plain in that case automatically).
 
+### Remote execution over SSH
+
+Set `DOKKU_HOST=[user@]host[:port]` (or pass `--host`) to route every dokku invocation through an `ssh` subprocess so docket can manage a remote dokku server from a developer laptop or CI runner without installing the binary on the server. All invocations in one run share a single TCP+SSH connection via OpenSSH ControlMaster multiplexing.
+
+```shell
+# Apply against a remote dokku server.
+DOKKU_HOST=deploy@dokku.example.com docket apply
+
+# Same, via the CLI flag (overrides the env var).
+docket apply --host deploy@dokku.example.com:2222
+```
+
+Because docket shells out to your `ssh` binary, the user's `~/.ssh/config`, `ProxyJump`, ssh-agent, and `known_hosts` work natively - you do not need to teach docket about them.
+
+The flags are:
+
+| Flag | Effect |
+|------|--------|
+| `--host <user@host:port>` | Remote host to ssh into. Overrides `DOKKU_HOST`. |
+| `--sudo` | Wrap the remote `dokku` invocation in `sudo -n` (passwordless sudo only). Equivalent to `DOKKU_SUDO=1`. |
+| `--accept-new-host-keys` | Pass `-o StrictHostKeyChecking=accept-new` so SSH adds an unknown host's key on first connect. Convenient for CI where pre-seeding `known_hosts` is impractical, but loses MITM protection on the first connection. Equivalent to `DOKKU_SSH_ACCEPT_NEW_HOST_KEYS=1`. Prefer pre-seeding via `ssh-keyscan host >> ~/.ssh/known_hosts` when you can. |
+
+Errors are categorised so it is clear which side failed: SSH-level failures (connect refused, auth, host-key mismatch) render with an `ssh:` prefix, and remote dokku command failures render with a `dokku:` prefix.
+
+```text
+[error]   create app
+          ! ssh: ssh deploy@dokku.example.com: Permission denied (publickey).
+```
+
+```text
+[error]   add buildpack
+          ! dokku: app foo does not exist
+```
+
+When a task references file paths (e.g. the `cert` and `key` fields on `dokku_certs`), those paths are interpreted on the *remote* host. Local file uploads are not implemented in this release; pre-place referenced files on the remote server.
+
 ### Previewing changes with `plan`
 
 `docket plan` reads each task's current state from the live dokku server and reports what `apply` would change, without invoking any mutating dokku command. The output uses the same play header and column layout as `apply`, with a different marker set:

--- a/commands/apply.go
+++ b/commands/apply.go
@@ -16,9 +16,12 @@ import (
 type ApplyCommand struct {
 	command.Meta
 
-	tasksFile string
-	verbose   bool
-	arguments map[string]*Argument
+	tasksFile         string
+	verbose           bool
+	host              string
+	sudo              bool
+	acceptNewHostKeys bool
+	arguments         map[string]*Argument
 }
 
 func (c *ApplyCommand) Name() string {
@@ -59,6 +62,9 @@ func (c *ApplyCommand) FlagSet() *flag.FlagSet {
 	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
 	f.StringVar(&c.tasksFile, "tasks", "tasks.yml", "a yaml file containing a task list")
 	f.BoolVar(&c.verbose, "verbose", false, "echo the resolved dokku command for each task as a continuation line. Values from inputs declared `sensitive: true` and from task struct fields tagged `sensitive:\"true\"` are masked as `***`")
+	f.StringVar(&c.host, "host", "", "remote dokku host as [user@]host[:port]; equivalent to DOKKU_HOST. Routes every dokku invocation through ssh.")
+	f.BoolVar(&c.sudo, "sudo", false, "wrap remote dokku invocations with `sudo -n`; equivalent to DOKKU_SUDO=1")
+	f.BoolVar(&c.acceptNewHostKeys, "accept-new-host-keys", false, "for SSH transport, accept new host keys on first connection (`-o StrictHostKeyChecking=accept-new`). MITM risk on first connect.")
 
 	taskFile := getTaskYamlFilename(os.Args)
 	data, err := os.ReadFile(taskFile)
@@ -79,8 +85,11 @@ func (c *ApplyCommand) AutocompleteFlags() complete.Flags {
 	return command.MergeAutocompleteFlags(
 		c.Meta.AutocompleteFlags(command.FlagSetClient),
 		complete.Flags{
-			"--tasks":   complete.PredictFiles("*.yml"),
-			"--verbose": complete.PredictNothing,
+			"--tasks":                complete.PredictFiles("*.yml"),
+			"--verbose":              complete.PredictNothing,
+			"--host":                 complete.PredictAnything,
+			"--sudo":                 complete.PredictNothing,
+			"--accept-new-host-keys": complete.PredictNothing,
 		},
 	)
 }
@@ -93,6 +102,8 @@ func (c *ApplyCommand) Run(args []string) int {
 		c.Ui.Error(command.CommandErrorText(c))
 		return 1
 	}
+
+	applySshFlagsToEnv(c.host, c.sudo, c.acceptNewHostKeys)
 
 	data, err := os.ReadFile(c.tasksFile)
 	if err != nil {
@@ -125,8 +136,13 @@ func (c *ApplyCommand) Run(args []string) int {
 	subprocess.SetGlobalSensitive(sensitiveValues)
 	defer subprocess.SetGlobalSensitive(nil)
 
+	resolvedHost := os.Getenv("DOKKU_HOST")
+	if resolvedHost != "" {
+		defer subprocess.CloseSshControlMaster(resolvedHost)
+	}
+
 	formatter := NewFormatter(c.Ui, c.verbose)
-	formatter.PlayHeader("tasks")
+	formatter.PlayHeaderWithHost("tasks", resolvedHost)
 
 	start := time.Now()
 	counts := ApplyCounts{}
@@ -140,7 +156,7 @@ func (c *ApplyCommand) Run(args []string) int {
 		case state.Error != nil:
 			counts.Errors++
 			formatter.TaskLine(MarkerError, name, "")
-			formatter.Continuation('!', state.Error.Error())
+			formatter.ErrorContinuation(state.Error)
 			if c.verbose {
 				for _, cmd := range state.Commands {
 					formatter.Continuation('\u2192', cmd)

--- a/commands/apply.go
+++ b/commands/apply.go
@@ -103,7 +103,7 @@ func (c *ApplyCommand) Run(args []string) int {
 		return 1
 	}
 
-	applySshFlagsToEnv(c.host, c.sudo, c.acceptNewHostKeys)
+	resolvedHost := resolveSshFlags(c.host, c.sudo, c.acceptNewHostKeys)
 
 	data, err := os.ReadFile(c.tasksFile)
 	if err != nil {
@@ -136,7 +136,6 @@ func (c *ApplyCommand) Run(args []string) int {
 	subprocess.SetGlobalSensitive(sensitiveValues)
 	defer subprocess.SetGlobalSensitive(nil)
 
-	resolvedHost := os.Getenv("DOKKU_HOST")
 	if resolvedHost != "" {
 		defer subprocess.CloseSshControlMaster(resolvedHost)
 	}

--- a/commands/output.go
+++ b/commands/output.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -104,6 +105,47 @@ func (f *Formatter) PlayHeader(name string) {
 	f.ui.Output(fmt.Sprintf("==> Play: %s", name))
 }
 
+// PlayHeaderWithHost is like PlayHeader but appends a `(host: <name>)`
+// annotation when the apply/plan run targets a remote dokku host
+// (DOKKU_HOST set). When host is empty it delegates to PlayHeader so
+// callers can pass `os.Getenv("DOKKU_HOST")` unconditionally.
+func (f *Formatter) PlayHeaderWithHost(name, host string) {
+	if host == "" {
+		f.PlayHeader(name)
+		return
+	}
+	f.ui.Output(fmt.Sprintf("==> Play: %s  (host: %s)", name, host))
+}
+
+// ErrorContinuation emits an `! <prefix>: <body>` continuation line
+// under an errored task. The prefix is `ssh` when err unwraps to a
+// *subprocess.SSHError (transport-level failure: connect, auth,
+// host-key) and `dokku` otherwise (remote command exit). Multi-line
+// bodies are masked and rendered as separate continuation lines under
+// the same indent.
+func (f *Formatter) ErrorContinuation(err error) {
+	if err == nil {
+		return
+	}
+	f.Continuation('!', PrefixErrorMessage(err))
+}
+
+// PrefixErrorMessage prepends `ssh:` or `dokku:` to err.Error() based
+// on whether err unwraps to a *subprocess.SSHError. Exported so the
+// plan command can reuse the same prefixing logic for the probe-error
+// suffix that surfaces inline in the TaskLine instead of in a
+// continuation line.
+func PrefixErrorMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	var sshErr *subprocess.SSHError
+	if errors.As(err, &sshErr) {
+		return "ssh: " + err.Error()
+	}
+	return "dokku: " + err.Error()
+}
+
 // TaskLine emits one structured task line: a colored, bracketed,
 // padded marker followed by the task name. suffix, when non-empty, is
 // appended after two spaces (matching the legacy plan-line layout).
@@ -188,4 +230,3 @@ func (f *Formatter) paintMarker(m Marker) string {
 	}
 	return padded
 }
-

--- a/commands/output_test.go
+++ b/commands/output_test.go
@@ -1,10 +1,12 @@
 package commands
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/dokku/docket/subprocess"
 	"github.com/fatih/color"
 	"github.com/mitchellh/cli"
 )
@@ -26,6 +28,77 @@ func TestFormatterPlayHeader(t *testing.T) {
 	want := "==> Play: tasks\n"
 	if got != want {
 		t.Errorf("PlayHeader output mismatch\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestFormatterPlayHeaderWithHost(t *testing.T) {
+	f, ui := newTestFormatter(false)
+	f.PlayHeaderWithHost("tasks", "alice@host:2222")
+	got := ui.OutputWriter.String()
+	want := "==> Play: tasks  (host: alice@host:2222)\n"
+	if got != want {
+		t.Errorf("PlayHeaderWithHost output mismatch\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestFormatterPlayHeaderWithHostEmptyDelegates(t *testing.T) {
+	f, ui := newTestFormatter(false)
+	f.PlayHeaderWithHost("tasks", "")
+	got := ui.OutputWriter.String()
+	want := "==> Play: tasks\n"
+	if got != want {
+		t.Errorf("PlayHeaderWithHost empty host\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestFormatterErrorContinuationDokkuPrefix(t *testing.T) {
+	f, ui := newTestFormatter(false)
+	f.ErrorContinuation(errors.New("app foo does not exist"))
+	got := ui.OutputWriter.String()
+	want := "          ! dokku: app foo does not exist\n"
+	if got != want {
+		t.Errorf("ErrorContinuation dokku\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestFormatterErrorContinuationSshPrefix(t *testing.T) {
+	f, ui := newTestFormatter(false)
+	f.ErrorContinuation(&subprocess.SSHError{Host: "alice@host", Stderr: "Permission denied (publickey)."})
+	got := ui.OutputWriter.String()
+	want := "          ! ssh: ssh alice@host: Permission denied (publickey).\n"
+	if got != want {
+		t.Errorf("ErrorContinuation ssh\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestFormatterErrorContinuationSshWrappedPrefix(t *testing.T) {
+	wrapped := &subprocess.SSHError{Host: "host", Err: errors.New("connect refused")}
+	f, ui := newTestFormatter(false)
+	f.ErrorContinuation(wrapped)
+	got := ui.OutputWriter.String()
+	if !strings.HasPrefix(strings.TrimLeft(got, " "), "! ssh:") {
+		t.Errorf("expected ssh: prefix, got %q", got)
+	}
+}
+
+func TestFormatterErrorContinuationNilNoOp(t *testing.T) {
+	f, ui := newTestFormatter(false)
+	f.ErrorContinuation(nil)
+	if got := ui.OutputWriter.String(); got != "" {
+		t.Errorf("nil error should produce no output, got %q", got)
+	}
+}
+
+func TestPrefixErrorMessage(t *testing.T) {
+	if got := PrefixErrorMessage(nil); got != "" {
+		t.Errorf("nil should return empty, got %q", got)
+	}
+	if got := PrefixErrorMessage(errors.New("boom")); got != "dokku: boom" {
+		t.Errorf("plain err\ngot:  %q\nwant: %q", got, "dokku: boom")
+	}
+	sshErr := &subprocess.SSHError{Host: "h", Err: errors.New("boom")}
+	if got := PrefixErrorMessage(sshErr); !strings.HasPrefix(got, "ssh:") {
+		t.Errorf("ssh err should be prefixed `ssh:`, got %q", got)
 	}
 }
 

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -110,7 +110,7 @@ func (c *PlanCommand) Run(args []string) int {
 		return 1
 	}
 
-	applySshFlagsToEnv(c.host, c.sudo, c.acceptNewHostKeys)
+	resolvedHost := resolveSshFlags(c.host, c.sudo, c.acceptNewHostKeys)
 
 	data, err := os.ReadFile(c.tasksFile)
 	if err != nil {
@@ -143,7 +143,6 @@ func (c *PlanCommand) Run(args []string) int {
 	subprocess.SetGlobalSensitive(sensitiveValues)
 	defer subprocess.SetGlobalSensitive(nil)
 
-	resolvedHost := os.Getenv("DOKKU_HOST")
 	if resolvedHost != "" {
 		defer subprocess.CloseSshControlMaster(resolvedHost)
 	}

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -18,8 +18,11 @@ import (
 type PlanCommand struct {
 	command.Meta
 
-	tasksFile string
-	arguments map[string]*Argument
+	tasksFile         string
+	host              string
+	sudo              bool
+	acceptNewHostKeys bool
+	arguments         map[string]*Argument
 }
 
 func (c *PlanCommand) Name() string {
@@ -59,6 +62,9 @@ func (c *PlanCommand) ParsedArguments(args []string) (map[string]command.Argumen
 func (c *PlanCommand) FlagSet() *flag.FlagSet {
 	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
 	f.StringVar(&c.tasksFile, "tasks", "tasks.yml", "a yaml file containing a task list")
+	f.StringVar(&c.host, "host", "", "remote dokku host as [user@]host[:port]; equivalent to DOKKU_HOST. Routes every dokku invocation through ssh.")
+	f.BoolVar(&c.sudo, "sudo", false, "wrap remote dokku invocations with `sudo -n`; equivalent to DOKKU_SUDO=1")
+	f.BoolVar(&c.acceptNewHostKeys, "accept-new-host-keys", false, "for SSH transport, accept new host keys on first connection (`-o StrictHostKeyChecking=accept-new`). MITM risk on first connect.")
 
 	taskFile := getTaskYamlFilename(os.Args)
 	data, err := os.ReadFile(taskFile)
@@ -79,7 +85,10 @@ func (c *PlanCommand) AutocompleteFlags() complete.Flags {
 	return command.MergeAutocompleteFlags(
 		c.Meta.AutocompleteFlags(command.FlagSetClient),
 		complete.Flags{
-			"--tasks": complete.PredictFiles("*.yml"),
+			"--tasks":                complete.PredictFiles("*.yml"),
+			"--host":                 complete.PredictAnything,
+			"--sudo":                 complete.PredictNothing,
+			"--accept-new-host-keys": complete.PredictNothing,
 		},
 	)
 }
@@ -100,6 +109,8 @@ func (c *PlanCommand) Run(args []string) int {
 		c.Ui.Error(command.CommandErrorText(c))
 		return 1
 	}
+
+	applySshFlagsToEnv(c.host, c.sudo, c.acceptNewHostKeys)
 
 	data, err := os.ReadFile(c.tasksFile)
 	if err != nil {
@@ -132,8 +143,13 @@ func (c *PlanCommand) Run(args []string) int {
 	subprocess.SetGlobalSensitive(sensitiveValues)
 	defer subprocess.SetGlobalSensitive(nil)
 
+	resolvedHost := os.Getenv("DOKKU_HOST")
+	if resolvedHost != "" {
+		defer subprocess.CloseSshControlMaster(resolvedHost)
+	}
+
 	formatter := NewFormatter(c.Ui, false)
-	formatter.PlayHeader("tasks")
+	formatter.PlayHeaderWithHost("tasks", resolvedHost)
 
 	counts := PlanCounts{}
 	hasError := false
@@ -147,7 +163,7 @@ func (c *PlanCommand) Run(args []string) int {
 		case result.Error != nil:
 			counts.Errors++
 			hasError = true
-			formatter.TaskLine(MarkerProbeError, name, fmt.Sprintf("(%v)", result.Error))
+			formatter.TaskLine(MarkerProbeError, name, fmt.Sprintf("(%s)", PrefixErrorMessage(result.Error)))
 		case result.InSync:
 			counts.InSync++
 			formatter.TaskLine(MarkerOK, name, "(in sync)")

--- a/commands/ssh_flags.go
+++ b/commands/ssh_flags.go
@@ -1,0 +1,24 @@
+package commands
+
+import "os"
+
+// applySshFlagsToEnv promotes the apply/plan SSH-related CLI flags
+// (--host, --sudo, --accept-new-host-keys) to the env vars that
+// subprocess/ssh.go reads at dispatch time. Precedence is CLI flag >
+// pre-existing env var > default. Once set here, the env value is the
+// single source of truth for the rest of the run.
+//
+// We do not Unsetenv on exit: docket commands run as one-shot processes
+// and the env mutation does not escape. If the package is later imported
+// as a library, revisit.
+func applySshFlagsToEnv(host string, sudo, acceptNewHostKeys bool) {
+	if host != "" {
+		_ = os.Setenv("DOKKU_HOST", host)
+	}
+	if sudo {
+		_ = os.Setenv("DOKKU_SUDO", "1")
+	}
+	if acceptNewHostKeys {
+		_ = os.Setenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS", "1")
+	}
+}

--- a/commands/ssh_flags.go
+++ b/commands/ssh_flags.go
@@ -1,24 +1,35 @@
 package commands
 
-import "os"
+import (
+	"os"
 
-// applySshFlagsToEnv promotes the apply/plan SSH-related CLI flags
-// (--host, --sudo, --accept-new-host-keys) to the env vars that
-// subprocess/ssh.go reads at dispatch time. Precedence is CLI flag >
-// pre-existing env var > default. Once set here, the env value is the
-// single source of truth for the rest of the run.
+	"github.com/dokku/docket/subprocess"
+)
+
+// resolveSshFlags merges the apply/plan SSH-related CLI flags with their
+// env-var counterparts and applies the result to package state for the
+// rest of the run:
 //
-// We do not Unsetenv on exit: docket commands run as one-shot processes
-// and the env mutation does not escape. If the package is later imported
-// as a library, revisit.
-func applySshFlagsToEnv(host string, sudo, acceptNewHostKeys bool) {
-	if host != "" {
-		_ = os.Setenv("DOKKU_HOST", host)
+//   - --host wins over DOKKU_HOST; the resolved value is stored on the
+//     subprocess package via SetDefaultHost so the dispatcher can read
+//     it from ExecCommandInput.Host without consulting the environment.
+//   - --sudo and --accept-new-host-keys are bridged to the env vars
+//     subprocess/ssh.go reads at argv-build time (DOKKU_SUDO,
+//     DOKKU_SSH_ACCEPT_NEW_HOST_KEYS).
+//
+// Returns the resolved host so callers can use it for play-header
+// rendering and ControlMaster teardown without re-reading env state.
+func resolveSshFlags(hostFlag string, sudo, acceptNewHostKeys bool) string {
+	host := hostFlag
+	if host == "" {
+		host = os.Getenv("DOKKU_HOST")
 	}
+	subprocess.SetDefaultHost(host)
 	if sudo {
 		_ = os.Setenv("DOKKU_SUDO", "1")
 	}
 	if acceptNewHostKeys {
 		_ = os.Setenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS", "1")
 	}
+	return host
 }

--- a/docs/dokku_certs.md
+++ b/docs/dokku_certs.md
@@ -1,6 +1,6 @@
 # dokku_certs
 
-Manages SSL certificates for a dokku app or globally
+Manages SSL certificates for a dokku app or globally. The `cert` and `key` fields are paths on the dokku server, so when running with `DOKKU_HOST` set the referenced files must already exist on the remote host - docket does not upload them.
 
 ## Add an SSL certificate to an app
 

--- a/generate/docs.go
+++ b/generate/docs.go
@@ -4,16 +4,26 @@ package main
 import (
 	"fmt"
 	"log"
-	"github.com/dokku/docket/tasks"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+
+	"github.com/dokku/docket/tasks"
 )
 
 func main() {
-	docsFolderName := "../" + os.Args[1]
-	// expand docsFolderName
-	docsFolderName, err := filepath.Abs(docsFolderName)
+	// Anchor the output directory to the repo root (one level above this
+	// generate/ file) regardless of where `go generate` or `go run` was
+	// invoked from. Without this, `go run generate/docs.go docs` from the
+	// repo root would resolve `../docs` to a sibling repo and clobber it.
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		log.Fatal("failed to determine generator file location")
+	}
+	repoRoot := filepath.Dir(filepath.Dir(thisFile))
+
+	docsFolderName, err := filepath.Abs(filepath.Join(repoRoot, os.Args[1]))
 	if err != nil {
 		log.Fatalf("failed to expand docs folder name: %v", err)
 	}

--- a/generate/docs.go
+++ b/generate/docs.go
@@ -4,26 +4,16 @@ package main
 import (
 	"fmt"
 	"log"
+	"github.com/dokku/docket/tasks"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
-
-	"github.com/dokku/docket/tasks"
 )
 
 func main() {
-	// Anchor the output directory to the repo root (one level above this
-	// generate/ file) regardless of where `go generate` or `go run` was
-	// invoked from. Without this, `go run generate/docs.go docs` from the
-	// repo root would resolve `../docs` to a sibling repo and clobber it.
-	_, thisFile, _, ok := runtime.Caller(0)
-	if !ok {
-		log.Fatal("failed to determine generator file location")
-	}
-	repoRoot := filepath.Dir(filepath.Dir(thisFile))
-
-	docsFolderName, err := filepath.Abs(filepath.Join(repoRoot, os.Args[1]))
+	docsFolderName := "../" + os.Args[1]
+	// expand docsFolderName
+	docsFolderName, err := filepath.Abs(docsFolderName)
 	if err != nil {
 		log.Fatalf("failed to expand docs folder name: %v", err)
 	}

--- a/subprocess/exec.go
+++ b/subprocess/exec.go
@@ -102,8 +102,18 @@ func CallExecCommand(input ExecCommandInput) (ExecCommandResponse, error) {
 	return CallExecCommandWithContext(ctx, input)
 }
 
-// CallExecCommandWithContext executes a command on the local host with the given context
+// CallExecCommandWithContext executes a command on the local host with the given context.
+//
+// When DOKKU_HOST is set and the command is `dokku`, dispatch is routed
+// through the SSH transport so the dokku invocation runs on the remote
+// host. Non-dokku subprocesses (echo/git/etc.) always run locally even
+// when DOKKU_HOST is set, since the remote side may not have those
+// binaries (and tests expect local execution).
 func CallExecCommandWithContext(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
+	if host := os.Getenv("DOKKU_HOST"); host != "" && input.Command == "dokku" {
+		return CallSshCommandWithContext(ctx, host, input)
+	}
+
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, syscall.SIGHUP,
 		syscall.SIGINT,

--- a/subprocess/exec.go
+++ b/subprocess/exec.go
@@ -54,6 +54,13 @@ type ExecCommandInput struct {
 
 	// WorkingDirectory is the working directory to run the command in
 	WorkingDirectory string
+
+	// Host, when non-empty, routes the command through an `ssh` subprocess
+	// against [user@]host[:port] instead of executing locally. Only used
+	// when Command is "dokku"; non-dokku commands always run locally
+	// (the remote side may not have those binaries). When empty, the
+	// dispatcher consults the package default set by SetDefaultHost.
+	Host string
 }
 
 // ExecCommandResponse is the response for the ExecCommand function
@@ -104,14 +111,18 @@ func CallExecCommand(input ExecCommandInput) (ExecCommandResponse, error) {
 
 // CallExecCommandWithContext executes a command on the local host with the given context.
 //
-// When DOKKU_HOST is set and the command is `dokku`, dispatch is routed
+// When `input.Host` is set (or a default has been configured via
+// SetDefaultHost) and the command is `dokku`, dispatch is routed
 // through the SSH transport so the dokku invocation runs on the remote
 // host. Non-dokku subprocesses (echo/git/etc.) always run locally even
-// when DOKKU_HOST is set, since the remote side may not have those
+// when a host is configured, since the remote side may not have those
 // binaries (and tests expect local execution).
 func CallExecCommandWithContext(ctx context.Context, input ExecCommandInput) (ExecCommandResponse, error) {
-	if host := os.Getenv("DOKKU_HOST"); host != "" && input.Command == "dokku" {
-		return CallSshCommandWithContext(ctx, host, input)
+	if input.Host == "" {
+		input.Host = GetDefaultHost()
+	}
+	if input.Host != "" && input.Command == "dokku" {
+		return CallSshCommandWithContext(ctx, input.Host, input)
 	}
 
 	signals := make(chan os.Signal, 1)

--- a/subprocess/ssh.go
+++ b/subprocess/ssh.go
@@ -194,6 +194,33 @@ var (
 	sshLookPathErr  error
 )
 
+// defaultHost is the package-level fallback used by CallExecCommand
+// when the per-call ExecCommandInput.Host is empty. The commands layer
+// (commands/apply.go and commands/plan.go) sets this once at start-of-
+// run from the resolved CLI flag / env var so tasks can keep building
+// transport-agnostic ExecCommandInput values.
+var (
+	defaultHostMu sync.RWMutex
+	defaultHost   string
+)
+
+// SetDefaultHost registers the host that CallExecCommandWithContext
+// should use when ExecCommandInput.Host is empty. Pass an empty string
+// to clear the default. Mirrors the SetGlobalSensitive pattern.
+func SetDefaultHost(host string) {
+	defaultHostMu.Lock()
+	defer defaultHostMu.Unlock()
+	defaultHost = host
+}
+
+// GetDefaultHost returns the currently registered default host (or
+// empty string when none).
+func GetDefaultHost() string {
+	defaultHostMu.RLock()
+	defer defaultHostMu.RUnlock()
+	return defaultHost
+}
+
 func ensureSshAvailable() error {
 	sshLookPathOnce.Do(func() {
 		_, err := exec.LookPath("ssh")

--- a/subprocess/ssh.go
+++ b/subprocess/ssh.go
@@ -1,0 +1,358 @@
+// Package subprocess SSH transport.
+//
+// When DOKKU_HOST is set, every dokku subprocess invocation is routed
+// through an `ssh` subprocess wrapper instead of executing locally. We
+// shell out to the user's `ssh` binary rather than using a Go SSH
+// library so we inherit the user's `~/.ssh/config`, `ProxyJump`, agent,
+// and known_hosts handling for free.
+//
+// All invocations in a single docket run share one TCP+SSH handshake
+// via OpenSSH ControlMaster multiplexing. The first `ssh` invocation
+// negotiates the master connection and writes a unix-domain socket at
+// `<tmpdir>/docket-<hash>.sock`; subsequent invocations reuse it. The
+// socket name hashes the resolved host plus the docket PID so two
+// docket processes targeting the same host do not collide on the
+// socket path.
+//
+// The ControlPersist option keeps the master alive 60 seconds past the
+// last command exit; the command package additionally invokes
+// CloseSshControlMaster as a defer to tear the master down cleanly when
+// the run exits normally.
+//
+// Error attribution. OpenSSH exits with code 255 when the transport
+// itself fails (connect refused, auth, host-key mismatch) and forwards
+// the remote command's exit code otherwise. We use exit 255 to classify
+// failures: a 255 exit is wrapped as `*SSHError` so the formatter can
+// render it with an `ssh:` prefix; any other non-zero exit is returned
+// as the underlying error so the formatter renders it as a `dokku:`
+// failure.
+//
+// `input.Sudo` in `ExecCommandInput` means "wrap with local sudo" and
+// is meaningless when DOKKU_HOST is set. SSH dispatch ignores
+// `input.Sudo` and consults `DOKKU_SUDO=1` to decide whether to wrap
+// the *remote* dokku invocation in `sudo -n`.
+package subprocess
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/url"
+	"os"
+	"os/exec"
+	"os/signal"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+
+	execute "github.com/alexellis/go-execute/v2"
+	"github.com/fatih/color"
+)
+
+// SSHError wraps a transport-level failure of the ssh subprocess
+// (connect, auth, host-key) as opposed to a non-zero exit from the
+// remote dokku command. The output formatter renders SSHError values
+// with an `ssh:` prefix; all other errors render with a `dokku:`
+// prefix.
+type SSHError struct {
+	Host    string
+	Command []string
+	Err     error
+	Stderr  string
+}
+
+func (e *SSHError) Error() string {
+	if e == nil {
+		return ""
+	}
+	stderr := strings.TrimSpace(e.Stderr)
+	if stderr != "" {
+		return fmt.Sprintf("ssh %s: %s", e.Host, stderr)
+	}
+	if e.Err != nil {
+		return fmt.Sprintf("ssh %s: %s", e.Host, e.Err)
+	}
+	return fmt.Sprintf("ssh %s: transport failure", e.Host)
+}
+
+func (e *SSHError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// sshTarget is the parsed form of DOKKU_HOST.
+type sshTarget struct {
+	User string
+	Host string
+	Port string
+}
+
+// UserHost returns the [user@]host portion suitable for passing to ssh.
+func (t sshTarget) UserHost() string {
+	if t.User == "" {
+		return t.Host
+	}
+	return t.User + "@" + t.Host
+}
+
+// parseDokkuHost parses a DOKKU_HOST value of the form `[user@]host[:port]`.
+// We prepend `ssh://` and use net/url so port and IPv6 hosts get parsed
+// correctly. An empty user defaults to $USER (then $LOGNAME, then
+// user.Current); an empty port defaults to "22".
+func parseDokkuHost(raw string) (sshTarget, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return sshTarget{}, errors.New("DOKKU_HOST is empty")
+	}
+	u, err := url.Parse("ssh://" + raw)
+	if err != nil {
+		return sshTarget{}, fmt.Errorf("invalid DOKKU_HOST %q: %w", raw, err)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return sshTarget{}, fmt.Errorf("invalid DOKKU_HOST %q: no host", raw)
+	}
+	target := sshTarget{
+		Host: host,
+		Port: u.Port(),
+	}
+	if u.User != nil {
+		target.User = u.User.Username()
+	}
+	if target.User == "" {
+		target.User = defaultSshUser()
+	}
+	if target.Port == "" {
+		target.Port = "22"
+	}
+	return target, nil
+}
+
+func defaultSshUser() string {
+	if v := os.Getenv("USER"); v != "" {
+		return v
+	}
+	if v := os.Getenv("LOGNAME"); v != "" {
+		return v
+	}
+	if u, err := user.Current(); err == nil {
+		return u.Username
+	}
+	return ""
+}
+
+// controlPath returns the unix-domain socket path used by ControlMaster
+// for the given host and PID. Hashing the host + PID gives concurrent
+// docket runs against the same host distinct sockets so they cannot
+// collide.
+func controlPath(host string, pid int) string {
+	sum := sha256.Sum256([]byte(host + ":" + strconv.Itoa(pid)))
+	return filepath.Join(os.TempDir(), "docket-"+hex.EncodeToString(sum[:])[:16]+".sock")
+}
+
+// buildSshArgv assembles the full argv for the `ssh` subprocess. The
+// remote command is passed as separate argv elements; OpenSSH handles
+// quoting so callers must not pre-quote.
+//
+// Reads two env vars at build time: DOKKU_SSH_ACCEPT_NEW_HOST_KEYS=1
+// adds `-o StrictHostKeyChecking=accept-new`; DOKKU_SUDO=1 wraps the
+// remote command in `sudo -n`.
+func buildSshArgv(target sshTarget, remote []string) []string {
+	argv := []string{
+		"-o", "ControlMaster=auto",
+		"-o", "ControlPath=" + controlPath(target.UserHost(), os.Getpid()),
+		"-o", "ControlPersist=60",
+		"-o", "BatchMode=yes",
+	}
+	if os.Getenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS") == "1" {
+		argv = append(argv, "-o", "StrictHostKeyChecking=accept-new")
+	}
+	if target.Port != "" && target.Port != "22" {
+		argv = append(argv, "-p", target.Port)
+	}
+	argv = append(argv, target.UserHost(), "--")
+	if os.Getenv("DOKKU_SUDO") == "1" {
+		argv = append(argv, "sudo", "-n")
+	}
+	argv = append(argv, remote...)
+	return argv
+}
+
+// sshLookPathOnce caches the result of looking up the `ssh` binary so
+// we don't pay LookPath on every dispatch.
+var (
+	sshLookPathOnce sync.Once
+	sshLookPathErr  error
+)
+
+func ensureSshAvailable() error {
+	sshLookPathOnce.Do(func() {
+		_, err := exec.LookPath("ssh")
+		if err != nil {
+			sshLookPathErr = errors.New("ssh binary not found in PATH; install OpenSSH client to use DOKKU_HOST")
+		}
+	})
+	return sshLookPathErr
+}
+
+// CallSshCommand executes a remote command over ssh against host using
+// the background context.
+func CallSshCommand(host string, input ExecCommandInput) (ExecCommandResponse, error) {
+	return CallSshCommandWithContext(context.Background(), host, input)
+}
+
+// CallSshCommandWithContext executes a remote command over ssh against
+// host. The execution pipeline mirrors CallExecCommandWithContext (same
+// signal handling, env propagation, DOKKU_TRACE logging, masking, stdio
+// wiring) so callers see identical behavior aside from the transport.
+//
+// On exit code 255 (OpenSSH's transport-failure code), the returned
+// error is `*SSHError`. On any other non-zero exit, the returned error
+// is the plain underlying error so the formatter renders the failure
+// as a remote dokku error.
+func CallSshCommandWithContext(ctx context.Context, host string, input ExecCommandInput) (ExecCommandResponse, error) {
+	target, err := parseDokkuHost(host)
+	if err != nil {
+		return ExecCommandResponse{}, &SSHError{Host: host, Err: err}
+	}
+	if err := ensureSshAvailable(); err != nil {
+		return ExecCommandResponse{}, &SSHError{Host: target.UserHost(), Err: err}
+	}
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGQUIT,
+		syscall.SIGTERM)
+	ctx, cancel := context.WithCancel(ctx)
+	go func() {
+		<-signals
+		cancel()
+	}()
+
+	isatty := !color.NoColor
+	env := os.Environ()
+	if isatty && input.DisableStdioBuffer {
+		env = append(env, "FORCE_TTY=1")
+	}
+	if input.Env != nil {
+		for k, v := range input.Env {
+			env = append(env, fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+
+	remote := append([]string{input.Command}, input.Args...)
+	argv := buildSshArgv(target, remote)
+
+	cmd := execute.ExecTask{
+		Command:            "ssh",
+		Args:               argv,
+		Env:                env,
+		DisableStdioBuffer: input.DisableStdioBuffer,
+	}
+	if input.WorkingDirectory != "" {
+		cmd.Cwd = input.WorkingDirectory
+	}
+
+	if os.Getenv("DOKKU_TRACE") == "1" {
+		log.Printf("ssh: %s %s", MaskString("ssh"), MaskString(strings.Join(argv, " ")))
+	}
+
+	if input.Stdin != nil {
+		cmd.Stdin = input.Stdin
+	} else if isatty {
+		cmd.Stdin = os.Stdin
+	}
+	if input.StreamStdio {
+		cmd.StreamStdio = true
+	}
+	if input.StreamStdout {
+		cmd.StdOutWriter = os.Stdout
+	}
+	if input.StreamStderr {
+		cmd.StdErrWriter = os.Stderr
+	}
+	if input.StdoutWriter != nil {
+		cmd.StdOutWriter = input.StdoutWriter
+	}
+	if input.StderrWriter != nil {
+		cmd.StdErrWriter = input.StderrWriter
+	}
+
+	resolved := MaskString(input.Command + " " + strings.Join(input.Args, " "))
+
+	res, runErr := cmd.Execute(ctx)
+	resp := ExecCommandResponse{
+		Command:   resolved,
+		Stdout:    res.Stdout,
+		Stderr:    res.Stderr,
+		ExitCode:  res.ExitCode,
+		Cancelled: res.Cancelled,
+	}
+
+	return classifySshResult(target, remote, resp, runErr)
+}
+
+// classifySshResult maps an ssh ExecTask result onto the docket error
+// model. Exit 255 (and any error before the process started) is wrapped
+// as *SSHError. Any other non-zero exit returns a plain error built
+// from stderr so the existing dokku-error rendering keeps working.
+func classifySshResult(target sshTarget, remote []string, resp ExecCommandResponse, runErr error) (ExecCommandResponse, error) {
+	if runErr != nil {
+		return resp, &SSHError{
+			Host:    target.UserHost(),
+			Command: remote,
+			Err:     runErr,
+			Stderr:  resp.Stderr,
+		}
+	}
+	if resp.ExitCode == 255 {
+		return resp, &SSHError{
+			Host:    target.UserHost(),
+			Command: remote,
+			Err:     errors.New("ssh exited 255"),
+			Stderr:  resp.Stderr,
+		}
+	}
+	if resp.ExitCode != 0 {
+		return resp, errors.New(resp.Stderr)
+	}
+	return resp, nil
+}
+
+// CloseSshControlMaster sends `ssh -O exit` to the ControlMaster for
+// host so the multiplexed connection is torn down cleanly. Best-effort:
+// errors are swallowed because the master may already have exited
+// (ControlPersist timeout, kill -9, etc.). Intended to be called as a
+// `defer` from command run loops.
+func CloseSshControlMaster(host string) error {
+	target, err := parseDokkuHost(host)
+	if err != nil {
+		return nil
+	}
+	if _, err := exec.LookPath("ssh"); err != nil {
+		return nil
+	}
+	socket := controlPath(target.UserHost(), os.Getpid())
+	if _, err := os.Stat(socket); err != nil {
+		return nil
+	}
+	cmd := exec.Command("ssh",
+		"-o", "ControlPath="+socket,
+		"-O", "exit",
+		target.UserHost(),
+	)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	_ = cmd.Run()
+	return nil
+}

--- a/subprocess/ssh_test.go
+++ b/subprocess/ssh_test.go
@@ -1,0 +1,325 @@
+package subprocess
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseDokkuHost(t *testing.T) {
+	t.Setenv("USER", "deploy")
+	t.Setenv("LOGNAME", "")
+
+	tests := []struct {
+		name     string
+		raw      string
+		wantUser string
+		wantHost string
+		wantPort string
+		wantErr  bool
+	}{
+		{"bare host", "host", "deploy", "host", "22", false},
+		{"user@host", "alice@host", "alice", "host", "22", false},
+		{"user@host:port", "alice@host.example:2222", "alice", "host.example", "2222", false},
+		{"host:port", "host:2222", "deploy", "host", "2222", false},
+		{"ipv6 with port", "[::1]:2222", "deploy", "::1", "2222", false},
+		{"empty", "", "", "", "", true},
+		{"whitespace", "   ", "", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDokkuHost(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tt.raw)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseDokkuHost(%q) returned error: %v", tt.raw, err)
+			}
+			if got.User != tt.wantUser {
+				t.Errorf("user = %q, want %q", got.User, tt.wantUser)
+			}
+			if got.Host != tt.wantHost {
+				t.Errorf("host = %q, want %q", got.Host, tt.wantHost)
+			}
+			if got.Port != tt.wantPort {
+				t.Errorf("port = %q, want %q", got.Port, tt.wantPort)
+			}
+		})
+	}
+}
+
+func TestParseDokkuHostFallsBackToLogname(t *testing.T) {
+	t.Setenv("USER", "")
+	t.Setenv("LOGNAME", "fallback")
+
+	target, err := parseDokkuHost("host")
+	if err != nil {
+		t.Fatalf("parseDokkuHost returned error: %v", err)
+	}
+	if target.User != "fallback" {
+		t.Errorf("user = %q, want %q", target.User, "fallback")
+	}
+}
+
+func TestSshTargetUserHost(t *testing.T) {
+	if got := (sshTarget{User: "alice", Host: "host"}).UserHost(); got != "alice@host" {
+		t.Errorf("UserHost() = %q, want alice@host", got)
+	}
+	if got := (sshTarget{Host: "host"}).UserHost(); got != "host" {
+		t.Errorf("UserHost() = %q, want host", got)
+	}
+}
+
+func TestControlPathStableForSamePidHost(t *testing.T) {
+	a := controlPath("alice@host", 1234)
+	b := controlPath("alice@host", 1234)
+	if a != b {
+		t.Errorf("controlPath should be stable: %q vs %q", a, b)
+	}
+}
+
+func TestControlPathDiffersByPid(t *testing.T) {
+	a := controlPath("alice@host", 1234)
+	b := controlPath("alice@host", 5678)
+	if a == b {
+		t.Errorf("controlPath should differ by pid (got %q for both)", a)
+	}
+}
+
+func TestControlPathDiffersByHost(t *testing.T) {
+	a := controlPath("alice@hostA", 1234)
+	b := controlPath("alice@hostB", 1234)
+	if a == b {
+		t.Errorf("controlPath should differ by host (got %q for both)", a)
+	}
+}
+
+func TestControlPathExtension(t *testing.T) {
+	got := controlPath("host", 1)
+	if !strings.HasSuffix(got, ".sock") {
+		t.Errorf("controlPath should end with .sock: %q", got)
+	}
+	if !strings.Contains(got, "docket-") {
+		t.Errorf("controlPath should contain docket- prefix: %q", got)
+	}
+}
+
+func TestBuildSshArgvDefault(t *testing.T) {
+	t.Setenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS", "")
+	t.Setenv("DOKKU_SUDO", "")
+
+	target := sshTarget{User: "alice", Host: "host", Port: "22"}
+	argv := buildSshArgv(target, []string{"dokku", "apps:list"})
+
+	wantOpts := []string{
+		"ControlMaster=auto",
+		"ControlPersist=60",
+		"BatchMode=yes",
+	}
+	joined := strings.Join(argv, " ")
+	for _, opt := range wantOpts {
+		if !strings.Contains(joined, opt) {
+			t.Errorf("argv missing %q: %v", opt, argv)
+		}
+	}
+	if !strings.Contains(joined, "ControlPath=") {
+		t.Errorf("argv missing ControlPath=: %v", argv)
+	}
+	if !containsExact(argv, "alice@host") {
+		t.Errorf("argv missing user@host: %v", argv)
+	}
+	if !containsExact(argv, "--") {
+		t.Errorf("argv missing -- separator: %v", argv)
+	}
+	// Remote command must come after `--`.
+	dashIdx := indexOf(argv, "--")
+	if dashIdx < 0 || dashIdx == len(argv)-1 {
+		t.Fatalf("argv has no remote portion after --: %v", argv)
+	}
+	if argv[dashIdx+1] != "dokku" || argv[dashIdx+2] != "apps:list" {
+		t.Errorf("remote command not at expected position: %v", argv[dashIdx+1:])
+	}
+	if containsExact(argv, "-p") {
+		t.Errorf("argv should not include -p for default port 22: %v", argv)
+	}
+	if containsExact(argv, "StrictHostKeyChecking=accept-new") {
+		t.Errorf("argv should not include accept-new without env var: %v", argv)
+	}
+}
+
+func TestBuildSshArgvNonStandardPort(t *testing.T) {
+	t.Setenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS", "")
+	t.Setenv("DOKKU_SUDO", "")
+
+	target := sshTarget{User: "alice", Host: "host", Port: "2222"}
+	argv := buildSshArgv(target, []string{"dokku", "version"})
+	if !containsExact(argv, "-p") {
+		t.Errorf("argv missing -p flag: %v", argv)
+	}
+	if !containsExact(argv, "2222") {
+		t.Errorf("argv missing port value: %v", argv)
+	}
+}
+
+func TestBuildSshArgvAcceptNewHostKeys(t *testing.T) {
+	t.Setenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS", "1")
+	t.Setenv("DOKKU_SUDO", "")
+
+	target := sshTarget{User: "alice", Host: "host", Port: "22"}
+	argv := buildSshArgv(target, []string{"dokku", "version"})
+	joined := strings.Join(argv, " ")
+	if !strings.Contains(joined, "StrictHostKeyChecking=accept-new") {
+		t.Errorf("argv missing StrictHostKeyChecking=accept-new: %v", argv)
+	}
+}
+
+func TestBuildSshArgvDokkuSudo(t *testing.T) {
+	t.Setenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS", "")
+	t.Setenv("DOKKU_SUDO", "1")
+
+	target := sshTarget{User: "alice", Host: "host", Port: "22"}
+	argv := buildSshArgv(target, []string{"dokku", "version"})
+
+	// sudo must appear after `--`, not before (we never run `sudo ssh`).
+	dashIdx := indexOf(argv, "--")
+	if dashIdx < 0 {
+		t.Fatalf("argv missing -- separator: %v", argv)
+	}
+	pre, post := argv[:dashIdx], argv[dashIdx+1:]
+	if containsExact(pre, "sudo") {
+		t.Errorf("sudo should not appear before --: %v", pre)
+	}
+	if len(post) < 4 || post[0] != "sudo" || post[1] != "-n" || post[2] != "dokku" || post[3] != "version" {
+		t.Errorf("expected post-`--` argv [sudo -n dokku version], got %v", post)
+	}
+}
+
+func TestBuildSshArgvDoubleDashSeparator(t *testing.T) {
+	target := sshTarget{User: "alice", Host: "host", Port: "22"}
+	argv := buildSshArgv(target, []string{"dokku", "config:set", "--no-restart"})
+	dashIdx := indexOf(argv, "--")
+	if dashIdx < 0 {
+		t.Fatalf("argv missing -- separator: %v", argv)
+	}
+	post := argv[dashIdx+1:]
+	if len(post) < 3 || post[0] != "dokku" || post[1] != "config:set" || post[2] != "--no-restart" {
+		t.Errorf("remote command not preserved across --: %v", post)
+	}
+}
+
+func TestSSHErrorMessage(t *testing.T) {
+	e := &SSHError{Host: "alice@host", Stderr: "Permission denied (publickey)."}
+	got := e.Error()
+	want := "ssh alice@host: Permission denied (publickey)."
+	if got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestSSHErrorMessageFallsBackToErr(t *testing.T) {
+	inner := errors.New("dial tcp: connection refused")
+	e := &SSHError{Host: "alice@host", Err: inner}
+	got := e.Error()
+	if !strings.Contains(got, "alice@host") {
+		t.Errorf("Error() = %q, want it to contain host", got)
+	}
+	if !strings.Contains(got, "connection refused") {
+		t.Errorf("Error() = %q, want it to contain inner error", got)
+	}
+}
+
+func TestSSHErrorUnwrap(t *testing.T) {
+	inner := errors.New("inner")
+	e := &SSHError{Host: "host", Err: inner}
+	if !errors.Is(e, inner) {
+		t.Error("errors.Is should match inner error")
+	}
+	var target *SSHError
+	if !errors.As(e, &target) {
+		t.Error("errors.As should match *SSHError")
+	}
+}
+
+func TestClassifySshResultExit255(t *testing.T) {
+	target := sshTarget{User: "alice", Host: "host", Port: "22"}
+	resp := ExecCommandResponse{ExitCode: 255, Stderr: "ssh: connect to host: Connection refused"}
+	_, err := classifySshResult(target, []string{"dokku", "version"}, resp, nil)
+	if err == nil {
+		t.Fatal("expected error for exit 255")
+	}
+	var sshErr *SSHError
+	if !errors.As(err, &sshErr) {
+		t.Fatalf("expected *SSHError, got %T", err)
+	}
+}
+
+func TestClassifySshResultRemoteFailureIsNotSshError(t *testing.T) {
+	target := sshTarget{User: "alice", Host: "host", Port: "22"}
+	resp := ExecCommandResponse{ExitCode: 1, Stderr: "App test does not exist"}
+	_, err := classifySshResult(target, []string{"dokku", "apps:exists", "test"}, resp, nil)
+	if err == nil {
+		t.Fatal("expected error for non-zero exit")
+	}
+	var sshErr *SSHError
+	if errors.As(err, &sshErr) {
+		t.Errorf("non-255 exit should not be SSHError; got %#v", err)
+	}
+	if !strings.Contains(err.Error(), "App test does not exist") {
+		t.Errorf("error should preserve remote stderr: %v", err)
+	}
+}
+
+func TestClassifySshResultPreProcessErrorIsSshError(t *testing.T) {
+	target := sshTarget{User: "alice", Host: "host", Port: "22"}
+	resp := ExecCommandResponse{}
+	runErr := errors.New("exec: \"ssh\": executable file not found")
+	_, err := classifySshResult(target, []string{"dokku", "version"}, resp, runErr)
+	var sshErr *SSHError
+	if !errors.As(err, &sshErr) {
+		t.Fatalf("expected *SSHError, got %T", err)
+	}
+}
+
+func TestClassifySshResultSuccess(t *testing.T) {
+	target := sshTarget{User: "alice", Host: "host", Port: "22"}
+	resp := ExecCommandResponse{ExitCode: 0}
+	_, err := classifySshResult(target, []string{"dokku", "version"}, resp, nil)
+	if err != nil {
+		t.Errorf("expected no error for exit 0, got %v", err)
+	}
+}
+
+func TestCallSshCommandReturnsSshErrorOnEmptyHost(t *testing.T) {
+	_, err := CallSshCommand("", ExecCommandInput{Command: "dokku", Args: []string{"version"}})
+	if err == nil {
+		t.Fatal("expected error for empty host")
+	}
+	var sshErr *SSHError
+	if !errors.As(err, &sshErr) {
+		t.Fatalf("expected *SSHError, got %T", err)
+	}
+}
+
+// helpers
+
+func containsExact(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func indexOf(haystack []string, needle string) int {
+	for i, s := range haystack {
+		if s == needle {
+			return i
+		}
+	}
+	return -1
+}

--- a/subprocess/ssh_test.go
+++ b/subprocess/ssh_test.go
@@ -304,6 +304,18 @@ func TestCallSshCommandReturnsSshErrorOnEmptyHost(t *testing.T) {
 	}
 }
 
+func TestSetAndGetDefaultHost(t *testing.T) {
+	t.Cleanup(func() { SetDefaultHost("") })
+	SetDefaultHost("alice@host:2222")
+	if got := GetDefaultHost(); got != "alice@host:2222" {
+		t.Errorf("GetDefaultHost() = %q, want %q", got, "alice@host:2222")
+	}
+	SetDefaultHost("")
+	if got := GetDefaultHost(); got != "" {
+		t.Errorf("GetDefaultHost() = %q, want empty after clear", got)
+	}
+}
+
 // helpers
 
 func containsExact(haystack []string, needle string) bool {

--- a/tasks/certs_task.go
+++ b/tasks/certs_task.go
@@ -42,7 +42,10 @@ func (e CertsTaskExample) GetName() string {
 
 // Doc returns the docblock for the certs task
 func (t CertsTask) Doc() string {
-	return "Manages SSL certificates for a dokku app or globally"
+	return "Manages SSL certificates for a dokku app or globally. The `cert` " +
+		"and `key` fields are paths on the dokku server, so when running with " +
+		"`DOKKU_HOST` set the referenced files must already exist on the " +
+		"remote host - docket does not upload them."
 }
 
 // Examples returns the examples for the certs task

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -505,7 +505,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&BuildpacksPropertyTask{}, "Manages the buildpacks configuration for a given dokku application"},
 		{&BuildpacksTask{}, "Manages the buildpacks for a given dokku application"},
 		{&CaddyPropertyTask{}, "Manages the caddy configuration for a given dokku application"},
-		{&CertsTask{}, "Manages SSL certificates for a dokku app or globally"},
+		{&CertsTask{}, "Manages SSL certificates for a dokku app or globally. The `cert` and `key` fields are paths on the dokku server, so when running with `DOKKU_HOST` set the referenced files must already exist on the remote host - docket does not upload them."},
 		{&ChecksPropertyTask{}, "Manages the checks configuration for a given dokku application"},
 		{&ChecksToggleTask{}, "Enables or disables the checks plugin for a given dokku application"},
 		{&ConfigTask{}, "Manages the configuration for a given dokku application"},

--- a/tests/bats/ssh.bats
+++ b/tests/bats/ssh.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  require_remote_dokku
+  docket_build
+  ssh_clean_app
+}
+
+teardown() {
+  if [ -n "${DOCKET_TEST_REMOTE_HOST:-}" ]; then
+    ssh_clean_app || true
+  fi
+}
+
+# ssh_clean_app destroys the per-test app on the remote host if it
+# exists. Mirrors dokku_clean_app but routes through ssh so the bats
+# host does not need a local dokku binary.
+ssh_clean_app() {
+  local app="docket-test-ssh"
+  if ssh -o BatchMode=yes "$DOCKET_TEST_REMOTE_HOST" "dokku apps:exists $app" >/dev/null 2>&1; then
+    ssh -o BatchMode=yes "$DOCKET_TEST_REMOTE_HOST" "dokku --force apps:destroy $app" >/dev/null 2>&1 || true
+  fi
+}
+
+@test "DOKKU_HOST routes apply through ssh" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-ssh
+      dokku_app:
+        app: docket-test-ssh
+EOF
+  DOKKU_HOST="$DOCKET_TEST_REMOTE_HOST" run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  run ssh -o BatchMode=yes "$DOCKET_TEST_REMOTE_HOST" "dokku apps:exists docket-test-ssh"
+  assert_success
+}
+
+@test "play header annotates host when DOKKU_HOST is set" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-ssh
+      dokku_app:
+        app: docket-test-ssh
+EOF
+  DOKKU_HOST="$DOCKET_TEST_REMOTE_HOST" run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "(host: $DOCKET_TEST_REMOTE_HOST)"
+}
+
+@test "DOKKU_HOST plan does not mutate remote state" {
+  ssh_clean_app
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-ssh
+      dokku_app:
+        app: docket-test-ssh
+EOF
+  DOKKU_HOST="$DOCKET_TEST_REMOTE_HOST" run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "[+]"
+  run ssh -o BatchMode=yes "$DOCKET_TEST_REMOTE_HOST" "dokku apps:exists docket-test-ssh"
+  assert_failure
+}
+
+@test "ssh transport failure renders ssh-prefixed error" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-ssh
+      dokku_app:
+        app: docket-test-ssh
+EOF
+  DOKKU_HOST="$USER@127.0.0.1:1" run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "ssh:"
+}
+
+@test "--host flag overrides DOKKU_HOST env var" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-ssh
+      dokku_app:
+        app: docket-test-ssh
+EOF
+  DOKKU_HOST="bogus-should-not-be-used" run "$(docket_bin)" apply \
+    --tasks "$TASKS_FILE" --host "$DOCKET_TEST_REMOTE_HOST"
+  assert_success
+  assert_output --partial "(host: $DOCKET_TEST_REMOTE_HOST)"
+  refute_output --partial "(host: bogus-should-not-be-used)"
+}

--- a/tests/bats/ssh.bats
+++ b/tests/bats/ssh.bats
@@ -75,7 +75,11 @@ EOF
       dokku_app:
         app: docket-test-ssh
 EOF
-  DOKKU_HOST="$USER@127.0.0.1:1" run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  # Use apply (not plan) so a probe-level "app does not exist" outcome
+  # cannot mask the transport failure: apply unconditionally runs at
+  # least one ssh-wrapped dokku command and routes the error through
+  # the formatter where the `ssh:` prefix is applied.
+  DOKKU_HOST="$USER@127.0.0.1:1" run "$(docket_bin)" apply --tasks "$TASKS_FILE"
   assert_failure
   assert_output --partial "ssh:"
 }

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -81,3 +81,19 @@ require_dokku() {
     skip "dokku not available"
   fi
 }
+
+# require_remote_dokku skips the current test when SSH transport tests
+# cannot run. The localhost-ssh-to-dokku fixture is only wired up on
+# Linux CI; macOS dev boxes typically lack a local dokku and the
+# install/plumbing differs.
+require_remote_dokku() {
+  if [ "$(uname -s)" != "Linux" ]; then
+    skip "ssh transport tests run on Linux only"
+  fi
+  if [ -z "${DOCKET_TEST_REMOTE_HOST:-}" ]; then
+    skip "DOCKET_TEST_REMOTE_HOST not set"
+  fi
+  if ! command -v ssh >/dev/null 2>&1; then
+    skip "ssh client not available"
+  fi
+}


### PR DESCRIPTION
When `DOKKU_HOST` is set (or `--host` is passed to apply/plan), every dokku subprocess call is routed through an `ssh` subprocess wrapper instead of executing locally, so docket can manage a remote dokku server from a developer laptop or CI runner. Connections share one TCP+SSH handshake via OpenSSH `ControlMaster` multiplexing. SSH-level failures (connect, auth, host-key) render with an `ssh:` prefix while remote dokku failures render with `dokku:` so users can tell which side broke. The `--sudo` flag and `DOKKU_SUDO=1` wrap the remote command in `sudo -n`; `--accept-new-host-keys` adds `StrictHostKeyChecking=accept-new` for CI hosts. The play header gains a `(host: <name>)` annotation when a remote target is in use. The doc generator now anchors its output path to the repo root via `runtime.Caller` so invocations from any cwd are safe.

Closes #204.