### PR TITLE
feat: add --json output and --detailed-exitcode for plan and apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ The flags are:
 | Flag | Effect |
 |------|--------|
 | `--tasks <path>` | Use a specific task file (default `./tasks.yml`) |
-| `--verbose` | After each task line, echo every resolved Dokku command the task ran on a `→`-prefixed continuation line, in invocation order. Tasks that loop over inputs (e.g. `dokku_buildpacks` adding several URLs) emit one continuation per call. Commands are not masked - avoid on recipes that pass secrets via task arguments. |
+| `--verbose` | After each task line, echo every resolved Dokku command the task ran on a `→`-prefixed continuation line, in invocation order. Tasks that loop over inputs (e.g. `dokku_buildpacks` adding several URLs) emit one continuation per call. Commands are masked against the global sensitive value set. Ignored when `--json` is set; the JSON output already includes the resolved commands. |
+| `--json` | Suppress the human formatter and emit one JSON-lines event per `play_start`, `task`, or `summary` to stdout. Sensitive values mask to `***`. See "JSON output" below for the schema. |
 
 For example, a multi-command task renders one continuation per invocation:
 
@@ -278,6 +279,41 @@ Plan: 1 task(s); 1 would change, 0 in sync, 0 error(s).
 `Plan()` results drive `apply`: every task probes the server once, and `apply` reuses that probe to decide whether to mutate. `apply` on an already-converged server reports `Changed=false` for every task; back-to-back applies are no-ops by design.
 
 A handful of tasks (notably `dokku_git_auth`, `dokku_registry_auth`, and `dokku_storage_ensure`) cannot probe their current state without invoking the corresponding dokku command, so their plan output reports drift unconditionally with `(... not probed)` in the reason.
+
+The flags are:
+
+| Flag | Effect |
+|------|--------|
+| `--tasks <path>` | Use a specific task file (default `./tasks.yml`) |
+| `--json` | Suppress the human formatter and emit one JSON-lines event per `play_start`, `task`, or `summary` to stdout. Sensitive values mask to `***`. See "JSON output" below for the schema. |
+| `--detailed-exitcode` | Exit `0` when no drift is detected, `2` when at least one task reports drift, `1` on read or probe error. Errors win over drift. Without this flag, plan exits `0` regardless of drift. Mirrors the `git diff --exit-code` / `terraform plan -detailed-exitcode` convention. |
+
+```shell
+# CI gate: fail the job if any task would change the server.
+docket plan --detailed-exitcode || exit $?
+```
+
+### JSON output
+
+`docket apply --json` and `docket plan --json` emit one JSON-lines event per line on stdout. Every event carries a `version` integer pinned at `1`; consumers branch on `version` for forward compatibility. Sensitive values registered via inputs declared `sensitive: true` or task struct fields tagged `sensitive:"true"` are masked as `***`.
+
+| Event | Required fields | Optional fields |
+|-------|-----------------|-----------------|
+| `play_start` | `version`, `type`, `name`, `ts` | `host` |
+| `task` (apply) | `version`, `type`, `play`, `name`, `status` (`ok`/`changed`/`skipped`/`error`), `changed`, `state`, `desired_state`, `duration_ms`, `ts` | `error`, `commands` |
+| `task` (plan) | `version`, `type`, `play`, `name`, `status` (`ok`/`+`/`~`/`-`/`skipped`/`error`), `would_change`, `state`, `desired_state`, `duration_ms`, `ts` | `reason`, `mutations`, `commands`, `error` |
+| `summary` (apply) | `version`, `type`, `tasks`, `changed`, `ok`, `skipped`, `errors`, `duration_ms` | - |
+| `summary` (plan) | `version`, `type`, `tasks`, `would_change`, `in_sync`, `skipped`, `errors`, `duration_ms` | - |
+
+Both `task` event flavors include `commands` as an array of resolved, masked dokku command strings (singular `command` was considered but tasks like `dokku_buildpacks` legitimately invoke N subprocess calls, so an array preserves structure for `jq '.commands[]'`). The plan `commands` array reports the dokku invocations `apply` *would* run; the apply `commands` array reports what was actually executed. Both arrays use the same rendering rules, so plan output and apply output stay byte-identical for the same logical operation.
+
+Sample `plan --json` line for a config task with two new keys:
+
+```jsonl
+{"version":1,"type":"task","play":"tasks","name":"configure","status":"~","would_change":true,"state":"present","desired_state":"present","reason":"2 key(s) to set","mutations":["set KEY (new)","set SECRET (new)"],"commands":["dokku --quiet config:set --encoded api KEY=*** SECRET=***"],"duration_ms":58,"ts":"2026-04-26T11:30:00Z"}
+```
+
+`--json` and `--detailed-exitcode` compose; CI pipelines can stream JSON to a dashboard while still branching on the exit code.
 
 ### Validating recipes with `validate`
 

--- a/commands/apply.go
+++ b/commands/apply.go
@@ -18,6 +18,7 @@ type ApplyCommand struct {
 
 	tasksFile         string
 	verbose           bool
+	json              bool
 	host              string
 	sudo              bool
 	acceptNewHostKeys bool
@@ -63,7 +64,8 @@ func (c *ApplyCommand) ParsedArguments(args []string) (map[string]command.Argume
 func (c *ApplyCommand) FlagSet() *flag.FlagSet {
 	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
 	f.StringVar(&c.tasksFile, "tasks", "tasks.yml", "a yaml file containing a task list")
-	f.BoolVar(&c.verbose, "verbose", false, "echo the resolved dokku command for each task as a continuation line. Values from inputs declared `sensitive: true` and from task struct fields tagged `sensitive:\"true\"` are masked as `***`")
+	f.BoolVar(&c.verbose, "verbose", false, "echo the resolved dokku command for each task as a continuation line. Values from inputs declared `sensitive: true` and from task struct fields tagged `sensitive:\"true\"` are masked as `***`. Ignored when --json is set; the JSON output already includes the resolved commands.")
+	f.BoolVar(&c.json, "json", false, "emit one JSON-lines event per play/task/summary instead of human-readable output. Schema is keyed by `version: 1`; sensitive values mask to `***`.")
 	f.StringVar(&c.host, "host", "", "remote dokku host as [user@]host[:port]; equivalent to DOKKU_HOST. Routes every dokku invocation through ssh.")
 	f.BoolVar(&c.sudo, "sudo", false, "wrap remote dokku invocations with `sudo -n`; equivalent to DOKKU_SUDO=1")
 	f.BoolVar(&c.acceptNewHostKeys, "accept-new-host-keys", false, "for SSH transport, accept new host keys on first connection (`-o StrictHostKeyChecking=accept-new`). MITM risk on first connect.")
@@ -91,6 +93,7 @@ func (c *ApplyCommand) AutocompleteFlags() complete.Flags {
 		complete.Flags{
 			"--tasks":                complete.PredictFiles("*.yml"),
 			"--verbose":              complete.PredictNothing,
+			"--json":                 complete.PredictNothing,
 			"--host":                 complete.PredictAnything,
 			"--sudo":                 complete.PredictNothing,
 			"--accept-new-host-keys": complete.PredictNothing,
@@ -146,32 +149,45 @@ func (c *ApplyCommand) Run(args []string) int {
 		defer subprocess.CloseSshControlMaster(resolvedHost)
 	}
 
-	formatter := NewFormatter(c.Ui, c.verbose)
-	formatter.PlayHeaderWithHost("tasks", resolvedHost)
+	emitter := c.newEmitter()
+	emitter.PlayStart("tasks", resolvedHost)
 
 	start := time.Now()
 	counts := ApplyCounts{}
+	playName := "tasks"
 
 	keys := tasks.FilterByTags(taskList, c.tags, c.skipTags)
 	exprBaseCtx := buildEnvelopeExprContext(context)
 
 	for _, name := range keys {
 		env := taskList.GetEnvelope(name)
+		taskStart := time.Now()
 
 		if env.HasWhen() {
 			ok, err := tasks.EvalBool(env.WhenProgram(), envelopeExprContext(exprBaseCtx, env))
 			if err != nil {
 				counts.Tasks++
 				counts.Errors++
-				formatter.TaskLine(MarkerError, name, "")
-				formatter.Continuation('!', fmt.Sprintf("when expression error: %v", err))
-				formatter.ApplySummary(counts, time.Since(start))
+				emitter.ApplyTask(ApplyTaskEvent{
+					Play:      playName,
+					Name:      name,
+					WhenError: err,
+					Duration:  time.Since(taskStart),
+					Timestamp: time.Now().UTC(),
+				})
+				emitter.ApplySummary(counts, time.Since(start))
 				return 1
 			}
 			if !ok {
 				counts.Tasks++
 				counts.Skipped++
-				formatter.TaskLine(MarkerSkipped, name, "")
+				emitter.ApplyTask(ApplyTaskEvent{
+					Play:      playName,
+					Name:      name,
+					Skipped:   true,
+					Duration:  time.Since(taskStart),
+					Timestamp: time.Now().UTC(),
+				})
 				continue
 			}
 		}
@@ -182,38 +198,59 @@ func (c *ApplyCommand) Run(args []string) int {
 		switch {
 		case state.Error != nil:
 			counts.Errors++
-			formatter.TaskLine(MarkerError, name, "")
-			formatter.ErrorContinuation(state.Error)
-			if c.verbose {
-				for _, cmd := range state.Commands {
-					formatter.Continuation('\u2192', cmd)
-				}
-			}
-			formatter.ApplySummary(counts, time.Since(start))
+			emitter.ApplyTask(ApplyTaskEvent{
+				Play:      playName,
+				Name:      name,
+				State:     state,
+				Duration:  time.Since(taskStart),
+				Timestamp: time.Now().UTC(),
+			})
+			emitter.ApplySummary(counts, time.Since(start))
+			return 1
+		case state.State != state.DesiredState:
+			counts.Errors++
+			emitter.ApplyTask(ApplyTaskEvent{
+				Play:         playName,
+				Name:         name,
+				State:        state,
+				InvalidState: true,
+				Duration:     time.Since(taskStart),
+				Timestamp:    time.Now().UTC(),
+			})
+			emitter.ApplySummary(counts, time.Since(start))
 			return 1
 		case state.Changed:
 			counts.Changed++
-			formatter.TaskLine(MarkerChanged, name, "")
+			emitter.ApplyTask(ApplyTaskEvent{
+				Play:      playName,
+				Name:      name,
+				State:     state,
+				Duration:  time.Since(taskStart),
+				Timestamp: time.Now().UTC(),
+			})
 		default:
 			counts.OK++
-			formatter.TaskLine(MarkerOK, name, "")
-		}
-
-		if c.verbose {
-			for _, cmd := range state.Commands {
-				formatter.Continuation('\u2192', cmd)
-			}
-		}
-
-		if state.State != state.DesiredState {
-			counts.Errors++
-			formatter.TaskLine(MarkerError, name, "")
-			formatter.Continuation('!', fmt.Sprintf("invalid state: expected=%v actual=%v", state.DesiredState, state.State))
-			formatter.ApplySummary(counts, time.Since(start))
-			return 1
+			emitter.ApplyTask(ApplyTaskEvent{
+				Play:      playName,
+				Name:      name,
+				State:     state,
+				Duration:  time.Since(taskStart),
+				Timestamp: time.Now().UTC(),
+			})
 		}
 	}
 
-	formatter.ApplySummary(counts, time.Since(start))
+	emitter.ApplySummary(counts, time.Since(start))
 	return 0
+}
+
+// newEmitter constructs the EventEmitter for this run. --json builds a
+// JSONEmitter; otherwise the human Formatter is used. The verbose flag is
+// only meaningful for the human path - JSON output already includes the
+// resolved commands in each task event's `commands` array.
+func (c *ApplyCommand) newEmitter() EventEmitter {
+	if c.json {
+		return NewJSONEmitter(c.Ui)
+	}
+	return NewFormatter(c.Ui, c.verbose)
 }

--- a/commands/output.go
+++ b/commands/output.go
@@ -7,9 +7,70 @@ import (
 	"time"
 
 	"github.com/dokku/docket/subprocess"
+	"github.com/dokku/docket/tasks"
 	"github.com/fatih/color"
 	"github.com/mitchellh/cli"
 )
+
+// EventEmitter is the structured event sink consumed by `apply` and `plan`.
+// Both the human Formatter and the JSONEmitter implement it. The executor
+// in apply.go / plan.go constructs the right emitter at the top of Run()
+// based on the --json flag and funnels each per-task branch through the
+// interface so the two output modes stay in lock-step.
+type EventEmitter interface {
+	// PlayStart announces the beginning of a play. host is the optional
+	// remote host annotation, "" for local execution.
+	PlayStart(name, host string)
+	// ApplyTask emits one event per task in an `apply` run.
+	ApplyTask(ev ApplyTaskEvent)
+	// PlanTask emits one event per task in a `plan` run.
+	PlanTask(ev PlanTaskEvent)
+	// ApplySummary emits the end-of-run footer for `apply`.
+	ApplySummary(c ApplyCounts, d time.Duration)
+	// PlanSummary emits the end-of-run footer for `plan`.
+	PlanSummary(c PlanCounts, d time.Duration)
+}
+
+// ApplyTaskEvent describes a single task outcome from an apply run. The
+// run-loop in commands/apply.go populates this once per task and hands it
+// to the active emitter; the emitter decides how to render it.
+type ApplyTaskEvent struct {
+	// Play is the name of the enclosing play (today always "tasks").
+	Play string
+	// Name is the task's envelope name.
+	Name string
+	// State is the post-execute state returned by Task.Execute.
+	// Zero-value State is acceptable for the WhenError / Skipped branches.
+	State tasks.TaskOutputState
+	// WhenError, when non-nil, indicates the `when:` predicate raised an
+	// expr error and the task did not run. Mutually exclusive with the
+	// other branches.
+	WhenError error
+	// Skipped indicates the `when:` predicate evaluated to false and the
+	// task was filtered out. Mutually exclusive with the other branches.
+	Skipped bool
+	// InvalidState, when true, indicates Execute reported success but the
+	// final State did not match DesiredState; treated as an error in
+	// counts and exit logic.
+	InvalidState bool
+	// Duration is the wall-clock time Execute took (or zero for the
+	// when-skipped / when-error branches).
+	Duration time.Duration
+	// Timestamp is when the event was produced (UTC). The JSON emitter
+	// serialises this as the `ts` field; the human emitter ignores it.
+	Timestamp time.Time
+}
+
+// PlanTaskEvent describes a single task outcome from a plan run.
+type PlanTaskEvent struct {
+	Play      string
+	Name      string
+	Result    tasks.PlanResult
+	WhenError error
+	Skipped   bool
+	Duration  time.Duration
+	Timestamp time.Time
+}
 
 // Marker is the bracketed status marker that prefixes a task line. The
 // concrete strings (without brackets) match the conventions documented
@@ -118,6 +179,76 @@ func (f *Formatter) PlayHeaderWithHost(name, host string) {
 	f.ui.Output(fmt.Sprintf("==> Play: %s  (host: %s)", name, host))
 }
 
+// PlayStart satisfies EventEmitter; delegates to PlayHeaderWithHost.
+func (f *Formatter) PlayStart(name, host string) {
+	f.PlayHeaderWithHost(name, host)
+}
+
+// ApplyTask renders one apply task line plus optional continuations,
+// matching the legacy formatter dispatch in commands/apply.go.
+func (f *Formatter) ApplyTask(ev ApplyTaskEvent) {
+	switch {
+	case ev.WhenError != nil:
+		f.TaskLine(MarkerError, ev.Name, "")
+		f.Continuation('!', fmt.Sprintf("when expression error: %v", ev.WhenError))
+	case ev.Skipped:
+		f.TaskLine(MarkerSkipped, ev.Name, "")
+	case ev.State.Error != nil:
+		f.TaskLine(MarkerError, ev.Name, "")
+		f.ErrorContinuation(ev.State.Error)
+		if f.verbose {
+			for _, cmd := range ev.State.Commands {
+				f.Continuation('\u2192', cmd)
+			}
+		}
+	case ev.InvalidState:
+		f.TaskLine(MarkerError, ev.Name, "")
+		f.Continuation('!', fmt.Sprintf("invalid state: expected=%v actual=%v", ev.State.DesiredState, ev.State.State))
+	case ev.State.Changed:
+		f.TaskLine(MarkerChanged, ev.Name, "")
+		if f.verbose {
+			for _, cmd := range ev.State.Commands {
+				f.Continuation('\u2192', cmd)
+			}
+		}
+	default:
+		f.TaskLine(MarkerOK, ev.Name, "")
+		if f.verbose {
+			for _, cmd := range ev.State.Commands {
+				f.Continuation('\u2192', cmd)
+			}
+		}
+	}
+}
+
+// PlanTask renders one plan task line plus optional continuations,
+// matching the legacy formatter dispatch in commands/plan.go.
+func (f *Formatter) PlanTask(ev PlanTaskEvent) {
+	switch {
+	case ev.WhenError != nil:
+		f.TaskLine(MarkerProbeError, ev.Name, fmt.Sprintf("(when expression error: %v)", ev.WhenError))
+	case ev.Skipped:
+		f.TaskLine(MarkerSkipped, ev.Name, "(when: false)")
+	case ev.Result.Error != nil:
+		f.TaskLine(MarkerProbeError, ev.Name, fmt.Sprintf("(%s)", PrefixErrorMessage(ev.Result.Error)))
+	case ev.Result.InSync:
+		f.TaskLine(MarkerOK, ev.Name, "(in sync)")
+	default:
+		marker := Marker(ev.Result.Status)
+		if marker == "" {
+			marker = Marker(tasks.PlanStatusModify)
+		}
+		suffix := ""
+		if ev.Result.Reason != "" {
+			suffix = "(" + ev.Result.Reason + ")"
+		}
+		f.TaskLine(marker, ev.Name, suffix)
+		for _, m := range ev.Result.Mutations {
+			f.Continuation('-', m)
+		}
+	}
+}
+
 // ErrorContinuation emits an `! <prefix>: <body>` continuation line
 // under an errored task. The prefix is `ssh` when err unwraps to a
 // *subprocess.SSHError (transport-level failure: connect, auth,
@@ -207,7 +338,11 @@ func (f *Formatter) ApplySummary(c ApplyCounts, elapsed time.Duration) {
 // count is appended only when at least one task was filtered out by
 // `when:`, so recipes that do not exercise envelope predicates still
 // produce the legacy summary.
-func (f *Formatter) PlanSummary(c PlanCounts) {
+//
+// The elapsed duration is accepted for parity with ApplySummary and
+// EventEmitter, but the human plan summary line does not render it
+// (the legacy format omits timing). The JSON emitter consumes it.
+func (f *Formatter) PlanSummary(c PlanCounts, _ time.Duration) {
 	f.ui.Output("")
 	if c.Skipped > 0 {
 		f.ui.Output(fmt.Sprintf(

--- a/commands/output_json.go
+++ b/commands/output_json.go
@@ -1,0 +1,200 @@
+package commands
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/dokku/docket/subprocess"
+	"github.com/dokku/docket/tasks"
+	"github.com/mitchellh/cli"
+)
+
+// jsonSchemaVersion is the wire-format version every emitted event carries
+// in its `version` field. Bumps are reserved for breaking schema changes;
+// additive changes within a major version do not bump.
+const jsonSchemaVersion = 1
+
+// JSONEmitter writes one JSON-lines event per call to the underlying Ui's
+// stdout (Output) sink. Sensitive values registered via
+// subprocess.SetGlobalSensitive are masked before any string field that
+// could carry them is serialised.
+type JSONEmitter struct {
+	ui cli.Ui
+}
+
+// NewJSONEmitter constructs a JSONEmitter bound to the given Ui.
+func NewJSONEmitter(ui cli.Ui) *JSONEmitter {
+	return &JSONEmitter{ui: ui}
+}
+
+// PlayStart emits a `play_start` event.
+func (e *JSONEmitter) PlayStart(name, host string) {
+	ev := map[string]interface{}{
+		"version": jsonSchemaVersion,
+		"type":    "play_start",
+		"name":    name,
+		"ts":      nowRFC3339(),
+	}
+	if host != "" {
+		ev["host"] = host
+	}
+	e.write(ev)
+}
+
+// ApplyTask emits one `task` event for an apply run. Status is one of
+// "ok", "changed", "skipped", "error".
+func (e *JSONEmitter) ApplyTask(ev ApplyTaskEvent) {
+	out := map[string]interface{}{
+		"version":       jsonSchemaVersion,
+		"type":          "task",
+		"play":          ev.Play,
+		"name":          ev.Name,
+		"changed":       ev.State.Changed,
+		"state":         string(ev.State.State),
+		"desired_state": string(ev.State.DesiredState),
+		"duration_ms":   ev.Duration.Milliseconds(),
+		"ts":            timestampOrNow(ev.Timestamp),
+	}
+	switch {
+	case ev.WhenError != nil:
+		out["status"] = "error"
+		out["error"] = subprocess.MaskString(ev.WhenError.Error())
+	case ev.Skipped:
+		out["status"] = "skipped"
+	case ev.State.Error != nil:
+		out["status"] = "error"
+		out["error"] = subprocess.MaskString(PrefixErrorMessage(ev.State.Error))
+	case ev.InvalidState:
+		out["status"] = "error"
+		out["error"] = subprocess.MaskString(invalidStateMessage(ev.State))
+	case ev.State.Changed:
+		out["status"] = "changed"
+	default:
+		out["status"] = "ok"
+	}
+	if cmds := maskedCommands(ev.State.Commands); len(cmds) > 0 {
+		out["commands"] = cmds
+	}
+	e.write(out)
+}
+
+// PlanTask emits one `task` event for a plan run. Status is one of
+// "ok", "+", "~", "-", "skipped", "error".
+func (e *JSONEmitter) PlanTask(ev PlanTaskEvent) {
+	out := map[string]interface{}{
+		"version":       jsonSchemaVersion,
+		"type":          "task",
+		"play":          ev.Play,
+		"name":          ev.Name,
+		"would_change":  !ev.Result.InSync && ev.Result.Error == nil && !ev.Skipped && ev.WhenError == nil,
+		"state":         string(ev.Result.DesiredState),
+		"desired_state": string(ev.Result.DesiredState),
+		"duration_ms":   ev.Duration.Milliseconds(),
+		"ts":            timestampOrNow(ev.Timestamp),
+	}
+	switch {
+	case ev.WhenError != nil:
+		out["status"] = "error"
+		out["would_change"] = false
+		out["error"] = subprocess.MaskString(ev.WhenError.Error())
+	case ev.Skipped:
+		out["status"] = "skipped"
+		out["would_change"] = false
+	case ev.Result.Error != nil:
+		out["status"] = "error"
+		out["would_change"] = false
+		out["error"] = subprocess.MaskString(PrefixErrorMessage(ev.Result.Error))
+	case ev.Result.InSync:
+		out["status"] = "ok"
+	default:
+		out["status"] = string(ev.Result.Status)
+		if out["status"] == "" {
+			out["status"] = string(tasks.PlanStatusModify)
+		}
+		if ev.Result.Reason != "" {
+			out["reason"] = subprocess.MaskString(ev.Result.Reason)
+		}
+		if len(ev.Result.Mutations) > 0 {
+			out["mutations"] = maskedCommands(ev.Result.Mutations)
+		}
+		if cmds := maskedCommands(ev.Result.Commands); len(cmds) > 0 {
+			out["commands"] = cmds
+		}
+	}
+	e.write(out)
+}
+
+// ApplySummary emits the end-of-run summary event for apply.
+func (e *JSONEmitter) ApplySummary(c ApplyCounts, d time.Duration) {
+	e.write(map[string]interface{}{
+		"version":     jsonSchemaVersion,
+		"type":        "summary",
+		"tasks":       c.Tasks,
+		"changed":     c.Changed,
+		"ok":          c.OK,
+		"skipped":     c.Skipped,
+		"errors":      c.Errors,
+		"duration_ms": d.Milliseconds(),
+	})
+}
+
+// PlanSummary emits the end-of-run summary event for plan.
+func (e *JSONEmitter) PlanSummary(c PlanCounts, d time.Duration) {
+	e.write(map[string]interface{}{
+		"version":      jsonSchemaVersion,
+		"type":         "summary",
+		"tasks":        c.Tasks,
+		"would_change": c.WouldChange,
+		"in_sync":      c.InSync,
+		"skipped":      c.Skipped,
+		"errors":       c.Errors,
+		"duration_ms":  d.Milliseconds(),
+	})
+}
+
+// write serialises ev to a single JSON line on stdout. Errors during marshal
+// are surfaced via the Ui's Error sink so the consumer sees the failure
+// without corrupting the stream.
+func (e *JSONEmitter) write(ev map[string]interface{}) {
+	b, err := json.Marshal(ev)
+	if err != nil {
+		e.ui.Error("json marshal error: " + err.Error())
+		return
+	}
+	e.ui.Output(string(b))
+}
+
+// maskedCommands returns a copy of cmds with each entry passed through
+// subprocess.MaskString. Returns nil for an empty slice so the caller can
+// detect "no commands" and omit the JSON field.
+func maskedCommands(cmds []string) []string {
+	if len(cmds) == 0 {
+		return nil
+	}
+	out := make([]string, len(cmds))
+	for i, c := range cmds {
+		out[i] = subprocess.MaskString(c)
+	}
+	return out
+}
+
+// invalidStateMessage formats the state-mismatch error apply.go reports
+// inline today. Kept here so the JSON path renders identical wording.
+func invalidStateMessage(s tasks.TaskOutputState) string {
+	return "invalid state: expected=" + string(s.DesiredState) + " actual=" + string(s.State)
+}
+
+// nowRFC3339 returns the current UTC instant formatted RFC3339.
+func nowRFC3339() string {
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
+// timestampOrNow renders ts as RFC3339 UTC; if ts is zero, returns the
+// current time. apply.go / plan.go fill in Timestamp at event-build time
+// so a single run produces strictly increasing timestamps.
+func timestampOrNow(ts time.Time) string {
+	if ts.IsZero() {
+		return nowRFC3339()
+	}
+	return ts.UTC().Format(time.RFC3339)
+}

--- a/commands/output_json_test.go
+++ b/commands/output_json_test.go
@@ -1,0 +1,359 @@
+package commands
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dokku/docket/subprocess"
+	"github.com/dokku/docket/tasks"
+	"github.com/mitchellh/cli"
+)
+
+// emitterTestUI returns a fresh MockUi and the emitter under test.
+func emitterTestUI() (*JSONEmitter, *cli.MockUi) {
+	ui := cli.NewMockUi()
+	return NewJSONEmitter(ui), ui
+}
+
+// decodeOnly parses the captured stdout as a single JSON-lines event and
+// returns the resulting map. Fails the test on any parse error.
+func decodeOnly(t *testing.T, out string) map[string]interface{} {
+	t.Helper()
+	out = strings.TrimRight(out, "\n")
+	var ev map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &ev); err != nil {
+		t.Fatalf("invalid JSON: %v\nraw: %q", err, out)
+	}
+	return ev
+}
+
+// decodeLines parses every newline-delimited JSON event from out.
+func decodeLines(t *testing.T, out string) []map[string]interface{} {
+	t.Helper()
+	var events []map[string]interface{}
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var ev map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("invalid JSON line %q: %v", line, err)
+		}
+		events = append(events, ev)
+	}
+	return events
+}
+
+func TestJSONEmitterPlayStart(t *testing.T) {
+	e, ui := emitterTestUI()
+	e.PlayStart("tasks", "")
+	ev := decodeOnly(t, ui.OutputWriter.String())
+
+	if got, want := ev["version"], float64(1); got != want {
+		t.Errorf("version = %v, want %v", got, want)
+	}
+	if got, want := ev["type"], "play_start"; got != want {
+		t.Errorf("type = %v, want %v", got, want)
+	}
+	if got, want := ev["name"], "tasks"; got != want {
+		t.Errorf("name = %v, want %v", got, want)
+	}
+	if _, ok := ev["host"]; ok {
+		t.Errorf("host should be omitted when empty; got %v", ev["host"])
+	}
+	if _, ok := ev["ts"]; !ok {
+		t.Error("ts must be set")
+	}
+}
+
+func TestJSONEmitterPlayStartIncludesHostWhenSet(t *testing.T) {
+	e, ui := emitterTestUI()
+	e.PlayStart("tasks", "alice@host:2222")
+	ev := decodeOnly(t, ui.OutputWriter.String())
+	if got, want := ev["host"], "alice@host:2222"; got != want {
+		t.Errorf("host = %v, want %v", got, want)
+	}
+}
+
+func TestJSONEmitterApplyTaskOK(t *testing.T) {
+	e, ui := emitterTestUI()
+	e.ApplyTask(ApplyTaskEvent{
+		Play: "tasks",
+		Name: "ensure api",
+		State: tasks.TaskOutputState{
+			Changed:      false,
+			State:        tasks.StatePresent,
+			DesiredState: tasks.StatePresent,
+		},
+		Duration:  42 * time.Millisecond,
+		Timestamp: time.Date(2026, 4, 26, 11, 30, 0, 0, time.UTC),
+	})
+	ev := decodeOnly(t, ui.OutputWriter.String())
+
+	if ev["version"].(float64) != 1 {
+		t.Errorf("version mismatch")
+	}
+	if ev["type"] != "task" {
+		t.Errorf("type mismatch")
+	}
+	if ev["status"] != "ok" {
+		t.Errorf("status = %v, want ok", ev["status"])
+	}
+	if ev["changed"] != false {
+		t.Errorf("changed should be false")
+	}
+	if ev["duration_ms"].(float64) != 42 {
+		t.Errorf("duration_ms = %v, want 42", ev["duration_ms"])
+	}
+	if ev["state"] != string(tasks.StatePresent) {
+		t.Errorf("state = %v, want %v", ev["state"], tasks.StatePresent)
+	}
+	if ev["ts"] != "2026-04-26T11:30:00Z" {
+		t.Errorf("ts = %v, want 2026-04-26T11:30:00Z", ev["ts"])
+	}
+}
+
+func TestJSONEmitterApplyTaskChangedIncludesCommands(t *testing.T) {
+	e, ui := emitterTestUI()
+	e.ApplyTask(ApplyTaskEvent{
+		Play: "tasks",
+		Name: "ensure api",
+		State: tasks.TaskOutputState{
+			Changed:      true,
+			State:        tasks.StatePresent,
+			DesiredState: tasks.StatePresent,
+			Commands:     []string{"dokku --quiet apps:create api"},
+		},
+		Duration: 100 * time.Millisecond,
+	})
+	ev := decodeOnly(t, ui.OutputWriter.String())
+	if ev["status"] != "changed" {
+		t.Errorf("status = %v, want changed", ev["status"])
+	}
+	if ev["changed"] != true {
+		t.Errorf("changed should be true")
+	}
+	cmds, ok := ev["commands"].([]interface{})
+	if !ok {
+		t.Fatalf("commands should be an array, got %T", ev["commands"])
+	}
+	if len(cmds) != 1 || cmds[0] != "dokku --quiet apps:create api" {
+		t.Errorf("commands = %v", cmds)
+	}
+}
+
+func TestJSONEmitterApplyTaskError(t *testing.T) {
+	e, ui := emitterTestUI()
+	e.ApplyTask(ApplyTaskEvent{
+		Play: "tasks",
+		Name: "create app",
+		State: tasks.TaskOutputState{
+			Error:        errors.New("app foo does not exist"),
+			DesiredState: tasks.StatePresent,
+		},
+	})
+	ev := decodeOnly(t, ui.OutputWriter.String())
+	if ev["status"] != "error" {
+		t.Errorf("status = %v, want error", ev["status"])
+	}
+	errStr, _ := ev["error"].(string)
+	if !strings.HasPrefix(errStr, "dokku: ") {
+		t.Errorf("error should be prefixed `dokku: `, got %q", errStr)
+	}
+}
+
+func TestJSONEmitterApplyTaskWhenError(t *testing.T) {
+	e, ui := emitterTestUI()
+	e.ApplyTask(ApplyTaskEvent{
+		Play:      "tasks",
+		Name:      "skip me",
+		WhenError: errors.New("boom"),
+	})
+	ev := decodeOnly(t, ui.OutputWriter.String())
+	if ev["status"] != "error" {
+		t.Errorf("status = %v, want error", ev["status"])
+	}
+	if ev["error"] != "boom" {
+		t.Errorf("error = %v, want boom", ev["error"])
+	}
+}
+
+func TestJSONEmitterApplyTaskSkipped(t *testing.T) {
+	e, ui := emitterTestUI()
+	e.ApplyTask(ApplyTaskEvent{Play: "tasks", Name: "skipped", Skipped: true})
+	ev := decodeOnly(t, ui.OutputWriter.String())
+	if ev["status"] != "skipped" {
+		t.Errorf("status = %v, want skipped", ev["status"])
+	}
+}
+
+func TestJSONEmitterApplyTaskInvalidState(t *testing.T) {
+	e, ui := emitterTestUI()
+	e.ApplyTask(ApplyTaskEvent{
+		Play: "tasks",
+		Name: "weird",
+		State: tasks.TaskOutputState{
+			State:        tasks.StateAbsent,
+			DesiredState: tasks.StatePresent,
+		},
+		InvalidState: true,
+	})
+	ev := decodeOnly(t, ui.OutputWriter.String())
+	if ev["status"] != "error" {
+		t.Errorf("status = %v, want error", ev["status"])
+	}
+	errStr, _ := ev["error"].(string)
+	if !strings.Contains(errStr, "expected=present actual=absent") {
+		t.Errorf("error = %q does not mention expected/actual", errStr)
+	}
+}
+
+func TestJSONEmitterPlanTaskInSync(t *testing.T) {
+	e, ui := emitterTestUI()
+	e.PlanTask(PlanTaskEvent{
+		Play:   "tasks",
+		Name:   "stable",
+		Result: tasks.PlanResult{InSync: true, Status: tasks.PlanStatusOK, DesiredState: tasks.StatePresent},
+	})
+	ev := decodeOnly(t, ui.OutputWriter.String())
+	if ev["status"] != "ok" {
+		t.Errorf("status = %v, want ok", ev["status"])
+	}
+	if ev["would_change"] != false {
+		t.Errorf("would_change should be false for in-sync")
+	}
+}
+
+func TestJSONEmitterPlanTaskWouldChange(t *testing.T) {
+	e, ui := emitterTestUI()
+	e.PlanTask(PlanTaskEvent{
+		Play: "tasks",
+		Name: "configure",
+		Result: tasks.PlanResult{
+			Status:       tasks.PlanStatusModify,
+			Reason:       "2 keys to set",
+			Mutations:    []string{"set KEY", "set SECRET"},
+			Commands:     []string{"dokku --quiet config:set --encoded api KEY=*** SECRET=***"},
+			DesiredState: tasks.StatePresent,
+		},
+	})
+	ev := decodeOnly(t, ui.OutputWriter.String())
+	if ev["status"] != "~" {
+		t.Errorf("status = %v, want ~", ev["status"])
+	}
+	if ev["would_change"] != true {
+		t.Errorf("would_change should be true for drift")
+	}
+	if ev["reason"] != "2 keys to set" {
+		t.Errorf("reason = %v", ev["reason"])
+	}
+	muts, ok := ev["mutations"].([]interface{})
+	if !ok || len(muts) != 2 {
+		t.Errorf("mutations = %v", ev["mutations"])
+	}
+	cmds, ok := ev["commands"].([]interface{})
+	if !ok || len(cmds) != 1 {
+		t.Errorf("commands = %v", ev["commands"])
+	}
+}
+
+func TestJSONEmitterPlanTaskProbeError(t *testing.T) {
+	e, ui := emitterTestUI()
+	e.PlanTask(PlanTaskEvent{
+		Play:   "tasks",
+		Name:   "broken",
+		Result: tasks.PlanResult{Status: tasks.PlanStatusError, Error: errors.New("missing app")},
+	})
+	ev := decodeOnly(t, ui.OutputWriter.String())
+	if ev["status"] != "error" {
+		t.Errorf("status = %v, want error", ev["status"])
+	}
+	if ev["would_change"] != false {
+		t.Errorf("would_change should be false for probe error")
+	}
+}
+
+func TestJSONEmitterApplySummary(t *testing.T) {
+	e, ui := emitterTestUI()
+	e.ApplySummary(ApplyCounts{Tasks: 3, Changed: 1, OK: 2, Skipped: 0, Errors: 0}, 1234*time.Millisecond)
+	ev := decodeOnly(t, ui.OutputWriter.String())
+	if ev["type"] != "summary" {
+		t.Errorf("type = %v", ev["type"])
+	}
+	if ev["tasks"].(float64) != 3 {
+		t.Errorf("tasks count")
+	}
+	if ev["changed"].(float64) != 1 {
+		t.Errorf("changed count")
+	}
+	if ev["duration_ms"].(float64) != 1234 {
+		t.Errorf("duration_ms = %v, want 1234", ev["duration_ms"])
+	}
+}
+
+func TestJSONEmitterPlanSummary(t *testing.T) {
+	e, ui := emitterTestUI()
+	e.PlanSummary(PlanCounts{Tasks: 3, WouldChange: 2, InSync: 1, Skipped: 0, Errors: 0}, 500*time.Millisecond)
+	ev := decodeOnly(t, ui.OutputWriter.String())
+	if ev["type"] != "summary" {
+		t.Errorf("type = %v", ev["type"])
+	}
+	if ev["would_change"].(float64) != 2 {
+		t.Errorf("would_change count")
+	}
+	if ev["in_sync"].(float64) != 1 {
+		t.Errorf("in_sync count")
+	}
+	if ev["duration_ms"].(float64) != 500 {
+		t.Errorf("duration_ms = %v, want 500", ev["duration_ms"])
+	}
+}
+
+func TestJSONEmitterMasksSensitiveValues(t *testing.T) {
+	subprocess.SetGlobalSensitive([]string{"topsecret"})
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+
+	e, ui := emitterTestUI()
+	e.ApplyTask(ApplyTaskEvent{
+		Play: "tasks",
+		Name: "set config",
+		State: tasks.TaskOutputState{
+			Changed:      true,
+			State:        tasks.StatePresent,
+			DesiredState: tasks.StatePresent,
+			Commands:     []string{"dokku config:set api KEY=topsecret"},
+		},
+	})
+	out := ui.OutputWriter.String()
+	if strings.Contains(out, "topsecret") {
+		t.Errorf("sensitive value leaked into JSON output: %s", out)
+	}
+	if !strings.Contains(out, "***") {
+		t.Errorf("expected mask placeholder in JSON output, got %s", out)
+	}
+}
+
+func TestJSONEmitterEveryEventHasVersion1(t *testing.T) {
+	e, ui := emitterTestUI()
+	e.PlayStart("tasks", "")
+	e.ApplyTask(ApplyTaskEvent{Play: "tasks", Name: "x", State: tasks.TaskOutputState{Changed: true, State: tasks.StatePresent, DesiredState: tasks.StatePresent}})
+	e.PlanTask(PlanTaskEvent{Play: "tasks", Name: "y", Result: tasks.PlanResult{InSync: true, Status: tasks.PlanStatusOK}})
+	e.ApplySummary(ApplyCounts{}, 0)
+	e.PlanSummary(PlanCounts{}, 0)
+
+	for _, ev := range decodeLines(t, ui.OutputWriter.String()) {
+		if ev["version"].(float64) != 1 {
+			t.Errorf("event missing version=1: %v", ev)
+		}
+	}
+}
+
+// TestEmitterInterfaceSatisfied compiles iff Formatter and JSONEmitter both
+// satisfy the EventEmitter contract. Catches signature drift at build time.
+func TestEmitterInterfaceSatisfied(t *testing.T) {
+	var _ EventEmitter = (*Formatter)(nil)
+	var _ EventEmitter = (*JSONEmitter)(nil)
+}

--- a/commands/output_test.go
+++ b/commands/output_test.go
@@ -234,7 +234,7 @@ func TestFormatterApplySummaryErrorWord(t *testing.T) {
 
 func TestFormatterPlanSummary(t *testing.T) {
 	f, ui := newTestFormatter(false)
-	f.PlanSummary(PlanCounts{Tasks: 3, WouldChange: 2, InSync: 1, Errors: 0})
+	f.PlanSummary(PlanCounts{Tasks: 3, WouldChange: 2, InSync: 1, Errors: 0}, 0)
 	got := ui.OutputWriter.String()
 	want := "Plan: 3 task(s); 2 would change, 1 in sync, 0 error(s)."
 	if !strings.Contains(got, want) {
@@ -247,7 +247,7 @@ func TestFormatterPlanSummaryWithSkipped(t *testing.T) {
 	// skipped by `when:` so recipes that do not exercise envelope
 	// predicates keep the legacy summary shape (covered above).
 	f, ui := newTestFormatter(false)
-	f.PlanSummary(PlanCounts{Tasks: 3, WouldChange: 1, InSync: 1, Skipped: 1, Errors: 0})
+	f.PlanSummary(PlanCounts{Tasks: 3, WouldChange: 1, InSync: 1, Skipped: 1, Errors: 0}, 0)
 	got := ui.OutputWriter.String()
 	want := "Plan: 3 task(s); 1 would change, 1 in sync, 1 skipped, 0 error(s)."
 	if !strings.Contains(got, want) {

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/dokku/docket/subprocess"
 	"github.com/dokku/docket/tasks"
@@ -19,6 +20,8 @@ type PlanCommand struct {
 	command.Meta
 
 	tasksFile         string
+	json              bool
+	detailedExitCode  bool
 	host              string
 	sudo              bool
 	acceptNewHostKeys bool
@@ -64,6 +67,8 @@ func (c *PlanCommand) ParsedArguments(args []string) (map[string]command.Argumen
 func (c *PlanCommand) FlagSet() *flag.FlagSet {
 	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
 	f.StringVar(&c.tasksFile, "tasks", "tasks.yml", "a yaml file containing a task list")
+	f.BoolVar(&c.json, "json", false, "emit one JSON-lines event per play/task/summary instead of human-readable output. Schema is keyed by `version: 1`; sensitive values mask to `***`.")
+	f.BoolVar(&c.detailedExitCode, "detailed-exitcode", false, "exit 0 when no drift is detected, 2 when drift is detected, 1 on error. Without this flag plan exits 0 regardless of drift.")
 	f.StringVar(&c.host, "host", "", "remote dokku host as [user@]host[:port]; equivalent to DOKKU_HOST. Routes every dokku invocation through ssh.")
 	f.BoolVar(&c.sudo, "sudo", false, "wrap remote dokku invocations with `sudo -n`; equivalent to DOKKU_SUDO=1")
 	f.BoolVar(&c.acceptNewHostKeys, "accept-new-host-keys", false, "for SSH transport, accept new host keys on first connection (`-o StrictHostKeyChecking=accept-new`). MITM risk on first connect.")
@@ -90,6 +95,8 @@ func (c *PlanCommand) AutocompleteFlags() complete.Flags {
 		c.Meta.AutocompleteFlags(command.FlagSetClient),
 		complete.Flags{
 			"--tasks":                complete.PredictFiles("*.yml"),
+			"--json":                 complete.PredictNothing,
+			"--detailed-exitcode":    complete.PredictNothing,
 			"--host":                 complete.PredictAnything,
 			"--sudo":                 complete.PredictNothing,
 			"--accept-new-host-keys": complete.PredictNothing,
@@ -103,10 +110,16 @@ func (c *PlanCommand) AutocompleteFlags() complete.Flags {
 // by contract), and prints a one-line summary per task plus a final
 // summary line.
 //
-// Exit codes:
+// Exit codes (default):
 //
 //	0 - plan completed successfully (regardless of drift)
 //	1 - read error, parse error, or read-state probe error
+//
+// Exit codes (--detailed-exitcode):
+//
+//	0 - plan completed cleanly; no drift detected
+//	1 - read error, parse error, or read-state probe error (errors win)
+//	2 - plan completed; at least one task reported drift
 func (c *PlanCommand) Run(args []string) int {
 	flags := c.FlagSet()
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
@@ -153,17 +166,21 @@ func (c *PlanCommand) Run(args []string) int {
 		defer subprocess.CloseSshControlMaster(resolvedHost)
 	}
 
-	formatter := NewFormatter(c.Ui, false)
-	formatter.PlayHeaderWithHost("tasks", resolvedHost)
+	emitter := c.newEmitter()
+	emitter.PlayStart("tasks", resolvedHost)
 
+	start := time.Now()
 	counts := PlanCounts{}
 	hasError := false
+	hasDrift := false
+	playName := "tasks"
 
 	keys := tasks.FilterByTags(taskList, c.tags, c.skipTags)
 	exprBaseCtx := buildEnvelopeExprContext(context)
 
 	for _, name := range keys {
 		env := taskList.GetEnvelope(name)
+		taskStart := time.Now()
 
 		if env.HasWhen() {
 			ok, err := tasks.EvalBool(env.WhenProgram(), envelopeExprContext(exprBaseCtx, env))
@@ -171,13 +188,25 @@ func (c *PlanCommand) Run(args []string) int {
 				counts.Tasks++
 				counts.Errors++
 				hasError = true
-				formatter.TaskLine(MarkerProbeError, name, fmt.Sprintf("(when expression error: %v)", err))
+				emitter.PlanTask(PlanTaskEvent{
+					Play:      playName,
+					Name:      name,
+					WhenError: err,
+					Duration:  time.Since(taskStart),
+					Timestamp: time.Now().UTC(),
+				})
 				continue
 			}
 			if !ok {
 				counts.Tasks++
 				counts.Skipped++
-				formatter.TaskLine(MarkerSkipped, name, "(when: false)")
+				emitter.PlanTask(PlanTaskEvent{
+					Play:      playName,
+					Name:      name,
+					Skipped:   true,
+					Duration:  time.Since(taskStart),
+					Timestamp: time.Now().UTC(),
+				})
 				continue
 			}
 		}
@@ -189,31 +218,38 @@ func (c *PlanCommand) Run(args []string) int {
 		case result.Error != nil:
 			counts.Errors++
 			hasError = true
-			formatter.TaskLine(MarkerProbeError, name, fmt.Sprintf("(%s)", PrefixErrorMessage(result.Error)))
 		case result.InSync:
 			counts.InSync++
-			formatter.TaskLine(MarkerOK, name, "(in sync)")
 		default:
 			counts.WouldChange++
-			marker := Marker(result.Status)
-			if marker == "" {
-				marker = Marker(tasks.PlanStatusModify)
-			}
-			suffix := ""
-			if result.Reason != "" {
-				suffix = "(" + result.Reason + ")"
-			}
-			formatter.TaskLine(marker, name, suffix)
-			for _, m := range result.Mutations {
-				formatter.Continuation('-', m)
-			}
+			hasDrift = true
 		}
+
+		emitter.PlanTask(PlanTaskEvent{
+			Play:      playName,
+			Name:      name,
+			Result:    result,
+			Duration:  time.Since(taskStart),
+			Timestamp: time.Now().UTC(),
+		})
 	}
 
-	formatter.PlanSummary(counts)
+	emitter.PlanSummary(counts, time.Since(start))
 
 	if hasError {
 		return 1
 	}
+	if c.detailedExitCode && hasDrift {
+		return 2
+	}
 	return 0
+}
+
+// newEmitter constructs the EventEmitter for this run. --json builds a
+// JSONEmitter; otherwise the human Formatter is used.
+func (c *PlanCommand) newEmitter() EventEmitter {
+	if c.json {
+		return NewJSONEmitter(c.Ui)
+	}
+	return NewFormatter(c.Ui, false)
 }

--- a/subprocess/exec.go
+++ b/subprocess/exec.go
@@ -103,6 +103,51 @@ func (ecr ExecCommandResponse) StdoutBytes() []byte {
 	return []byte(ecr.StdoutContents())
 }
 
+// ResolveCommandString returns the masked command line ExecCommandResponse.Command
+// would carry if input were executed now. Used by tasks' Plan() methods so
+// PlanResult.Commands renders byte-identical to the strings apply emits via
+// state.Commands; sharing the rendering logic keeps the two views from drifting.
+//
+// The function mirrors the dispatch in CallExecCommandWithContext and
+// CallSshCommandWithContext: when the (possibly defaulted) Host is set and the
+// command is `dokku`, the SSH transport's bare `cmd args` form is returned
+// because remote sudo is wrapped server-side via DOKKU_SUDO and never appears
+// in the displayed command. Otherwise the local path's sudo-wrap-when-true
+// form is returned.
+func ResolveCommandString(input ExecCommandInput) string {
+	if input.Host == "" {
+		input.Host = GetDefaultHost()
+	}
+	if input.Host != "" && input.Command == "dokku" {
+		return resolveSshCommandString(input.Command, input.Args)
+	}
+	cmd := input.Command
+	args := input.Args
+	if input.Sudo {
+		args = append([]string{"-n", "-u", "root", cmd}, args...)
+		cmd = "sudo"
+	}
+	return resolveLocalCommandString(cmd, args)
+}
+
+// resolveLocalCommandString joins a local command and args into the masked
+// form CallExecCommandWithContext records on the response.
+func resolveLocalCommandString(command string, args []string) string {
+	if len(args) == 0 {
+		return MaskString(command)
+	}
+	return MaskString(command + " " + strings.Join(args, " "))
+}
+
+// resolveSshCommandString renders the bare `cmd arg1 arg2 ...` form the SSH
+// transport reports (sudo wrapping happens remotely and is not displayed).
+func resolveSshCommandString(command string, args []string) string {
+	if len(args) == 0 {
+		return MaskString(command)
+	}
+	return MaskString(command + " " + strings.Join(args, " "))
+}
+
 // CallExecCommand executes a command on the local host
 func CallExecCommand(input ExecCommandInput) (ExecCommandResponse, error) {
 	ctx := context.Background()
@@ -198,11 +243,7 @@ func CallExecCommandWithContext(ctx context.Context, input ExecCommandInput) (Ex
 		cmd.StdErrWriter = input.StderrWriter
 	}
 
-	resolved := command
-	if len(commandArgs) > 0 {
-		resolved = command + " " + strings.Join(commandArgs, " ")
-	}
-	resolved = MaskString(resolved)
+	resolved := resolveLocalCommandString(command, commandArgs)
 
 	res, err := cmd.Execute(ctx)
 	if err != nil {

--- a/subprocess/exec_test.go
+++ b/subprocess/exec_test.go
@@ -9,6 +9,69 @@ import (
 	"time"
 )
 
+func TestResolveCommandString(t *testing.T) {
+	t.Cleanup(func() { SetGlobalSensitive(nil) })
+	t.Cleanup(func() { SetDefaultHost("") })
+
+	tests := []struct {
+		name      string
+		input     ExecCommandInput
+		sensitive []string
+		want      string
+	}{
+		{
+			name:  "bare command, no args",
+			input: ExecCommandInput{Command: "dokku"},
+			want:  "dokku",
+		},
+		{
+			name:  "command with args",
+			input: ExecCommandInput{Command: "dokku", Args: []string{"--quiet", "apps:create", "api"}},
+			want:  "dokku --quiet apps:create api",
+		},
+		{
+			name:  "sudo wraps the command and args",
+			input: ExecCommandInput{Command: "dokku", Args: []string{"apps:create", "api"}, Sudo: true},
+			want:  "sudo -n -u root dokku apps:create api",
+		},
+		{
+			name:      "sensitive values are masked",
+			input:     ExecCommandInput{Command: "dokku", Args: []string{"config:set", "api", "KEY=topsecret"}},
+			sensitive: []string{"topsecret"},
+			want:      "dokku config:set api KEY=***",
+		},
+		{
+			name:  "ssh transport returns the bare form even with Sudo set",
+			input: ExecCommandInput{Command: "dokku", Args: []string{"apps:create", "api"}, Host: "alice@host", Sudo: true},
+			want:  "dokku apps:create api",
+		},
+		{
+			name:  "non-dokku command runs locally even with Host set",
+			input: ExecCommandInput{Command: "echo", Args: []string{"hi"}, Host: "alice@host"},
+			want:  "echo hi",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			SetGlobalSensitive(tc.sensitive)
+			t.Cleanup(func() { SetGlobalSensitive(nil) })
+			if got := ResolveCommandString(tc.input); got != tc.want {
+				t.Errorf("ResolveCommandString = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveCommandStringHonorsDefaultHost(t *testing.T) {
+	t.Cleanup(func() { SetDefaultHost("") })
+	SetDefaultHost("alice@host")
+	got := ResolveCommandString(ExecCommandInput{Command: "dokku", Args: []string{"apps:create", "api"}, Sudo: true})
+	want := "dokku apps:create api"
+	if got != want {
+		t.Errorf("ResolveCommandString with default host = %q, want %q", got, want)
+	}
+}
+
 func TestExecCommandResponseStdoutContents(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -207,4 +270,3 @@ func TestCallExecCommandResponseCommandUnmaskedWhenNoSecrets(t *testing.T) {
 		t.Errorf("response.Command unexpectedly altered: %q", resp.Command)
 	}
 }
-

--- a/subprocess/ssh.go
+++ b/subprocess/ssh.go
@@ -339,7 +339,7 @@ func CallSshCommandWithContext(ctx context.Context, host string, input ExecComma
 		cmd.StdErrWriter = input.StderrWriter
 	}
 
-	resolved := MaskString(input.Command + " " + strings.Join(input.Args, " "))
+	resolved := resolveSshCommandString(input.Command, input.Args)
 
 	res, runErr := cmd.Execute(ctx)
 	resp := ExecCommandResponse{

--- a/tasks/acl_app_task.go
+++ b/tasks/acl_app_task.go
@@ -96,26 +96,21 @@ func (t AclAppTask) Plan() PlanResult {
 			if len(toAdd) == 0 {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := make([]subprocess.ExecCommandInput, 0, len(toAdd))
+			for _, u := range toAdd {
+				inputs = append(inputs, subprocess.ExecCommandInput{
+					Command: "dokku",
+					Args:    []string{"--quiet", "acl:add", t.App, u},
+				})
+			}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
 				Reason:    fmt.Sprintf("%d user(s) to add", len(toAdd)),
 				Mutations: mutations,
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StateAbsent}
-					for _, u := range toAdd {
-						result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-							Command: "dokku",
-							Args:    []string{"--quiet", "acl:add", t.App, u},
-						})
-						state.Commands = append(state.Commands, result.Command)
-						if err != nil {
-							return TaskOutputErrorFromExec(state, err, result)
-						}
-					}
-					state.Changed = true
-					state.State = StatePresent
-					return state
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
@@ -142,26 +137,21 @@ func (t AclAppTask) Plan() PlanResult {
 			if len(toRemove) == 0 {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := make([]subprocess.ExecCommandInput, 0, len(toRemove))
+			for _, u := range toRemove {
+				inputs = append(inputs, subprocess.ExecCommandInput{
+					Command: "dokku",
+					Args:    []string{"--quiet", "acl:remove", t.App, u},
+				})
+			}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
 				Reason:    fmt.Sprintf("%d user(s) to remove", len(toRemove)),
 				Mutations: mutations,
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StatePresent}
-					for _, u := range toRemove {
-						result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-							Command: "dokku",
-							Args:    []string{"--quiet", "acl:remove", t.App, u},
-						})
-						state.Commands = append(state.Commands, result.Command)
-						if err != nil {
-							return TaskOutputErrorFromExec(state, err, result)
-						}
-					}
-					state.Changed = true
-					state.State = StateAbsent
-					return state
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},

--- a/tasks/acl_service_task.go
+++ b/tasks/acl_service_task.go
@@ -102,26 +102,21 @@ func (t AclServiceTask) Plan() PlanResult {
 			if len(toAdd) == 0 {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := make([]subprocess.ExecCommandInput, 0, len(toAdd))
+			for _, u := range toAdd {
+				inputs = append(inputs, subprocess.ExecCommandInput{
+					Command: "dokku",
+					Args:    []string{"--quiet", "acl:add-service", t.Type, t.Service, u},
+				})
+			}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
 				Reason:    fmt.Sprintf("%d user(s) to add", len(toAdd)),
 				Mutations: mutations,
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StateAbsent}
-					for _, u := range toAdd {
-						result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-							Command: "dokku",
-							Args:    []string{"--quiet", "acl:add-service", t.Type, t.Service, u},
-						})
-						state.Commands = append(state.Commands, result.Command)
-						if err != nil {
-							return TaskOutputErrorFromExec(state, err, result)
-						}
-					}
-					state.Changed = true
-					state.State = StatePresent
-					return state
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
@@ -148,26 +143,21 @@ func (t AclServiceTask) Plan() PlanResult {
 			if len(toRemove) == 0 {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := make([]subprocess.ExecCommandInput, 0, len(toRemove))
+			for _, u := range toRemove {
+				inputs = append(inputs, subprocess.ExecCommandInput{
+					Command: "dokku",
+					Args:    []string{"--quiet", "acl:remove-service", t.Type, t.Service, u},
+				})
+			}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
 				Reason:    fmt.Sprintf("%d user(s) to remove", len(toRemove)),
 				Mutations: mutations,
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StatePresent}
-					for _, u := range toRemove {
-						result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-							Command: "dokku",
-							Args:    []string{"--quiet", "acl:remove-service", t.Type, t.Service, u},
-						})
-						state.Commands = append(state.Commands, result.Command)
-						if err != nil {
-							return TaskOutputErrorFromExec(state, err, result)
-						}
-					}
-					state.Changed = true
-					state.State = StateAbsent
-					return state
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},

--- a/tasks/app_clone_task.go
+++ b/tasks/app_clone_task.go
@@ -83,29 +83,20 @@ func (t AppCloneTask) Plan() PlanResult {
 			if exists {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			args := []string{"--quiet", "apps:clone"}
+			if t.SkipDeploy {
+				args = append(args, "--skip-deploy")
+			}
+			args = append(args, t.SourceApp, t.App)
+			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusCreate,
 				Reason:    fmt.Sprintf("target app %s missing", t.App),
 				Mutations: []string{fmt.Sprintf("clone %s -> %s", t.SourceApp, t.App)},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StateAbsent}
-					args := []string{"--quiet", "apps:clone"}
-					if t.SkipDeploy {
-						args = append(args, "--skip-deploy")
-					}
-					args = append(args, t.SourceApp, t.App)
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    args,
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StatePresent
-					return state
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},

--- a/tasks/app_lock_task.go
+++ b/tasks/app_lock_task.go
@@ -72,24 +72,18 @@ func (t AppLockTask) Plan() PlanResult {
 			if locked {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", "apps:lock", t.App},
+			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
 				Reason:    "app unlocked",
 				Mutations: []string{"lock " + t.App},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StateAbsent}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    []string{"--quiet", "apps:lock", t.App},
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StatePresent
-					return state
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
@@ -101,24 +95,18 @@ func (t AppLockTask) Plan() PlanResult {
 			if !locked {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", "apps:unlock", t.App},
+			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
 				Reason:    "app locked",
 				Mutations: []string{"unlock " + t.App},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StatePresent}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    []string{"--quiet", "apps:unlock", t.App},
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StateAbsent
-					return state
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},

--- a/tasks/app_task.go
+++ b/tasks/app_task.go
@@ -67,12 +67,16 @@ func (t AppTask) Plan() PlanResult {
 			if exists {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := createAppInputs(t.App)
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusCreate,
 				Reason:    "app missing",
 				Mutations: []string{"create app " + t.App},
-				apply:     applyCreateApp(t.App),
+				Commands:  resolveCommands(inputs),
+				apply: func() TaskOutputState {
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				},
 			}
 		},
 		StateAbsent: func() PlanResult {
@@ -83,12 +87,16 @@ func (t AppTask) Plan() PlanResult {
 			if !exists {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := destroyAppInputs(t.App)
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
 				Reason:    "app present",
 				Mutations: []string{"destroy app " + t.App},
-				apply:     applyDestroyApp(t.App),
+				Commands:  resolveCommands(inputs),
+				apply: func() TaskOutputState {
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				},
 			}
 		},
 	})
@@ -105,39 +113,17 @@ func appExists(appName string) (bool, error) {
 	})
 }
 
-// applyCreateApp returns a closure that runs `dokku apps:create <app>`.
-func applyCreateApp(app string) func() TaskOutputState {
-	return func() TaskOutputState {
-		state := TaskOutputState{Changed: false, State: StateAbsent}
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    []string{"--quiet", "apps:create", app},
-		})
-		state.Commands = append(state.Commands, result.Command)
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-		state.Changed = true
-		state.State = StatePresent
-		return state
+// createAppInputs returns the subprocess inputs that create app.
+func createAppInputs(app string) []subprocess.ExecCommandInput {
+	return []subprocess.ExecCommandInput{
+		{Command: "dokku", Args: []string{"--quiet", "apps:create", app}},
 	}
 }
 
-// applyDestroyApp returns a closure that runs `dokku --force apps:destroy <app>`.
-func applyDestroyApp(app string) func() TaskOutputState {
-	return func() TaskOutputState {
-		state := TaskOutputState{Changed: false, State: StatePresent}
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    []string{"--quiet", "--force", "apps:destroy", app},
-		})
-		state.Commands = append(state.Commands, result.Command)
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-		state.Changed = true
-		state.State = StateAbsent
-		return state
+// destroyAppInputs returns the subprocess inputs that destroy app.
+func destroyAppInputs(app string) []subprocess.ExecCommandInput {
+	return []subprocess.ExecCommandInput{
+		{Command: "dokku", Args: []string{"--quiet", "--force", "apps:destroy", app}},
 	}
 }
 
@@ -148,7 +134,7 @@ func destroyApp(app string) TaskOutputState {
 	if !exists {
 		return TaskOutputState{Changed: false, State: StateAbsent}
 	}
-	return applyDestroyApp(app)()
+	return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, destroyAppInputs(app))
 }
 
 // createApp is retained as an integration-test helper. It runs the
@@ -158,7 +144,7 @@ func createApp(app string) TaskOutputState {
 	if exists {
 		return TaskOutputState{Changed: false, State: StatePresent}
 	}
-	return applyCreateApp(app)()
+	return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, createAppInputs(app))
 }
 
 // init registers the AppTask with the task registry

--- a/tasks/buildpacks_task.go
+++ b/tasks/buildpacks_task.go
@@ -110,26 +110,21 @@ func planBuildpacksAdd(t BuildpacksTask) PlanResult {
 	if len(current) == 0 {
 		status = PlanStatusCreate
 	}
+	inputs := make([]subprocess.ExecCommandInput, 0, len(toAdd))
+	for _, bp := range toAdd {
+		inputs = append(inputs, subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", "buildpacks:add", t.App, bp},
+		})
+	}
 	return PlanResult{
 		InSync:    false,
 		Status:    status,
 		Reason:    fmt.Sprintf("%d buildpack(s) to add", len(toAdd)),
 		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
 		apply: func() TaskOutputState {
-			state := TaskOutputState{Changed: false, State: StateAbsent}
-			for _, bp := range toAdd {
-				result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-					Command: "dokku",
-					Args:    []string{"--quiet", "buildpacks:add", t.App, bp},
-				})
-				state.Commands = append(state.Commands, result.Command)
-				if err != nil {
-					return TaskOutputErrorFromExec(state, err, result)
-				}
-			}
-			state.Changed = true
-			state.State = StatePresent
-			return state
+			return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 		},
 	}
 }
@@ -150,25 +145,18 @@ func planBuildpacksRemove(t BuildpacksTask) PlanResult {
 		for bp := range current {
 			mutations = append(mutations, "remove "+bp)
 		}
-		app := t.App
+		inputs := []subprocess.ExecCommandInput{{
+			Command: "dokku",
+			Args:    []string{"--quiet", "buildpacks:clear", t.App},
+		}}
 		return PlanResult{
 			InSync:    false,
 			Status:    PlanStatusDestroy,
 			Reason:    fmt.Sprintf("clear %d buildpack(s)", len(current)),
 			Mutations: mutations,
+			Commands:  resolveCommands(inputs),
 			apply: func() TaskOutputState {
-				state := TaskOutputState{Changed: false, State: StatePresent}
-				result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-					Command: "dokku",
-					Args:    []string{"--quiet", "buildpacks:clear", app},
-				})
-				state.Commands = append(state.Commands, result.Command)
-				if err != nil {
-					return TaskOutputErrorFromExec(state, err, result)
-				}
-				state.Changed = true
-				state.State = StateAbsent
-				return state
+				return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 			},
 		}
 	}
@@ -183,26 +171,21 @@ func planBuildpacksRemove(t BuildpacksTask) PlanResult {
 	if len(toRemove) == 0 {
 		return PlanResult{InSync: true, Status: PlanStatusOK}
 	}
+	inputs := make([]subprocess.ExecCommandInput, 0, len(toRemove))
+	for _, bp := range toRemove {
+		inputs = append(inputs, subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", "buildpacks:remove", t.App, bp},
+		})
+	}
 	return PlanResult{
 		InSync:    false,
 		Status:    PlanStatusDestroy,
 		Reason:    fmt.Sprintf("%d buildpack(s) to remove", len(toRemove)),
 		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
 		apply: func() TaskOutputState {
-			state := TaskOutputState{Changed: false, State: StatePresent}
-			for _, bp := range toRemove {
-				result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-					Command: "dokku",
-					Args:    []string{"--quiet", "buildpacks:remove", t.App, bp},
-				})
-				state.Commands = append(state.Commands, result.Command)
-				if err != nil {
-					return TaskOutputErrorFromExec(state, err, result)
-				}
-			}
-			state.Changed = true
-			state.State = StateAbsent
-			return state
+			return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 		},
 	}
 }

--- a/tasks/certs_task.go
+++ b/tasks/certs_task.go
@@ -110,28 +110,19 @@ func (t CertsTask) Plan() PlanResult {
 			if t.Global {
 				target = "(global)"
 			}
+			args := []string{"--quiet", "certs:add", t.App, t.Cert, t.Key}
+			if t.Global {
+				args = []string{"--quiet", "global-cert:set", t.Cert, t.Key}
+			}
+			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusCreate,
 				Reason:    "certificate not installed",
 				Mutations: []string{fmt.Sprintf("install certificate for %s", target)},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StateAbsent}
-					args := []string{"--quiet", "certs:add", t.App, t.Cert, t.Key}
-					if t.Global {
-						args = []string{"--quiet", "global-cert:set", t.Cert, t.Key}
-					}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    args,
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StatePresent
-					return state
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
@@ -150,28 +141,19 @@ func (t CertsTask) Plan() PlanResult {
 			if t.Global {
 				target = "(global)"
 			}
+			args := []string{"--quiet", "certs:remove", t.App}
+			if t.Global {
+				args = []string{"--quiet", "global-cert:remove"}
+			}
+			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
 				Reason:    "certificate present",
 				Mutations: []string{fmt.Sprintf("remove certificate for %s", target)},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StatePresent}
-					args := []string{"--quiet", "certs:remove", t.App}
-					if t.Global {
-						args = []string{"--quiet", "global-cert:remove"}
-					}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    args,
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StateAbsent
-					return state
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},

--- a/tasks/config_task.go
+++ b/tasks/config_task.go
@@ -144,32 +144,23 @@ func planConfigSet(t ConfigTask) PlanResult {
 	if allNew {
 		status = PlanStatusCreate
 	}
+	args := []string{"--quiet", "config:set", "--encoded"}
+	if !t.Restart {
+		args = append(args, "--no-restart")
+	}
+	args = append(args, t.App)
+	for _, k := range keys {
+		args = append(args, fmt.Sprintf("%s=%s", k, base64.StdEncoding.EncodeToString([]byte(t.Config[k]))))
+	}
+	inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
 	return PlanResult{
 		InSync:    false,
 		Status:    status,
 		Reason:    fmt.Sprintf("%d key(s) to set", len(keys)),
 		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
 		apply: func() TaskOutputState {
-			state := TaskOutputState{Changed: false, State: StateAbsent}
-			args := []string{"--quiet", "config:set", "--encoded"}
-			if !t.Restart {
-				args = append(args, "--no-restart")
-			}
-			args = append(args, t.App)
-			for _, k := range keys {
-				args = append(args, fmt.Sprintf("%s=%s", k, base64.StdEncoding.EncodeToString([]byte(t.Config[k]))))
-			}
-			result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-				Command: "dokku",
-				Args:    args,
-			})
-			state.Commands = append(state.Commands, result.Command)
-			if err != nil {
-				return TaskOutputErrorFromExec(state, err, result)
-			}
-			state.Changed = true
-			state.State = StatePresent
-			return state
+			return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 		},
 	}
 }
@@ -189,30 +180,21 @@ func planConfigUnset(t ConfigTask) PlanResult {
 	for _, k := range keys {
 		mutations = append(mutations, fmt.Sprintf("unset %s", k))
 	}
+	args := []string{"--quiet", "config:unset"}
+	if !t.Restart {
+		args = append(args, "--no-restart")
+	}
+	args = append(args, t.App)
+	args = append(args, keys...)
+	inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
 	return PlanResult{
 		InSync:    false,
 		Status:    PlanStatusDestroy,
 		Reason:    fmt.Sprintf("%d key(s) to unset", len(keys)),
 		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
 		apply: func() TaskOutputState {
-			state := TaskOutputState{Changed: false, State: StatePresent}
-			args := []string{"--quiet", "config:unset"}
-			if !t.Restart {
-				args = append(args, "--no-restart")
-			}
-			args = append(args, t.App)
-			args = append(args, keys...)
-			result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-				Command: "dokku",
-				Args:    args,
-			})
-			state.Commands = append(state.Commands, result.Command)
-			if err != nil {
-				return TaskOutputErrorFromExec(state, err, result)
-			}
-			state.Changed = true
-			state.State = StateAbsent
-			return state
+			return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 		},
 	}
 }

--- a/tasks/dispatch.go
+++ b/tasks/dispatch.go
@@ -1,6 +1,40 @@
 package tasks
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// resolveCommands renders the list of ExecCommandInputs to the masked,
+// dispatch-aware command lines apply would echo on execution. Tasks call
+// it from Plan() to populate PlanResult.Commands so plan output and
+// apply --verbose render byte-identical strings for the same operation.
+func resolveCommands(inputs []subprocess.ExecCommandInput) []string {
+	out := make([]string, len(inputs))
+	for i, in := range inputs {
+		out[i] = subprocess.ResolveCommandString(in)
+	}
+	return out
+}
+
+// runExecInputs runs each input in order, appending the resolved command
+// line to state.Commands and bailing on the first error. Used by
+// Plan-built apply closures that just need to invoke a list of dokku
+// commands sequentially.
+func runExecInputs(initial TaskOutputState, finalState State, inputs []subprocess.ExecCommandInput) TaskOutputState {
+	state := initial
+	for _, in := range inputs {
+		result, err := subprocess.CallExecCommand(in)
+		state.Commands = append(state.Commands, result.Command)
+		if err != nil {
+			return TaskOutputErrorFromExec(state, err, result)
+		}
+	}
+	state.Changed = true
+	state.State = finalState
+	return state
+}
 
 // DispatchState looks up the given state in the funcMap, calls the matching function,
 // and returns an error TaskOutputState if the state is not found.

--- a/tasks/docker_options_task.go
+++ b/tasks/docker_options_task.go
@@ -84,24 +84,18 @@ func (t DockerOptionsTask) Plan() PlanResult {
 			if optionPresent(current[t.Phase], t.Option) {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", "docker-options:add", t.App, t.Phase, t.Option},
+			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusCreate,
 				Reason:    fmt.Sprintf("missing on %s phase", t.Phase),
 				Mutations: []string{fmt.Sprintf("add %s option %q", t.Phase, t.Option)},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StateAbsent}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    []string{"--quiet", "docker-options:add", t.App, t.Phase, t.Option},
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StatePresent
-					return state
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
@@ -116,24 +110,18 @@ func (t DockerOptionsTask) Plan() PlanResult {
 			if !optionPresent(current[t.Phase], t.Option) {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", "docker-options:remove", t.App, t.Phase, t.Option},
+			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
 				Reason:    fmt.Sprintf("present on %s phase", t.Phase),
 				Mutations: []string{fmt.Sprintf("remove %s option %q", t.Phase, t.Option)},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StatePresent}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    []string{"--quiet", "docker-options:remove", t.App, t.Phase, t.Option},
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StateAbsent
-					return state
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},

--- a/tasks/domains_task.go
+++ b/tasks/domains_task.go
@@ -121,11 +121,13 @@ func planDomainsPresent(t DomainsTask) PlanResult {
 		subcommand = "domains:add-global"
 		appName = "--global"
 	}
+	inputs := dokkuArgsInputs(subcommand, appName, toAdd)
 	return PlanResult{
 		InSync:    false,
 		Status:    status,
 		Reason:    fmt.Sprintf("%d domain(s) to add", len(toAdd)),
 		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
 		apply:     applyDokkuArgs(subcommand, appName, toAdd, StatePresent, StateAbsent),
 	}
 }
@@ -156,11 +158,13 @@ func planDomainsAbsent(t DomainsTask) PlanResult {
 		subcommand = "domains:remove-global"
 		appName = "--global"
 	}
+	inputs := dokkuArgsInputs(subcommand, appName, toRemove)
 	return PlanResult{
 		InSync:    false,
 		Status:    PlanStatusDestroy,
 		Reason:    fmt.Sprintf("%d domain(s) to remove", len(toRemove)),
 		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
 		apply:     applyDokkuArgs(subcommand, appName, toRemove, StateAbsent, StatePresent),
 	}
 }
@@ -198,11 +202,13 @@ func planDomainsSet(t DomainsTask) PlanResult {
 		subcommand = "domains:set-global"
 		appName = "--global"
 	}
+	inputs := dokkuArgsInputs(subcommand, appName, t.Domains)
 	return PlanResult{
 		InSync:    false,
 		Status:    PlanStatusModify,
 		Reason:    fmt.Sprintf("%d domain change(s)", len(mutations)),
 		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
 		apply:     applyDokkuArgs(subcommand, appName, t.Domains, StateSet, StateAbsent),
 	}
 }
@@ -229,34 +235,32 @@ func planDomainsClear(t DomainsTask) PlanResult {
 		subcommand = "domains:clear-global"
 		appName = "--global"
 	}
+	inputs := dokkuArgsInputs(subcommand, appName, nil)
 	return PlanResult{
 		InSync:    false,
 		Status:    PlanStatusDestroy,
 		Reason:    fmt.Sprintf("clear %d domain(s)", len(currentDomains)),
 		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
 		apply:     applyDokkuArgs(subcommand, appName, nil, StateClear, StatePresent),
 	}
+}
+
+// dokkuArgsInputs returns the subprocess inputs that run `dokku --quiet
+// <subcommand> <target> <extra...>`.
+func dokkuArgsInputs(subcommand, target string, extra []string) []subprocess.ExecCommandInput {
+	args := []string{"--quiet", subcommand, target}
+	args = append(args, extra...)
+	return []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
 }
 
 // applyDokkuArgs returns a closure that runs `dokku --quiet <subcommand>
 // <target> <extra...>`. It is used by domains plan paths to share the
 // boilerplate around constructing the subprocess call.
 func applyDokkuArgs(subcommand, target string, extra []string, finalState State, errState State) func() TaskOutputState {
+	inputs := dokkuArgsInputs(subcommand, target, extra)
 	return func() TaskOutputState {
-		state := TaskOutputState{Changed: false, State: errState}
-		args := []string{"--quiet", subcommand, target}
-		args = append(args, extra...)
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    args,
-		})
-		state.Commands = append(state.Commands, result.Command)
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-		state.Changed = true
-		state.State = finalState
-		return state
+		return runExecInputs(TaskOutputState{State: errState}, finalState, inputs)
 	}
 }
 

--- a/tasks/git_auth_task.go
+++ b/tasks/git_auth_task.go
@@ -83,46 +83,34 @@ func (t GitAuthTask) Plan() PlanResult {
 			if t.Username == "" || t.Password == "" {
 				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'username' and 'password' are required when state is 'present'")}
 			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", "git:auth", t.Host, t.Username, t.Password},
+			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
 				Reason:    "netrc state not probed",
 				Mutations: []string{"git:auth " + t.Host + " " + t.Username + " " + t.Password},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StateAbsent}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    []string{"--quiet", "git:auth", t.Host, t.Username, t.Password},
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StatePresent
-					return state
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", "git:auth", t.Host},
+			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
 				Reason:    "netrc state not probed",
 				Mutations: []string{"git:auth " + t.Host + " (clear)"},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StatePresent}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    []string{"--quiet", "git:auth", t.Host},
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StateAbsent
-					return state
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},

--- a/tasks/git_from_archive_task.go
+++ b/tasks/git_from_archive_task.go
@@ -105,28 +105,19 @@ func (t GitFromArchiveTask) Plan() PlanResult {
 			if match {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			args := []string{"git:from-archive", "--archive-type", archiveType, t.App, t.ArchiveURL}
+			if t.GitUsername != "" {
+				args = append(args, t.GitUsername, t.GitEmail)
+			}
+			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
 				Reason:    "archive source drift",
 				Mutations: []string{fmt.Sprintf("git:from-archive %s %s (%s)", t.App, t.ArchiveURL, archiveType)},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: "undeployed"}
-					args := []string{"git:from-archive", "--archive-type", archiveType, t.App, t.ArchiveURL}
-					if t.GitUsername != "" {
-						args = append(args, t.GitUsername, t.GitEmail)
-					}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    args,
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StateDeployed
-					return state
+					return runExecInputs(TaskOutputState{State: "undeployed"}, StateDeployed, inputs)
 				},
 			}
 		},

--- a/tasks/git_from_image_task.go
+++ b/tasks/git_from_image_task.go
@@ -71,35 +71,26 @@ func (t GitFromImageTask) Plan() PlanResult {
 			if match {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			args := []string{"git:from-image"}
+			if t.BuildDir != "" {
+				args = append(args, "--build-dir", t.BuildDir)
+			}
+			args = append(args, t.App, t.Image)
+			if t.GitUsername != "" {
+				args = append(args, t.GitUsername)
+			}
+			if t.GitEmail != "" {
+				args = append(args, t.GitEmail)
+			}
+			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
 				Reason:    "image source drift",
 				Mutations: []string{fmt.Sprintf("git:from-image %s %s", t.App, t.Image)},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: "undeployed"}
-					args := []string{"git:from-image"}
-					if t.BuildDir != "" {
-						args = append(args, "--build-dir", t.BuildDir)
-					}
-					args = append(args, t.App, t.Image)
-					if t.GitUsername != "" {
-						args = append(args, t.GitUsername)
-					}
-					if t.GitEmail != "" {
-						args = append(args, t.GitEmail)
-					}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    args,
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StateDeployed
-					return state
+					return runExecInputs(TaskOutputState{State: "undeployed"}, StateDeployed, inputs)
 				},
 			}
 		},

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -92,38 +92,29 @@ func (t GitSyncTask) Plan() PlanResult {
 			if ref == "" {
 				ref = "(default branch)"
 			}
+			args := []string{"git:sync"}
+			if t.Build {
+				args = append(args, "--build")
+			}
+			if t.BuildIfChanges {
+				args = append(args, "--build-if-changes")
+			}
+			if t.SkipDeployBranch {
+				args = append(args, "--skip-deploy-branch")
+			}
+			args = append(args, t.App, t.Remote)
+			if t.GitRef != "" {
+				args = append(args, t.GitRef)
+			}
+			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
 				Reason:    "remote/ref drift",
 				Mutations: []string{fmt.Sprintf("git:sync %s %s %s", t.App, t.Remote, ref)},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StateAbsent}
-					args := []string{"git:sync"}
-					if t.Build {
-						args = append(args, "--build")
-					}
-					if t.BuildIfChanges {
-						args = append(args, "--build-if-changes")
-					}
-					if t.SkipDeployBranch {
-						args = append(args, "--skip-deploy-branch")
-					}
-					args = append(args, t.App, t.Remote)
-					if t.GitRef != "" {
-						args = append(args, t.GitRef)
-					}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    args,
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StatePresent
-					return state
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},

--- a/tasks/http_auth_task.go
+++ b/tasks/http_auth_task.go
@@ -85,24 +85,18 @@ func (t HttpAuthTask) Plan() PlanResult {
 			if enabled {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", "http-auth:on", t.App, t.Username, t.Password},
+			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusCreate,
 				Reason:    "http-auth disabled",
 				Mutations: []string{"http-auth:on " + t.App},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StateAbsent}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    []string{"--quiet", "http-auth:on", t.App, t.Username, t.Password},
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StatePresent
-					return state
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
@@ -114,24 +108,18 @@ func (t HttpAuthTask) Plan() PlanResult {
 			if !enabled {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", "http-auth:off", t.App},
+			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
 				Reason:    "http-auth enabled",
 				Mutations: []string{"http-auth:off " + t.App},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StatePresent}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    []string{"--quiet", "http-auth:off", t.App},
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StateAbsent
-					return state
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},

--- a/tasks/letsencrypt_task.go
+++ b/tasks/letsencrypt_task.go
@@ -73,24 +73,18 @@ func (t LetsencryptTask) Plan() PlanResult {
 			if active {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", "letsencrypt:enable", t.App},
+			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusCreate,
 				Reason:    "letsencrypt not active",
 				Mutations: []string{"letsencrypt:enable " + t.App},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StateAbsent}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    []string{"--quiet", "letsencrypt:enable", t.App},
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StatePresent
-					return state
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
@@ -102,24 +96,18 @@ func (t LetsencryptTask) Plan() PlanResult {
 			if !active {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", "letsencrypt:disable", t.App},
+			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
 				Reason:    "letsencrypt active",
 				Mutations: []string{"letsencrypt:disable " + t.App},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StatePresent}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    []string{"--quiet", "letsencrypt:disable", t.App},
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StateAbsent
-					return state
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -135,6 +135,18 @@ type PlanResult struct {
 	// individual keys). One entry per atomic change.
 	Mutations []string
 
+	// Commands is the resolved dokku command line(s) that ExecutePlan
+	// would invoke if Plan reported drift, in invocation order. Tasks
+	// populate it via subprocess.ResolveCommandString from the same
+	// ExecCommandInput values the apply closure executes, so plan and
+	// apply render byte-identical strings for the same operation.
+	//
+	// Contract: non-empty whenever Status is "+", "~", or "-" (drift);
+	// empty when InSync is true or when Status is "!" (probe error).
+	// Sensitive values are already masked because ResolveCommandString
+	// runs MaskString on the rendered form.
+	Commands []string
+
 	// DesiredState mirrors TaskOutputState.DesiredState so plan output can
 	// render the same context as apply output.
 	DesiredState State

--- a/tasks/network_task.go
+++ b/tasks/network_task.go
@@ -67,24 +67,18 @@ func (t NetworkTask) Plan() PlanResult {
 			if exists {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", "network:create", t.Name},
+			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusCreate,
 				Reason:    "network missing",
 				Mutations: []string{"create network " + t.Name},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StateAbsent}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    []string{"--quiet", "network:create", t.Name},
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StatePresent
-					return state
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
@@ -96,24 +90,18 @@ func (t NetworkTask) Plan() PlanResult {
 			if !exists {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", "--force", "network:destroy", t.Name},
+			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
 				Reason:    "network present",
 				Mutations: []string{"destroy network " + t.Name},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StatePresent}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    []string{"--quiet", "--force", "network:destroy", t.Name},
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StateAbsent
-					return state
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},

--- a/tasks/plan_integration_test.go
+++ b/tasks/plan_integration_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -98,6 +99,35 @@ func TestIntegrationPlanConfigItemizes(t *testing.T) {
 	}
 	if len(plan.Mutations) != 2 {
 		t.Errorf("expected 2 mutations (one per key), got %d: %v", len(plan.Mutations), plan.Mutations)
+	}
+	if len(plan.Commands) == 0 {
+		t.Error("expected Commands to be populated for drift; got empty slice")
+	}
+}
+
+// TestIntegrationPlanCommandsPopulatedOnDrift asserts the per-task contract
+// that whenever Plan() reports drift (Status `+`/`~`/`-`), Commands carries
+// at least one resolved dokku command line. The matching strings are what
+// `docket plan --json` emits in the `commands` array.
+func TestIntegrationPlanCommandsPopulatedOnDrift(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-plan-commands"
+	destroyApp(appName)
+	defer destroyApp(appName)
+
+	plan := (AppTask{App: appName, State: StatePresent}).Plan()
+	if plan.Error != nil {
+		t.Fatalf("plan errored: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Fatal("expected drift on missing app")
+	}
+	if len(plan.Commands) == 0 {
+		t.Fatal("expected Commands to be populated for drift")
+	}
+	if !strings.Contains(plan.Commands[0], "apps:create") {
+		t.Errorf("expected first command to mention apps:create, got %q", plan.Commands[0])
 	}
 }
 

--- a/tasks/plan_result_test.go
+++ b/tasks/plan_result_test.go
@@ -1,0 +1,86 @@
+package tasks
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPlanResultCommandsContractStatic walks every *_task.go (and the shared
+// helper files properties.go / toggle.go / resources.go) in the tasks package
+// and asserts that every PlanResult composite literal carrying a non-empty
+// `apply:` field also sets `Commands:`. Catches future tasks added without
+// populating Commands when drift is reported - a regression would silently
+// drop the `commands` array from `docket plan --json` output.
+//
+// The check is purely structural and runs without a Dokku server, complementing
+// the integration tests in plan_integration_test.go that exercise Plan() end
+// to end against a real server.
+func TestPlanResultCommandsContractStatic(t *testing.T) {
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	files, err := filepath.Glob(filepath.Join(dir, "*.go"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+
+	fs := token.NewFileSet()
+	for _, path := range files {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		base := filepath.Base(path)
+		if !strings.HasSuffix(base, "_task.go") &&
+			base != "properties.go" && base != "toggle.go" && base != "resources.go" {
+			continue
+		}
+
+		f, err := parser.ParseFile(fs, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parse %s: %v", base, err)
+		}
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			lit, ok := n.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			id, ok := lit.Type.(*ast.Ident)
+			if !ok || id.Name != "PlanResult" {
+				return true
+			}
+			hasApply := false
+			hasCommands := false
+			for _, elt := range lit.Elts {
+				kv, ok := elt.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				key, ok := kv.Key.(*ast.Ident)
+				if !ok {
+					continue
+				}
+				switch key.Name {
+				case "apply":
+					hasApply = true
+				case "Commands":
+					hasCommands = true
+				}
+			}
+			if hasApply && !hasCommands {
+				pos := fs.Position(lit.Pos())
+				t.Errorf("%s:%d: PlanResult composite literal sets `apply:` but not `Commands:` - "+
+					"populate Commands via resolveCommands(inputs) so `docket plan --json` "+
+					"reports the dokku command(s) apply would run.",
+					filepath.Base(pos.Filename), pos.Line)
+			}
+			return true
+		})
+	}
+}

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -92,28 +92,19 @@ func (t PortsTask) Plan() PlanResult {
 			if len(currentPorts) == 0 {
 				status = PlanStatusCreate
 			}
+			args := []string{"--quiet", "ports:add", t.App}
+			for _, pm := range toAdd {
+				args = append(args, pm.String())
+			}
+			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
 			return PlanResult{
 				InSync:    false,
 				Status:    status,
 				Reason:    fmt.Sprintf("%d port mapping(s) to add", len(toAdd)),
 				Mutations: mutations,
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StateAbsent}
-					args := []string{"--quiet", "ports:add", t.App}
-					for _, pm := range toAdd {
-						args = append(args, pm.String())
-					}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    args,
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StatePresent
-					return state
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
@@ -133,28 +124,19 @@ func (t PortsTask) Plan() PlanResult {
 			if len(toRemove) == 0 {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			args := []string{"--quiet", "ports:remove", t.App}
+			for _, pm := range toRemove {
+				args = append(args, pm.String())
+			}
+			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
 				Reason:    fmt.Sprintf("%d port mapping(s) to remove", len(toRemove)),
 				Mutations: mutations,
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StatePresent}
-					args := []string{"--quiet", "ports:remove", t.App}
-					for _, pm := range toRemove {
-						args = append(args, pm.String())
-					}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    args,
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StateAbsent
-					return state
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -118,11 +118,13 @@ func planProperty(state State, app string, global bool, property, value, subcomm
 				reason = fmt.Sprintf("%s drift on %s (was %q)", property, target, current)
 			}
 
+			inputs := propertySetInputs(subcommand, target, property, value)
 			return PlanResult{
 				InSync:    false,
 				Status:    status,
 				Reason:    reason,
 				Mutations: []string{fmt.Sprintf("set %s=%s", property, value)},
+				Commands:  resolveCommands(inputs),
 				apply:     applyPropertySet(subcommand, target, property, value),
 			}
 		},
@@ -152,33 +154,39 @@ func planProperty(state State, app string, global bool, property, value, subcomm
 				reason = fmt.Sprintf("would unset %s on %s (was %q)", property, target, current)
 			}
 
+			inputs := propertyUnsetInputs(subcommand, target, property)
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
 				Reason:    reason,
 				Mutations: []string{fmt.Sprintf("unset %s", property)},
+				Commands:  resolveCommands(inputs),
 				apply:     applyPropertyUnset(subcommand, target, property),
 			}
 		},
 	})
 }
 
+// propertySetInputs returns the subprocess inputs that set a property.
+func propertySetInputs(subcommand, target, property, value string) []subprocess.ExecCommandInput {
+	return []subprocess.ExecCommandInput{
+		{Command: "dokku", Args: []string{"--quiet", subcommand, target, property, value}},
+	}
+}
+
+// propertyUnsetInputs returns the subprocess inputs that unset a property.
+func propertyUnsetInputs(subcommand, target, property string) []subprocess.ExecCommandInput {
+	return []subprocess.ExecCommandInput{
+		{Command: "dokku", Args: []string{"--quiet", subcommand, target, property}},
+	}
+}
+
 // applyPropertySet returns a closure that runs `dokku <subcommand> <target>
 // <property> <value>` and converts the result into a TaskOutputState.
 func applyPropertySet(subcommand, target, property, value string) func() TaskOutputState {
+	inputs := propertySetInputs(subcommand, target, property, value)
 	return func() TaskOutputState {
-		state := TaskOutputState{Changed: false, State: StateAbsent}
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    []string{"--quiet", subcommand, target, property, value},
-		})
-		state.Commands = append(state.Commands, result.Command)
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-		state.Changed = true
-		state.State = StatePresent
-		return state
+		return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 	}
 }
 
@@ -186,18 +194,8 @@ func applyPropertySet(subcommand, target, property, value string) func() TaskOut
 // <property>` (no value, which dokku interprets as unset) and converts the
 // result into a TaskOutputState.
 func applyPropertyUnset(subcommand, target, property string) func() TaskOutputState {
+	inputs := propertyUnsetInputs(subcommand, target, property)
 	return func() TaskOutputState {
-		state := TaskOutputState{Changed: false, State: StatePresent}
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    []string{"--quiet", subcommand, target, property},
-		})
-		state.Commands = append(state.Commands, result.Command)
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-		state.Changed = true
-		state.State = StateAbsent
-		return state
+		return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 	}
 }

--- a/tasks/ps_scale_task.go
+++ b/tasks/ps_scale_task.go
@@ -100,30 +100,21 @@ func (t PsScaleTask) Plan() PlanResult {
 			if len(toScale) == 0 {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			args := []string{"ps:scale"}
+			if t.SkipDeploy {
+				args = append(args, "--skip-deploy")
+			}
+			args = append(args, t.App)
+			args = append(args, toScale...)
+			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
 				Reason:    fmt.Sprintf("%d process scale change(s)", len(mutations)),
 				Mutations: mutations,
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StateAbsent}
-					args := []string{"ps:scale"}
-					if t.SkipDeploy {
-						args = append(args, "--skip-deploy")
-					}
-					args = append(args, t.App)
-					args = append(args, toScale...)
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    args,
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StatePresent
-					return state
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},

--- a/tasks/registry_auth_task.go
+++ b/tasks/registry_auth_task.go
@@ -109,61 +109,46 @@ func (t RegistryAuthTask) Plan() PlanResult {
 			if t.Username == "" || t.Password == "" {
 				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'username' and 'password' are required when state is 'present'")}
 			}
+			args := []string{"--quiet", "registry:login", "--password-stdin"}
+			if t.Global {
+				args = append(args, "--global")
+			} else {
+				args = append(args, t.App)
+			}
+			args = append(args, t.Server, t.Username)
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    args,
+				Stdin:   strings.NewReader(t.Password),
+			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
 				Reason:    "registry login state not probed",
 				Mutations: []string{fmt.Sprintf("registry:login %s %s as %s", target, t.Server, t.Username)},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StateAbsent}
-					args := []string{"--quiet", "registry:login", "--password-stdin"}
-					if t.Global {
-						args = append(args, "--global")
-					} else {
-						args = append(args, t.App)
-					}
-					args = append(args, t.Server, t.Username)
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    args,
-						Stdin:   strings.NewReader(t.Password),
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StatePresent
-					return state
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
 		StateAbsent: func() PlanResult {
+			args := []string{"--quiet", "registry:logout"}
+			if t.Global {
+				args = append(args, "--global")
+			} else {
+				args = append(args, t.App)
+			}
+			args = append(args, t.Server)
+			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
 				Reason:    "registry login state not probed",
 				Mutations: []string{fmt.Sprintf("registry:logout %s %s", target, t.Server)},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StatePresent}
-					args := []string{"--quiet", "registry:logout"}
-					if t.Global {
-						args = append(args, "--global")
-					} else {
-						args = append(args, t.App)
-					}
-					args = append(args, t.Server)
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    args,
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StateAbsent
-					return state
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},

--- a/tasks/resources.go
+++ b/tasks/resources.go
@@ -114,11 +114,13 @@ func planSetResource(subcommand string, rctx ResourceContext) PlanResult {
 	if len(mutations) == 0 {
 		return PlanResult{InSync: true, Status: PlanStatusOK}
 	}
+	inputs := resourceSetInputs(subcommand, rctx)
 	return PlanResult{
 		InSync:    false,
 		Status:    PlanStatusModify,
 		Reason:    fmt.Sprintf("%d resource(s) to set", len(mutations)),
 		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
 		apply:     applyResourceSet(subcommand, rctx),
 	}
 }
@@ -141,89 +143,63 @@ func planClearResource(subcommand string, rctx ResourceContext) PlanResult {
 	if !hasResources {
 		return PlanResult{InSync: true, Status: PlanStatusOK}
 	}
+	inputs := []subprocess.ExecCommandInput{resourceClearInput(subcommand, rctx)}
 	return PlanResult{
 		InSync:    false,
 		Status:    PlanStatusDestroy,
 		Reason:    "would clear all resources",
 		Mutations: []string{fmt.Sprintf("clear resources via %s-clear", subcommand)},
+		Commands:  resolveCommands(inputs),
 		apply:     applyResourceClear(subcommand, rctx),
 	}
+}
+
+// resourceClearInput returns the subprocess input that runs the resource
+// clear command (`<subcommand>-clear`).
+func resourceClearInput(subcommand string, rctx ResourceContext) subprocess.ExecCommandInput {
+	args := []string{subcommand + "-clear"}
+	if rctx.ProcessType != "" {
+		args = append(args, "--process-type", rctx.ProcessType)
+	}
+	args = append(args, rctx.App)
+	return subprocess.ExecCommandInput{Command: "dokku", Args: args}
+}
+
+// resourceSetInputs returns the subprocess inputs that set resource limits.
+// When ClearBefore is true, the first input clears before the set runs.
+func resourceSetInputs(subcommand string, rctx ResourceContext) []subprocess.ExecCommandInput {
+	inputs := []subprocess.ExecCommandInput{}
+	if rctx.ClearBefore {
+		inputs = append(inputs, resourceClearInput(subcommand, rctx))
+	}
+	args := []string{subcommand}
+	for key, value := range rctx.Resources {
+		args = append(args, fmt.Sprintf("--%s", key), value)
+	}
+	if rctx.ProcessType != "" {
+		args = append(args, "--process-type", rctx.ProcessType)
+	}
+	args = append(args, rctx.App)
+	inputs = append(inputs, subprocess.ExecCommandInput{Command: "dokku", Args: args})
+	return inputs
 }
 
 // applyResourceSet returns a closure that runs the underlying resource
 // set command. ClearBefore is honored by clearing before setting.
 func applyResourceSet(subcommand string, rctx ResourceContext) func() TaskOutputState {
+	inputs := resourceSetInputs(subcommand, rctx)
 	return func() TaskOutputState {
-		state := TaskOutputState{Changed: false, State: StateAbsent}
-		if rctx.ClearBefore {
-			if err := execResourceClear(subcommand, rctx); err != nil {
-				state.Error = err
-				state.Message = err.Error()
-				return state
-			}
-			state.Changed = true
-		}
-
-		args := []string{subcommand}
-		for key, value := range rctx.Resources {
-			args = append(args, fmt.Sprintf("--%s", key), value)
-		}
-		if rctx.ProcessType != "" {
-			args = append(args, "--process-type", rctx.ProcessType)
-		}
-		args = append(args, rctx.App)
-
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    args,
-		})
-		state.Commands = append(state.Commands, result.Command)
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-		state.Changed = true
-		state.State = StatePresent
-		return state
+		return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 	}
 }
 
 // applyResourceClear returns a closure that runs the underlying resource
 // clear command (subcommand + "-clear").
 func applyResourceClear(subcommand string, rctx ResourceContext) func() TaskOutputState {
+	inputs := []subprocess.ExecCommandInput{resourceClearInput(subcommand, rctx)}
 	return func() TaskOutputState {
-		state := TaskOutputState{Changed: false, State: StatePresent}
-		if err := execResourceClear(subcommand, rctx); err != nil {
-			state.Error = err
-			state.Message = err.Error()
-			return state
-		}
-		state.Changed = true
-		state.State = StateAbsent
-		return state
+		return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 	}
-}
-
-// execResourceClear executes the dokku resource clear command
-func execResourceClear(subcommand string, rctx ResourceContext) error {
-	args := []string{
-		subcommand + "-clear",
-	}
-
-	if rctx.ProcessType != "" {
-		args = append(args, "--process-type", rctx.ProcessType)
-	}
-
-	args = append(args, rctx.App)
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return fmt.Errorf("%s", result.StderrContents())
-	}
-
-	return nil
 }
 
 // mapKeys returns the keys of a map as a slice

--- a/tasks/service_create_task.go
+++ b/tasks/service_create_task.go
@@ -80,24 +80,18 @@ func (t ServiceCreateTask) Plan() PlanResult {
 			if exists {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", fmt.Sprintf("%s:create", t.Service), t.Name},
+			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusCreate,
 				Reason:    fmt.Sprintf("%s service %s missing", t.Service, t.Name),
 				Mutations: []string{fmt.Sprintf("%s:create %s", t.Service, t.Name)},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StateAbsent}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    []string{"--quiet", fmt.Sprintf("%s:create", t.Service), t.Name},
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StatePresent
-					return state
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
@@ -109,24 +103,18 @@ func (t ServiceCreateTask) Plan() PlanResult {
 			if !exists {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", "--force", fmt.Sprintf("%s:destroy", t.Service), t.Name},
+			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
 				Reason:    fmt.Sprintf("%s service %s present", t.Service, t.Name),
 				Mutations: []string{fmt.Sprintf("%s:destroy %s", t.Service, t.Name)},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StatePresent}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    []string{"--quiet", "--force", fmt.Sprintf("%s:destroy", t.Service), t.Name},
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StateAbsent
-					return state
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},

--- a/tasks/service_link_task.go
+++ b/tasks/service_link_task.go
@@ -100,24 +100,18 @@ func (t ServiceLinkTask) Plan() PlanResult {
 			if linked {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", fmt.Sprintf("%s:link", t.Service), t.Name, t.App},
+			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusCreate,
 				Reason:    fmt.Sprintf("%s service %s not linked to %s", t.Service, t.Name, t.App),
 				Mutations: []string{fmt.Sprintf("%s:link %s %s", t.Service, t.Name, t.App)},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StateAbsent}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    []string{"--quiet", fmt.Sprintf("%s:link", t.Service), t.Name, t.App},
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StatePresent
-					return state
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
@@ -143,24 +137,18 @@ func (t ServiceLinkTask) Plan() PlanResult {
 			if !linked {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", fmt.Sprintf("%s:unlink", t.Service), t.Name, t.App},
+			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
 				Reason:    fmt.Sprintf("%s service %s linked to %s", t.Service, t.Name, t.App),
 				Mutations: []string{fmt.Sprintf("%s:unlink %s %s", t.Service, t.Name, t.App)},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StatePresent}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    []string{"--quiet", fmt.Sprintf("%s:unlink", t.Service), t.Name, t.App},
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StateAbsent
-					return state
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},

--- a/tasks/storage_ensure_task.go
+++ b/tasks/storage_ensure_task.go
@@ -58,24 +58,18 @@ func (t StorageEnsureTask) Plan() PlanResult {
 			if !chownValues[t.Chown] {
 				return PlanResult{Status: PlanStatusError, Error: errors.New("invalid chown value specified")}
 			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", "storage:ensure-directory", "--chown", t.Chown, t.App},
+			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
 				Reason:    "directory presence not probed",
 				Mutations: []string{"storage:ensure-directory --chown " + t.Chown + " " + t.App},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StateAbsent}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    []string{"--quiet", "storage:ensure-directory", "--chown", t.Chown, t.App},
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StatePresent
-					return state
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -64,24 +64,18 @@ func (t StorageMountTask) Plan() PlanResult {
 			if exists {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", "storage:mount", t.App, mountSpec},
+			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusCreate,
 				Reason:    "mount missing",
 				Mutations: []string{fmt.Sprintf("mount %s on %s", mountSpec, t.App)},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StateAbsent}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    []string{"--quiet", "storage:mount", t.App, mountSpec},
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StatePresent
-					return state
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
 		},
@@ -93,24 +87,18 @@ func (t StorageMountTask) Plan() PlanResult {
 			if !exists {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", "storage:unmount", t.App, mountSpec},
+			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
 				Reason:    "mount present",
 				Mutations: []string{fmt.Sprintf("unmount %s on %s", mountSpec, t.App)},
+				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
-					state := TaskOutputState{Changed: false, State: StatePresent}
-					result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-						Command: "dokku",
-						Args:    []string{"--quiet", "storage:unmount", t.App, mountSpec},
-					})
-					state.Commands = append(state.Commands, result.Command)
-					if err != nil {
-						return TaskOutputErrorFromExec(state, err, result)
-					}
-					state.Changed = true
-					state.State = StateAbsent
-					return state
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
 				},
 			}
 		},

--- a/tasks/toggle.go
+++ b/tasks/toggle.go
@@ -53,11 +53,13 @@ func planToggle(state State, app string, global bool, allowGlobal bool, enableCm
 					return PlanResult{InSync: true, Status: PlanStatusOK}
 				}
 			}
+			inputs := toggleInputs(enableCmd, target)
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
 				Reason:    fmt.Sprintf("would run %s on %s", enableCmd, target),
 				Mutations: []string{fmt.Sprintf("%s %s", enableCmd, target)},
+				Commands:  resolveCommands(inputs),
 				apply:     applyToggle(enableCmd, target, StatePresent),
 			}
 		},
@@ -67,32 +69,33 @@ func planToggle(state State, app string, global bool, allowGlobal bool, enableCm
 					return PlanResult{InSync: true, Status: PlanStatusOK}
 				}
 			}
+			inputs := toggleInputs(disableCmd, target)
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
 				Reason:    fmt.Sprintf("would run %s on %s", disableCmd, target),
 				Mutations: []string{fmt.Sprintf("%s %s", disableCmd, target)},
+				Commands:  resolveCommands(inputs),
 				apply:     applyToggle(disableCmd, target, StateAbsent),
 			}
 		},
 	})
 }
 
+// toggleInputs returns the subprocess inputs that run a toggle command.
+func toggleInputs(subcommand, target string) []subprocess.ExecCommandInput {
+	return []subprocess.ExecCommandInput{
+		{Command: "dokku", Args: []string{"--quiet", subcommand, target}},
+	}
+}
+
 // applyToggle returns a closure that runs `dokku <subcommand> <target>` and
-// reports the resulting state.
+// reports the resulting state. The original initial state matches finalState
+// (preserved from the pre-refactor behavior), so on error the reported State
+// remains finalState.
 func applyToggle(subcommand, target string, finalState State) func() TaskOutputState {
+	inputs := toggleInputs(subcommand, target)
 	return func() TaskOutputState {
-		state := TaskOutputState{Changed: false, State: finalState}
-		result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    []string{"--quiet", subcommand, target},
-		})
-		state.Commands = append(state.Commands, result.Command)
-		if err != nil {
-			return TaskOutputErrorFromExec(state, err, result)
-		}
-		state.Changed = true
-		state.State = finalState
-		return state
+		return runExecInputs(TaskOutputState{State: finalState}, finalState, inputs)
 	}
 }

--- a/tests/bats/json.bats
+++ b/tests/bats/json.bats
@@ -31,7 +31,7 @@ EOF
   while IFS= read -r line; do
     [ -z "$line" ] && continue
     echo "$line" | jq . >/dev/null || fail "invalid JSON: $line"
-  done <<< "$output"
+  done <<<"$output"
 }
 
 @test "docket apply --json includes version 1 on every event" {
@@ -47,7 +47,7 @@ EOF
   while IFS= read -r line; do
     [ -z "$line" ] && continue
     [ "$(echo "$line" | jq -r .version)" = "1" ] || fail "missing or wrong version: $line"
-  done <<< "$output"
+  done <<<"$output"
 }
 
 @test "docket apply --json emits a play_start event before the first task" {
@@ -108,7 +108,7 @@ EOF
   while IFS= read -r line; do
     [ -z "$line" ] && continue
     echo "$line" | jq . >/dev/null || fail "non-JSON on stdout: $line"
-  done <<< "$output"
+  done <<<"$output"
 }
 
 @test "docket plan --json includes per-task mutations array" {
@@ -202,7 +202,7 @@ EOF
   while IFS= read -r line; do
     [ -z "$line" ] && continue
     echo "$line" | jq . >/dev/null || fail "invalid JSON: $line"
-  done <<< "$output"
+  done <<<"$output"
 }
 
 @test "docket apply --json masks sensitive values in commands" {

--- a/tests/bats/json.bats
+++ b/tests/bats/json.bats
@@ -1,0 +1,227 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  require_dokku
+  docket_build
+  dokku_clean_app docket-test-json
+  dokku_clean_app docket-test-json-clean
+  dokku_clean_app docket-test-json-drift
+  dokku_clean_app docket-test-json-mut
+}
+
+teardown() {
+  dokku_clean_app docket-test-json
+  dokku_clean_app docket-test-json-clean
+  dokku_clean_app docket-test-json-drift
+  dokku_clean_app docket-test-json-mut
+}
+
+@test "docket apply --json emits valid JSON-lines" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-json
+      dokku_app:
+        app: docket-test-json
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --json
+  assert_success
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    echo "$line" | jq . >/dev/null || fail "invalid JSON: $line"
+  done <<< "$output"
+}
+
+@test "docket apply --json includes version 1 on every event" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-json
+      dokku_app:
+        app: docket-test-json
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --json
+  assert_success
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    [ "$(echo "$line" | jq -r .version)" = "1" ] || fail "missing or wrong version: $line"
+  done <<< "$output"
+}
+
+@test "docket apply --json emits a play_start event before the first task" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-json
+      dokku_app:
+        app: docket-test-json
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --json
+  assert_success
+  first_type="$(echo "$output" | head -n1 | jq -r .type)"
+  [ "$first_type" = "play_start" ] || fail "first event was $first_type, want play_start"
+}
+
+@test "docket apply --json emits a summary event last" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-json
+      dokku_app:
+        app: docket-test-json
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --json
+  assert_success
+  last_type="$(echo "$output" | tail -n1 | jq -r .type)"
+  [ "$last_type" = "summary" ] || fail "last event was $last_type, want summary"
+}
+
+@test "docket apply --json task events use changed not would_change" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-json
+      dokku_app:
+        app: docket-test-json
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --json
+  assert_success
+  task_event="$(echo "$output" | jq -c 'select(.type == "task")' | head -n1)"
+  [ -n "$task_event" ] || fail "no task event found"
+  echo "$task_event" | jq -e '.changed != null' >/dev/null || fail "missing changed field: $task_event"
+  echo "$task_event" | jq -e '.would_change == null' >/dev/null || fail "would_change should not be set on apply: $task_event"
+}
+
+@test "docket apply --json with --verbose still emits only JSON on stdout" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-json
+      dokku_app:
+        app: docket-test-json
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --json --verbose
+  assert_success
+  refute_output --partial $'\u2192 dokku'
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    echo "$line" | jq . >/dev/null || fail "non-JSON on stdout: $line"
+  done <<< "$output"
+}
+
+@test "docket plan --json includes per-task mutations array" {
+  write_tasks_file create.yml <<EOF
+---
+- tasks:
+    - dokku_app:
+        app: docket-test-json-mut
+EOF
+  "$(docket_bin)" apply --tasks "$TASKS_FILE"
+
+  write_tasks_file plan.yml <<EOF
+---
+- tasks:
+    - name: configure
+      dokku_config:
+        app: docket-test-json-mut
+        restart: false
+        config:
+          KEY_ONE: value-one
+          KEY_TWO: value-two
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --json
+  assert_success
+  assert_output --partial '"mutations":'
+  task_event="$(echo "$output" | jq -c 'select(.type == "task" and .would_change == true)' | head -n1)"
+  [ -n "$task_event" ] || fail "no drift task event found"
+  count="$(echo "$task_event" | jq '.mutations | length')"
+  [ "$count" = "2" ] || fail "expected 2 mutations, got $count: $task_event"
+}
+
+@test "docket plan --json includes commands array on drift" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_app:
+        app: docket-test-json-drift
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --json
+  assert_success
+  task_event="$(echo "$output" | jq -c 'select(.type == "task" and .would_change == true)' | head -n1)"
+  [ -n "$task_event" ] || fail "no drift task event found"
+  cmd_count="$(echo "$task_event" | jq '.commands | length')"
+  [ "$cmd_count" -ge 1 ] || fail "expected at least 1 command, got $cmd_count: $task_event"
+  echo "$task_event" | jq -e '.commands[0] | contains("apps:create")' >/dev/null || fail "command should mention apps:create: $task_event"
+}
+
+@test "docket plan --detailed-exitcode returns 0 when in sync" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_app:
+        app: docket-test-json-clean
+EOF
+  "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --detailed-exitcode
+  assert_success
+}
+
+@test "docket plan --detailed-exitcode returns 2 when drift detected" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_app:
+        app: docket-test-json-drift
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --detailed-exitcode
+  [ "$status" -eq 2 ] || fail "expected exit 2 on drift, got $status: $output"
+}
+
+@test "docket plan default exit code stays 0 even with drift" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_app:
+        app: docket-test-json-drift
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+}
+
+@test "docket plan --json --detailed-exitcode composes" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_app:
+        app: docket-test-json-drift
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --json --detailed-exitcode
+  [ "$status" -eq 2 ] || fail "expected exit 2 on drift, got $status"
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    echo "$line" | jq . >/dev/null || fail "invalid JSON: $line"
+  done <<< "$output"
+}
+
+@test "docket apply --json masks sensitive values in commands" {
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - name: ensure docket-test-json
+      dokku_app:
+        app: docket-test-json
+    - name: set the secret
+      dokku_config:
+        app: docket-test-json
+        config:
+          MY_SECRET: "{{ .secret_value }}"
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --secret_value=topsecret999 --json
+  assert_success
+  refute_output --partial "topsecret999"
+  assert_output --partial "***"
+}


### PR DESCRIPTION
## Summary

`apply` and `plan` now accept `--json` to emit one JSON-lines event per `play_start`, `task`, and `summary` instead of the human formatter. Every event carries `version: 1` so consumers can branch on schema changes; sensitive values mask to `***` in the `commands` and `error` fields.

`plan` additionally accepts `--detailed-exitcode` to map clean to 0, drift to 2, and read or probe error to 1, matching the `git diff --exit-code` and `terraform plan -detailed-exitcode` convention. CI pipelines can branch on drift without log scraping.

`PlanResult` gains a `Commands []string` field populated by every task's `Plan()` so `plan --json` reports the same dokku invocations `apply` would run; the new `subprocess.ResolveCommandString` helper centralises the rendering so plan and apply output stay byte-identical.

## Schema deviations from the issue

The issue showed singular `command`; the implementation emits `commands` as an array because `TaskOutputState.Commands` is `[]string` (tasks like `dokku_buildpacks` legitimately invoke N subprocess calls) and joining loses structure for `jq '.commands[]'` consumers. `--verbose` is silently ignored when `--json` is set.

Closes #206