### PR TITLE
feat: add task envelope with tags, when, and loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,90 @@ docket apply
 
 Running `docket` with no subcommand prints the available commands. Use `docket init` to scaffold a starter `tasks.yml`, `docket apply` to execute a task file, `docket fmt` to canonically format a task file, `docket plan` to preview the changes a task file would make without mutating any state, `docket validate` to check a task file's schema and templates without contacting the server, or `docket version` to print the binary's version.
 
+### Task envelope
+
+Each task entry in `tasks.yml` admits a small set of cross-cutting envelope keys alongside the single `dokku_*` task-type key. Body templating uses [sigil](https://github.com/gliderlabs/sigil) (`{{ .input }}` substitutions) and envelope predicates use [expr-lang/expr](https://github.com/expr-lang/expr) so the two languages live in clearly separate positions.
+
+| Key | Status | What it does |
+|-----|--------|--------------|
+| `name` | active | Human label for the task. Auto-generated when omitted. |
+| `tags` | active | Tag list filtered by `--tags` / `--skip-tags` on `apply` and `plan`. |
+| `when` | active | expr expression. Falsy renders the task as `[skipped]`. |
+| `loop` | active | List literal, or expr returning a list. Expands one entry into N with `.item` / `.index` available in the body. |
+| `register` | reserved (#210) | Bind the task result for downstream tasks. |
+| `changed_when` | reserved (#210) | expr override for the task's "changed" verdict. |
+| `failed_when` | reserved (#210) | expr override for the task's "failed" verdict. |
+| `ignore_errors` | reserved (#210) | Continue on task failure. |
+
+Unknown envelope keys are rejected at parse time with a "did you mean" suggestion against the closest valid key.
+
+#### Tags and `--tags` / `--skip-tags`
+
+Tags are a small free-form set on each task:
+
+```yaml
+- tasks:
+    - name: deploy api
+      tags: [api, deploy]
+      dokku_app:
+        app: api
+    - name: deploy worker
+      tags: [worker, deploy]
+      dokku_app:
+        app: worker
+```
+
+`--tags foo,bar` keeps tasks whose tag set intersects `{foo, bar}`. Untagged tasks are excluded. `--skip-tags foo,bar` drops tasks whose tag set intersects `{foo, bar}`; untagged tasks are kept. Specifying both intersects "kept by `--tags`" with "not filtered by `--skip-tags`":
+
+```shell
+docket plan  --tasks tasks.yml --tags api          # only the api task
+docket apply --tasks tasks.yml --skip-tags worker  # everything except worker
+```
+
+#### `when:` per-task conditional
+
+`when:` is an expr expression evaluated per-task at execution time. Falsy results render as `[skipped]` in the apply / plan output and contribute to the new "skipped" summary count:
+
+```yaml
+- inputs:
+    - name: env
+      default: staging
+  tasks:
+    - name: enable letsencrypt
+      when: 'env == "prod"'
+      dokku_letsencrypt:
+        app: api
+        state: enabled
+```
+
+The expression context today carries the file-level inputs plus, for loop expansions, `.item` and `.index`. Other context keys (`.timestamp`, `.host`, `.play.name`, `.result`, `.registered`) are reserved for follow-on issues.
+
+#### `loop:` per-task iteration
+
+`loop:` expands one envelope into N before execution. The value is either a list literal:
+
+```yaml
+- tasks:
+    - name: deploy
+      loop: [api, worker, web]
+      dokku_app:
+        app: "{{ .item }}"
+```
+
+or an expr expression that returns a list:
+
+```yaml
+- tasks:
+    - name: deploy
+      loop: 'apps where length(name) > 0'
+      dokku_app:
+        app: "{{ .item.name }}"
+```
+
+Each iteration renders the body with `.item` (the iterator value) and `.index` (zero-based) injected. Expanded envelope names are suffixed with `(item=<value>)` to keep them unique; complex items fall back to `(item=#<index>)`. `.item` / `.index` references outside a `loop:` body are rejected at parse time so a stray reference does not silently render to an empty value.
+
+`when:` interacts with `loop:`: the predicate is evaluated per expansion, so `loop: [a, b, c]` plus `when: 'item != "b"'` runs only the `a` and `c` expansions.
+
 ### Scaffolding with `init`
 
 `docket init` writes a starter `tasks.yml` from an embedded template. It is offline only: no Dokku server contact, no `git` subprocess. The default scaffold ships four tasks (`dokku_app`, `dokku_config`, `dokku_domains`, `dokku_git_sync`) wrapped in a single play with `app` and `repo` inputs, and round-trips cleanly through `docket validate`.
@@ -199,7 +283,7 @@ A handful of tasks (notably `dokku_git_auth`, `dokku_registry_auth`, and `dokku_
 
 `docket validate` performs offline schema and template checks against a `tasks.yml` without contacting any Dokku server, suitable for CI lint jobs that need to reject broken recipes before deploy.
 
-The shipping checks cover: YAML parses, recipe shape (top-level list of plays with `inputs`/`tasks`), task entry shape (envelope keys plus exactly one task-type key), task type registered (with a "did you mean" suggestion for typos), required fields decode, and sigil templates render against input defaults.
+The shipping checks cover: YAML parses, recipe shape (top-level list of plays with `inputs`/`tasks`), task entry shape (envelope keys plus exactly one task-type key), task type registered (with a "did you mean" suggestion for typos), required fields decode, sigil templates render against input defaults, expr predicates (`when:`, scalar-form `loop:`) parse, and `.item` / `.index` references stay inside a `loop:` body. Reserved envelope keys (`register`, `changed_when`, `failed_when`, `ignore_errors`) emit a "reserved but not yet supported" diagnostic until #210 lands.
 
 ```shell
 docket validate --tasks path/to/tasks.yml

--- a/commands/apply.go
+++ b/commands/apply.go
@@ -21,6 +21,8 @@ type ApplyCommand struct {
 	host              string
 	sudo              bool
 	acceptNewHostKeys bool
+	tags              []string
+	skipTags          []string
 	arguments         map[string]*Argument
 }
 
@@ -65,6 +67,8 @@ func (c *ApplyCommand) FlagSet() *flag.FlagSet {
 	f.StringVar(&c.host, "host", "", "remote dokku host as [user@]host[:port]; equivalent to DOKKU_HOST. Routes every dokku invocation through ssh.")
 	f.BoolVar(&c.sudo, "sudo", false, "wrap remote dokku invocations with `sudo -n`; equivalent to DOKKU_SUDO=1")
 	f.BoolVar(&c.acceptNewHostKeys, "accept-new-host-keys", false, "for SSH transport, accept new host keys on first connection (`-o StrictHostKeyChecking=accept-new`). MITM risk on first connect.")
+	f.StringSliceVar(&c.tags, "tags", nil, "comma-separated tag list; only tasks whose `tags:` set intersects this list run")
+	f.StringSliceVar(&c.skipTags, "skip-tags", nil, "comma-separated tag list; tasks whose `tags:` set intersects this list are skipped")
 
 	taskFile := getTaskYamlFilename(os.Args)
 	data, err := os.ReadFile(taskFile)
@@ -90,6 +94,8 @@ func (c *ApplyCommand) AutocompleteFlags() complete.Flags {
 			"--host":                 complete.PredictAnything,
 			"--sudo":                 complete.PredictNothing,
 			"--accept-new-host-keys": complete.PredictNothing,
+			"--tags":                 complete.PredictAnything,
+			"--skip-tags":            complete.PredictAnything,
 		},
 	)
 }
@@ -146,9 +152,31 @@ func (c *ApplyCommand) Run(args []string) int {
 	start := time.Now()
 	counts := ApplyCounts{}
 
-	for _, name := range taskList.Keys() {
-		task := taskList.Get(name)
-		state := task.Execute()
+	keys := tasks.FilterByTags(taskList, c.tags, c.skipTags)
+	exprBaseCtx := buildEnvelopeExprContext(context)
+
+	for _, name := range keys {
+		env := taskList.GetEnvelope(name)
+
+		if env.HasWhen() {
+			ok, err := tasks.EvalBool(env.WhenProgram(), envelopeExprContext(exprBaseCtx, env))
+			if err != nil {
+				counts.Tasks++
+				counts.Errors++
+				formatter.TaskLine(MarkerError, name, "")
+				formatter.Continuation('!', fmt.Sprintf("when expression error: %v", err))
+				formatter.ApplySummary(counts, time.Since(start))
+				return 1
+			}
+			if !ok {
+				counts.Tasks++
+				counts.Skipped++
+				formatter.TaskLine(MarkerSkipped, name, "")
+				continue
+			}
+		}
+
+		state := env.Task.Execute()
 		counts.Tasks++
 
 		switch {

--- a/commands/apply_test.go
+++ b/commands/apply_test.go
@@ -1,0 +1,79 @@
+package commands
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/dokku/docket/tasks"
+)
+
+func TestApplyCommandMetadata(t *testing.T) {
+	c := &ApplyCommand{}
+	if c.Name() != "apply" {
+		t.Errorf("Name = %q, want \"apply\"", c.Name())
+	}
+	if c.Synopsis() == "" {
+		t.Error("Synopsis must not be empty")
+	}
+}
+
+func TestApplyCommandHelpDoesNotPanic(t *testing.T) {
+	c := &ApplyCommand{}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("FlagSet panicked without tasks.yml on disk: %v", r)
+		}
+	}()
+	_ = c.FlagSet()
+}
+
+// TestEnvelopeExprContextSkipsNonLoopEnvelopes ensures the per-envelope
+// expr context only injects `.item` / `.index` for loop expansions; a
+// non-loop envelope evaluates `when:` against the file-level inputs only.
+func TestEnvelopeExprContextSkipsNonLoopEnvelopes(t *testing.T) {
+	base := map[string]interface{}{"env": "prod"}
+	env := &tasks.TaskEnvelope{Name: "x"}
+	got := envelopeExprContext(base, env)
+	if !reflect.DeepEqual(got, base) {
+		t.Errorf("non-loop envelope must return base context unchanged; got %v", got)
+	}
+}
+
+func TestEnvelopeExprContextInjectsLoopVars(t *testing.T) {
+	base := map[string]interface{}{"env": "prod"}
+	env := &tasks.TaskEnvelope{Name: "x", IsLoopExpansion: true, LoopItem: "api", LoopIndex: 2}
+	got := envelopeExprContext(base, env)
+	if got["item"] != "api" {
+		t.Errorf("item = %v, want api", got["item"])
+	}
+	if got["index"] != 2 {
+		t.Errorf("index = %v, want 2", got["index"])
+	}
+	if got["env"] != "prod" {
+		t.Errorf("env should be inherited; got %v", got["env"])
+	}
+	if base["item"] != nil {
+		t.Errorf("base must not be mutated by envelopeExprContext")
+	}
+}
+
+// TestFilterByTagsThroughCommandsLayer covers the apply / plan path's
+// reliance on tasks.FilterByTags. Routing the flags through the helper
+// in the tasks package keeps the command-side wiring trivial; this test
+// pins the behaviour the commands rely on.
+func TestFilterByTagsThroughCommandsLayer(t *testing.T) {
+	m := tasks.OrderedStringEnvelopeMap{}
+	m.Set("api", &tasks.TaskEnvelope{Name: "api", Tags: []string{"api"}})
+	m.Set("worker", &tasks.TaskEnvelope{Name: "worker", Tags: []string{"worker"}})
+	m.Set("untagged", &tasks.TaskEnvelope{Name: "untagged"})
+
+	if got := tasks.FilterByTags(m, []string{"api"}, nil); !reflect.DeepEqual(got, []string{"api"}) {
+		t.Errorf("tags=[api] got %v, want [api]", got)
+	}
+	if got := tasks.FilterByTags(m, nil, []string{"api"}); !reflect.DeepEqual(got, []string{"worker", "untagged"}) {
+		t.Errorf("skip-tags=[api] got %v, want [worker untagged]", got)
+	}
+	if got := tasks.FilterByTags(m, nil, nil); len(got) != 3 {
+		t.Errorf("no flags: got %v, want all 3", got)
+	}
+}

--- a/commands/envelope_context.go
+++ b/commands/envelope_context.go
@@ -1,0 +1,33 @@
+package commands
+
+import (
+	"github.com/dokku/docket/tasks"
+)
+
+// buildEnvelopeExprContext returns the base expr context the apply / plan
+// path uses to evaluate envelope predicates (`when:` etc.). Today this is
+// just the file-level inputs map; #208 / #210 will add timestamp / host /
+// play / result / registered keys.
+func buildEnvelopeExprContext(inputs map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(inputs))
+	for k, v := range inputs {
+		out[k] = v
+	}
+	return out
+}
+
+// envelopeExprContext returns a per-envelope expr context. Loop-expansion
+// envelopes inject `.item` / `.index` so a `when: 'item != "web"'`
+// predicate evaluates against the iteration value.
+func envelopeExprContext(base map[string]interface{}, env *tasks.TaskEnvelope) map[string]interface{} {
+	if env == nil || !env.IsLoopExpansion {
+		return base
+	}
+	out := make(map[string]interface{}, len(base)+2)
+	for k, v := range base {
+		out[k] = v
+	}
+	out["item"] = env.LoopItem
+	out["index"] = env.LoopIndex
+	return out
+}

--- a/commands/output.go
+++ b/commands/output.go
@@ -55,6 +55,7 @@ type PlanCounts struct {
 	Tasks       int
 	WouldChange int
 	InSync      int
+	Skipped     int
 	Errors      int
 }
 
@@ -202,9 +203,19 @@ func (f *Formatter) ApplySummary(c ApplyCounts, elapsed time.Duration) {
 // PlanSummary emits the blank line and `Plan: ...` footer that
 // follows a plan run. The format intentionally matches the legacy
 // shape so existing CI consumers (and the bats partial-match
-// assertions in tests/bats/plan.bats) keep working.
+// assertions in tests/bats/plan.bats) keep working. The skipped
+// count is appended only when at least one task was filtered out by
+// `when:`, so recipes that do not exercise envelope predicates still
+// produce the legacy summary.
 func (f *Formatter) PlanSummary(c PlanCounts) {
 	f.ui.Output("")
+	if c.Skipped > 0 {
+		f.ui.Output(fmt.Sprintf(
+			"Plan: %d task(s); %d would change, %d in sync, %d skipped, %d error(s).",
+			c.Tasks, c.WouldChange, c.InSync, c.Skipped, c.Errors,
+		))
+		return
+	}
 	f.ui.Output(fmt.Sprintf(
 		"Plan: %d task(s); %d would change, %d in sync, %d error(s).",
 		c.Tasks, c.WouldChange, c.InSync, c.Errors,

--- a/commands/output_test.go
+++ b/commands/output_test.go
@@ -242,6 +242,19 @@ func TestFormatterPlanSummary(t *testing.T) {
 	}
 }
 
+func TestFormatterPlanSummaryWithSkipped(t *testing.T) {
+	// The skipped count is appended only when at least one task was
+	// skipped by `when:` so recipes that do not exercise envelope
+	// predicates keep the legacy summary shape (covered above).
+	f, ui := newTestFormatter(false)
+	f.PlanSummary(PlanCounts{Tasks: 3, WouldChange: 1, InSync: 1, Skipped: 1, Errors: 0})
+	got := ui.OutputWriter.String()
+	want := "Plan: 3 task(s); 1 would change, 1 in sync, 1 skipped, 0 error(s)."
+	if !strings.Contains(got, want) {
+		t.Errorf("PlanSummary with skipped missing %q in:\n%s", want, got)
+	}
+}
+
 func TestFormatterColorOffProducesPlainOutput(t *testing.T) {
 	f, ui := newTestFormatter(false) // color forced off
 	f.TaskLine(MarkerChanged, "task", "")

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -22,6 +22,8 @@ type PlanCommand struct {
 	host              string
 	sudo              bool
 	acceptNewHostKeys bool
+	tags              []string
+	skipTags          []string
 	arguments         map[string]*Argument
 }
 
@@ -65,6 +67,8 @@ func (c *PlanCommand) FlagSet() *flag.FlagSet {
 	f.StringVar(&c.host, "host", "", "remote dokku host as [user@]host[:port]; equivalent to DOKKU_HOST. Routes every dokku invocation through ssh.")
 	f.BoolVar(&c.sudo, "sudo", false, "wrap remote dokku invocations with `sudo -n`; equivalent to DOKKU_SUDO=1")
 	f.BoolVar(&c.acceptNewHostKeys, "accept-new-host-keys", false, "for SSH transport, accept new host keys on first connection (`-o StrictHostKeyChecking=accept-new`). MITM risk on first connect.")
+	f.StringSliceVar(&c.tags, "tags", nil, "comma-separated tag list; only tasks whose `tags:` set intersects this list are planned")
+	f.StringSliceVar(&c.skipTags, "skip-tags", nil, "comma-separated tag list; tasks whose `tags:` set intersects this list are skipped")
 
 	taskFile := getTaskYamlFilename(os.Args)
 	data, err := os.ReadFile(taskFile)
@@ -89,6 +93,8 @@ func (c *PlanCommand) AutocompleteFlags() complete.Flags {
 			"--host":                 complete.PredictAnything,
 			"--sudo":                 complete.PredictNothing,
 			"--accept-new-host-keys": complete.PredictNothing,
+			"--tags":                 complete.PredictAnything,
+			"--skip-tags":            complete.PredictAnything,
 		},
 	)
 }
@@ -153,9 +159,30 @@ func (c *PlanCommand) Run(args []string) int {
 	counts := PlanCounts{}
 	hasError := false
 
-	for _, name := range taskList.Keys() {
-		task := taskList.Get(name)
-		result := task.Plan()
+	keys := tasks.FilterByTags(taskList, c.tags, c.skipTags)
+	exprBaseCtx := buildEnvelopeExprContext(context)
+
+	for _, name := range keys {
+		env := taskList.GetEnvelope(name)
+
+		if env.HasWhen() {
+			ok, err := tasks.EvalBool(env.WhenProgram(), envelopeExprContext(exprBaseCtx, env))
+			if err != nil {
+				counts.Tasks++
+				counts.Errors++
+				hasError = true
+				formatter.TaskLine(MarkerProbeError, name, fmt.Sprintf("(when expression error: %v)", err))
+				continue
+			}
+			if !ok {
+				counts.Tasks++
+				counts.Skipped++
+				formatter.TaskLine(MarkerSkipped, name, "(when: false)")
+				continue
+			}
+		}
+
+		result := env.Task.Plan()
 		counts.Tasks++
 
 		switch {

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/bgentry/speakeasy v0.2.0 // indirect
 	github.com/dustin/go-jsonpointer v0.0.0-20160814072949-ba0abeacc3dc // indirect
 	github.com/dustin/gojson v0.0.0-20160307161227-2e71ec9dd5ad // indirect
+	github.com/expr-lang/expr v1.17.8 // indirect
 	github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/dustin/go-jsonpointer v0.0.0-20160814072949-ba0abeacc3dc h1:tP7tkU+vI
 github.com/dustin/go-jsonpointer v0.0.0-20160814072949-ba0abeacc3dc/go.mod h1:ORH5Qp2bskd9NzSfKqAF7tKfONsEkCarTE5ESr/RVBw=
 github.com/dustin/gojson v0.0.0-20160307161227-2e71ec9dd5ad h1:Qk76DOWdOp+GlyDKBAG3Klr9cn7N+LcYc82AZ2S7+cA=
 github.com/dustin/gojson v0.0.0-20160307161227-2e71ec9dd5ad/go.mod h1:mPKfmRa823oBIgl2r20LeMSpTAteW5j7FLkc0vjmzyQ=
+github.com/expr-lang/expr v1.17.8 h1:W1loDTT+0PQf5YteHSTpju2qfUfNoBt4yw9+wOEU9VM=
+github.com/expr-lang/expr v1.17.8/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=

--- a/tasks/envelope.go
+++ b/tasks/envelope.go
@@ -1,0 +1,146 @@
+package tasks
+
+import (
+	"github.com/expr-lang/expr/vm"
+)
+
+// TaskEnvelope wraps a single Task with the cross-cutting fields that the
+// task entry envelope admits. The envelope-key allowlist is the union of:
+//
+//   - the keys carrying values on this struct (name, tags, when, loop,
+//     register, changed_when, failed_when, ignore_errors), and
+//   - the registered task-type key (e.g. dokku_app) which is decoded into
+//     Task and identified by TypeName.
+//
+// register / changed_when / failed_when / ignore_errors are reserved by
+// #205 but their semantics are activated in #210; the loader recognises
+// the keys today so #210 does not need to revisit the cap.
+type TaskEnvelope struct {
+	// Name is the user-supplied human label for the task. Auto-generated
+	// when the entry omits a name (see GetTasks). Loop-expansions append
+	// an `(item=<value>)` suffix to keep ordered-map keys unique.
+	Name string
+
+	// Tags is the list of tag strings on the entry. The --tags / --skip-tags
+	// CLI flags filter against this set.
+	Tags []string
+
+	// When is the raw expr-lang/expr source for the per-task conditional.
+	// An empty string means "always run". When non-empty, whenProgram caches
+	// the compiled form so loop iterations re-evaluate cheaply.
+	When string
+
+	// Loop is the per-task iteration source. Either a list literal
+	// ([]interface{}) or an expr-lang/expr source string returning a list.
+	// nil means no loop. The loader resolves this into N expanded envelopes
+	// and replaces the original entry; downstream consumers see the
+	// expansions, not Loop itself.
+	Loop interface{}
+
+	// Register, ChangedWhen, FailedWhen, IgnoreErrors are reserved for #210.
+	// The loader recognises and decodes them so that issue does not have to
+	// revisit the envelope-key allowlist.
+	Register     string
+	ChangedWhen  string
+	FailedWhen   string
+	IgnoreErrors bool
+
+	// Task is the decoded task body. Always non-nil for envelopes the
+	// loader produces.
+	Task Task
+
+	// TypeName is the registered task name (e.g. "dokku_app") that
+	// dispatched this envelope's body decode. Used for diagnostics.
+	TypeName string
+
+	// LoopItem and LoopIndex are populated on envelopes produced by loop
+	// expansion. LoopItem is the iterator value (expr context `.item`);
+	// LoopIndex is the zero-based position. Non-loop envelopes leave both
+	// at their zero value.
+	LoopItem  interface{}
+	LoopIndex int
+
+	// IsLoopExpansion distinguishes a single-iteration envelope (e.g. when
+	// LoopIndex == 0 and LoopItem == nil) from one that came from loop
+	// expansion. Useful for predicate context construction.
+	IsLoopExpansion bool
+
+	// whenProgram is the pre-compiled expr program for When. Set by the
+	// loader so loop iterations re-use the same compiled bytecode.
+	whenProgram *vm.Program
+}
+
+// HasWhen reports whether the envelope carries a non-empty `when:`
+// predicate that must be evaluated before execution.
+func (e *TaskEnvelope) HasWhen() bool {
+	return e != nil && e.When != ""
+}
+
+// WhenProgram returns the pre-compiled expr program for When, or nil if
+// no `when:` predicate is present.
+func (e *TaskEnvelope) WhenProgram() *vm.Program {
+	if e == nil {
+		return nil
+	}
+	return e.whenProgram
+}
+
+// HasTag reports whether the envelope's tag set contains tag.
+func (e *TaskEnvelope) HasTag(tag string) bool {
+	if e == nil {
+		return false
+	}
+	for _, t := range e.Tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// IntersectsTags reports whether the envelope's tag set intersects with
+// any of the given tags. Returns false for an envelope with no tags.
+func (e *TaskEnvelope) IntersectsTags(tags []string) bool {
+	if e == nil || len(tags) == 0 {
+		return false
+	}
+	for _, t := range tags {
+		if e.HasTag(t) {
+			return true
+		}
+	}
+	return false
+}
+
+// FilterByTags returns the subset of m's keys that satisfy the include
+// (--tags) and skip (--skip-tags) filters. Rules:
+//
+//   - No flags supplied: every key.
+//   - --tags only: keep iff tag set intersects includes; untagged tasks
+//     are excluded.
+//   - --skip-tags only: drop iff tag set intersects skips; untagged tasks
+//     are kept.
+//   - Both: --tags narrows first, then --skip-tags drops from the result.
+//
+// The order of the returned keys mirrors m.Keys() (insertion order).
+func FilterByTags(m OrderedStringEnvelopeMap, includes, skips []string) []string {
+	keys := m.Keys()
+	if len(includes) == 0 && len(skips) == 0 {
+		return keys
+	}
+
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		env := m.GetEnvelope(k)
+		if len(includes) > 0 {
+			if !env.IntersectsTags(includes) {
+				continue
+			}
+		}
+		if len(skips) > 0 && env.IntersectsTags(skips) {
+			continue
+		}
+		out = append(out, k)
+	}
+	return out
+}

--- a/tasks/envelope_test.go
+++ b/tasks/envelope_test.go
@@ -1,0 +1,122 @@
+package tasks
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTaskEnvelopeHasTag(t *testing.T) {
+	env := &TaskEnvelope{Tags: []string{"api", "web"}}
+	if !env.HasTag("api") {
+		t.Error("expected HasTag(api) to be true")
+	}
+	if env.HasTag("worker") {
+		t.Error("expected HasTag(worker) to be false")
+	}
+}
+
+func TestTaskEnvelopeIntersectsTags(t *testing.T) {
+	env := &TaskEnvelope{Tags: []string{"api", "web"}}
+	if !env.IntersectsTags([]string{"web", "worker"}) {
+		t.Error("expected intersect with [web worker]")
+	}
+	if env.IntersectsTags([]string{"worker"}) {
+		t.Error("expected no intersect with [worker]")
+	}
+	if env.IntersectsTags(nil) {
+		t.Error("expected no intersect with nil")
+	}
+}
+
+func TestFilterByTagsNoFlagsReturnsAllKeys(t *testing.T) {
+	m := buildEnvelopeMap(map[string][]string{
+		"a": {"foo"},
+		"b": {"bar"},
+		"c": nil,
+	})
+	got := FilterByTags(m, nil, nil)
+	if len(got) != 3 {
+		t.Errorf("expected all 3 keys, got %v", got)
+	}
+}
+
+func TestFilterByTagsIncludeIntersection(t *testing.T) {
+	m := buildEnvelopeMap(map[string][]string{
+		"a": {"foo"},
+		"b": {"bar"},
+		"c": nil,
+	})
+	got := FilterByTags(m, []string{"foo"}, nil)
+	if !reflect.DeepEqual(got, []string{"a"}) {
+		t.Errorf("got %v, want [a]", got)
+	}
+}
+
+func TestFilterByTagsIncludeExcludesUntagged(t *testing.T) {
+	m := buildEnvelopeMap(map[string][]string{
+		"tagged":   {"foo"},
+		"untagged": nil,
+	})
+	got := FilterByTags(m, []string{"foo"}, nil)
+	if !reflect.DeepEqual(got, []string{"tagged"}) {
+		t.Errorf("got %v, want [tagged]", got)
+	}
+}
+
+func TestFilterByTagsSkipDropsMatching(t *testing.T) {
+	m := buildEnvelopeMap(map[string][]string{
+		"a": {"foo"},
+		"b": {"bar"},
+		"c": nil,
+	})
+	got := FilterByTags(m, nil, []string{"foo"})
+	if !reflect.DeepEqual(got, []string{"b", "c"}) {
+		t.Errorf("got %v, want [b c]", got)
+	}
+}
+
+func TestFilterByTagsSkipKeepsUntagged(t *testing.T) {
+	m := buildEnvelopeMap(map[string][]string{
+		"tagged":   {"foo"},
+		"untagged": nil,
+	})
+	got := FilterByTags(m, nil, []string{"foo"})
+	if !reflect.DeepEqual(got, []string{"untagged"}) {
+		t.Errorf("got %v, want [untagged]", got)
+	}
+}
+
+func TestFilterByTagsCombinedNarrowsThenDrops(t *testing.T) {
+	m := buildEnvelopeMap(map[string][]string{
+		"a": {"foo", "skip"},
+		"b": {"foo"},
+		"c": {"bar"},
+	})
+	got := FilterByTags(m, []string{"foo"}, []string{"skip"})
+	if !reflect.DeepEqual(got, []string{"b"}) {
+		t.Errorf("got %v, want [b]", got)
+	}
+}
+
+func buildEnvelopeMap(spec map[string][]string) OrderedStringEnvelopeMap {
+	// spec maps key -> tag list. Insertion order follows the alphabetical
+	// order of the keys so test assertions remain stable.
+	keys := make([]string, 0, len(spec))
+	for k := range spec {
+		keys = append(keys, k)
+	}
+	// Bubble sort - good enough for handful-of-entries fixtures.
+	for i := 0; i < len(keys); i++ {
+		for j := i + 1; j < len(keys); j++ {
+			if keys[j] < keys[i] {
+				keys[i], keys[j] = keys[j], keys[i]
+			}
+		}
+	}
+
+	m := OrderedStringEnvelopeMap{}
+	for _, k := range keys {
+		m.Set(k, &TaskEnvelope{Name: k, Tags: spec[k], Task: mockTask{name: k}})
+	}
+	return m
+}

--- a/tasks/loop.go
+++ b/tasks/loop.go
@@ -1,0 +1,137 @@
+package tasks
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+
+	sigil "github.com/gliderlabs/sigil"
+	defaults "github.com/mcuadros/go-defaults"
+	yaml "gopkg.in/yaml.v3"
+)
+
+// loopItemNameLimit caps the rendered `(item=<value>)` suffix so a long
+// or complex item value does not produce an unwieldy task name.
+const loopItemNameLimit = 40
+
+// expandLoop produces one TaskEnvelope per iteration the envelope's loop
+// resolves to. The base envelope already carries the resolved Loop value
+// (literal list or expr source); body is the raw YAML body associated
+// with the registered task type, decoded once at the file level. context
+// is the file-level sigil context used to populate `.item` and `.index`
+// during the second-pass render.
+//
+// The Loop value is resolved as follows:
+//
+//   - []interface{} or any reflect-able slice/array: used as-is.
+//   - string: compiled and evaluated as an expr program against the
+//     given expr context (file-level inputs); the result must be a list.
+//   - anything else: returns an error.
+//
+// For each item, the body is YAML-marshalled, sigil-rendered with
+// `.item`/`.index` set, then YAML-unmarshalled into a fresh registered
+// task struct. The expanded envelope inherits Tags / When / Register
+// from the base; LoopItem / LoopIndex carry the iteration value so the
+// per-task `when:` evaluation can see them.
+func expandLoop(base *TaskEnvelope, body interface{}, registered Task, sigilContext map[string]interface{}, exprContext map[string]interface{}) ([]*TaskEnvelope, error) {
+	items, err := resolveLoopList(base.Loop, exprContext)
+	if err != nil {
+		return nil, err
+	}
+
+	bodyBytes, err := yaml.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal loop body: %w", err)
+	}
+
+	out := make([]*TaskEnvelope, 0, len(items))
+	for i, item := range items {
+		iterCtx := make(map[string]interface{}, len(sigilContext)+2)
+		for k, v := range sigilContext {
+			iterCtx[k] = v
+		}
+		iterCtx["item"] = item
+		iterCtx["index"] = i
+
+		rendered, err := sigil.Execute(bodyBytes, iterCtx, "loop")
+		if err != nil {
+			return nil, fmt.Errorf("loop iteration %d: render error: %w", i, err)
+		}
+		renderedBytes, err := io.ReadAll(&rendered)
+		if err != nil {
+			return nil, fmt.Errorf("loop iteration %d: read error: %w", i, err)
+		}
+
+		taskValue := reflect.New(reflect.TypeOf(registered))
+		if err := yaml.Unmarshal(renderedBytes, taskValue.Interface()); err != nil {
+			return nil, fmt.Errorf("loop iteration %d: decode error: %w", i, err)
+		}
+		task := taskValue.Elem().Interface().(Task)
+		defaults.SetDefaults(task)
+
+		expanded := *base
+		expanded.Task = task
+		expanded.Loop = nil
+		expanded.LoopItem = item
+		expanded.LoopIndex = i
+		expanded.IsLoopExpansion = true
+		expanded.Name = loopExpansionName(base.Name, item, i)
+
+		out = append(out, &expanded)
+	}
+	return out, nil
+}
+
+// resolveLoopList normalises a loop value into a concrete list. Strings
+// are compiled and evaluated as expr programs; lists are returned
+// directly. Any other type yields an error.
+func resolveLoopList(loop interface{}, exprContext map[string]interface{}) ([]interface{}, error) {
+	switch v := loop.(type) {
+	case nil:
+		return nil, fmt.Errorf("loop value is nil")
+	case []interface{}:
+		return v, nil
+	case string:
+		prog, err := CompilePredicate(v)
+		if err != nil {
+			return nil, fmt.Errorf("loop expression compile error: %w", err)
+		}
+		return EvalList(prog, exprContext)
+	}
+	// Typed slices / arrays - normalise via reflection.
+	if list, err := reflectToList(loop); err == nil {
+		return list, nil
+	}
+	return nil, fmt.Errorf("loop value must be a list or expr string; got %T", loop)
+}
+
+// loopExpansionName derives a unique map key for each loop expansion.
+// Scalar items render as `<name> (item=<value>)`; complex items (maps,
+// lists, structs) or values longer than loopItemNameLimit fall back to
+// `<name> (item=#<index>)` so the resulting key stays readable.
+func loopExpansionName(base string, item interface{}, index int) string {
+	if base == "" {
+		base = fmt.Sprintf("loop task #%d", index+1)
+	}
+	rendered := renderItemForName(item)
+	if rendered == "" || len(rendered) > loopItemNameLimit {
+		return fmt.Sprintf("%s (item=#%d)", base, index)
+	}
+	return fmt.Sprintf("%s (item=%s)", base, rendered)
+}
+
+// renderItemForName returns a stringified item value safe for use in a
+// task-name suffix. Returns "" for non-scalar values so the caller can
+// fall back to an index-based suffix.
+func renderItemForName(item interface{}) string {
+	switch v := item.(type) {
+	case nil:
+		return "nil"
+	case string:
+		return strings.TrimSpace(v)
+	case bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		return fmt.Sprint(v)
+	}
+	return ""
+}

--- a/tasks/loop_test.go
+++ b/tasks/loop_test.go
@@ -1,0 +1,175 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoopLiteralListExpandsOneEnvelopePerItem(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: deploy app
+      loop: [api, worker, web]
+      dokku_app:
+        app: "{{ .item }}"
+`)
+	out, err := GetTasks(data, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetTasks: %v", err)
+	}
+	keys := out.Keys()
+	if len(keys) != 3 {
+		t.Fatalf("expected 3 expansions, got %d (%v)", len(keys), keys)
+	}
+	wantSuffixes := []string{"(item=api)", "(item=worker)", "(item=web)"}
+	for i, k := range keys {
+		if !strings.HasSuffix(k, wantSuffixes[i]) {
+			t.Errorf("key[%d] = %q; want suffix %q", i, k, wantSuffixes[i])
+		}
+	}
+
+	want := []string{"api", "worker", "web"}
+	for i, k := range keys {
+		env := out.GetEnvelope(k)
+		if !env.IsLoopExpansion {
+			t.Errorf("key[%d] %q is not flagged as a loop expansion", i, k)
+		}
+		if env.LoopIndex != i {
+			t.Errorf("key[%d] LoopIndex = %d, want %d", i, env.LoopIndex, i)
+		}
+		appTask, ok := env.Task.(*AppTask)
+		if !ok {
+			t.Fatalf("key[%d] task type %T, want *AppTask", i, env.Task)
+		}
+		if appTask.App != want[i] {
+			t.Errorf("key[%d] app = %q, want %q", i, appTask.App, want[i])
+		}
+	}
+}
+
+func TestLoopExprListExpandsByEvaluation(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: deploy app
+      loop: '["alpha", "beta"]'
+      dokku_app:
+        app: "{{ .item }}"
+`)
+	out, err := GetTasks(data, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetTasks: %v", err)
+	}
+	keys := out.Keys()
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 expansions, got %d (%v)", len(keys), keys)
+	}
+	if got := out.GetEnvelope(keys[0]).Task.(*AppTask).App; got != "alpha" {
+		t.Errorf("first app = %q, want alpha", got)
+	}
+}
+
+func TestLoopExprNonListErrors(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - loop: '"not a list"'
+      dokku_app:
+        app: x
+`)
+	_, err := GetTasks(data, map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected error for non-list loop expression")
+	}
+	if !strings.Contains(err.Error(), "list") {
+		t.Errorf("expected message to mention list, got: %v", err)
+	}
+}
+
+func TestLoopComplexItemsFallBackToIndexSuffix(t *testing.T) {
+	// Using a list of mappings means renderItemForName cannot produce a
+	// readable suffix and the fallback `(item=#<index>)` form kicks in.
+	data := []byte(`---
+- tasks:
+    - name: deploy app
+      loop:
+        - {app: api, port: 8080}
+        - {app: worker, port: 8081}
+      dokku_app:
+        app: "{{ .item.app }}"
+`)
+	out, err := GetTasks(data, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetTasks: %v", err)
+	}
+	keys := out.Keys()
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 expansions, got %d", len(keys))
+	}
+	if !strings.HasSuffix(keys[0], "(item=#0)") || !strings.HasSuffix(keys[1], "(item=#1)") {
+		t.Errorf("expected #0 / #1 suffix, got %v", keys)
+	}
+}
+
+func TestLoopIndexExposedToBody(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: deploy
+      loop: [a, b, c]
+      dokku_app:
+        app: "app-{{ .index }}"
+`)
+	out, err := GetTasks(data, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetTasks: %v", err)
+	}
+	keys := out.Keys()
+	if len(keys) != 3 {
+		t.Fatalf("expected 3 expansions, got %d", len(keys))
+	}
+	for i, k := range keys {
+		got := out.GetEnvelope(k).Task.(*AppTask).App
+		want := []string{"app-0", "app-1", "app-2"}[i]
+		if got != want {
+			t.Errorf("expansion %d app = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestLoopEnvelopesShareWhen(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: deploy
+      loop: [a, b, c]
+      when: 'item != "b"'
+      dokku_app:
+        app: "{{ .item }}"
+`)
+	out, err := GetTasks(data, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetTasks: %v", err)
+	}
+	for _, k := range out.Keys() {
+		env := out.GetEnvelope(k)
+		if env.When != `item != "b"` {
+			t.Errorf("expansion %q lost when, got %q", k, env.When)
+		}
+		if env.WhenProgram() == nil {
+			t.Errorf("expansion %q missing pre-compiled when program", k)
+		}
+	}
+}
+
+func TestLoopVarOutsideLoopRejectedAtParse(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: deploy
+      dokku_app:
+        app: "{{ .item }}"
+`)
+	_, err := GetTasks(data, map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected error for .item outside loop")
+	}
+	if !strings.Contains(err.Error(), ".item is only available inside a loop body") {
+		t.Errorf("got: %v", err)
+	}
+}

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"regexp"
 	"strings"
 
 	sigil "github.com/gliderlabs/sigil"
@@ -28,6 +29,11 @@ const (
 	StateSet State = "set"
 	// StateClear represents the clear state
 	StateClear State = "clear"
+	// StateSkipped is the sentinel value the apply / plan path emits when
+	// a task's `when:` predicate is false. Both State and DesiredState are
+	// set to this so the equality check in commands/apply.go does not flag
+	// a skipped task as a state mismatch.
+	StateSkipped State = "skipped"
 )
 
 // Recipe represents a recipe for a task
@@ -165,6 +171,94 @@ type Task interface {
 // Global registry for Tasks.
 var RegisteredTasks map[string]Task
 
+// envelopeAllowlistKeys are the cross-cutting envelope keys the loader
+// admits alongside the single task-type key. name / tags / when / loop
+// are activated by #205; register / changed_when / failed_when /
+// ignore_errors are reserved for #210 (the loader recognises and decodes
+// them so #210 does not need to revisit the cap).
+var envelopeAllowlistKeys = []string{
+	"name",
+	"tags",
+	"when",
+	"loop",
+	"register",
+	"changed_when",
+	"failed_when",
+	"ignore_errors",
+}
+
+// envelopeAllowlistSet is envelopeAllowlistKeys as a lookup set.
+var envelopeAllowlistSet = func() map[string]bool {
+	m := make(map[string]bool, len(envelopeAllowlistKeys))
+	for _, k := range envelopeAllowlistKeys {
+		m[k] = true
+	}
+	return m
+}()
+
+// loopVarPlaceholder is the literal substitution sigil renders for `.item`
+// and `.index` during the file-level pass. Keeping `{{ .item }}` /
+// `{{ .index }}` intact through the first pass means loop expansion sees
+// the original template and can render with real values. The loader
+// rejects any task body that still contains these tokens after the
+// per-task second pass, so misuse outside a loop is reported as a parse
+// error.
+const (
+	loopItemPlaceholder  = "{{ .item }}"
+	loopIndexPlaceholder = "{{ .index }}"
+)
+
+// loopVarSentinelPattern catches `{{ .item ... }}` and `{{ .index ... }}`
+// references (any whitespace, optional sub-field access, optional
+// pipelines) so they can be hidden from the file-level sigil pass and
+// restored before loop expansion runs the second pass. The sub-match
+// captures the full template token verbatim.
+//
+// Sub-field access (`{{ .item.app }}`) is the motivating case: with a
+// scalar self-referencing placeholder, sigil errors when traversing a
+// field on a string. Hiding the whole `{{ ... }}` token sidesteps the
+// problem entirely.
+var loopVarSentinelPattern = regexp.MustCompile(`\{\{[^}]*?\.(item|index)([^}]*)\}\}`)
+
+// loopVarSentinelOpen / Close wrap escaped loop-var tokens during the
+// file-level sigil pass. The pair must be unique enough to never appear
+// in a real recipe; the prefix doubles as documentation when one of
+// these survives a render error report.
+const (
+	loopVarSentinelOpen  = "__DOCKET_LOOPVAR<<"
+	loopVarSentinelClose = ">>__"
+)
+
+// escapeLoopVars hides `{{ .item ... }}` / `{{ .index ... }}` tokens from
+// sigil's file-level render. Returns the escaped data and the list of
+// captured tokens in encounter order so unescapeLoopVars can restore
+// them. Strings that contain no loop-var references round-trip unchanged.
+func escapeLoopVars(data []byte) ([]byte, []string) {
+	var captured []string
+	out := loopVarSentinelPattern.ReplaceAllFunc(data, func(match []byte) []byte {
+		idx := len(captured)
+		captured = append(captured, string(match))
+		return []byte(fmt.Sprintf("%s%d%s", loopVarSentinelOpen, idx, loopVarSentinelClose))
+	})
+	return out, captured
+}
+
+// unescapeLoopVars reverses escapeLoopVars. Each sentinel
+// `__DOCKET_LOOPVAR<<N>>__` is replaced with captured[N]. Sentinels that
+// reference an out-of-range index are left untouched (defensive against
+// upstream code that mangles the sentinel).
+func unescapeLoopVars(data []byte, captured []string) []byte {
+	if len(captured) == 0 {
+		return data
+	}
+	out := data
+	for i, tok := range captured {
+		sentinel := fmt.Sprintf("%s%d%s", loopVarSentinelOpen, i, loopVarSentinelClose)
+		out = []byte(strings.ReplaceAll(string(out), sentinel, tok))
+	}
+	return out
+}
+
 // RegisterTask registers a task
 func RegisterTask(t Task) {
 	if len(RegisteredTasks) == 0 {
@@ -198,90 +292,312 @@ func (i Input) GetValue() string {
 	return i.value
 }
 
-// GetTasks gets the tasks from the data
-// todo: use a slice instead of a map
-func GetTasks(data []byte, context map[string]interface{}) (OrderedStringTaskMap, error) {
-	tasks := OrderedStringTaskMap{}
-	render, err := sigil.Execute(data, context, "tasks")
+// GetTasks parses data as a docket recipe and returns the per-task
+// envelopes the executor consumes. The pipeline is:
+//
+//  1. Inject `.item` / `.index` self-reference placeholders into the
+//     sigil context so loop-body templates pass through the file-level
+//     render intact.
+//  2. Sigil-render the file with the augmented context.
+//  3. YAML-unmarshal into a Recipe.
+//  4. For each task entry: partition envelope keys vs the task-type key,
+//     reject unknown keys with a "did you mean" hint, decode envelope
+//     fields, decode task body, pre-compile any `when:` predicate.
+//  5. If `loop:` is present, expand into N envelopes via expandLoop;
+//     otherwise emit one envelope.
+//  6. Reject any envelope whose final body still contains
+//     `{{ .item }}` / `{{ .index }}` (i.e. the user referenced a loop
+//     variable from a non-loop task).
+func GetTasks(data []byte, context map[string]interface{}) (OrderedStringEnvelopeMap, error) {
+	tasks := OrderedStringEnvelopeMap{}
+
+	escaped, captured := escapeLoopVars(data)
+
+	render, err := sigil.Execute(escaped, context, "tasks")
 	if err != nil {
 		return tasks, fmt.Errorf("re-render error: %v", err.Error())
 	}
 
-	out, err := io.ReadAll(&render)
+	rendered, err := io.ReadAll(&render)
 	if err != nil {
 		return tasks, fmt.Errorf("read error: %v", err.Error())
 	}
+
+	out := unescapeLoopVars(rendered, captured)
 
 	recipe := Recipe{}
 	if err := yaml.Unmarshal([]byte(out), &recipe); err != nil {
 		return tasks, fmt.Errorf("unmarshal error: %v", err.Error())
 	}
 
-	i := 0
-	validTasks := make([]string, len(RegisteredTasks))
-	for k := range RegisteredTasks {
-		validTasks[i] = k
-		i++
-	}
-
 	if len(recipe) == 0 {
 		return tasks, fmt.Errorf("parse error: no recipe found in tasks file")
 	}
 
+	exprContext := buildExprContext(context)
+
 	for i, t := range recipe[0].Tasks {
-		if len(t) > 2 {
-			return tasks, fmt.Errorf("task parse error: task #%d has too many properties - expected=2 actual=%d", i+1, len(t))
+		envelopes, err := buildEnvelopesForEntry(i+1, t, context, exprContext)
+		if err != nil {
+			return tasks, err
 		}
-
-		name, ok := t["name"]
-		if len(t) == 2 && !ok {
-			keys := make([]string, len(t))
-
-			j := 0
-			for k := range t {
-				keys[j] = k
-				j++
-			}
-
-			return tasks, fmt.Errorf("task parse error: task #%d has an unexpected property - properties=%v", i+1, keys)
-		}
-
-		if !ok {
-			b := make([]byte, 8)
-			if _, err := rand.Read(b); err != nil {
-				return tasks, fmt.Errorf("task parse error: task #%d had no task name and there was a failure to generate random task name - %s", i+1, err)
-			}
-			name = fmt.Sprintf("task #%d %X", i+1, b)
-		}
-
-		detected := false
-		for taskName, registeredTask := range RegisteredTasks {
-			config, ok := t[taskName]
-			if !ok {
-				continue
-			}
-
-			marshaled, err := yaml.Marshal(config)
-			if err != nil {
-				return tasks, fmt.Errorf("task parse error: task #%d failed to marshal config to yaml - %s", i+1, err)
-			}
-
-			v := reflect.New(reflect.TypeOf(registeredTask))
-			if err := yaml.Unmarshal([]byte(marshaled), v.Interface()); err != nil {
-				return tasks, fmt.Errorf("task parse error: task #%d failed to decode to %s - %s", i+1, taskName, err)
-			}
-
-			task := v.Elem().Interface().(Task)
-			defaults.SetDefaults(task)
-			tasks.Set(name.(string), task)
-			detected = true
-			break
-		}
-
-		if !detected {
-			return tasks, fmt.Errorf("task parse error: task #%d was not a valid task - valid_tasks=%v", i+1, validTasks)
+		for _, env := range envelopes {
+			tasks.Set(env.Name, env)
 		}
 	}
 
 	return tasks, nil
+}
+
+// buildEnvelopesForEntry walks a single task entry, partitions envelope
+// keys vs the task-type key, decodes the body, pre-compiles `when:`, and
+// expands `loop:` if present. Returns one or more envelopes ready for
+// insertion into the ordered map.
+func buildEnvelopesForEntry(index int, entry map[string]interface{}, sigilContext, exprContext map[string]interface{}) ([]*TaskEnvelope, error) {
+	envelope := &TaskEnvelope{}
+
+	var (
+		taskTypeKey  string
+		taskBody     interface{}
+		taskTypeKeys []string
+		unknownKeys  []string
+	)
+
+	for key, value := range entry {
+		switch key {
+		case "name":
+			if s, ok := value.(string); ok {
+				envelope.Name = s
+			}
+		case "tags":
+			tags, err := decodeTags(value)
+			if err != nil {
+				return nil, fmt.Errorf("task parse error: task #%d: %s", index, err)
+			}
+			envelope.Tags = tags
+		case "when":
+			s, ok := value.(string)
+			if !ok {
+				return nil, fmt.Errorf("task parse error: task #%d: when must be a string expression, got %T", index, value)
+			}
+			envelope.When = s
+		case "loop":
+			envelope.Loop = value
+		case "register":
+			s, ok := value.(string)
+			if !ok {
+				return nil, fmt.Errorf("task parse error: task #%d: register must be a string, got %T", index, value)
+			}
+			envelope.Register = s
+		case "changed_when":
+			s, ok := value.(string)
+			if !ok {
+				return nil, fmt.Errorf("task parse error: task #%d: changed_when must be a string expression, got %T", index, value)
+			}
+			envelope.ChangedWhen = s
+		case "failed_when":
+			s, ok := value.(string)
+			if !ok {
+				return nil, fmt.Errorf("task parse error: task #%d: failed_when must be a string expression, got %T", index, value)
+			}
+			envelope.FailedWhen = s
+		case "ignore_errors":
+			b, ok := value.(bool)
+			if !ok {
+				return nil, fmt.Errorf("task parse error: task #%d: ignore_errors must be a bool, got %T", index, value)
+			}
+			envelope.IgnoreErrors = b
+		default:
+			if _, registered := RegisteredTasks[key]; registered {
+				taskTypeKeys = append(taskTypeKeys, key)
+				taskTypeKey = key
+				taskBody = value
+				continue
+			}
+			unknownKeys = append(unknownKeys, key)
+		}
+	}
+
+	if envelope.Name == "" {
+		generated, err := generateTaskName(index)
+		if err != nil {
+			return nil, err
+		}
+		envelope.Name = generated
+	}
+
+	if len(unknownKeys) > 0 {
+		return nil, unknownKeyError(index, envelope.Name, unknownKeys)
+	}
+
+	if len(taskTypeKeys) == 0 {
+		return nil, fmt.Errorf("task parse error: task #%d %q was not a valid task - valid_tasks=%v", index, envelope.Name, registeredTaskNamesSorted())
+	}
+	if len(taskTypeKeys) > 1 {
+		return nil, fmt.Errorf("task parse error: task #%d %q has %d task-type keys (%s); exactly one is allowed", index, envelope.Name, len(taskTypeKeys), strings.Join(taskTypeKeys, ", "))
+	}
+
+	envelope.TypeName = taskTypeKey
+	registered := RegisteredTasks[taskTypeKey]
+
+	bodyBytes, err := yaml.Marshal(taskBody)
+	if err != nil {
+		return nil, fmt.Errorf("task parse error: task #%d %q failed to marshal config to yaml - %s", index, envelope.Name, err)
+	}
+
+	if envelope.When != "" {
+		prog, err := CompilePredicate(envelope.When)
+		if err != nil {
+			return nil, fmt.Errorf("task parse error: task #%d %q: when compile error: %s", index, envelope.Name, err)
+		}
+		envelope.whenProgram = prog
+	}
+
+	if envelope.Loop != nil {
+		expanded, err := expandLoop(envelope, taskBody, registered, sigilContext, exprContext)
+		if err != nil {
+			return nil, fmt.Errorf("task parse error: task #%d %q: %s", index, envelope.Name, err)
+		}
+		for _, exp := range expanded {
+			if err := rejectLoopVarsInTask(index, exp.Name, exp.Task); err != nil {
+				return nil, err
+			}
+		}
+		return expanded, nil
+	}
+
+	taskValue := reflect.New(reflect.TypeOf(registered))
+	if err := yaml.Unmarshal(bodyBytes, taskValue.Interface()); err != nil {
+		return nil, fmt.Errorf("task parse error: task #%d %q failed to decode to %s - %s", index, envelope.Name, taskTypeKey, err)
+	}
+	task := taskValue.Elem().Interface().(Task)
+	defaults.SetDefaults(task)
+	envelope.Task = task
+
+	if err := rejectLoopVarsInTask(index, envelope.Name, task); err != nil {
+		return nil, err
+	}
+
+	return []*TaskEnvelope{envelope}, nil
+}
+
+// decodeTags coerces a yaml-parsed tags value into a []string. Supports
+// list-form (`tags: [foo, bar]`) and inline string-form (`tags: foo`).
+func decodeTags(value interface{}) ([]string, error) {
+	switch v := value.(type) {
+	case nil:
+		return nil, nil
+	case string:
+		return []string{v}, nil
+	case []interface{}:
+		out := make([]string, 0, len(v))
+		for i, raw := range v {
+			s, ok := raw.(string)
+			if !ok {
+				return nil, fmt.Errorf("tags[%d] must be a string, got %T", i, raw)
+			}
+			out = append(out, s)
+		}
+		return out, nil
+	}
+	return nil, fmt.Errorf("tags must be a list of strings, got %T", value)
+}
+
+// generateTaskName returns a unique task name when the user did not
+// supply one. The format mirrors the legacy `task #N XXXX` pattern.
+func generateTaskName(index int) (string, error) {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("task parse error: task #%d had no task name and there was a failure to generate random task name - %s", index, err)
+	}
+	return fmt.Sprintf("task #%d %X", index, b), nil
+}
+
+// unknownKeyError builds a parse error for an entry with one or more
+// unknown keys, including a "did you mean" suggestion when the closest
+// match is within Levenshtein distance 2.
+func unknownKeyError(index int, name string, unknown []string) error {
+	primary := unknown[0]
+	suggestion := nearestEnvelopeOrTaskKey(primary)
+	hint := ""
+	if suggestion != "" {
+		hint = fmt.Sprintf(" - did you mean %q?", suggestion)
+	}
+	return fmt.Errorf("task parse error: task #%d %q has unknown envelope key %q (allowed: %s, or any registered task type)%s", index, name, primary, strings.Join(envelopeAllowlistKeys, ", "), hint)
+}
+
+// nearestEnvelopeOrTaskKey returns the envelope-allowlist or registered
+// task name with the lowest Levenshtein distance to candidate, but only
+// if that distance is at most 2.
+func nearestEnvelopeOrTaskKey(candidate string) string {
+	best := ""
+	bestDist := 3
+	for _, k := range envelopeAllowlistKeys {
+		d := levenshtein(candidate, k)
+		if d < bestDist {
+			bestDist = d
+			best = k
+		}
+	}
+	for k := range RegisteredTasks {
+		d := levenshtein(candidate, k)
+		if d < bestDist {
+			bestDist = d
+			best = k
+		}
+	}
+	if bestDist <= 2 {
+		return best
+	}
+	return ""
+}
+
+// registeredTaskNamesSorted returns the registered task names sorted
+// alphabetically. Used for error messages so the output is stable.
+func registeredTaskNamesSorted() []string {
+	names := make([]string, 0, len(RegisteredTasks))
+	for k := range RegisteredTasks {
+		names = append(names, k)
+	}
+	// Bubble-sort works fine for ~50 entries and avoids the import cost.
+	for i := 0; i < len(names); i++ {
+		for j := i + 1; j < len(names); j++ {
+			if names[j] < names[i] {
+				names[i], names[j] = names[j], names[i]
+			}
+		}
+	}
+	return names
+}
+
+// buildExprContext returns the file-level expr context. Today this is
+// just the inputs map; later issues add timestamp / host / play / result
+// / registered keys (#208 / #210). Keys are reserved here but not yet
+// populated.
+func buildExprContext(context map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(context))
+	for k, v := range context {
+		out[k] = v
+	}
+	return out
+}
+
+// rejectLoopVarsInTask scans every string field on task for surviving
+// `{{ .item }}` / `{{ .index }}` references and returns an error when
+// it finds one. Loop expansions render those tokens to real values, so
+// any survivor implies the user referenced a loop variable from a
+// non-loop task.
+func rejectLoopVarsInTask(index int, name string, task Task) error {
+	bytes, err := yaml.Marshal(task)
+	if err != nil {
+		return nil
+	}
+	body := string(bytes)
+	if strings.Contains(body, ".item") && (strings.Contains(body, "{{ .item }}") || strings.Contains(body, "{{.item}}")) {
+		return fmt.Errorf("task parse error: task #%d %q: .item is only available inside a loop body", index, name)
+	}
+	if strings.Contains(body, ".index") && (strings.Contains(body, "{{ .index }}") || strings.Contains(body, "{{.index}}")) {
+		return fmt.Errorf("task parse error: task #%d %q: .index is only available inside a loop body", index, name)
+	}
+	return nil
 }

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -80,8 +80,11 @@ func TestGetTasksInvalidTaskType(t *testing.T) {
 		t.Fatal("GetTasks with invalid task type should return an error")
 	}
 
-	if !strings.Contains(err.Error(), "not a valid task") {
-		t.Errorf("expected 'not a valid task' error, got: %v", err)
+	// An unknown task type lands in the unknown-envelope-key bucket and
+	// is reported with a "did you mean" hint pointing at the closest
+	// registered task name.
+	if !strings.Contains(err.Error(), "unknown envelope key") {
+		t.Errorf("expected 'unknown envelope key' error, got: %v", err)
 	}
 }
 
@@ -98,11 +101,15 @@ func TestGetTasksTooManyProperties(t *testing.T) {
 
 	_, err := GetTasks(data, context)
 	if err == nil {
-		t.Fatal("GetTasks with too many properties should return an error")
+		t.Fatal("GetTasks with two task-type keys should return an error")
 	}
 
-	if !strings.Contains(err.Error(), "too many properties") {
-		t.Errorf("expected 'too many properties' error, got: %v", err)
+	// The cap is now expressed as "exactly one task-type key per entry"
+	// instead of the legacy `len(t) > 2` heuristic so envelope keys
+	// (name, tags, when, loop, register, ...) can coexist with the
+	// task-type key.
+	if !strings.Contains(err.Error(), "task-type keys") {
+		t.Errorf("expected 'task-type keys' error, got: %v", err)
 	}
 }
 
@@ -326,10 +333,12 @@ func TestGetTasksTwoPropertiesNoName(t *testing.T) {
 
 	_, err := GetTasks(data, context)
 	if err == nil {
-		t.Fatal("expected error for two properties without name")
+		t.Fatal("expected error for two task-type keys without name")
 	}
-	if !strings.Contains(err.Error(), "unexpected property") {
-		t.Errorf("expected 'unexpected property' error, got: %v", err)
+	// Two task-type keys (with or without a name) collapse onto the
+	// same "exactly one task-type key" rule.
+	if !strings.Contains(err.Error(), "task-type keys") {
+		t.Errorf("expected 'task-type keys' error, got: %v", err)
 	}
 }
 
@@ -481,6 +490,141 @@ func TestRegisteredTaskCount(t *testing.T) {
 	expected := 54
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
+	}
+}
+
+func TestGetTasksEnvelopeWithTagsAndWhen(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: deploy api
+      tags: [api, deploy]
+      when: 'env == "prod"'
+      dokku_app:
+        app: api
+`)
+	out, err := GetTasks(data, map[string]interface{}{"env": "prod"})
+	if err != nil {
+		t.Fatalf("GetTasks: %v", err)
+	}
+	env := out.GetEnvelope("deploy api")
+	if env == nil {
+		t.Fatal("envelope not found")
+	}
+	if got := env.Tags; len(got) != 2 || got[0] != "api" || got[1] != "deploy" {
+		t.Errorf("tags = %v, want [api deploy]", got)
+	}
+	if env.When != `env == "prod"` {
+		t.Errorf("when = %q", env.When)
+	}
+	if env.WhenProgram() == nil {
+		t.Error("expected when to be pre-compiled")
+	}
+}
+
+func TestGetTasksRejectsUnknownEnvelopeKey(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: x
+      onerror: ignore
+      dokku_app:
+        app: x
+`)
+	_, err := GetTasks(data, map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected error for unknown envelope key")
+	}
+	if !strings.Contains(err.Error(), "unknown envelope key") {
+		t.Errorf("got: %v", err)
+	}
+}
+
+func TestGetTasksUnknownEnvelopeKeyDidYouMean(t *testing.T) {
+	// "tag" is one Levenshtein step from "tags" so the suggestion fires.
+	data := []byte(`---
+- tasks:
+    - name: x
+      tag: foo
+      dokku_app:
+        app: x
+`)
+	_, err := GetTasks(data, map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected error for unknown envelope key")
+	}
+	if !strings.Contains(err.Error(), `did you mean "tags"`) {
+		t.Errorf("expected 'did you mean tags' hint, got: %v", err)
+	}
+}
+
+func TestGetTasksAcceptsMultipleEnvelopeKeys(t *testing.T) {
+	// Pre-#205 the parser capped each entry at 2 keys (`name` plus exactly
+	// one `dokku_*` key). Verify the cap is gone: name + tags + when +
+	// dokku_app should now parse cleanly.
+	data := []byte(`---
+- tasks:
+    - name: deploy api
+      tags: [api]
+      when: 'true'
+      dokku_app:
+        app: api
+`)
+	out, err := GetTasks(data, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetTasks: %v", err)
+	}
+	if len(out.Keys()) != 1 {
+		t.Errorf("expected 1 task, got %d", len(out.Keys()))
+	}
+}
+
+func TestGetTasksReservedEnvelopeKeysDecode(t *testing.T) {
+	// register / changed_when / failed_when / ignore_errors are reserved
+	// by #210; the loader still decodes them so #210 does not have to
+	// revisit the envelope-key allowlist.
+	data := []byte(`---
+- tasks:
+    - name: deploy api
+      register: app_result
+      changed_when: 'result.changed'
+      failed_when: 'result.failed'
+      ignore_errors: true
+      dokku_app:
+        app: api
+`)
+	out, err := GetTasks(data, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetTasks: %v", err)
+	}
+	env := out.GetEnvelope("deploy api")
+	if env.Register != "app_result" {
+		t.Errorf("register = %q", env.Register)
+	}
+	if env.ChangedWhen != "result.changed" {
+		t.Errorf("changed_when = %q", env.ChangedWhen)
+	}
+	if env.FailedWhen != "result.failed" {
+		t.Errorf("failed_when = %q", env.FailedWhen)
+	}
+	if !env.IgnoreErrors {
+		t.Errorf("ignore_errors = %v", env.IgnoreErrors)
+	}
+}
+
+func TestGetTasksTagsScalarFormDecodes(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: deploy api
+      tags: api
+      dokku_app:
+        app: api
+`)
+	out, err := GetTasks(data, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetTasks: %v", err)
+	}
+	env := out.GetEnvelope("deploy api")
+	if got := env.Tags; len(got) != 1 || got[0] != "api" {
+		t.Errorf("tags = %v, want [api]", got)
 	}
 }
 

--- a/tasks/ordered_map.go
+++ b/tasks/ordered_map.go
@@ -1,34 +1,52 @@
 package tasks
 
-// OrderedStringTaskMap is a map of tasks keyed by string
-type OrderedStringTaskMap struct {
-	// data is the map of tasks
-	data map[string]Task
-
-	// keys is the list of keys
+// OrderedStringEnvelopeMap is an insertion-ordered map of TaskEnvelopes
+// keyed by string. Keys() returns names in the order they were Set, which
+// is the order GetTasks parsed them out of the recipe. Loop expansions
+// each contribute their own key (`<name> (item=<value>)`) so the map's
+// uniqueness invariant holds across expanded envelopes.
+//
+// Get(name) returns the underlying Task so it stays ergonomic for tests
+// that only care about the decoded task body. Envelope-aware callers
+// (apply / plan, sensitive, validate) use GetEnvelope to access the
+// cross-cutting fields (tags / when / loop / register).
+type OrderedStringEnvelopeMap struct {
+	data map[string]*TaskEnvelope
 	keys []string
 }
 
-// Get gets the task by key
-func (o *OrderedStringTaskMap) Get(k string) Task {
+// Get returns the Task registered under k, or nil if absent. This is a
+// convenience wrapper for callers that only need the task body.
+func (o *OrderedStringEnvelopeMap) Get(k string) Task {
+	env := o.GetEnvelope(k)
+	if env == nil {
+		return nil
+	}
+	return env.Task
+}
+
+// GetEnvelope returns the envelope registered under k, or nil if absent.
+func (o *OrderedStringEnvelopeMap) GetEnvelope(k string) *TaskEnvelope {
 	if len(o.data) == 0 {
 		return nil
 	}
-
 	return o.data[k]
 }
 
-// Set sets the task by key
-func (o *OrderedStringTaskMap) Set(k string, v Task) {
-	if len(o.data) == 0 {
-		o.data = make(map[string]Task)
+// Set registers env under k. Setting a key that already exists overwrites
+// the value but does not record a duplicate key in the order list. The
+// loader avoids overwrites by suffixing loop-expansion names.
+func (o *OrderedStringEnvelopeMap) Set(k string, env *TaskEnvelope) {
+	if o.data == nil {
+		o.data = make(map[string]*TaskEnvelope)
 	}
-
-	o.data[k] = v
-	o.keys = append(o.keys, k)
+	if _, exists := o.data[k]; !exists {
+		o.keys = append(o.keys, k)
+	}
+	o.data[k] = env
 }
 
-// Keys returns the list of keys
-func (o *OrderedStringTaskMap) Keys() []string {
+// Keys returns the registered keys in insertion order.
+func (o *OrderedStringEnvelopeMap) Keys() []string {
 	return o.keys
 }

--- a/tasks/ordered_map_test.go
+++ b/tasks/ordered_map_test.go
@@ -15,51 +15,51 @@ func (m mockTask) Examples() ([]Doc, error) { return nil, nil }
 func (m mockTask) Plan() PlanResult         { return PlanResult{InSync: true, Status: PlanStatusOK} }
 func (m mockTask) Execute() TaskOutputState { return TaskOutputState{State: m.state} }
 
-func TestOrderedStringTaskMapSetAndGet(t *testing.T) {
-	m := OrderedStringTaskMap{}
+func envelopeOf(name string, state State) *TaskEnvelope {
+	return &TaskEnvelope{Name: name, Task: mockTask{name: name, state: state}}
+}
 
-	task := mockTask{name: "test", state: StatePresent}
-	m.Set("key1", task)
+func TestOrderedStringEnvelopeMapSetAndGet(t *testing.T) {
+	m := OrderedStringEnvelopeMap{}
+	m.Set("key1", envelopeOf("test", StatePresent))
 
 	got := m.Get("key1")
 	if got == nil {
 		t.Fatal("Get returned nil for existing key")
 	}
-
 	if got.Execute().State != StatePresent {
 		t.Errorf("expected state 'present', got '%s'", got.Execute().State)
 	}
+	if env := m.GetEnvelope("key1"); env == nil {
+		t.Fatal("GetEnvelope returned nil for existing key")
+	}
 }
 
-func TestOrderedStringTaskMapGetMissing(t *testing.T) {
-	m := OrderedStringTaskMap{}
+func TestOrderedStringEnvelopeMapGetMissing(t *testing.T) {
+	m := OrderedStringEnvelopeMap{}
 
-	got := m.Get("nonexistent")
-	if got != nil {
+	if got := m.Get("nonexistent"); got != nil {
 		t.Error("Get returned non-nil for nonexistent key on empty map")
 	}
 
-	m.Set("key1", mockTask{name: "test", state: StatePresent})
-	got = m.Get("nonexistent")
-	if got != nil {
+	m.Set("key1", envelopeOf("test", StatePresent))
+	if got := m.Get("nonexistent"); got != nil {
 		t.Error("Get returned non-nil for nonexistent key")
 	}
 }
 
-func TestOrderedStringTaskMapKeysPreservesOrder(t *testing.T) {
-	m := OrderedStringTaskMap{}
+func TestOrderedStringEnvelopeMapKeysPreservesOrder(t *testing.T) {
+	m := OrderedStringEnvelopeMap{}
 
-	m.Set("third", mockTask{name: "3", state: StatePresent})
-	m.Set("first", mockTask{name: "1", state: StatePresent})
-	m.Set("second", mockTask{name: "2", state: StatePresent})
+	m.Set("third", envelopeOf("3", StatePresent))
+	m.Set("first", envelopeOf("1", StatePresent))
+	m.Set("second", envelopeOf("2", StatePresent))
 
 	keys := m.Keys()
 	expected := []string{"third", "first", "second"}
-
 	if len(keys) != len(expected) {
 		t.Fatalf("expected %d keys, got %d", len(expected), len(keys))
 	}
-
 	for i, key := range keys {
 		if key != expected[i] {
 			t.Errorf("key[%d] = %q, want %q", i, key, expected[i])
@@ -67,25 +67,23 @@ func TestOrderedStringTaskMapKeysPreservesOrder(t *testing.T) {
 	}
 }
 
-func TestOrderedStringTaskMapEmptyKeys(t *testing.T) {
-	m := OrderedStringTaskMap{}
-
+func TestOrderedStringEnvelopeMapEmptyKeys(t *testing.T) {
+	m := OrderedStringEnvelopeMap{}
 	keys := m.Keys()
 	if keys != nil && len(keys) != 0 {
 		t.Errorf("expected nil or empty keys, got %v", keys)
 	}
 }
 
-func TestOrderedStringTaskMapOverwriteValue(t *testing.T) {
-	m := OrderedStringTaskMap{}
+// TestOrderedStringEnvelopeMapOverwriteValue covers the deduped-order
+// invariant: Set under an existing key replaces the value but does not
+// append a duplicate entry to Keys(). Loop expansion relies on this so
+// `<name> (item=a)` and `<name> (item=b)` each appear exactly once.
+func TestOrderedStringEnvelopeMapOverwriteValue(t *testing.T) {
+	m := OrderedStringEnvelopeMap{}
+	m.Set("key", envelopeOf("first", StatePresent))
+	m.Set("key", envelopeOf("second", StateAbsent))
 
-	task1 := mockTask{name: "first", state: StatePresent}
-	task2 := mockTask{name: "second", state: StateAbsent}
-
-	m.Set("key", task1)
-	m.Set("key", task2)
-
-	// Get should return the latest value
 	got := m.Get("key")
 	if got == nil {
 		t.Fatal("Get returned nil for overwritten key")
@@ -93,27 +91,21 @@ func TestOrderedStringTaskMapOverwriteValue(t *testing.T) {
 	if got.Execute().State != StateAbsent {
 		t.Errorf("expected overwritten state 'absent', got '%s'", got.Execute().State)
 	}
-
-	// Keys will contain the key twice (current implementation appends without dedup)
-	keys := m.Keys()
-	if len(keys) != 2 {
-		t.Fatalf("expected 2 keys (duplicate), got %d", len(keys))
+	if keys := m.Keys(); len(keys) != 1 {
+		t.Fatalf("expected 1 key (deduped), got %d", len(keys))
 	}
 }
 
-func TestOrderedStringTaskMapLargeSet(t *testing.T) {
-	m := OrderedStringTaskMap{}
-
+func TestOrderedStringEnvelopeMapLargeSet(t *testing.T) {
+	m := OrderedStringEnvelopeMap{}
 	for i := 0; i < 10; i++ {
 		name := fmt.Sprintf("task-%d", i)
-		m.Set(name, mockTask{name: name, state: StatePresent})
+		m.Set(name, envelopeOf(name, StatePresent))
 	}
-
 	keys := m.Keys()
 	if len(keys) != 10 {
 		t.Fatalf("expected 10 keys, got %d", len(keys))
 	}
-
 	for i, key := range keys {
 		expected := fmt.Sprintf("task-%d", i)
 		if key != expected {

--- a/tasks/predicate.go
+++ b/tasks/predicate.go
@@ -1,0 +1,102 @@
+package tasks
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/vm"
+)
+
+// programCache holds compiled expr programs keyed by their source string.
+// Loop iterations re-use the same compiled program so a literal recipe
+// like `loop: [a,b,c]` plus `when: 'item != "b"'` only compiles `when`
+// once. The cache is process-wide because expr programs are read-only
+// after compilation.
+var programCache sync.Map // map[string]*vm.Program
+
+// CompilePredicate compiles src as an expr-lang/expr program suitable for
+// envelope predicates (when:, changed_when:, failed_when:, scalar-form
+// loop:). Returns the cached compiled program when src has already been
+// compiled. Empty src returns (nil, nil); callers should treat nil as
+// "no predicate".
+//
+// The compiler is configured with AllowUndefinedVariables so a predicate
+// referencing a context key that the apply / plan path has not populated
+// yet (e.g. .registered.foo before #210 lands) does not error at compile
+// time - it evaluates to nil at runtime.
+func CompilePredicate(src string) (*vm.Program, error) {
+	if src == "" {
+		return nil, nil
+	}
+	if cached, ok := programCache.Load(src); ok {
+		return cached.(*vm.Program), nil
+	}
+	prog, err := expr.Compile(src, expr.AllowUndefinedVariables())
+	if err != nil {
+		return nil, err
+	}
+	actual, _ := programCache.LoadOrStore(src, prog)
+	return actual.(*vm.Program), nil
+}
+
+// EvalBool runs prog against env and reports the truthiness of the
+// result. Non-bool results are coerced via the standard expr truth rules
+// (nil, 0, "", and empty collections are false; everything else is
+// true). Returns an error when the program errors at run time.
+func EvalBool(prog *vm.Program, env map[string]interface{}) (bool, error) {
+	if prog == nil {
+		return true, nil
+	}
+	out, err := expr.Run(prog, env)
+	if err != nil {
+		return false, err
+	}
+	return truthy(out), nil
+}
+
+// EvalList runs prog against env and asserts that the result is a list.
+// Returns an error when the program errors or returns a non-list value.
+func EvalList(prog *vm.Program, env map[string]interface{}) ([]interface{}, error) {
+	if prog == nil {
+		return nil, fmt.Errorf("expr program is nil")
+	}
+	out, err := expr.Run(prog, env)
+	if err != nil {
+		return nil, err
+	}
+	switch v := out.(type) {
+	case []interface{}:
+		return v, nil
+	case nil:
+		return nil, fmt.Errorf("loop expression returned nil; expected a list")
+	}
+	// Reflect-based fallback for typed slices ([]string, []int, etc.).
+	return reflectToList(out)
+}
+
+// truthy mirrors expr's Boolean coercion: nil, false, zero numerics,
+// empty strings, and empty collections are false; everything else is
+// true. Reaching the default case for an unsupported type returns true
+// since a non-nil structural value is meaningful.
+func truthy(v interface{}) bool {
+	switch x := v.(type) {
+	case nil:
+		return false
+	case bool:
+		return x
+	case string:
+		return x != ""
+	case int:
+		return x != 0
+	case int64:
+		return x != 0
+	case float64:
+		return x != 0
+	case []interface{}:
+		return len(x) > 0
+	case map[string]interface{}:
+		return len(x) > 0
+	}
+	return true
+}

--- a/tasks/predicate_test.go
+++ b/tasks/predicate_test.go
@@ -1,0 +1,104 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCompilePredicateEmptyReturnsNil(t *testing.T) {
+	prog, err := CompilePredicate("")
+	if err != nil {
+		t.Fatalf("CompilePredicate(empty) err = %v", err)
+	}
+	if prog != nil {
+		t.Fatalf("CompilePredicate(empty) prog = %v, want nil", prog)
+	}
+}
+
+func TestCompilePredicateSyntaxErrorReports(t *testing.T) {
+	_, err := CompilePredicate("env ==")
+	if err == nil {
+		t.Fatal("expected syntax error, got nil")
+	}
+	if !strings.Contains(err.Error(), "(") {
+		t.Errorf("expected error to include position info, got: %v", err)
+	}
+}
+
+func TestCompilePredicateCacheReturnsSamePointer(t *testing.T) {
+	const src = "env == \"prod\""
+
+	a, err := CompilePredicate(src)
+	if err != nil {
+		t.Fatalf("first compile: %v", err)
+	}
+	b, err := CompilePredicate(src)
+	if err != nil {
+		t.Fatalf("second compile: %v", err)
+	}
+	if a != b {
+		t.Fatalf("cache miss: a=%p b=%p", a, b)
+	}
+}
+
+func TestEvalBoolTruthy(t *testing.T) {
+	prog, err := CompilePredicate("env == \"prod\"")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	got, err := EvalBool(prog, map[string]interface{}{"env": "prod"})
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if !got {
+		t.Errorf("got false, want true")
+	}
+}
+
+func TestEvalBoolFalsy(t *testing.T) {
+	prog, err := CompilePredicate("env == \"prod\"")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	got, err := EvalBool(prog, map[string]interface{}{"env": "staging"})
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if got {
+		t.Errorf("got true, want false")
+	}
+}
+
+func TestEvalBoolNilProgramIsTrue(t *testing.T) {
+	got, err := EvalBool(nil, nil)
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if !got {
+		t.Errorf("nil program must evaluate as true (no predicate)")
+	}
+}
+
+func TestEvalListReturnsSlice(t *testing.T) {
+	prog, err := CompilePredicate("[\"a\", \"b\", \"c\"]")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	got, err := EvalList(prog, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+}
+
+func TestEvalListNonListErrors(t *testing.T) {
+	prog, err := CompilePredicate("\"not a list\"")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if _, err := EvalList(prog, nil); err == nil {
+		t.Fatal("expected non-list error, got nil")
+	}
+}

--- a/tasks/reflect_helpers.go
+++ b/tasks/reflect_helpers.go
@@ -1,0 +1,20 @@
+package tasks
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// reflectToList converts a typed slice ([]string, []int, etc.) into a
+// generic []interface{}. Returns an error when v is not a slice or array.
+func reflectToList(v interface{}) ([]interface{}, error) {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
+		return nil, fmt.Errorf("loop expression returned %T; expected a list", v)
+	}
+	out := make([]interface{}, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		out[i] = rv.Index(i).Interface()
+	}
+	return out, nil
+}

--- a/tasks/sensitive.go
+++ b/tasks/sensitive.go
@@ -26,11 +26,14 @@ type SensitiveOverride interface {
 // String, []string, and map[string]string fields are supported. Nested
 // structs and pointers are walked recursively. Empty values are dropped by
 // the subprocess masker, not here.
-func CollectSensitiveValues(tasks OrderedStringTaskMap) []string {
+func CollectSensitiveValues(tasks OrderedStringEnvelopeMap) []string {
 	var out []string
 	for _, name := range tasks.Keys() {
-		t := tasks.Get(name)
-		out = append(out, sensitiveValuesFromTask(t)...)
+		env := tasks.GetEnvelope(name)
+		if env == nil || env.Task == nil {
+			continue
+		}
+		out = append(out, sensitiveValuesFromTask(env.Task)...)
 	}
 	return out
 }

--- a/tasks/sensitive_test.go
+++ b/tasks/sensitive_test.go
@@ -145,9 +145,9 @@ func TestSensitiveValuesOverrideMergesWithTags(t *testing.T) {
 }
 
 func TestCollectSensitiveValuesAcrossTasks(t *testing.T) {
-	m := OrderedStringTaskMap{}
-	m.Set("a", &fakeTask{Secret: "s1"})
-	m.Set("b", &taggedSliceTask{Tokens: []string{"s2"}})
+	m := OrderedStringEnvelopeMap{}
+	m.Set("a", &TaskEnvelope{Name: "a", Task: &fakeTask{Secret: "s1"}})
+	m.Set("b", &TaskEnvelope{Name: "b", Task: &taggedSliceTask{Tokens: []string{"s2"}}})
 	got := CollectSensitiveValues(m)
 	if !sortedEqual(got, []string{"s1", "s2"}) {
 		t.Errorf("got %v, want [s1 s2]", got)

--- a/tasks/validate.go
+++ b/tasks/validate.go
@@ -49,13 +49,23 @@ const validatePlaceholder = "__docket_validate_placeholder__"
 // task-type name (e.g. dokku_appp) is reported as "unknown task type" rather
 // than getting silently swallowed by an envelope allowlist.
 var reservedEnvelopeKeys = map[string]string{
-	"block":    "#211",
-	"rescue":   "#211",
-	"always":   "#211",
-	"when":     "#205",
-	"loop":     "#205",
-	"register": "#210",
-	"tags":     "#212",
+	"block":         "#211",
+	"rescue":        "#211",
+	"always":        "#211",
+	"register":      "#210",
+	"changed_when":  "#210",
+	"failed_when":   "#210",
+	"ignore_errors": "#210",
+}
+
+// activeEnvelopeKeys are the envelope keys this PR (#205) activates. They
+// are recognised by the validator and pass through to the loader without
+// generating an "envelope key reserved" diagnostic.
+var activeEnvelopeKeys = map[string]bool{
+	"name": true,
+	"tags": true,
+	"when": true,
+	"loop": true,
 }
 
 // Validate parses data as a docket recipe and returns every problem it finds.
@@ -259,6 +269,10 @@ func validateTaskEntry(task *yaml.Node, playLabel string, idx int) []Problem {
 			continue
 		}
 
+		if activeEnvelopeKeys[key] {
+			continue
+		}
+
 		if dependentIssue, reserved := reservedEnvelopeKeys[key]; reserved {
 			problems = append(problems, Problem{
 				Code:    "envelope_key_unsupported",
@@ -394,8 +408,15 @@ func validateTaskBody(registered Task, typeName string, body *yaml.Node, playLab
 // renderForValidate runs the recipe through sigil with the given context and
 // returns the rendered bytes. A non-nil Problem return signals a render
 // failure; the caller is responsible for surfacing it.
+//
+// Loop-variable references (`{{ .item ... }}`, `{{ .index ... }}`) are
+// hidden from sigil before the render and restored afterwards so non-
+// scalar item access (`{{ .item.app }}`) does not blow up the file-level
+// pass. The loop_var_outside_loop check then walks the rendered tree to
+// flag any reference in a non-loop task body.
 func renderForValidate(data []byte, context map[string]interface{}) ([]byte, *Problem) {
-	rendered, err := sigil.Execute(data, context, "tasks.yml")
+	escaped, captured := escapeLoopVars(data)
+	rendered, err := sigil.Execute(escaped, context, "tasks.yml")
 	if err != nil {
 		line, col := parseSigilErrorPosition(err.Error())
 		return nil, &Problem{
@@ -412,7 +433,7 @@ func renderForValidate(data []byte, context map[string]interface{}) ([]byte, *Pr
 			Message: fmt.Sprintf("template render read error: %v", err),
 		}
 	}
-	return out, nil
+	return unescapeLoopVars(out, captured), nil
 }
 
 func validateStrictInputs(inputs []inputWithNode, overrides map[string]bool, label string) []Problem {
@@ -445,10 +466,62 @@ func validateBlockStructure(_ *yaml.Node, _ string) []Problem {
 	return nil
 }
 
-// validateExprPredicates is a stub. #205 will populate it with checks that
-// when:/changed_when:/failed_when: and list-form loop: parse as expr.
-func validateExprPredicates(_ *yaml.Node, _ string) []Problem {
-	// TODO(#205): compile expr predicates once envelope-level expr lands.
+// validateExprPredicates compiles each scalar `when:` / `changed_when:` /
+// `failed_when:` value and the scalar form of `loop:` on every task entry.
+// Compile errors are reported with the source line/column from the
+// rendered yaml node so editors can jump straight to the problem.
+//
+// Loop-list literals (sequence form) are skipped here - they are not expr
+// programs. `register` / `changed_when` / `failed_when` are reserved at
+// the loader level for #210 but the syntax check is wired now so that
+// issue does not have to revisit the validator.
+func validateExprPredicates(tasksNode *yaml.Node, label string) []Problem {
+	if tasksNode == nil || tasksNode.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var problems []Problem
+	for i, task := range tasksNode.Content {
+		if task.Kind != yaml.MappingNode {
+			continue
+		}
+		taskLabel := taskLabelForNode(task, i+1)
+		problems = append(problems, compileExprNode(mappingValue(task, "when"), "when", label, taskLabel)...)
+		problems = append(problems, compileExprNode(mappingValue(task, "changed_when"), "changed_when", label, taskLabel)...)
+		problems = append(problems, compileExprNode(mappingValue(task, "failed_when"), "failed_when", label, taskLabel)...)
+		if loop := mappingValue(task, "loop"); loop != nil && loop.Kind == yaml.ScalarNode {
+			problems = append(problems, compileExprNode(loop, "loop", label, taskLabel)...)
+		}
+	}
+	return problems
+}
+
+// taskLabelForNode mirrors the labelling validateTaskEntry uses so plan /
+// expr / target diagnostics align in human output.
+func taskLabelForNode(task *yaml.Node, idx int) string {
+	name := scalarChild(task, "name")
+	if name != "" {
+		return fmt.Sprintf("task #%d %q", idx, name)
+	}
+	return fmt.Sprintf("task #%d", idx)
+}
+
+// compileExprNode runs expr.Compile on the scalar value of node and
+// returns a Problem when the source does not parse. nil node or
+// non-scalar / empty value is a no-op.
+func compileExprNode(node *yaml.Node, key, playLabel, taskLabel string) []Problem {
+	if node == nil || node.Kind != yaml.ScalarNode || node.Value == "" {
+		return nil
+	}
+	if _, err := CompilePredicate(node.Value); err != nil {
+		return []Problem{{
+			Code:    "expr_compile",
+			Play:    playLabel,
+			Task:    taskLabel,
+			Line:    node.Line,
+			Column:  node.Column,
+			Message: fmt.Sprintf("%s expression compile error: %v", key, err),
+		}}
+	}
 	return nil
 }
 
@@ -459,12 +532,72 @@ func validateRegisterReferences(_ *yaml.Node, _ string) []Problem {
 	return nil
 }
 
-// validateTargetReferences is a stub. #205/#208/#212 will populate it with
-// checks that --start-at-task / --play / --tags references actually exist
-// in the file.
-func validateTargetReferences(_ *yaml.Node, _ string) []Problem {
-	// TODO(#205/#208/#212): resolve target references once they exist.
-	return nil
+// validateTargetReferences guards `.item` / `.index` references. They
+// are loop-iteration variables and are only meaningful inside a task
+// entry that carries a `loop:` key. Any non-loop entry whose body still
+// references the placeholder tokens is reported here. #208 / #212 will
+// extend this stub for --start-at-task and --play target validation.
+func validateTargetReferences(tasksNode *yaml.Node, label string) []Problem {
+	if tasksNode == nil || tasksNode.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var problems []Problem
+	for i, task := range tasksNode.Content {
+		if task.Kind != yaml.MappingNode {
+			continue
+		}
+		if mappingValue(task, "loop") != nil {
+			continue
+		}
+		taskLabel := taskLabelForNode(task, i+1)
+		problems = append(problems, scanForLoopVars(task, label, taskLabel)...)
+	}
+	return problems
+}
+
+// scanForLoopVars walks every scalar value reachable from node and
+// reports a Problem for each `{{ .item }}` / `{{ .index }}` reference.
+// Scalars are matched against the placeholder substrings the loader
+// injects at file-level render time.
+func scanForLoopVars(node *yaml.Node, playLabel, taskLabel string) []Problem {
+	if node == nil {
+		return nil
+	}
+	var problems []Problem
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if containsLoopVar(node.Value) {
+			problems = append(problems, Problem{
+				Code:    "loop_var_outside_loop",
+				Play:    playLabel,
+				Task:    taskLabel,
+				Line:    node.Line,
+				Column:  node.Column,
+				Message: ".item / .index are only available inside a loop body",
+				Hint:    "wrap the task with `loop:` or remove the reference",
+			})
+		}
+	case yaml.SequenceNode, yaml.MappingNode, yaml.DocumentNode:
+		for _, child := range node.Content {
+			problems = append(problems, scanForLoopVars(child, playLabel, taskLabel)...)
+		}
+	}
+	return problems
+}
+
+// containsLoopVar reports whether s contains a `{{ .item }}` or
+// `{{ .index }}` reference (with or without surrounding whitespace).
+func containsLoopVar(s string) bool {
+	if s == "" {
+		return false
+	}
+	if strings.Contains(s, "{{ .item }}") || strings.Contains(s, "{{.item}}") {
+		return true
+	}
+	if strings.Contains(s, "{{ .index }}") || strings.Contains(s, "{{.index}}") {
+		return true
+	}
+	return false
 }
 
 // inputWithNode is the validate-time projection of an Input that also carries
@@ -520,6 +653,10 @@ func extractPlayInputs(recipe *yaml.Node) [][]inputWithNode {
 // default contribute validatePlaceholder so the render does not error on
 // missing keys. Names collide cleanly across plays since sigil receives a
 // single flat namespace.
+//
+// `.item` and `.index` references in loop-body templates are hidden from
+// the file-level render via escapeLoopVars / unescapeLoopVars, so they
+// do not need a placeholder entry here.
 func buildSigilContext(plays [][]inputWithNode) map[string]interface{} {
 	context := map[string]interface{}{}
 	for _, inputs := range plays {

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -297,11 +297,15 @@ func TestValidateLevenshtein(t *testing.T) {
 }
 
 func TestValidateReservedEnvelopeKeyFlagged(t *testing.T) {
+	// register / changed_when / failed_when / ignore_errors stay reserved
+	// for #210; the rest of the envelope keys (name, tags, when, loop)
+	// are activated by #205. Using `register:` here pins the assertion to
+	// a key whose semantics have not landed yet.
 	data := []byte(`---
 - tasks:
     - dokku_app:
         app: my-app
-      when: "true"
+      register: app_result
 `)
 	problems := Validate(data, ValidateOptions{})
 	if p := findProblem(problems, "envelope_key_unsupported"); p == nil {
@@ -369,5 +373,81 @@ func TestParseSigilErrorPosition(t *testing.T) {
 	}
 	if col != 0 {
 		t.Errorf("expected col 0, got %d", col)
+	}
+}
+
+func TestValidateExprPredicateCompileError(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: deploy
+      when: 'env =='
+      dokku_app:
+        app: x
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "expr_compile")
+	if p == nil {
+		t.Fatalf("expected expr_compile problem, got: %+v", problems)
+	}
+	if p.Line == 0 {
+		t.Errorf("expected non-zero source line, got %d", p.Line)
+	}
+}
+
+func TestValidateExprPredicateLoopStringForm(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: deploy
+      loop: 'apps where ('
+      dokku_app:
+        app: x
+`)
+	problems := Validate(data, ValidateOptions{})
+	if findProblem(problems, "expr_compile") == nil {
+		t.Fatalf("expected expr_compile problem on loop, got: %+v", problems)
+	}
+}
+
+func TestValidateLoopVarOutsideLoopFlagged(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: deploy
+      dokku_app:
+        app: "{{ .item }}"
+`)
+	problems := Validate(data, ValidateOptions{})
+	if findProblem(problems, "loop_var_outside_loop") == nil {
+		t.Fatalf("expected loop_var_outside_loop problem, got: %+v", problems)
+	}
+}
+
+func TestValidateLoopVarInsideLoopAllowed(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: deploy
+      loop: [a, b]
+      dokku_app:
+        app: "{{ .item }}"
+`)
+	problems := Validate(data, ValidateOptions{})
+	if p := findProblem(problems, "loop_var_outside_loop"); p != nil {
+		t.Fatalf("did not expect loop_var_outside_loop inside a loop body, got: %+v", p)
+	}
+}
+
+func TestValidateActiveEnvelopeKeysNotReserved(t *testing.T) {
+	// name / tags / when / loop are activated by #205 and must not
+	// produce an envelope_key_unsupported diagnostic.
+	data := []byte(`---
+- tasks:
+    - name: deploy
+      tags: [api]
+      when: 'true'
+      dokku_app:
+        app: x
+`)
+	problems := Validate(data, ValidateOptions{})
+	if p := findProblem(problems, "envelope_key_unsupported"); p != nil {
+		t.Fatalf("did not expect envelope_key_unsupported, got: %+v", p)
 	}
 }

--- a/tests/bats/envelope.bats
+++ b/tests/bats/envelope.bats
@@ -1,0 +1,156 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+# envelope.bats covers the #205 envelope features end-to-end against the
+# docket binary: the `tags:` filter (--tags / --skip-tags), the `when:`
+# conditional, `loop:` expansion, and the parse / validate diagnostics
+# that fire when an envelope key is unknown or a loop variable leaks
+# outside a loop body.
+#
+# Tests that exercise plan against a real Dokku gate on require_dokku;
+# the validate-only tests run anywhere because validate is offline by
+# contract.
+
+setup() {
+  docket_build
+}
+
+teardown() {
+  dokku_clean_app docket-test-tag-api
+  dokku_clean_app docket-test-tag-worker
+  dokku_clean_app docket-test-skip-api
+  dokku_clean_app docket-test-skip-worker
+  dokku_clean_app docket-test-when
+  dokku_clean_app docket-test-when-kept
+  dokku_clean_app docket-test-loop-a
+  dokku_clean_app docket-test-loop-b
+  dokku_clean_app docket-test-loop-c
+}
+
+@test "envelope: --tags filter selects matching tasks" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: app api
+      tags: [api]
+      dokku_app:
+        app: docket-test-tag-api
+    - name: app worker
+      tags: [worker]
+      dokku_app:
+        app: docket-test-tag-worker
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --tags api
+  assert_success
+  assert_output --partial "app api"
+  refute_output --partial "app worker"
+}
+
+@test "envelope: --skip-tags filter drops matching tasks" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: app api
+      tags: [api]
+      dokku_app:
+        app: docket-test-skip-api
+    - name: app worker
+      tags: [worker]
+      dokku_app:
+        app: docket-test-skip-worker
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --skip-tags api
+  assert_success
+  refute_output --partial "app api"
+  assert_output --partial "app worker"
+}
+
+@test "envelope: when:false renders [skipped]" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: skipped task
+      when: 'false'
+      dokku_app:
+        app: docket-test-when
+    - name: kept task
+      dokku_app:
+        app: docket-test-when-kept
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "[skipped]"
+  assert_output --partial "skipped task"
+  assert_output --partial "kept task"
+  assert_output --partial "1 skipped"
+}
+
+@test "envelope: loop expands one task into N" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: deploy
+      loop: [a, b, c]
+      dokku_app:
+        app: "docket-test-loop-{{ .item }}"
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "deploy (item=a)"
+  assert_output --partial "deploy (item=b)"
+  assert_output --partial "deploy (item=c)"
+}
+
+@test "envelope: loop with when: filters items per iteration" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: deploy
+      loop: [api, worker, web]
+      when: 'item != "web"'
+      dokku_app:
+        app: "docket-test-loop-{{ .item }}"
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "deploy (item=api)"
+  assert_output --partial "deploy (item=worker)"
+  assert_output --partial "[skipped]"
+}
+
+@test "envelope: unknown envelope key produces parse error with did-you-mean" {
+  # Apply / plan run the loader's strict allowlist; a typo of `tags`
+  # surfaces here with the closest match suggestion. Validate's path
+  # catches the same shape but reports it as an unknown task type.
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: x
+      tag: foo
+      dokku_app:
+        app: docket-test-unknown
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "unknown envelope key"
+  assert_output --partial 'did you mean "tags"'
+}
+
+@test "envelope: .item outside a loop is rejected by validate" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: stray
+      dokku_app:
+        app: "{{ .item }}"
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial ".item / .index are only available inside a loop body"
+}


### PR DESCRIPTION
## Summary

Closes #205. Replaces the legacy `len(t) > 2` cap on task entries with an envelope-key allowlist, introduces a `TaskEnvelope` wrapper, and ships three end-user features that exercise the new pipeline: `tags` filtering, `when:` predicates, and `loop:` iteration. Body templating continues to use sigil; envelope predicates use `expr-lang/expr` with a per-program cache so loop iterations re-evaluate without recompiling.

The full envelope-key allowlist is `name`, `tags`, `when`, `loop`, `register`, `changed_when`, `failed_when`, `ignore_errors`. The last four are reserved for #210 - the loader recognises and decodes them so #210 does not have to revisit the cap. Unknown envelope keys are rejected with a "did you mean" hint.

`when: false` produces a `[skipped]` task line and contributes to a new "skipped" summary count on both `apply` and `plan`. `loop:` accepts a list literal or an expr expression returning a list; expansions render the body with `.item` and `.index` injected via a per-task second-pass sigil render. References to `.item` / `.index` outside a `loop:` body are rejected at parse time and reported by `validate`.

The `validateExprPredicates` stub from #205's planning landed earlier is now populated: `when:`, `changed_when:`, `failed_when:` and scalar-form `loop:` are compiled at validate time and any compile error is anchored to its source line / column. The reserved envelope keys (`register`, `changed_when`, `failed_when`, `ignore_errors`) continue to emit the existing "envelope key reserved but not yet supported" diagnostic until #210 lands.