### PR TITLE
refactor: propagate ssh transport errors from task probes

### DIFF
--- a/subprocess/ssh.go
+++ b/subprocess/ssh.go
@@ -204,6 +204,30 @@ var (
 	defaultHost   string
 )
 
+// Probe runs input as a state probe and reports whether it matched
+// (exit 0). A dokku-level non-zero exit is reported as `(false, nil)`,
+// i.e. "the probed state is absent," so callers can write idempotent
+// probes without unwrapping errors themselves. A transport-level
+// failure (`*SSHError`) is propagated as `(false, err)` so the caller
+// can short-circuit `Plan()` with `PlanResult{Error: err}` and let the
+// formatter render `! ssh: ...`.
+//
+// Use this for any plan-time probe that today reads exit code only
+// (`apps:exists`, `network:exists`, `<service>:linked`, etc.). Probes
+// that need stdout should call CallExecCommand directly and use
+// `errors.As(err, &*SSHError)` to discriminate.
+func Probe(input ExecCommandInput) (bool, error) {
+	result, err := CallExecCommand(input)
+	if err != nil {
+		var sshErr *SSHError
+		if errors.As(err, &sshErr) {
+			return false, err
+		}
+		return false, nil
+	}
+	return result.ExitCode == 0, nil
+}
+
 // SetDefaultHost registers the host that CallExecCommandWithContext
 // should use when ExecCommandInput.Host is empty. Pass an empty string
 // to clear the default. Mirrors the SetGlobalSensitive pattern.

--- a/subprocess/ssh_test.go
+++ b/subprocess/ssh_test.go
@@ -304,6 +304,49 @@ func TestCallSshCommandReturnsSshErrorOnEmptyHost(t *testing.T) {
 	}
 }
 
+func TestProbeSuccess(t *testing.T) {
+	matched, err := Probe(ExecCommandInput{Command: "true"})
+	if err != nil {
+		t.Fatalf("Probe(true) returned error: %v", err)
+	}
+	if !matched {
+		t.Error("Probe(true) should report matched=true")
+	}
+}
+
+func TestProbeDokkuLevelFailure(t *testing.T) {
+	matched, err := Probe(ExecCommandInput{Command: "false"})
+	if err != nil {
+		t.Errorf("Probe(false) returned non-nil error %v - dokku-level exit should be normalised", err)
+	}
+	if matched {
+		t.Error("Probe(false) should report matched=false")
+	}
+}
+
+func TestProbeSshTransportErrorPropagates(t *testing.T) {
+	// Inject a default host that points at a closed port so the SSH
+	// dispatcher routes the probe and OpenSSH exits 255 (transport
+	// failure). Dispatch only triggers for input.Command=="dokku".
+	t.Cleanup(func() { SetDefaultHost("") })
+	SetDefaultHost("docket-test@127.0.0.1:1")
+
+	matched, err := Probe(ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "apps:exists", "anything"},
+	})
+	if matched {
+		t.Error("Probe should report matched=false on transport failure")
+	}
+	if err == nil {
+		t.Fatal("Probe should propagate the SSH transport error")
+	}
+	var sshErr *SSHError
+	if !errors.As(err, &sshErr) {
+		t.Fatalf("Probe error should be *SSHError, got %T (%v)", err, err)
+	}
+}
+
 func TestSetAndGetDefaultHost(t *testing.T) {
 	t.Cleanup(func() { SetDefaultHost("") })
 	SetDefaultHost("alice@host:2222")

--- a/tasks/app_clone_task.go
+++ b/tasks/app_clone_task.go
@@ -76,7 +76,11 @@ func (t AppCloneTask) Plan() PlanResult {
 			if t.SourceApp == "" {
 				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'source_app' is required")}
 			}
-			if appExists(t.App) {
+			exists, err := appExists(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if exists {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{

--- a/tasks/app_clone_task_integration_test.go
+++ b/tasks/app_clone_task_integration_test.go
@@ -33,7 +33,8 @@ func TestIntegrationAppClone(t *testing.T) {
 	if result.State != StatePresent {
 		t.Errorf("expected state 'present', got '%s'", result.State)
 	}
-	if !appExists(targetApp) {
+	exists, _ := appExists(targetApp)
+	if !exists {
 		t.Errorf("expected target app %q to exist after clone", targetApp)
 	}
 

--- a/tasks/app_lock_task.go
+++ b/tasks/app_lock_task.go
@@ -65,7 +65,11 @@ func (t AppLockTask) Plan() PlanResult {
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if appLocked(t.App) {
+			locked, err := appLocked(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if locked {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
@@ -90,7 +94,11 @@ func (t AppLockTask) Plan() PlanResult {
 			}
 		},
 		StateAbsent: func() PlanResult {
-			if !appLocked(t.App) {
+			locked, err := appLocked(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !locked {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
@@ -117,16 +125,14 @@ func (t AppLockTask) Plan() PlanResult {
 	})
 }
 
-// appLocked checks if a dokku app is locked
-func appLocked(app string) bool {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+// appLocked checks if a dokku app is locked. Returns (false,
+// *subprocess.SSHError) on transport failure; (false, nil) when dokku
+// reports unlocked; (true, nil) when locked.
+func appLocked(app string) (bool, error) {
+	return subprocess.Probe(subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "apps:locked", app},
 	})
-	if err != nil {
-		return false
-	}
-	return result.ExitCode == 0
 }
 
 // init registers the AppLockTask with the task registry

--- a/tasks/app_lock_task_integration_test.go
+++ b/tasks/app_lock_task_integration_test.go
@@ -14,7 +14,7 @@ func TestIntegrationAppLock(t *testing.T) {
 	defer destroyApp(appName)
 
 	// initial state - not locked
-	if appLocked(appName) {
+	if locked, _ := appLocked(appName); locked {
 		t.Fatalf("expected newly-created app %q to be unlocked", appName)
 	}
 
@@ -30,7 +30,7 @@ func TestIntegrationAppLock(t *testing.T) {
 	if result.State != StatePresent {
 		t.Errorf("expected state 'present', got '%s'", result.State)
 	}
-	if !appLocked(appName) {
+	if locked, _ := appLocked(appName); !locked {
 		t.Errorf("expected app %q to be locked after lock task", appName)
 	}
 
@@ -42,7 +42,7 @@ func TestIntegrationAppLock(t *testing.T) {
 	if result.Changed {
 		t.Errorf("expected Changed=false on idempotent lock")
 	}
-	if !appLocked(appName) {
+	if locked, _ := appLocked(appName); !locked {
 		t.Errorf("expected app %q to remain locked", appName)
 	}
 
@@ -58,7 +58,7 @@ func TestIntegrationAppLock(t *testing.T) {
 	if result.State != StateAbsent {
 		t.Errorf("expected state 'absent', got '%s'", result.State)
 	}
-	if appLocked(appName) {
+	if locked, _ := appLocked(appName); locked {
 		t.Errorf("expected app %q to be unlocked after unlock task", appName)
 	}
 
@@ -70,7 +70,7 @@ func TestIntegrationAppLock(t *testing.T) {
 	if result.Changed {
 		t.Errorf("expected Changed=false on idempotent unlock")
 	}
-	if appLocked(appName) {
+	if locked, _ := appLocked(appName); locked {
 		t.Errorf("expected app %q to remain unlocked", appName)
 	}
 }

--- a/tasks/app_task.go
+++ b/tasks/app_task.go
@@ -60,7 +60,11 @@ func (t AppTask) Execute() TaskOutputState {
 func (t AppTask) Plan() PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if appExists(t.App) {
+			exists, err := appExists(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if exists {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
@@ -72,7 +76,11 @@ func (t AppTask) Plan() PlanResult {
 			}
 		},
 		StateAbsent: func() PlanResult {
-			if !appExists(t.App) {
+			exists, err := appExists(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !exists {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
@@ -86,21 +94,15 @@ func (t AppTask) Plan() PlanResult {
 	})
 }
 
-// appExists checks if an app exists
-func appExists(appName string) bool {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+// appExists checks if an app exists. Returns (true, nil) when the app
+// is present, (false, nil) when dokku reports it absent, and
+// (false, *subprocess.SSHError) when the probe could not reach the
+// server. Plan() callers must short-circuit on the error.
+func appExists(appName string) (bool, error) {
+	return subprocess.Probe(subprocess.ExecCommandInput{
 		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			"apps:exists",
-			appName,
-		},
+		Args:    []string{"--quiet", "apps:exists", appName},
 	})
-	if err != nil {
-		return false
-	}
-
-	return result.ExitCode == 0
 }
 
 // applyCreateApp returns a closure that runs `dokku apps:create <app>`.
@@ -142,7 +144,8 @@ func applyDestroyApp(app string) func() TaskOutputState {
 // destroyApp is retained as an integration-test helper. It runs the
 // destroy-app apply path synchronously.
 func destroyApp(app string) TaskOutputState {
-	if !appExists(app) {
+	exists, _ := appExists(app)
+	if !exists {
 		return TaskOutputState{Changed: false, State: StateAbsent}
 	}
 	return applyDestroyApp(app)()
@@ -151,7 +154,8 @@ func destroyApp(app string) TaskOutputState {
 // createApp is retained as an integration-test helper. It runs the
 // create-app apply path synchronously.
 func createApp(app string) TaskOutputState {
-	if appExists(app) {
+	exists, _ := appExists(app)
+	if exists {
 		return TaskOutputState{Changed: false, State: StatePresent}
 	}
 	return applyCreateApp(app)()

--- a/tasks/git_from_archive_task.go
+++ b/tasks/git_from_archive_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/dokku/docket/subprocess"
@@ -97,7 +98,11 @@ func (t GitFromArchiveTask) Plan() PlanResult {
 			if (t.GitUsername == "") != (t.GitEmail == "") {
 				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'git_username' and 'git_email' must be set together")}
 			}
-			if checkAppSourceArchive(t.App, archiveType, t.ArchiveURL) {
+			match, err := checkAppSourceArchive(t.App, archiveType, t.ArchiveURL)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if match {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
@@ -128,15 +133,22 @@ func (t GitFromArchiveTask) Plan() PlanResult {
 	})
 }
 
-// checkAppSourceArchive returns true if the app is already deployed from the
-// expected archive URL with the expected archive type. The archive type is
-// stored as the deploy source value, so a tar.gz deploy reports source "tar.gz".
-func checkAppSourceArchive(app, expectedType, expectedURL string) bool {
+// checkAppSourceArchive returns true if the app is already deployed
+// from the expected archive URL with the expected archive type. The
+// archive type is stored as the deploy source value, so a tar.gz
+// deploy reports source "tar.gz". A transport-level failure
+// (`*subprocess.SSHError`) is propagated; any other error is treated
+// as "no match" so the planner proposes a re-deploy.
+func checkAppSourceArchive(app, expectedType, expectedURL string) (bool, error) {
 	source, err := getAppDeploySource(app)
 	if err != nil {
-		return false
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return false, err
+		}
+		return false, nil
 	}
-	return source.Source == expectedType && source.SourceMetadata == expectedURL
+	return source.Source == expectedType && source.SourceMetadata == expectedURL, nil
 }
 
 // init registers the GitFromArchiveTask with the task registry

--- a/tasks/git_from_image_task.go
+++ b/tasks/git_from_image_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/dokku/docket/subprocess"
@@ -63,7 +64,11 @@ func (t GitFromImageTask) Execute() TaskOutputState {
 func (t GitFromImageTask) Plan() PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StateDeployed: func() PlanResult {
-			if checkAppSourceImage(t.App, t.Image) {
+			match, err := checkAppSourceImage(t.App, t.Image)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if match {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
@@ -101,14 +106,21 @@ func (t GitFromImageTask) Plan() PlanResult {
 	})
 }
 
-// checkAppSourceImage checks if the app is already deployed from a docker image
-func checkAppSourceImage(app, expectedImage string) bool {
+// checkAppSourceImage checks if the app is already deployed from a
+// docker image. A transport-level failure (`*subprocess.SSHError`) is
+// propagated; any other error is treated as "no match" so the planner
+// proposes a re-deploy.
+func checkAppSourceImage(app, expectedImage string) (bool, error) {
 	source, err := getAppDeploySource(app)
 	if err != nil {
-		return false
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return false, err
+		}
+		return false, nil
 	}
 
-	return source.Source == "docker-image" && source.SourceMetadata == expectedImage
+	return source.Source == "docker-image" && source.SourceMetadata == expectedImage, nil
 }
 
 // init registers the GitFromImageTask with the task registry

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -1,7 +1,9 @@
 package tasks
 
 import (
+	"errors"
 	"fmt"
+
 	"github.com/dokku/docket/subprocess"
 )
 
@@ -79,7 +81,11 @@ func (t GitSyncTask) Execute() TaskOutputState {
 func (t GitSyncTask) Plan() PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if checkAppSyncState(t.App, t.Remote, t.GitRef) {
+			match, err := checkAppSyncState(t.App, t.Remote, t.GitRef)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if match {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			ref := t.GitRef
@@ -124,15 +130,22 @@ func (t GitSyncTask) Plan() PlanResult {
 	})
 }
 
-// checkAppSyncState checks if the app is already synced from the expected remote and ref
-func checkAppSyncState(app, expectedRemote, expectedRef string) bool {
+// checkAppSyncState checks if the app is already synced from the
+// expected remote and ref. A transport-level failure
+// (`*subprocess.SSHError`) is propagated; any other error is treated
+// as "no match" so the planner proposes a re-sync.
+func checkAppSyncState(app, expectedRemote, expectedRef string) (bool, error) {
 	source, err := getAppDeploySource(app)
 	if err != nil {
-		return false
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return false, err
+		}
+		return false, nil
 	}
 
 	expectedMetadata := fmt.Sprintf("%s#%s", expectedRemote, expectedRef)
-	return source.Source == "git-sync" && source.SourceMetadata == expectedMetadata
+	return source.Source == "git-sync" && source.SourceMetadata == expectedMetadata, nil
 }
 
 // init registers the GitSyncTask with the task registry

--- a/tasks/http_auth_task.go
+++ b/tasks/http_auth_task.go
@@ -1,9 +1,11 @@
 package tasks
 
 import (
+	"errors"
 	"fmt"
-	"github.com/dokku/docket/subprocess"
 	"strings"
+
+	"github.com/dokku/docket/subprocess"
 )
 
 // HttpAuthTask manages HTTP authentication for a dokku application
@@ -76,7 +78,11 @@ func (t HttpAuthTask) Plan() PlanResult {
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if httpAuthEnabled(t.App) {
+			enabled, err := httpAuthEnabled(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if enabled {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
@@ -101,7 +107,11 @@ func (t HttpAuthTask) Plan() PlanResult {
 			}
 		},
 		StateAbsent: func() PlanResult {
-			if !httpAuthEnabled(t.App) {
+			enabled, err := httpAuthEnabled(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !enabled {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
@@ -128,8 +138,11 @@ func (t HttpAuthTask) Plan() PlanResult {
 	})
 }
 
-// httpAuthEnabled checks if HTTP authentication is enabled for an app
-func httpAuthEnabled(appName string) bool {
+// httpAuthEnabled checks if HTTP authentication is enabled for an app.
+// A transport-level failure (`*subprocess.SSHError`) is propagated; a
+// dokku-level non-zero exit (e.g. app does not exist) is treated as
+// "disabled."
+func httpAuthEnabled(appName string) (bool, error) {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
@@ -139,20 +152,24 @@ func httpAuthEnabled(appName string) bool {
 		},
 	})
 	if err != nil {
-		return false
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return false, err
+		}
+		return false, nil
 	}
 
 	lines := strings.SplitN(result.StdoutContents(), "\n", 2)
 	if len(lines) == 0 {
-		return false
+		return false, nil
 	}
 
 	parts := strings.SplitN(lines[0], ":", 2)
 	if len(parts) < 2 {
-		return false
+		return false, nil
 	}
 
-	return strings.TrimSpace(parts[1]) == "true"
+	return strings.TrimSpace(parts[1]) == "true", nil
 }
 
 // enableHttpAuth enables HTTP authentication for an app
@@ -161,7 +178,8 @@ func enableHttpAuth(app, username, password string) TaskOutputState {
 		Changed: false,
 		State:   "absent",
 	}
-	if httpAuthEnabled(app) {
+	enabled, _ := httpAuthEnabled(app)
+	if enabled {
 		state.State = "present"
 		return state
 	}
@@ -192,7 +210,8 @@ func disableHttpAuth(app string) TaskOutputState {
 		Changed: false,
 		State:   "present",
 	}
-	if !httpAuthEnabled(app) {
+	enabled, _ := httpAuthEnabled(app)
+	if !enabled {
 		state.State = "absent"
 		return state
 	}

--- a/tasks/http_auth_task_integration_test.go
+++ b/tasks/http_auth_task_integration_test.go
@@ -33,7 +33,7 @@ func TestIntegrationHttpAuth(t *testing.T) {
 	}
 
 	// verify auth is enabled via http-auth:report
-	if !httpAuthEnabled(appName) {
+	if enabled, _ := httpAuthEnabled(appName); !enabled {
 		t.Error("expected http auth to be enabled after enable")
 	}
 
@@ -66,7 +66,7 @@ func TestIntegrationHttpAuth(t *testing.T) {
 	}
 
 	// verify auth is disabled via http-auth:report
-	if httpAuthEnabled(appName) {
+	if enabled, _ := httpAuthEnabled(appName); enabled {
 		t.Error("expected http auth to be disabled after disable")
 	}
 

--- a/tasks/network_task.go
+++ b/tasks/network_task.go
@@ -60,7 +60,11 @@ func (t NetworkTask) Execute() TaskOutputState {
 func (t NetworkTask) Plan() PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if networkExists(t.Name) {
+			exists, err := networkExists(t.Name)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if exists {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
@@ -85,7 +89,11 @@ func (t NetworkTask) Plan() PlanResult {
 			}
 		},
 		StateAbsent: func() PlanResult {
-			if !networkExists(t.Name) {
+			exists, err := networkExists(t.Name)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !exists {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
@@ -112,9 +120,11 @@ func (t NetworkTask) Plan() PlanResult {
 	})
 }
 
-// networkExists checks if a Docker network exists
-func networkExists(name string) bool {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+// networkExists checks if a Docker network exists. Returns (false,
+// *subprocess.SSHError) on transport failure; (false, nil) when dokku
+// reports the network absent; (true, nil) when present.
+func networkExists(name string) (bool, error) {
+	return subprocess.Probe(subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
 			"--quiet",
@@ -122,18 +132,14 @@ func networkExists(name string) bool {
 			name,
 		},
 	})
-	if err != nil {
-		return false
-	}
-
-	return result.ExitCode == 0
 }
 
 // destroyNetwork is retained as an integration-test helper. It runs the
 // destroy-network apply path synchronously.
 func destroyNetwork(name string) TaskOutputState {
 	state := TaskOutputState{Changed: false, State: StatePresent}
-	if !networkExists(name) {
+	exists, _ := networkExists(name)
+	if !exists {
 		state.State = StateAbsent
 		return state
 	}

--- a/tasks/plan_integration_test.go
+++ b/tasks/plan_integration_test.go
@@ -63,7 +63,8 @@ func TestIntegrationPlanDoesNotMutate(t *testing.T) {
 	task := AppTask{App: appName, State: StatePresent}
 	_ = task.Plan()
 
-	if appExists(appName) {
+	exists, _ := appExists(appName)
+	if exists {
 		t.Errorf("Plan() unexpectedly created %s", appName)
 	}
 }

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -73,7 +73,10 @@ func (t PortsTask) Plan() PlanResult {
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			currentPorts := getPorts(t.App)
+			currentPorts, err := getPorts(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
 			toAdd := []PortMapping{}
 			mutations := []string{}
 			for _, pm := range t.PortMappings {
@@ -115,7 +118,10 @@ func (t PortsTask) Plan() PlanResult {
 			}
 		},
 		StateAbsent: func() PlanResult {
-			currentPorts := getPorts(t.App)
+			currentPorts, err := getPorts(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
 			toRemove := []PortMapping{}
 			mutations := []string{}
 			for _, pm := range t.PortMappings {
@@ -155,8 +161,10 @@ func (t PortsTask) Plan() PlanResult {
 	})
 }
 
-// getPorts gets the ports for a given app
-func getPorts(appName string) map[string]PortMapping {
+// getPorts gets the ports for a given app. A transport-level failure
+// (`*subprocess.SSHError`) is propagated; a dokku-level non-zero exit
+// (e.g. app does not exist) is treated as "no ports configured."
+func getPorts(appName string) (map[string]PortMapping, error) {
 	// todo: update dokku to add proper json output for this
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
@@ -168,7 +176,11 @@ func getPorts(appName string) map[string]PortMapping {
 		},
 	})
 	if err != nil {
-		return map[string]PortMapping{}
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return nil, err
+		}
+		return map[string]PortMapping{}, nil
 	}
 
 	portMappings := map[string]PortMapping{}
@@ -196,7 +208,7 @@ func getPorts(appName string) map[string]PortMapping {
 		}
 	}
 
-	return portMappings
+	return portMappings, nil
 }
 
 // init registers the PortsTask with the task registry

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -93,8 +93,16 @@ func planProperty(state State, app string, global bool, property, value, subcomm
 				}
 			}
 
-			// Probe; treat probe failure as "drift, must mutate".
+			// Probe; treat dokku-level failure as "drift, must mutate"
+			// (matches pre-probe behavior for unsupported plugins) but
+			// surface SSH transport failures so the user sees `! ssh:`.
 			current, probeErr := getProperty(subcommand, app, global, property)
+			if probeErr != nil {
+				var sshErr *subprocess.SSHError
+				if errors.As(probeErr, &sshErr) {
+					return PlanResult{Status: PlanStatusError, Error: probeErr}
+				}
+			}
 			if probeErr == nil && current == value {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
@@ -127,6 +135,12 @@ func planProperty(state State, app string, global bool, property, value, subcomm
 			}
 
 			current, probeErr := getProperty(subcommand, app, global, property)
+			if probeErr != nil {
+				var sshErr *subprocess.SSHError
+				if errors.As(probeErr, &sshErr) {
+					return PlanResult{Status: PlanStatusError, Error: probeErr}
+				}
+			}
 			if probeErr == nil && current == "" {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}

--- a/tasks/service_create_task.go
+++ b/tasks/service_create_task.go
@@ -73,7 +73,11 @@ func (t ServiceCreateTask) Execute() TaskOutputState {
 func (t ServiceCreateTask) Plan() PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if serviceExists(t.Service, t.Name) {
+			exists, err := serviceExists(t.Service, t.Name)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if exists {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
@@ -98,7 +102,11 @@ func (t ServiceCreateTask) Plan() PlanResult {
 			}
 		},
 		StateAbsent: func() PlanResult {
-			if !serviceExists(t.Service, t.Name) {
+			exists, err := serviceExists(t.Service, t.Name)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !exists {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
@@ -125,9 +133,11 @@ func (t ServiceCreateTask) Plan() PlanResult {
 	})
 }
 
-// serviceExists checks if a dokku service exists
-func serviceExists(service, name string) bool {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+// serviceExists checks if a dokku service exists. Returns (false,
+// *subprocess.SSHError) on transport failure, (false, nil) when dokku
+// reports the service absent, (true, nil) when present.
+func serviceExists(service, name string) (bool, error) {
+	return subprocess.Probe(subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
 			"--quiet",
@@ -135,11 +145,6 @@ func serviceExists(service, name string) bool {
 			name,
 		},
 	})
-	if err != nil {
-		return false
-	}
-
-	return result.ExitCode == 0
 }
 
 // createService creates a dokku service
@@ -148,7 +153,8 @@ func createService(service, name string) TaskOutputState {
 		Changed: false,
 		State:   "absent",
 	}
-	if serviceExists(service, name) {
+	exists, _ := serviceExists(service, name)
+	if exists {
 		state.State = "present"
 		return state
 	}
@@ -177,7 +183,8 @@ func destroyService(service, name string) TaskOutputState {
 		Changed: false,
 		State:   "present",
 	}
-	if !serviceExists(service, name) {
+	exists, _ := serviceExists(service, name)
+	if !exists {
 		state.State = "absent"
 		return state
 	}

--- a/tasks/service_link_task.go
+++ b/tasks/service_link_task.go
@@ -79,13 +79,25 @@ func (t ServiceLinkTask) Execute() TaskOutputState {
 func (t ServiceLinkTask) Plan() PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if !serviceExists(t.Service, t.Name) {
+			svcExists, err := serviceExists(t.Service, t.Name)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !svcExists {
 				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("service %s %s does not exist", t.Service, t.Name)}
 			}
-			if !appExists(t.App) {
+			appOK, err := appExists(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !appOK {
 				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("app %s does not exist", t.App)}
 			}
-			if serviceLinked(t.Service, t.Name, t.App) {
+			linked, err := serviceLinked(t.Service, t.Name, t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if linked {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
@@ -110,13 +122,25 @@ func (t ServiceLinkTask) Plan() PlanResult {
 			}
 		},
 		StateAbsent: func() PlanResult {
-			if !serviceExists(t.Service, t.Name) {
+			svcExists, err := serviceExists(t.Service, t.Name)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !svcExists {
 				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("service %s %s does not exist", t.Service, t.Name)}
 			}
-			if !appExists(t.App) {
+			appOK, err := appExists(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !appOK {
 				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("app %s does not exist", t.App)}
 			}
-			if !serviceLinked(t.Service, t.Name, t.App) {
+			linked, err := serviceLinked(t.Service, t.Name, t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !linked {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
@@ -143,9 +167,11 @@ func (t ServiceLinkTask) Plan() PlanResult {
 	})
 }
 
-// serviceLinked checks if a dokku service is linked to an app
-func serviceLinked(service, name, app string) bool {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+// serviceLinked checks if a dokku service is linked to an app. Returns
+// (false, *subprocess.SSHError) on transport failure; (false, nil) when
+// dokku reports no link; (true, nil) when linked.
+func serviceLinked(service, name, app string) (bool, error) {
+	return subprocess.Probe(subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
 			"--quiet",
@@ -154,11 +180,6 @@ func serviceLinked(service, name, app string) bool {
 			app,
 		},
 	})
-	if err != nil {
-		return false
-	}
-
-	return result.ExitCode == 0
 }
 
 // linkService links a dokku service to an app
@@ -168,17 +189,20 @@ func linkService(service, name, app string) TaskOutputState {
 		State:   "absent",
 	}
 
-	if !serviceExists(service, name) {
+	svcExists, _ := serviceExists(service, name)
+	if !svcExists {
 		state.Error = fmt.Errorf("service %s %s does not exist", service, name)
 		return state
 	}
 
-	if !appExists(app) {
+	appOK, _ := appExists(app)
+	if !appOK {
 		state.Error = fmt.Errorf("app %s does not exist", app)
 		return state
 	}
 
-	if serviceLinked(service, name, app) {
+	linked, _ := serviceLinked(service, name, app)
+	if linked {
 		state.State = "present"
 		return state
 	}
@@ -209,17 +233,20 @@ func unlinkService(service, name, app string) TaskOutputState {
 		State:   "present",
 	}
 
-	if !serviceExists(service, name) {
+	svcExists, _ := serviceExists(service, name)
+	if !svcExists {
 		state.Error = fmt.Errorf("service %s %s does not exist", service, name)
 		return state
 	}
 
-	if !appExists(app) {
+	appOK, _ := appExists(app)
+	if !appOK {
 		state.Error = fmt.Errorf("app %s does not exist", app)
 		return state
 	}
 
-	if !serviceLinked(service, name, app) {
+	linked, _ := serviceLinked(service, name, app)
+	if !linked {
 		state.State = "absent"
 		return state
 	}

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -2,7 +2,9 @@ package tasks
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+
 	"github.com/dokku/docket/subprocess"
 )
 
@@ -55,7 +57,11 @@ func (t StorageMountTask) Plan() PlanResult {
 	mountSpec := fmt.Sprintf("%s:%s", t.HostDir, t.ContainerDir)
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if mountExists(t.App, t.HostDir, t.ContainerDir) {
+			exists, err := mountExists(t.App, t.HostDir, t.ContainerDir)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if exists {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
@@ -80,7 +86,11 @@ func (t StorageMountTask) Plan() PlanResult {
 			}
 		},
 		StateAbsent: func() PlanResult {
-			if !mountExists(t.App, t.HostDir, t.ContainerDir) {
+			exists, err := mountExists(t.App, t.HostDir, t.ContainerDir)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !exists {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			return PlanResult{
@@ -107,8 +117,10 @@ func (t StorageMountTask) Plan() PlanResult {
 	})
 }
 
-// mountExists checks if the storage mount exists
-func mountExists(app, hostDir, containerDir string) bool {
+// mountExists checks if the storage mount exists. A transport-level
+// failure (`*subprocess.SSHError`) is propagated; a dokku-level non-
+// zero exit (e.g. app does not exist) is treated as "no mount."
+func mountExists(app, hostDir, containerDir string) (bool, error) {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
@@ -120,7 +132,11 @@ func mountExists(app, hostDir, containerDir string) bool {
 		},
 	})
 	if err != nil {
-		return false
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return false, err
+		}
+		return false, nil
 	}
 
 	var mounts []struct {
@@ -128,17 +144,16 @@ func mountExists(app, hostDir, containerDir string) bool {
 		ContainerPath string `json:"container_path"`
 	}
 
-	err = json.Unmarshal(result.StdoutBytes(), &mounts)
-	if err != nil {
-		return false
+	if err := json.Unmarshal(result.StdoutBytes(), &mounts); err != nil {
+		return false, nil
 	}
 
 	for _, mount := range mounts {
 		if mount.HostPath == hostDir && mount.ContainerPath == containerDir {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // init registers the StorageMountTask with the task registry

--- a/tests/bats/ssh.bats
+++ b/tests/bats/ssh.bats
@@ -67,7 +67,7 @@ EOF
   assert_failure
 }
 
-@test "ssh transport failure renders ssh-prefixed error" {
+@test "ssh transport failure renders ssh-prefixed error during plan" {
   write_tasks_file <<EOF
 ---
 - tasks:
@@ -75,11 +75,9 @@ EOF
       dokku_app:
         app: docket-test-ssh
 EOF
-  # Use apply (not plan) so a probe-level "app does not exist" outcome
-  # cannot mask the transport failure: apply unconditionally runs at
-  # least one ssh-wrapped dokku command and routes the error through
-  # the formatter where the `ssh:` prefix is applied.
-  DOKKU_HOST="$USER@127.0.0.1:1" run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  # Probes propagate *subprocess.SSHError, so plan surfaces transport
+  # failures with the same `ssh:` prefix as apply does.
+  DOKKU_HOST="$USER@127.0.0.1:1" run "$(docket_bin)" plan --tasks "$TASKS_FILE"
   assert_failure
   assert_output --partial "ssh:"
 }


### PR DESCRIPTION
Plan-time probes such as `appExists` and `serviceExists` previously discarded errors and returned `false` on any failure, so an SSH transport-level error during `plan` was silently misread as "the resource doesn't exist." The result was phantom drift in plan output instead of an `! ssh: ...` line.

This PR introduces `subprocess.Probe` that classifies a non-zero exit as absent state `(false, nil)` but propagates `*subprocess.SSHError` so callers can short-circuit `Plan()` with `PlanResult{Error}`. All ten production probe helpers now thread an error return; per-task `Plan()` methods short-circuit on `*SSHError` and fall through on a plain dokku-level absence as before. `getProperty`'s callers in `planProperty` get the same treatment so property tasks no longer swallow transport errors as "drift, must mutate."

Local sanity check against an unreachable host:

```
$ DOKKU_HOST=docket@127.0.0.1:1 docket plan --tasks tasks.yml
==> Play: tasks  (host: docket@127.0.0.1:1)
[!]       task #1  (ssh: ssh docket@127.0.0.1: ssh: connect to host 127.0.0.1 port 1: Connection refused)

Plan: 1 task(s); 0 would change, 0 in sync, 1 error(s).
```

Closes the follow-up note from #223.