### PR TITLE
feat: add multi-play tasks.yml support and --play filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ docket apply --tasks tasks.yml --fail-fast # legacy: abort the entire run
 
 The summary line gains a `· N play skipped` segment when one or more plays were skipped (by `when:` or by a per-task `when:` predicate at the play level):
 
-```
+```text
 ==> Play: api
 [ok]      dokku apps:create api
 [changed] dokku git:sync api

--- a/README.md
+++ b/README.md
@@ -39,6 +39,102 @@ docket apply
 
 Running `docket` with no subcommand prints the available commands. Use `docket init` to scaffold a starter `tasks.yml`, `docket apply` to execute a task file, `docket fmt` to canonically format a task file, `docket plan` to preview the changes a task file would make without mutating any state, `docket validate` to check a task file's schema and templates without contacting the server, or `docket version` to print the binary's version.
 
+### Multi-play recipes
+
+`tasks.yml` is a YAML list of plays. Each play has its own `name`, optional `tags`, optional `when:`, optional `inputs:`, and a `tasks:` list. The executor walks every play in source order, so a single recipe can describe multiple coordinated apps or services in one file.
+
+```yaml
+---
+- name: api
+  tags: [web]
+  inputs:
+    - { name: app, default: api }
+  tasks:
+    - dokku_app:    { app: "{{ .app }}" }
+    - dokku_config: { app: "{{ .app }}", config: { LOG_LEVEL: info } }
+
+- name: worker
+  when: 'env != "preview"'
+  inputs:
+    - { name: app, default: worker }
+  tasks:
+    - dokku_app: { app: "{{ .app }}" }
+```
+
+Single-play recipes - the legacy shape - keep working unchanged because they are already a one-element list.
+
+| Key | Status | What it does |
+|-----|--------|--------------|
+| `name` | active | Human label for the play. Auto-generated as `play #N` when omitted, except for single-play files which use the legacy `tasks` header. |
+| `tags` | active | Tag list inherited by every task in the play (additive with per-task `tags`). |
+| `when` | active | expr expression. Falsy renders the play as `(skipped: when "...")` and the play's tasks are not executed. |
+| `inputs` | active | Per-play input defaults. Override file-level defaults within their play; CLI `--name=value` and `--vars-file` always win. |
+| `tasks` | active | The play's task list (existing per-task envelope). |
+
+#### Per-play `inputs:` precedence
+
+Per-play inputs slot into layer 2 of the precedence chain from `--vars-file`:
+
+| Layer | Source |
+|-------|--------|
+| 1 | File-level `inputs:` defaults (declared on a play with no tasks). |
+| 2 | Per-play `inputs:` defaults (declared on a play that also has tasks). |
+| 3 | `--vars-file <path>` (repeatable; later files override earlier). |
+| 4 | `--name=value` CLI flags (always win). |
+
+A play-local input default is visible to that play's tasks; it is *not* visible to any play's `when:` predicate (including its own) and *not* visible to other plays' tasks. A file-level input - one declared on an inputs-only play - is visible to every play.
+
+```yaml
+---
+- inputs:
+    - { name: env, default: prod }     # file-level: visible to every play
+- name: api
+  inputs:
+    - { name: app, default: api }       # play-local: visible to api's tasks only
+  tasks:
+    - dokku_app: { app: "{{ .app }}" }
+```
+
+#### `--play <name>` filter
+
+Run only one play from the recipe by name:
+
+```shell
+docket apply --tasks tasks.yml --play api
+docket plan  --tasks tasks.yml --play api --tags deploy
+```
+
+`--play` composes with `--tags` / `--skip-tags`: the play filter narrows to one play, then the tag filter applies to the tasks inside it. An unknown `--play` name produces a clear error listing the available plays.
+
+#### Per-play `when:` scoping
+
+A play-level `when:` is evaluated against the file-level merged context only - file-level input defaults, plus `--vars-file` and CLI overrides. The play's own `inputs:` are intentionally not visible to its own `when:` (the spec calls this circular). Sibling plays' play-local inputs are also not visible. Per-task `when:` inside the play does see the play's own inputs.
+
+#### Error semantics: abort the play, not the run
+
+By default, an error in a task aborts the *current play* and the next play still runs. Use `--fail-fast` to opt back into the legacy "abort the entire run on first error" behaviour:
+
+```shell
+docket apply --tasks tasks.yml             # default: bail current play, continue next
+docket apply --tasks tasks.yml --fail-fast # legacy: abort the entire run
+```
+
+The summary line gains a `· N play skipped` segment when one or more plays were skipped (by `when:` or by a per-task `when:` predicate at the play level):
+
+```
+==> Play: api
+[ok]      dokku apps:create api
+[changed] dokku git:sync api
+
+==> Play: worker  (skipped: when "env != \"preview\"")
+
+==> Play: web
+[ok]      dokku apps:create web
+[changed] dokku domains:set web
+
+Summary: 4 tasks · 2 changed · 2 ok · 0 skipped · 0 errors · 1 play skipped  (took 5.1s)
+```
+
 ### Task envelope
 
 Each task entry in `tasks.yml` admits a small set of cross-cutting envelope keys alongside the single `dokku_*` task-type key. Body templating uses [sigil](https://github.com/gliderlabs/sigil) (`{{ .input }}` substitutions) and envelope predicates use [expr-lang/expr](https://github.com/expr-lang/expr) so the two languages live in clearly separate positions.
@@ -207,6 +303,8 @@ The flags are:
 | `--verbose` | After each task line, echo every resolved Dokku command the task ran on a `→`-prefixed continuation line, in invocation order. Tasks that loop over inputs (e.g. `dokku_buildpacks` adding several URLs) emit one continuation per call. Commands are masked against the global sensitive value set. Ignored when `--json` is set; the JSON output already includes the resolved commands. |
 | `--json` | Suppress the human formatter and emit one JSON-lines event per `play_start`, `task`, or `summary` to stdout. Sensitive values mask to `***`. See "JSON output" below for the schema. |
 | `--vars-file <path>` | Load input values from a YAML or JSON file. Repeatable; later files override earlier files for the same key. CLI `--name=value` flags always win. See "Layered input variables with `--vars-file`" below. |
+| `--play <name>` | Run only the play with this name. Matches the play's `name:` field; auto-named plays use `play #N`. Composes with `--tags`. |
+| `--fail-fast` | Abort the entire run on the first task error. Without this flag, an error aborts only the current play and the next play still runs. |
 
 For example, a multi-command task renders one continuation per invocation:
 
@@ -289,6 +387,7 @@ The flags are:
 | `--json` | Suppress the human formatter and emit one JSON-lines event per `play_start`, `task`, or `summary` to stdout. Sensitive values mask to `***`. See "JSON output" below for the schema. |
 | `--detailed-exitcode` | Exit `0` when no drift is detected, `2` when at least one task reports drift, `1` on read or probe error. Errors win over drift. Without this flag, plan exits `0` regardless of drift. Mirrors the `git diff --exit-code` / `terraform plan -detailed-exitcode` convention. |
 | `--vars-file <path>` | Load input values from a YAML or JSON file. Repeatable; later files override earlier files for the same key. CLI `--name=value` flags always win. See "Layered input variables with `--vars-file`" below. |
+| `--play <name>` | Plan only the play with this name. Matches the play's `name:` field; auto-named plays use `play #N`. Composes with `--tags`. |
 
 ```shell
 # CI gate: fail the job if any task would change the server.
@@ -302,10 +401,11 @@ docket plan --detailed-exitcode || exit $?
 | Event | Required fields | Optional fields |
 |-------|-----------------|-----------------|
 | `play_start` | `version`, `type`, `name`, `ts` | `host` |
+| `play_skipped` | `version`, `type`, `name`, `ts` | `when`, `reason` |
 | `task` (apply) | `version`, `type`, `play`, `name`, `status` (`ok`/`changed`/`skipped`/`error`), `changed`, `state`, `desired_state`, `duration_ms`, `ts` | `error`, `commands` |
 | `task` (plan) | `version`, `type`, `play`, `name`, `status` (`ok`/`+`/`~`/`-`/`skipped`/`error`), `would_change`, `state`, `desired_state`, `duration_ms`, `ts` | `reason`, `mutations`, `commands`, `error` |
-| `summary` (apply) | `version`, `type`, `tasks`, `changed`, `ok`, `skipped`, `errors`, `duration_ms` | - |
-| `summary` (plan) | `version`, `type`, `tasks`, `would_change`, `in_sync`, `skipped`, `errors`, `duration_ms` | - |
+| `summary` (apply) | `version`, `type`, `tasks`, `changed`, `ok`, `skipped`, `errors`, `plays_skipped`, `duration_ms` | - |
+| `summary` (plan) | `version`, `type`, `tasks`, `would_change`, `in_sync`, `skipped`, `errors`, `plays_skipped`, `duration_ms` | - |
 
 Both `task` event flavors include `commands` as an array of resolved, masked dokku command strings (singular `command` was considered but tasks like `dokku_buildpacks` legitimately invoke N subprocess calls, so an array preserves structure for `jq '.commands[]'`). The plan `commands` array reports the dokku invocations `apply` *would* run; the apply `commands` array reports what was actually executed. Both arrays use the same rendering rules, so plan output and apply output stay byte-identical for the same logical operation.
 
@@ -420,7 +520,7 @@ The full precedence order, lowest to highest:
 | Layer | Source |
 |-------|--------|
 | 1 | File-level `inputs:` defaults declared in `tasks.yml` |
-| 2 | Play-level `inputs:` defaults (per-play; reserved for #208) |
+| 2 | Per-play `inputs:` defaults (active; see "Multi-play recipes" above) |
 | 3 | `--vars-file <path>` (repeatable; later files override earlier) |
 | 4 | `--name=value` CLI flags (always win) |
 

--- a/commands/apply.go
+++ b/commands/apply.go
@@ -25,6 +25,8 @@ type ApplyCommand struct {
 	tags              []string
 	skipTags          []string
 	varsFiles         []string
+	play              string
+	failFast          bool
 	arguments         map[string]*Argument
 }
 
@@ -73,6 +75,8 @@ func (c *ApplyCommand) FlagSet() *flag.FlagSet {
 	f.StringSliceVar(&c.tags, "tags", nil, "comma-separated tag list; only tasks whose `tags:` set intersects this list run")
 	f.StringSliceVar(&c.skipTags, "skip-tags", nil, "comma-separated tag list; tasks whose `tags:` set intersects this list are skipped")
 	f.StringArrayVar(&c.varsFiles, "vars-file", nil, "load input values from a YAML or JSON file (repeatable; later files override earlier; CLI --name=value flags always win). A .json extension parses as JSON; otherwise YAML.")
+	f.StringVar(&c.play, "play", "", "run only the play with this name (matches the play's `name:` field; auto-named plays use `play #N`)")
+	f.BoolVar(&c.failFast, "fail-fast", false, "abort the entire run on the first task error. By default, an error aborts only the current play and the next play still runs.")
 
 	taskFile := getTaskYamlFilename(os.Args)
 	data, err := os.ReadFile(taskFile)
@@ -102,6 +106,8 @@ func (c *ApplyCommand) AutocompleteFlags() complete.Flags {
 			"--tags":                 complete.PredictAnything,
 			"--skip-tags":            complete.PredictAnything,
 			"--vars-file":            complete.PredictFiles("*"),
+			"--play":                 complete.PredictAnything,
+			"--fail-fast":            complete.PredictNothing,
 		},
 	)
 }
@@ -115,7 +121,8 @@ func (c *ApplyCommand) Run(args []string) int {
 		return 1
 	}
 
-	if err := applyVarsFiles(c.arguments, flags, c.varsFiles); err != nil {
+	varsFileKeys, err := applyVarsFiles(c.arguments, flags, c.varsFiles)
+	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
 	}
@@ -143,13 +150,26 @@ func (c *ApplyCommand) Run(args []string) int {
 		}
 	}
 
-	taskList, err := tasks.GetTasks(data, context)
+	userSet := userSetKeys(flags, varsFileKeys, c.arguments)
+
+	plays, err := tasks.GetPlays(data, context, userSet)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("task error: %v", err))
 		return 1
 	}
 
-	sensitiveValues = append(sensitiveValues, tasks.CollectSensitiveValues(taskList)...)
+	// Compute file-level input names from the *unfiltered* play list so
+	// --play does not accidentally hide an inputs-only play whose
+	// declared inputs the surviving play's when: depends on.
+	fileLevelKeys := tasks.FileLevelInputNames(plays)
+
+	plays, err = filterPlaysByName(plays, c.play)
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	sensitiveValues = append(sensitiveValues, tasks.CollectPlaySensitiveValues(plays)...)
 	subprocess.SetGlobalSensitive(sensitiveValues)
 	defer subprocess.SetGlobalSensitive(nil)
 
@@ -158,98 +178,168 @@ func (c *ApplyCommand) Run(args []string) int {
 	}
 
 	emitter := c.newEmitter()
-	emitter.PlayStart("tasks", resolvedHost)
-
 	start := time.Now()
 	counts := ApplyCounts{}
-	playName := "tasks"
+	playWhenExprCtx := buildEnvelopeExprContext(buildPlayWhenContext(context, fileLevelKeys, userSet))
+	hasError := false
 
-	keys := tasks.FilterByTags(taskList, c.tags, c.skipTags)
-	exprBaseCtx := buildEnvelopeExprContext(context)
-
-	for _, name := range keys {
-		env := taskList.GetEnvelope(name)
-		taskStart := time.Now()
-
-		if env.HasWhen() {
-			ok, err := tasks.EvalBool(env.WhenProgram(), envelopeExprContext(exprBaseCtx, env))
+playLoop:
+	for _, play := range plays {
+		if play.IsFileLevel() {
+			// Inputs-only plays carry no tasks; their inputs are
+			// already folded into fileLevelKeys above. They produce
+			// no output and do not count toward play totals.
+			continue
+		}
+		if play.HasWhen() {
+			ok, err := tasks.EvalBool(play.WhenProgram(), playWhenExprCtx)
 			if err != nil {
-				counts.Tasks++
-				counts.Errors++
-				emitter.ApplyTask(ApplyTaskEvent{
-					Play:      playName,
-					Name:      name,
-					WhenError: err,
-					Duration:  time.Since(taskStart),
-					Timestamp: time.Now().UTC(),
-				})
-				emitter.ApplySummary(counts, time.Since(start))
-				return 1
+				counts.PlaysSkipped++
+				hasError = true
+				emitter.PlaySkipped(play.Name, fmt.Sprintf("%s (error: %v)", play.When, err))
+				if c.failFast {
+					break playLoop
+				}
+				continue
 			}
 			if !ok {
-				counts.Tasks++
-				counts.Skipped++
-				emitter.ApplyTask(ApplyTaskEvent{
-					Play:      playName,
-					Name:      name,
-					Skipped:   true,
-					Duration:  time.Since(taskStart),
-					Timestamp: time.Now().UTC(),
-				})
+				counts.PlaysSkipped++
+				emitter.PlaySkipped(play.Name, play.When)
 				continue
 			}
 		}
 
-		state := env.Task.Execute()
-		counts.Tasks++
+		emitter.PlayStart(play.Name, resolvedHost)
 
-		switch {
-		case state.Error != nil:
-			counts.Errors++
-			emitter.ApplyTask(ApplyTaskEvent{
-				Play:      playName,
-				Name:      name,
-				State:     state,
-				Duration:  time.Since(taskStart),
-				Timestamp: time.Now().UTC(),
-			})
-			emitter.ApplySummary(counts, time.Since(start))
-			return 1
-		case state.State != state.DesiredState:
-			counts.Errors++
-			emitter.ApplyTask(ApplyTaskEvent{
-				Play:         playName,
-				Name:         name,
-				State:        state,
-				InvalidState: true,
-				Duration:     time.Since(taskStart),
-				Timestamp:    time.Now().UTC(),
-			})
-			emitter.ApplySummary(counts, time.Since(start))
-			return 1
-		case state.Changed:
-			counts.Changed++
-			emitter.ApplyTask(ApplyTaskEvent{
-				Play:      playName,
-				Name:      name,
-				State:     state,
-				Duration:  time.Since(taskStart),
-				Timestamp: time.Now().UTC(),
-			})
-		default:
-			counts.OK++
-			emitter.ApplyTask(ApplyTaskEvent{
-				Play:      playName,
-				Name:      name,
-				State:     state,
-				Duration:  time.Since(taskStart),
-				Timestamp: time.Now().UTC(),
-			})
+		playExprCtx := buildEnvelopeExprContext(tasks.BuildPerPlayContext(context, play.Inputs, userSet))
+
+		failed := false
+		for _, name := range tasks.FilterByTags(play.Tasks, c.tags, c.skipTags) {
+			env := play.Tasks.GetEnvelope(name)
+			taskStart := time.Now()
+
+			if env.HasWhen() {
+				ok, err := tasks.EvalBool(env.WhenProgram(), envelopeExprContext(playExprCtx, env))
+				if err != nil {
+					counts.Tasks++
+					counts.Errors++
+					failed = true
+					hasError = true
+					emitter.ApplyTask(ApplyTaskEvent{
+						Play:      play.Name,
+						Name:      name,
+						WhenError: err,
+						Duration:  time.Since(taskStart),
+						Timestamp: time.Now().UTC(),
+					})
+					if c.failFast {
+						emitter.ApplySummary(counts, time.Since(start))
+						return 1
+					}
+					break
+				}
+				if !ok {
+					counts.Tasks++
+					counts.Skipped++
+					emitter.ApplyTask(ApplyTaskEvent{
+						Play:      play.Name,
+						Name:      name,
+						Skipped:   true,
+						Duration:  time.Since(taskStart),
+						Timestamp: time.Now().UTC(),
+					})
+					continue
+				}
+			}
+
+			state := env.Task.Execute()
+			counts.Tasks++
+
+			switch {
+			case state.Error != nil:
+				counts.Errors++
+				failed = true
+				hasError = true
+				emitter.ApplyTask(ApplyTaskEvent{
+					Play:      play.Name,
+					Name:      name,
+					State:     state,
+					Duration:  time.Since(taskStart),
+					Timestamp: time.Now().UTC(),
+				})
+				if c.failFast {
+					emitter.ApplySummary(counts, time.Since(start))
+					return 1
+				}
+			case state.State != state.DesiredState:
+				counts.Errors++
+				failed = true
+				hasError = true
+				emitter.ApplyTask(ApplyTaskEvent{
+					Play:         play.Name,
+					Name:         name,
+					State:        state,
+					InvalidState: true,
+					Duration:     time.Since(taskStart),
+					Timestamp:    time.Now().UTC(),
+				})
+				if c.failFast {
+					emitter.ApplySummary(counts, time.Since(start))
+					return 1
+				}
+			case state.Changed:
+				counts.Changed++
+				emitter.ApplyTask(ApplyTaskEvent{
+					Play:      play.Name,
+					Name:      name,
+					State:     state,
+					Duration:  time.Since(taskStart),
+					Timestamp: time.Now().UTC(),
+				})
+			default:
+				counts.OK++
+				emitter.ApplyTask(ApplyTaskEvent{
+					Play:      play.Name,
+					Name:      name,
+					State:     state,
+					Duration:  time.Since(taskStart),
+					Timestamp: time.Now().UTC(),
+				})
+			}
+
+			if failed {
+				// Without --fail-fast, an error in this play aborts the
+				// rest of this play but the next play still runs.
+				break
+			}
 		}
 	}
 
 	emitter.ApplySummary(counts, time.Since(start))
+	if hasError {
+		return 1
+	}
 	return 0
+}
+
+// filterPlaysByName narrows plays to the single play whose Name matches
+// target. An empty target returns plays unchanged. An unmatched target
+// returns an error so the user sees a clear "no such play" diagnostic
+// rather than silently doing nothing.
+func filterPlaysByName(plays []*tasks.Play, target string) ([]*tasks.Play, error) {
+	if target == "" {
+		return plays, nil
+	}
+	for _, play := range plays {
+		if play.Name == target {
+			return []*tasks.Play{play}, nil
+		}
+	}
+	names := make([]string, 0, len(plays))
+	for _, play := range plays {
+		names = append(names, fmt.Sprintf("%q", play.Name))
+	}
+	return nil, fmt.Errorf("--play %q: no play with that name; available plays: %v", target, names)
 }
 
 // newEmitter constructs the EventEmitter for this run. --json builds a

--- a/commands/apply_args.go
+++ b/commands/apply_args.go
@@ -432,7 +432,7 @@ func normaliseYAMLMap(in map[interface{}]interface{}) (map[string]interface{}, e
 // registered Argument set, honouring the precedence rules from #207:
 //
 //  1. file-level inputs: defaults  (already in flag pointers from registerInputFlags)
-//  2. play-level inputs: defaults  (depends on #208; layer empty today)
+//  2. play-level inputs: defaults  (layered per-play in tasks.GetPlays via #208)
 //  3. --vars-file values
 //  4. --name=value CLI flags       (highest)
 //
@@ -440,13 +440,18 @@ func normaliseYAMLMap(in map[interface{}]interface{}) (map[string]interface{}, e
 // type on the command line"; the visitor only fires for flags whose Changed
 // bit is set. Any unknown vars-file key is a hard error with a Levenshtein
 // suggestion against the registered input names.
-func applyVarsFiles(arguments map[string]*Argument, flags *flag.FlagSet, paths []string) error {
+//
+// The returned map contains the input names this call wrote into the
+// argument set from a vars file. Callers union it with flags.Visit to
+// derive the full "user has overridden this key" set, which #208 needs so
+// per-play input defaults do not shadow user overrides.
+func applyVarsFiles(arguments map[string]*Argument, flags *flag.FlagSet, paths []string) (map[string]bool, error) {
 	if len(paths) == 0 {
-		return nil
+		return nil, nil
 	}
 	merged, sources, err := loadVarsFiles(paths)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	cliSet := map[string]bool{}
@@ -467,6 +472,7 @@ func applyVarsFiles(arguments map[string]*Argument, flags *flag.FlagSet, paths [
 		knownNames = append(knownNames, name)
 	}
 
+	applied := map[string]bool{}
 	for _, key := range keys {
 		arg, ok := arguments[key]
 		if !ok {
@@ -475,16 +481,36 @@ func applyVarsFiles(arguments map[string]*Argument, flags *flag.FlagSet, paths [
 			if suggestion != "" {
 				hint = fmt.Sprintf("; did you mean %q?", suggestion)
 			}
-			return fmt.Errorf("unknown input %q in --vars-file %s%s", key, sources[key], hint)
+			return nil, fmt.Errorf("unknown input %q in --vars-file %s%s", key, sources[key], hint)
 		}
 		if cliSet[key] {
 			continue
 		}
 		if err := arg.SetFromVarsFile(key, merged[key]); err != nil {
-			return fmt.Errorf("--vars-file %s: %v", sources[key], err)
+			return nil, fmt.Errorf("--vars-file %s: %v", sources[key], err)
 		}
+		applied[key] = true
 	}
-	return nil
+	return applied, nil
+}
+
+// userSetKeys merges the set of input names the user has overridden via
+// --vars-file (varsFileKeys) with those they have typed on the CLI
+// (flags.Visit). Used by #208 so per-play input defaults do not shadow a
+// user override.
+func userSetKeys(flags *flag.FlagSet, varsFileKeys map[string]bool, arguments map[string]*Argument) map[string]bool {
+	out := make(map[string]bool, len(varsFileKeys))
+	for k := range varsFileKeys {
+		out[k] = true
+	}
+	if flags != nil {
+		flags.Visit(func(f *flag.Flag) {
+			if _, ok := arguments[f.Name]; ok {
+				out[f.Name] = true
+			}
+		})
+	}
+	return out
 }
 
 // nearestInputName returns the registered input name with the lowest

--- a/commands/apply_args_test.go
+++ b/commands/apply_args_test.go
@@ -647,7 +647,7 @@ func TestSetFromVarsFileBool(t *testing.T) {
 func TestApplyVarsFilesEmptyPathsNoOp(t *testing.T) {
 	args := map[string]*Argument{"app": argFor(t, "string", "default")}
 	flags := flag.NewFlagSet("t", flag.ContinueOnError)
-	if err := applyVarsFiles(args, flags, nil); err != nil {
+	if _, err := applyVarsFiles(args, flags, nil); err != nil {
 		t.Fatalf("expected nil error for empty paths, got %v", err)
 	}
 	if *args["app"].stringValue != "default" {
@@ -663,7 +663,7 @@ func TestApplyVarsFilesUpdatesUnsetArgument(t *testing.T) {
 	flags := flag.NewFlagSet("t", flag.ContinueOnError)
 	flags.String("app", "default", "")
 
-	if err := applyVarsFiles(args, flags, []string{path}); err != nil {
+	if _, err := applyVarsFiles(args, flags, []string{path}); err != nil {
 		t.Fatalf("applyVarsFiles failed: %v", err)
 	}
 	if got := *args["app"].stringValue; got != "from-vars" {
@@ -684,7 +684,7 @@ func TestApplyVarsFilesCLIOverridesVarsFile(t *testing.T) {
 		t.Fatalf("flags.Parse failed: %v", err)
 	}
 
-	if err := applyVarsFiles(args, flags, []string{path}); err != nil {
+	if _, err := applyVarsFiles(args, flags, []string{path}); err != nil {
 		t.Fatalf("applyVarsFiles failed: %v", err)
 	}
 	if got := *args["app"].stringValue; got != "from-cli" {
@@ -699,7 +699,7 @@ func TestApplyVarsFilesUnknownKey(t *testing.T) {
 	args := map[string]*Argument{"app": argFor(t, "string", "")}
 	flags := flag.NewFlagSet("t", flag.ContinueOnError)
 
-	err := applyVarsFiles(args, flags, []string{path})
+	_, err := applyVarsFiles(args, flags, []string{path})
 	if err == nil {
 		t.Fatal("expected error for unknown key")
 	}
@@ -717,7 +717,7 @@ func TestApplyVarsFilesUnknownKeyNoSuggestionWhenFar(t *testing.T) {
 	args := map[string]*Argument{"app": argFor(t, "string", "")}
 	flags := flag.NewFlagSet("t", flag.ContinueOnError)
 
-	err := applyVarsFiles(args, flags, []string{path})
+	_, err := applyVarsFiles(args, flags, []string{path})
 	if err == nil {
 		t.Fatal("expected error for unknown key")
 	}
@@ -734,7 +734,7 @@ func TestApplyVarsFilesMultiFileLastWins(t *testing.T) {
 	args := map[string]*Argument{"app": argFor(t, "string", "")}
 	flags := flag.NewFlagSet("t", flag.ContinueOnError)
 
-	if err := applyVarsFiles(args, flags, []string{a, b}); err != nil {
+	if _, err := applyVarsFiles(args, flags, []string{a, b}); err != nil {
 		t.Fatalf("applyVarsFiles failed: %v", err)
 	}
 	if got := *args["app"].stringValue; got != "from-b" {
@@ -749,7 +749,7 @@ func TestApplyVarsFilesCoercionFailureNamesInput(t *testing.T) {
 	args := map[string]*Argument{"replicas": argFor(t, "int", 0)}
 	flags := flag.NewFlagSet("t", flag.ContinueOnError)
 
-	err := applyVarsFiles(args, flags, []string{path})
+	_, err := applyVarsFiles(args, flags, []string{path})
 	if err == nil {
 		t.Fatal("expected coercion error")
 	}
@@ -767,7 +767,7 @@ func TestApplyVarsFilesJSONFloatCoercesToInt(t *testing.T) {
 	args := map[string]*Argument{"replicas": argFor(t, "int", 0)}
 	flags := flag.NewFlagSet("t", flag.ContinueOnError)
 
-	if err := applyVarsFiles(args, flags, []string{path}); err != nil {
+	if _, err := applyVarsFiles(args, flags, []string{path}); err != nil {
 		t.Fatalf("applyVarsFiles failed: %v", err)
 	}
 	if got := *args["replicas"].intValue; got != 5 {

--- a/commands/apply_test.go
+++ b/commands/apply_test.go
@@ -2,9 +2,11 @@ package commands
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/dokku/docket/tasks"
+	pflag "github.com/spf13/pflag"
 )
 
 func TestApplyCommandMetadata(t *testing.T) {
@@ -75,5 +77,81 @@ func TestFilterByTagsThroughCommandsLayer(t *testing.T) {
 	}
 	if got := tasks.FilterByTags(m, nil, nil); len(got) != 3 {
 		t.Errorf("no flags: got %v, want all 3", got)
+	}
+}
+
+// TestFilterPlaysByName covers the --play filter helper used by both
+// apply and plan. An empty target returns the slice unchanged; a hit
+// returns just the matched play; a miss returns an error that names the
+// available plays.
+func TestFilterPlaysByName(t *testing.T) {
+	plays := []*tasks.Play{
+		{Name: "api"},
+		{Name: "worker"},
+	}
+
+	out, err := filterPlaysByName(plays, "")
+	if err != nil || len(out) != 2 {
+		t.Errorf("empty target should pass through; got len=%d err=%v", len(out), err)
+	}
+
+	out, err = filterPlaysByName(plays, "api")
+	if err != nil || len(out) != 1 || out[0].Name != "api" {
+		t.Errorf(`--play "api" got len=%d names=%v err=%v`, len(out), playNames(out), err)
+	}
+
+	_, err = filterPlaysByName(plays, "missing")
+	if err == nil {
+		t.Fatal("expected error for unknown play")
+	}
+	for _, want := range []string{`--play "missing"`, `"api"`, `"worker"`} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error missing %q\nfull: %v", want, err)
+		}
+	}
+}
+
+func playNames(plays []*tasks.Play) []string {
+	out := make([]string, len(plays))
+	for i, p := range plays {
+		out[i] = p.Name
+	}
+	return out
+}
+
+// TestUserSetKeysMergesCLIAndVarsFile pins the precedence-tracking
+// helper that #208 needs to layer per-play inputs correctly. CLI-set
+// flags and vars-file keys both contribute; non-input flags are filtered
+// out so internal flags (--tasks etc.) do not pollute the per-play
+// override set.
+func TestUserSetKeysMergesCLIAndVarsFile(t *testing.T) {
+	flags := pflag.NewFlagSet("t", pflag.ContinueOnError)
+	flags.String("app", "default", "")
+	flags.String("env", "default", "")
+	flags.String("tasks", "tasks.yml", "")
+	if err := flags.Parse([]string{"--app=cli-app", "--tasks=other.yml"}); err != nil {
+		t.Fatalf("flags.Parse: %v", err)
+	}
+
+	args := map[string]*Argument{
+		"app": argFor(t, "string", ""),
+		"env": argFor(t, "string", ""),
+	}
+	varsFileKeys := map[string]bool{"env": true}
+
+	got := userSetKeys(flags, varsFileKeys, args)
+	want := map[string]bool{"app": true, "env": true}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("userSetKeys = %v, want %v (tasks should drop because not in arguments)", got, want)
+	}
+}
+
+// TestUserSetKeysWithoutFlagSet covers the nil-flags edge case. Vars-file
+// keys still flow through; no panic when callers haven't registered a
+// FlagSet yet.
+func TestUserSetKeysWithoutFlagSet(t *testing.T) {
+	got := userSetKeys(nil, map[string]bool{"env": true}, nil)
+	if !reflect.DeepEqual(got, map[string]bool{"env": true}) {
+		t.Errorf("userSetKeys(nil, ...) = %v, want only env", got)
 	}
 }

--- a/commands/envelope_context.go
+++ b/commands/envelope_context.go
@@ -31,3 +31,25 @@ func envelopeExprContext(base map[string]interface{}, env *tasks.TaskEnvelope) m
 	out["index"] = env.LoopIndex
 	return out
 }
+
+// buildPlayWhenContext returns the expr context the play-level `when:`
+// predicate evaluates against. Per the spec, a play's own `inputs:`
+// are NOT visible to its own when (the issue body calls this circular),
+// and other plays' play-local inputs are also not visible. Only
+// file-level input defaults and user-provided overrides reach this
+// context.
+//
+// The base context is the apply / plan command's merged map (file-level
+// + vars-file + CLI). fileLevelKeys is the set of input names declared
+// on inputs-only plays. userSet is the union of CLI-set and
+// vars-file-set keys. A key passes through when it is file-level OR the
+// user has explicitly overridden it.
+func buildPlayWhenContext(base map[string]interface{}, fileLevelKeys, userSet map[string]bool) map[string]interface{} {
+	out := make(map[string]interface{}, len(base))
+	for k, v := range base {
+		if fileLevelKeys[k] || userSet[k] {
+			out[k] = v
+		}
+	}
+	return out
+}

--- a/commands/init.go
+++ b/commands/init.go
@@ -146,13 +146,13 @@ func (c *InitCommand) Run(args []string) int {
 		return 1
 	}
 
-	taskCount, err := countTasks(rendered)
+	taskCount, playCount, err := countTasks(rendered)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("internal error: rendered scaffold did not parse: %v", err))
 		return 1
 	}
 
-	c.Ui.Output(fmt.Sprintf("==> Created %s (%s, 1 play)", c.output, pluralize(taskCount, "task")))
+	c.Ui.Output(fmt.Sprintf("==> Created %s (%s, %s)", c.output, pluralize(taskCount, "task"), pluralize(playCount, "play")))
 	c.Ui.Output("")
 	c.Ui.Output("Next steps:")
 	c.Ui.Output(fmt.Sprintf("  $ %s validate          # offline check", appName()))
@@ -256,18 +256,18 @@ func defaultRepo() string {
 }
 
 // countTasks parses rendered YAML and returns the total number of tasks
-// across all plays. Used for the "==> Created tasks.yml (N tasks, 1 play)"
-// summary line.
-func countTasks(data []byte) (int, error) {
+// across all plays plus the play count. Used for the "==> Created
+// tasks.yml (N tasks, M plays)" summary line.
+func countTasks(data []byte) (int, int, error) {
 	var recipe tasks.Recipe
 	if err := yaml.Unmarshal(data, &recipe); err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	total := 0
 	for _, play := range recipe {
 		total += len(play.Tasks)
 	}
-	return total, nil
+	return total, len(recipe), nil
 }
 
 func pluralize(n int, word string) string {

--- a/commands/output.go
+++ b/commands/output.go
@@ -21,6 +21,10 @@ type EventEmitter interface {
 	// PlayStart announces the beginning of a play. host is the optional
 	// remote host annotation, "" for local execution.
 	PlayStart(name, host string)
+	// PlaySkipped announces a play that was filtered out by its `when:`
+	// predicate. whenSrc is the raw expr source so the human formatter
+	// can quote it back at the user.
+	PlaySkipped(name, whenSrc string)
 	// ApplyTask emits one event per task in an `apply` run.
 	ApplyTask(ev ApplyTaskEvent)
 	// PlanTask emits one event per task in a `plan` run.
@@ -104,20 +108,22 @@ var continuationIndent = strings.Repeat(" ", markerWidth)
 // ApplyCounts holds the running totals printed by the apply summary
 // line.
 type ApplyCounts struct {
-	Tasks   int
-	Changed int
-	OK      int
-	Skipped int
-	Errors  int
+	Tasks        int
+	Changed      int
+	OK           int
+	Skipped      int
+	Errors       int
+	PlaysSkipped int
 }
 
 // PlanCounts holds the running totals printed by the plan summary line.
 type PlanCounts struct {
-	Tasks       int
-	WouldChange int
-	InSync      int
-	Skipped     int
-	Errors      int
+	Tasks        int
+	WouldChange  int
+	InSync       int
+	Skipped      int
+	Errors       int
+	PlaysSkipped int
 }
 
 // Formatter renders the structured per-task output for `apply` and
@@ -182,6 +188,18 @@ func (f *Formatter) PlayHeaderWithHost(name, host string) {
 // PlayStart satisfies EventEmitter; delegates to PlayHeaderWithHost.
 func (f *Formatter) PlayStart(name, host string) {
 	f.PlayHeaderWithHost(name, host)
+}
+
+// PlaySkipped renders a `==> Play: <name>  (skipped: when "<src>")`
+// line for a play whose `when:` predicate evaluated to false. whenSrc
+// is the raw expr source; the formatter quotes it back so the user can
+// see which predicate caused the skip.
+func (f *Formatter) PlaySkipped(name, whenSrc string) {
+	if whenSrc == "" {
+		f.ui.Output(fmt.Sprintf("==> Play: %s  (skipped)", name))
+		return
+	}
+	f.ui.Output(fmt.Sprintf("==> Play: %s  (skipped: when %q)", name, whenSrc))
 }
 
 // ApplyTask renders one apply task line plus optional continuations,
@@ -319,15 +337,28 @@ func (f *Formatter) Continuation(prefix rune, body string) {
 // ApplySummary emits the blank line and `Summary: ...` footer that
 // follows an apply run. elapsed is rendered with one decimal of
 // seconds, matching the spec in issue #202.
+//
+// When one or more plays were filtered out by their `when:` predicate
+// (#208), an extra `· N play(s) skipped` segment is appended before the
+// duration so the user sees both the per-task skip count and the
+// per-play skip count.
 func (f *Formatter) ApplySummary(c ApplyCounts, elapsed time.Duration) {
 	errWord := "errors"
 	if c.Errors == 1 {
 		errWord = "error"
 	}
+	playSegment := ""
+	if c.PlaysSkipped > 0 {
+		playWord := "plays"
+		if c.PlaysSkipped == 1 {
+			playWord = "play"
+		}
+		playSegment = fmt.Sprintf(" · %d %s skipped", c.PlaysSkipped, playWord)
+	}
 	f.ui.Output("")
 	f.ui.Output(fmt.Sprintf(
-		"Summary: %d tasks · %d changed · %d ok · %d skipped · %d %s  (took %.1fs)",
-		c.Tasks, c.Changed, c.OK, c.Skipped, c.Errors, errWord, elapsed.Seconds(),
+		"Summary: %d tasks · %d changed · %d ok · %d skipped · %d %s%s  (took %.1fs)",
+		c.Tasks, c.Changed, c.OK, c.Skipped, c.Errors, errWord, playSegment, elapsed.Seconds(),
 	))
 }
 
@@ -344,16 +375,24 @@ func (f *Formatter) ApplySummary(c ApplyCounts, elapsed time.Duration) {
 // (the legacy format omits timing). The JSON emitter consumes it.
 func (f *Formatter) PlanSummary(c PlanCounts, _ time.Duration) {
 	f.ui.Output("")
+	playSegment := ""
+	if c.PlaysSkipped > 0 {
+		playWord := "plays"
+		if c.PlaysSkipped == 1 {
+			playWord = "play"
+		}
+		playSegment = fmt.Sprintf(", %d %s skipped", c.PlaysSkipped, playWord)
+	}
 	if c.Skipped > 0 {
 		f.ui.Output(fmt.Sprintf(
-			"Plan: %d task(s); %d would change, %d in sync, %d skipped, %d error(s).",
-			c.Tasks, c.WouldChange, c.InSync, c.Skipped, c.Errors,
+			"Plan: %d task(s); %d would change, %d in sync, %d skipped, %d error(s)%s.",
+			c.Tasks, c.WouldChange, c.InSync, c.Skipped, c.Errors, playSegment,
 		))
 		return
 	}
 	f.ui.Output(fmt.Sprintf(
-		"Plan: %d task(s); %d would change, %d in sync, %d error(s).",
-		c.Tasks, c.WouldChange, c.InSync, c.Errors,
+		"Plan: %d task(s); %d would change, %d in sync, %d error(s)%s.",
+		c.Tasks, c.WouldChange, c.InSync, c.Errors, playSegment,
 	))
 }
 

--- a/commands/output_json.go
+++ b/commands/output_json.go
@@ -41,6 +41,23 @@ func (e *JSONEmitter) PlayStart(name, host string) {
 	e.write(ev)
 }
 
+// PlaySkipped emits a `play_skipped` event for a play that was filtered
+// out by its `when:` predicate. The reason field carries the raw expr
+// source so consumers can correlate the skip with the recipe.
+func (e *JSONEmitter) PlaySkipped(name, whenSrc string) {
+	ev := map[string]interface{}{
+		"version": jsonSchemaVersion,
+		"type":    "play_skipped",
+		"name":    name,
+		"ts":      nowRFC3339(),
+	}
+	if whenSrc != "" {
+		ev["when"] = whenSrc
+		ev["reason"] = "when: " + whenSrc
+	}
+	e.write(ev)
+}
+
 // ApplyTask emits one `task` event for an apply run. Status is one of
 // "ok", "changed", "skipped", "error".
 func (e *JSONEmitter) ApplyTask(ev ApplyTaskEvent) {
@@ -127,28 +144,30 @@ func (e *JSONEmitter) PlanTask(ev PlanTaskEvent) {
 // ApplySummary emits the end-of-run summary event for apply.
 func (e *JSONEmitter) ApplySummary(c ApplyCounts, d time.Duration) {
 	e.write(map[string]interface{}{
-		"version":     jsonSchemaVersion,
-		"type":        "summary",
-		"tasks":       c.Tasks,
-		"changed":     c.Changed,
-		"ok":          c.OK,
-		"skipped":     c.Skipped,
-		"errors":      c.Errors,
-		"duration_ms": d.Milliseconds(),
+		"version":       jsonSchemaVersion,
+		"type":          "summary",
+		"tasks":         c.Tasks,
+		"changed":       c.Changed,
+		"ok":            c.OK,
+		"skipped":       c.Skipped,
+		"errors":        c.Errors,
+		"plays_skipped": c.PlaysSkipped,
+		"duration_ms":   d.Milliseconds(),
 	})
 }
 
 // PlanSummary emits the end-of-run summary event for plan.
 func (e *JSONEmitter) PlanSummary(c PlanCounts, d time.Duration) {
 	e.write(map[string]interface{}{
-		"version":      jsonSchemaVersion,
-		"type":         "summary",
-		"tasks":        c.Tasks,
-		"would_change": c.WouldChange,
-		"in_sync":      c.InSync,
-		"skipped":      c.Skipped,
-		"errors":       c.Errors,
-		"duration_ms":  d.Milliseconds(),
+		"version":       jsonSchemaVersion,
+		"type":          "summary",
+		"tasks":         c.Tasks,
+		"would_change":  c.WouldChange,
+		"in_sync":       c.InSync,
+		"skipped":       c.Skipped,
+		"errors":        c.Errors,
+		"plays_skipped": c.PlaysSkipped,
+		"duration_ms":   d.Milliseconds(),
 	})
 }
 

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -28,6 +28,7 @@ type PlanCommand struct {
 	tags              []string
 	skipTags          []string
 	varsFiles         []string
+	play              string
 	arguments         map[string]*Argument
 }
 
@@ -76,6 +77,7 @@ func (c *PlanCommand) FlagSet() *flag.FlagSet {
 	f.StringSliceVar(&c.tags, "tags", nil, "comma-separated tag list; only tasks whose `tags:` set intersects this list are planned")
 	f.StringSliceVar(&c.skipTags, "skip-tags", nil, "comma-separated tag list; tasks whose `tags:` set intersects this list are skipped")
 	f.StringArrayVar(&c.varsFiles, "vars-file", nil, "load input values from a YAML or JSON file (repeatable; later files override earlier; CLI --name=value flags always win). A .json extension parses as JSON; otherwise YAML.")
+	f.StringVar(&c.play, "play", "", "plan only the play with this name (matches the play's `name:` field; auto-named plays use `play #N`)")
 
 	taskFile := getTaskYamlFilename(os.Args)
 	data, err := os.ReadFile(taskFile)
@@ -105,6 +107,7 @@ func (c *PlanCommand) AutocompleteFlags() complete.Flags {
 			"--tags":                 complete.PredictAnything,
 			"--skip-tags":            complete.PredictAnything,
 			"--vars-file":            complete.PredictFiles("*"),
+			"--play":                 complete.PredictAnything,
 		},
 	)
 }
@@ -132,7 +135,8 @@ func (c *PlanCommand) Run(args []string) int {
 		return 1
 	}
 
-	if err := applyVarsFiles(c.arguments, flags, c.varsFiles); err != nil {
+	varsFileKeys, err := applyVarsFiles(c.arguments, flags, c.varsFiles)
+	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
 	}
@@ -160,13 +164,26 @@ func (c *PlanCommand) Run(args []string) int {
 		}
 	}
 
-	taskList, err := tasks.GetTasks(data, context)
+	userSet := userSetKeys(flags, varsFileKeys, c.arguments)
+
+	plays, err := tasks.GetPlays(data, context, userSet)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("task error: %v", err))
 		return 1
 	}
 
-	sensitiveValues = append(sensitiveValues, tasks.CollectSensitiveValues(taskList)...)
+	// Compute file-level input names from the *unfiltered* play list so
+	// --play does not accidentally hide an inputs-only play whose
+	// declared inputs the surviving play's when: depends on.
+	fileLevelKeys := tasks.FileLevelInputNames(plays)
+
+	plays, err = filterPlaysByName(plays, c.play)
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	sensitiveValues = append(sensitiveValues, tasks.CollectPlaySensitiveValues(plays)...)
 	subprocess.SetGlobalSensitive(sensitiveValues)
 	defer subprocess.SetGlobalSensitive(nil)
 
@@ -175,71 +192,93 @@ func (c *PlanCommand) Run(args []string) int {
 	}
 
 	emitter := c.newEmitter()
-	emitter.PlayStart("tasks", resolvedHost)
-
 	start := time.Now()
 	counts := PlanCounts{}
 	hasError := false
 	hasDrift := false
-	playName := "tasks"
+	playWhenExprCtx := buildEnvelopeExprContext(buildPlayWhenContext(context, fileLevelKeys, userSet))
 
-	keys := tasks.FilterByTags(taskList, c.tags, c.skipTags)
-	exprBaseCtx := buildEnvelopeExprContext(context)
-
-	for _, name := range keys {
-		env := taskList.GetEnvelope(name)
-		taskStart := time.Now()
-
-		if env.HasWhen() {
-			ok, err := tasks.EvalBool(env.WhenProgram(), envelopeExprContext(exprBaseCtx, env))
+	for _, play := range plays {
+		if play.IsFileLevel() {
+			// Inputs-only plays carry no tasks; their inputs are
+			// already folded into fileLevelKeys above. They produce
+			// no output and do not count toward play totals.
+			continue
+		}
+		if play.HasWhen() {
+			ok, err := tasks.EvalBool(play.WhenProgram(), playWhenExprCtx)
 			if err != nil {
-				counts.Tasks++
-				counts.Errors++
+				counts.PlaysSkipped++
 				hasError = true
-				emitter.PlanTask(PlanTaskEvent{
-					Play:      playName,
-					Name:      name,
-					WhenError: err,
-					Duration:  time.Since(taskStart),
-					Timestamp: time.Now().UTC(),
-				})
+				emitter.PlaySkipped(play.Name, fmt.Sprintf("%s (error: %v)", play.When, err))
 				continue
 			}
 			if !ok {
-				counts.Tasks++
-				counts.Skipped++
-				emitter.PlanTask(PlanTaskEvent{
-					Play:      playName,
-					Name:      name,
-					Skipped:   true,
-					Duration:  time.Since(taskStart),
-					Timestamp: time.Now().UTC(),
-				})
+				counts.PlaysSkipped++
+				emitter.PlaySkipped(play.Name, play.When)
 				continue
 			}
 		}
 
-		result := env.Task.Plan()
-		counts.Tasks++
+		emitter.PlayStart(play.Name, resolvedHost)
 
-		switch {
-		case result.Error != nil:
-			counts.Errors++
-			hasError = true
-		case result.InSync:
-			counts.InSync++
-		default:
-			counts.WouldChange++
-			hasDrift = true
+		playExprCtx := buildEnvelopeExprContext(tasks.BuildPerPlayContext(context, play.Inputs, userSet))
+
+		for _, name := range tasks.FilterByTags(play.Tasks, c.tags, c.skipTags) {
+			env := play.Tasks.GetEnvelope(name)
+			taskStart := time.Now()
+
+			if env.HasWhen() {
+				ok, err := tasks.EvalBool(env.WhenProgram(), envelopeExprContext(playExprCtx, env))
+				if err != nil {
+					counts.Tasks++
+					counts.Errors++
+					hasError = true
+					emitter.PlanTask(PlanTaskEvent{
+						Play:      play.Name,
+						Name:      name,
+						WhenError: err,
+						Duration:  time.Since(taskStart),
+						Timestamp: time.Now().UTC(),
+					})
+					continue
+				}
+				if !ok {
+					counts.Tasks++
+					counts.Skipped++
+					emitter.PlanTask(PlanTaskEvent{
+						Play:      play.Name,
+						Name:      name,
+						Skipped:   true,
+						Duration:  time.Since(taskStart),
+						Timestamp: time.Now().UTC(),
+					})
+					continue
+				}
+			}
+
+			result := env.Task.Plan()
+			counts.Tasks++
+
+			switch {
+			case result.Error != nil:
+				counts.Errors++
+				hasError = true
+			case result.InSync:
+				counts.InSync++
+			default:
+				counts.WouldChange++
+				hasDrift = true
+			}
+
+			emitter.PlanTask(PlanTaskEvent{
+				Play:      play.Name,
+				Name:      name,
+				Result:    result,
+				Duration:  time.Since(taskStart),
+				Timestamp: time.Now().UTC(),
+			})
 		}
-
-		emitter.PlanTask(PlanTaskEvent{
-			Play:      playName,
-			Name:      name,
-			Result:    result,
-			Duration:  time.Since(taskStart),
-			Timestamp: time.Now().UTC(),
-		})
 	}
 
 	emitter.PlanSummary(counts, time.Since(start))

--- a/commands/play_executor_test.go
+++ b/commands/play_executor_test.go
@@ -1,0 +1,211 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/mitchellh/cli"
+)
+
+// These tests drive the multi-play executor on the plan path so the
+// assertions stay deterministic without a Dokku server. Apply-only
+// behaviour (--fail-fast vs default abort-current-play) is exercised
+// against real Dokku in tests/bats/plays.bats.
+
+func writeMultiPlayTasks(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write tasks.yml: %v", err)
+	}
+	return path
+}
+
+// runPlan stages os.Args because PlanCommand.FlagSet() reads --tasks
+// from os.Args (so it can pre-register input flags before flag.Parse
+// runs against the per-call args).
+func runPlan(t *testing.T, path string, args ...string) (string, string, int) {
+	t.Helper()
+	origArgs := os.Args
+	os.Args = []string{"docket-test", "plan", "--tasks", path}
+	t.Cleanup(func() { os.Args = origArgs })
+
+	c := &PlanCommand{}
+	c.Meta = command.Meta{Ui: cli.NewMockUi()}
+	all := append([]string{"--tasks", path}, args...)
+	exit := c.Run(all)
+	ui := c.Ui.(*cli.MockUi)
+	return ui.OutputWriter.String(), ui.ErrorWriter.String(), exit
+}
+
+// TestMultiPlayPlanRunsAllPlaysInOrder is the headline multi-play case:
+// two plays both produce a `==> Play:` header in source order.
+func TestMultiPlayPlanRunsAllPlaysInOrder(t *testing.T) {
+	path := writeMultiPlayTasks(t, `---
+- name: api
+  tasks:
+    - name: noop-api
+      dokku_app:
+        app: docket-test-noop-api
+- name: worker
+  tasks:
+    - name: noop-worker
+      dokku_app:
+        app: docket-test-noop-worker
+`)
+	stdout, _, _ := runPlan(t, path)
+	idxAPI := strings.Index(stdout, "==> Play: api")
+	idxWorker := strings.Index(stdout, "==> Play: worker")
+	if idxAPI < 0 || idxWorker < 0 {
+		t.Fatalf("missing play headers; got:\n%s", stdout)
+	}
+	if idxAPI > idxWorker {
+		t.Errorf("plays out of order; api should come before worker; got:\n%s", stdout)
+	}
+}
+
+// TestMultiPlayPlayFilterRunsOnlyNamedPlay covers --play. Only the
+// matched play should produce a header; the other play's tasks should
+// not appear.
+func TestMultiPlayPlayFilterRunsOnlyNamedPlay(t *testing.T) {
+	path := writeMultiPlayTasks(t, `---
+- name: api
+  tasks:
+    - name: noop-api
+      dokku_app:
+        app: docket-test-noop-api
+- name: worker
+  tasks:
+    - name: noop-worker
+      dokku_app:
+        app: docket-test-noop-worker
+`)
+	stdout, _, _ := runPlan(t, path, "--play", "api")
+	if !strings.Contains(stdout, "==> Play: api") {
+		t.Errorf("api play header missing; got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "==> Play: worker") {
+		t.Errorf("worker play should be filtered out; got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "noop-worker") {
+		t.Errorf("worker tasks should not appear; got:\n%s", stdout)
+	}
+}
+
+// TestMultiPlayPlayFilterUnknownNameErrors verifies the user sees a
+// useful diagnostic when --play does not match any play, including the
+// available play names so they can correct the typo.
+func TestMultiPlayPlayFilterUnknownNameErrors(t *testing.T) {
+	path := writeMultiPlayTasks(t, `---
+- name: api
+  tasks:
+    - name: noop
+      dokku_app:
+        app: docket-test-noop-api
+- name: worker
+  tasks:
+    - name: noop
+      dokku_app:
+        app: docket-test-noop-worker
+`)
+	_, stderr, exit := runPlan(t, path, "--play", "missing")
+	if exit == 0 {
+		t.Error("expected non-zero exit when --play does not match")
+	}
+	for _, want := range []string{`--play "missing"`, `"api"`, `"worker"`} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr missing %q; got:\n%s", want, stderr)
+		}
+	}
+}
+
+// TestMultiPlayPlayFilterComposesWithTags pins the --play + --tags
+// composition: --play narrows to one play, --tags then filters tasks
+// within that play.
+func TestMultiPlayPlayFilterComposesWithTags(t *testing.T) {
+	path := writeMultiPlayTasks(t, `---
+- name: api
+  tasks:
+    - name: deploy-api
+      tags: [deploy]
+      dokku_app:
+        app: docket-test-deploy-api
+    - name: configure-api
+      tags: [configure]
+      dokku_app:
+        app: docket-test-configure-api
+- name: worker
+  tasks:
+    - name: deploy-worker
+      tags: [deploy]
+      dokku_app:
+        app: docket-test-deploy-worker
+`)
+	stdout, _, _ := runPlan(t, path, "--play", "api", "--tags", "deploy")
+	if !strings.Contains(stdout, "deploy-api") {
+		t.Errorf("deploy-api should run; got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "configure-api") {
+		t.Errorf("configure-api should be filtered by --tags; got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "deploy-worker") {
+		t.Errorf("worker play tasks should be filtered by --play; got:\n%s", stdout)
+	}
+}
+
+// TestMultiPlayPlayLevelTagsPropagateToTasks: --tags filters against
+// the task's effective tag set, which includes the play's tags. A task
+// with no per-task tag still passes a --tags filter that matches the
+// play tag.
+func TestMultiPlayPlayLevelTagsPropagateToTasks(t *testing.T) {
+	path := writeMultiPlayTasks(t, `---
+- name: api
+  tags: [api]
+  tasks:
+    - name: deploy-api
+      dokku_app:
+        app: docket-test-deploy-api
+- name: worker
+  tags: [worker]
+  tasks:
+    - name: deploy-worker
+      dokku_app:
+        app: docket-test-deploy-worker
+`)
+	stdout, _, _ := runPlan(t, path, "--tags", "api")
+	if !strings.Contains(stdout, "deploy-api") {
+		t.Errorf("deploy-api should match play tag; got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "deploy-worker") {
+		t.Errorf("deploy-worker should be filtered by --tags; got:\n%s", stdout)
+	}
+}
+
+// TestMultiPlayWhenSkippedShowsInSummary: skipped plays count toward
+// the new "n play skipped" summary segment.
+func TestMultiPlayWhenSkippedShowsInSummary(t *testing.T) {
+	path := writeMultiPlayTasks(t, `---
+- inputs:
+    - name: env
+      default: dev
+- name: api
+  when: 'env == "prod"'
+  tasks:
+    - name: noop
+      dokku_app:
+        app: docket-test-noop-api
+- name: worker
+  tasks:
+    - name: noop
+      dokku_app:
+        app: docket-test-noop-worker
+`)
+	stdout, _, _ := runPlan(t, path)
+	if !strings.Contains(stdout, "1 play skipped") {
+		t.Errorf("summary should include `1 play skipped`; got:\n%s", stdout)
+	}
+}

--- a/commands/play_when_test.go
+++ b/commands/play_when_test.go
@@ -1,0 +1,251 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/mitchellh/cli"
+)
+
+// These tests pin the spec's "play `when:` sees the file-level merged
+// context only" rule. The play's own `inputs:` are intentionally NOT
+// visible to its own `when:` predicate (the issue body calls this
+// circular). The tests drive the plan path because plan does not
+// require a Dokku server, so the assertions stay deterministic in CI.
+//
+// Predicate negative tests use equality (`==`) rather than negation
+// (`!=`) because expr is configured with AllowUndefinedVariables, which
+// renders unknown identifiers as nil at runtime. With `==`, an unknown
+// identifier produces `nil == "x"` (false → skipped), which is the
+// outcome we want to assert. With `!=`, `nil != "x"` is true and the
+// play would run regardless of whether the variable was visible.
+
+func newTestPlanCommand() *PlanCommand {
+	c := &PlanCommand{}
+	c.Meta = command.Meta{Ui: cli.NewMockUi()}
+	return c
+}
+
+// playOutput drives plan with the given args against the tasks file at
+// path and returns the captured stdout / stderr / exit code. It also
+// stages os.Args because PlanCommand.FlagSet() reads --tasks from
+// os.Args (not from the args slice) so it can pre-register input flags
+// before flag.Parse runs against the per-call args.
+func playOutput(t *testing.T, path string, args ...string) (string, string, int) {
+	t.Helper()
+	origArgs := os.Args
+	os.Args = []string{"docket-test", "plan", "--tasks", path}
+	t.Cleanup(func() { os.Args = origArgs })
+
+	c := newTestPlanCommand()
+	all := append([]string{"--tasks", path}, args...)
+	exit := c.Run(all)
+	ui := c.Ui.(*cli.MockUi)
+	return ui.OutputWriter.String(), ui.ErrorWriter.String(), exit
+}
+
+func writePlayTasks(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write tasks.yml: %v", err)
+	}
+	return path
+}
+
+// TestPlayWhenSeesFileLevelInputDefault: the play's `when:` evaluates a
+// file-level input default. The truthy default runs the play.
+func TestPlayWhenSeesFileLevelInputDefault(t *testing.T) {
+	path := writePlayTasks(t, `---
+- inputs:
+    - name: env
+      default: prod
+- name: api
+  when: 'env == "prod"'
+  tasks:
+    - name: noop
+      dokku_app:
+        app: docket-test-noop
+`)
+	stdout, _, _ := playOutput(t, path)
+	if !strings.Contains(stdout, "==> Play: api") {
+		t.Errorf("expected api play header (truthy default); got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, `Play: api  (skipped`) {
+		t.Errorf("api play should NOT be skipped when default makes when truthy; got:\n%s", stdout)
+	}
+}
+
+// TestPlayWhenSeesFileLevelInputDefaultFalsy: file-level default does
+// not satisfy the predicate; the play is skipped.
+func TestPlayWhenSeesFileLevelInputDefaultFalsy(t *testing.T) {
+	path := writePlayTasks(t, `---
+- inputs:
+    - name: env
+      default: staging
+- name: api
+  when: 'env == "prod"'
+  tasks:
+    - name: noop
+      dokku_app:
+        app: docket-test-noop
+`)
+	stdout, _, _ := playOutput(t, path)
+	if !strings.Contains(stdout, `Play: api  (skipped`) {
+		t.Errorf("expected api play to be skipped; got:\n%s", stdout)
+	}
+}
+
+// TestPlayWhenCLIOverridesFileDefault: --env=prod beats the file-level
+// staging default and the play runs.
+func TestPlayWhenCLIOverridesFileDefault(t *testing.T) {
+	path := writePlayTasks(t, `---
+- inputs:
+    - name: env
+      default: staging
+- name: api
+  when: 'env == "prod"'
+  tasks:
+    - name: noop
+      dokku_app:
+        app: docket-test-noop
+`)
+	stdout, _, _ := playOutput(t, path, "--env", "prod")
+	if !strings.Contains(stdout, "==> Play: api") {
+		t.Errorf("expected api play header after --env=prod override; got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, `Play: api  (skipped`) {
+		t.Errorf("play should NOT be skipped when CLI override makes when truthy; got:\n%s", stdout)
+	}
+}
+
+// TestPlayWhenVarsFileOverridesFileDefault: --vars-file value beats the
+// file-level default.
+func TestPlayWhenVarsFileOverridesFileDefault(t *testing.T) {
+	path := writePlayTasks(t, `---
+- inputs:
+    - name: env
+      default: staging
+- name: api
+  when: 'env == "prod"'
+  tasks:
+    - name: noop
+      dokku_app:
+        app: docket-test-noop
+`)
+	dir := filepath.Dir(path)
+	varsPath := filepath.Join(dir, "vars.yml")
+	if err := os.WriteFile(varsPath, []byte("env: prod\n"), 0o644); err != nil {
+		t.Fatalf("write vars.yml: %v", err)
+	}
+	stdout, _, _ := playOutput(t, path, "--vars-file", varsPath)
+	if !strings.Contains(stdout, "==> Play: api") {
+		t.Errorf("expected api play header after vars-file override; got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, `Play: api  (skipped`) {
+		t.Errorf("play should NOT be skipped after vars-file override; got:\n%s", stdout)
+	}
+}
+
+// TestPlayWhenCLIBeatsVarsFile: vars-file says staging, CLI says prod;
+// the play runs (CLI wins).
+func TestPlayWhenCLIBeatsVarsFile(t *testing.T) {
+	path := writePlayTasks(t, `---
+- inputs:
+    - name: env
+      default: dev
+- name: api
+  when: 'env == "prod"'
+  tasks:
+    - name: noop
+      dokku_app:
+        app: docket-test-noop
+`)
+	dir := filepath.Dir(path)
+	varsPath := filepath.Join(dir, "vars.yml")
+	if err := os.WriteFile(varsPath, []byte("env: staging\n"), 0o644); err != nil {
+		t.Fatalf("write vars.yml: %v", err)
+	}
+	stdout, _, _ := playOutput(t, path, "--vars-file", varsPath, "--env", "prod")
+	if !strings.Contains(stdout, "==> Play: api") {
+		t.Errorf("expected api play header (CLI must beat vars-file); got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, `Play: api  (skipped`) {
+		t.Errorf("play should NOT be skipped when CLI beats vars-file; got:\n%s", stdout)
+	}
+}
+
+// TestPlayWhenCannotSeeOwnInputs: a play declares `enabled` and asks
+// `when: 'enabled == "true"'`. The play's own inputs are NOT in the
+// when context, so `enabled` resolves to nil; `nil == "true"` is false
+// and the play is skipped. The play would run only if its own input
+// leaked into its own when context.
+func TestPlayWhenCannotSeeOwnInputs(t *testing.T) {
+	path := writePlayTasks(t, `---
+- name: api
+  inputs:
+    - name: enabled
+      default: "true"
+  when: 'enabled == "true"'
+  tasks:
+    - name: noop
+      dokku_app:
+        app: docket-test-noop
+`)
+	stdout, _, _ := playOutput(t, path)
+	if !strings.Contains(stdout, `Play: api  (skipped`) {
+		t.Errorf("api play should be skipped (own input must not be visible to own when); got:\n%s", stdout)
+	}
+}
+
+// TestPlayWhenCannotSeeSiblingPlayInputs: play `worker` references the
+// sibling play `api`'s input. Sibling-play inputs must not be visible,
+// so the comparison resolves to nil == "api" → false and worker is
+// skipped.
+func TestPlayWhenCannotSeeSiblingPlayInputs(t *testing.T) {
+	path := writePlayTasks(t, `---
+- name: api
+  inputs:
+    - name: app
+      default: api
+  tasks:
+    - name: api-noop
+      dokku_app:
+        app: docket-test-noop
+- name: worker
+  when: 'app == "api"'
+  tasks:
+    - name: worker-noop
+      dokku_app:
+        app: docket-test-noop
+`)
+	stdout, _, _ := playOutput(t, path)
+	if !strings.Contains(stdout, "==> Play: api") {
+		t.Errorf("api play header missing; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, `Play: worker  (skipped`) {
+		t.Errorf("worker play should be skipped (sibling input must not leak); got:\n%s", stdout)
+	}
+}
+
+// TestPlayWhenCannotSeeLoopVars: `.item` is a loop-iteration value;
+// it must not be available to a play-level `when:`. With `==` the
+// undefined identifier resolves to nil → comparison false → skipped.
+func TestPlayWhenCannotSeeLoopVars(t *testing.T) {
+	path := writePlayTasks(t, `---
+- name: api
+  when: 'item == "expected"'
+  tasks:
+    - name: noop
+      dokku_app:
+        app: docket-test-noop
+`)
+	stdout, _, _ := playOutput(t, path)
+	if !strings.Contains(stdout, `Play: api  (skipped`) {
+		t.Errorf(".item should not be visible to play when (expected skip); got:\n%s", stdout)
+	}
+}

--- a/commands/validate.go
+++ b/commands/validate.go
@@ -109,7 +109,7 @@ func (c *ValidateCommand) Run(args []string) int {
 		return 1
 	}
 
-	if err := applyVarsFiles(c.arguments, flags, c.varsFiles); err != nil {
+	if _, err := applyVarsFiles(c.arguments, flags, c.varsFiles); err != nil {
 		if c.json {
 			c.emitJSONProblem(tasks.Problem{
 				Code:    "vars_file_error",

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -36,12 +36,35 @@ const (
 	StateSkipped State = "skipped"
 )
 
-// Recipe represents a recipe for a task
-type Recipe []struct {
-	// Inputs are the inputs for the task
+// Recipe represents a docket recipe: a YAML list of plays. Each entry is
+// a play envelope carrying the play-level metadata (name, tags, when,
+// inputs) and the per-play tasks list. Single-play files are simply a
+// one-element list and require no special handling.
+type Recipe []RecipeEntry
+
+// RecipeEntry is the on-disk shape of one play. The yaml-unmarshalled
+// form; the runtime-facing Play struct (in play.go) is built from this
+// by GetPlays.
+type RecipeEntry struct {
+	// Name is the play's user-facing label. Auto-generated as
+	// "play #N" by GetPlays when omitted.
+	Name string `yaml:"name,omitempty"`
+
+	// Tags accepts either a YAML list (`tags: [a, b]`) or a scalar
+	// (`tags: a`). Decoded via decodeTags into the Play.Tags slice.
+	Tags interface{} `yaml:"tags,omitempty"`
+
+	// When is the raw expr source for the play-level conditional. Empty
+	// means "always run". Compiled into the Play.whenProgram by GetPlays.
+	When string `yaml:"when,omitempty"`
+
+	// Inputs are the play-local input defaults. Layer above file-level
+	// defaults but below --vars-file / CLI overrides (per-play merge
+	// happens in GetPlays).
 	Inputs []Input `yaml:"inputs,omitempty"`
 
-	// Tasks are the tasks for the recipe
+	// Tasks is the raw per-play task list, decoded into envelopes by
+	// GetPlays via buildEnvelopesForEntry.
 	Tasks []map[string]interface{} `yaml:"tasks,omitempty"`
 }
 
@@ -304,61 +327,212 @@ func (i Input) GetValue() string {
 	return i.value
 }
 
-// GetTasks parses data as a docket recipe and returns the per-task
-// envelopes the executor consumes. The pipeline is:
-//
-//  1. Inject `.item` / `.index` self-reference placeholders into the
-//     sigil context so loop-body templates pass through the file-level
-//     render intact.
-//  2. Sigil-render the file with the augmented context.
-//  3. YAML-unmarshal into a Recipe.
-//  4. For each task entry: partition envelope keys vs the task-type key,
-//     reject unknown keys with a "did you mean" hint, decode envelope
-//     fields, decode task body, pre-compile any `when:` predicate.
-//  5. If `loop:` is present, expand into N envelopes via expandLoop;
-//     otherwise emit one envelope.
-//  6. Reject any envelope whose final body still contains
-//     `{{ .item }}` / `{{ .index }}` (i.e. the user referenced a loop
-//     variable from a non-loop task).
+// GetTasks is a back-compat shim that returns the first play's task
+// envelopes. New code should call GetPlays. The wrapper is kept because a
+// large number of unit tests (tasks/*_test.go) exercise GetTasks directly
+// against single-play recipes; those tests inspect the flat ordered map
+// without caring about the multi-play envelope.
 func GetTasks(data []byte, context map[string]interface{}) (OrderedStringEnvelopeMap, error) {
-	tasks := OrderedStringEnvelopeMap{}
+	plays, err := GetPlays(data, context, nil)
+	if err != nil {
+		return OrderedStringEnvelopeMap{}, err
+	}
+	if len(plays) == 0 {
+		return OrderedStringEnvelopeMap{}, nil
+	}
+	return plays[0].Tasks, nil
+}
 
+// GetPlays parses data as a docket recipe and returns one Play per
+// top-level entry, each carrying its own envelope map. The executor
+// (commands/apply.go, commands/plan.go) walks the result in order.
+//
+// The render pipeline is:
+//
+//  1. Render the whole file with `context` (file-level inputs + vars-file
+//     + CLI overrides) for the structure pass. This catches template
+//     syntax errors at the same point GetTasks did before #208 and gives
+//     us the play count plus per-play metadata (name/tags/when/inputs).
+//  2. For each play, build a per-play context by layering the play's own
+//     `inputs:` defaults above file-level defaults, but only for keys the
+//     user has not overridden via --vars-file or CLI. The userSet map
+//     identifies user-overridden keys; pass nil to disable the layering
+//     (the GetTasks shim does this since back-compat tests do not need
+//     multi-play context).
+//  3. Re-render the whole file with the per-play context so task body
+//     templates substitute the play-local values, then walk to that
+//     play's tasks and build envelopes through the existing
+//     buildEnvelopesForEntry helper.
+//  4. Append the play's tags to every envelope (additive with per-task
+//     tags) so FilterByTags treats them uniformly.
+//
+// Per-play `when:` predicates are pre-compiled here; the executor decides
+// the evaluation context (file-level only, per the spec - the play's own
+// inputs are not visible to its own when).
+func GetPlays(data []byte, context map[string]interface{}, userSet map[string]bool) ([]*Play, error) {
+	baseRendered, err := renderRecipeBytes(data, context)
+	if err != nil {
+		return nil, err
+	}
+
+	baseRecipe := Recipe{}
+	if err := yaml.Unmarshal(baseRendered, &baseRecipe); err != nil {
+		return nil, fmt.Errorf("unmarshal error: %v", err.Error())
+	}
+
+	if len(baseRecipe) == 0 {
+		return nil, fmt.Errorf("parse error: no recipe found in tasks file")
+	}
+
+	plays := make([]*Play, 0, len(baseRecipe))
+	singleUnnamed := len(baseRecipe) == 1 && baseRecipe[0].Name == ""
+	for i, raw := range baseRecipe {
+		play := &Play{
+			Name:   raw.Name,
+			When:   raw.When,
+			Inputs: raw.Inputs,
+		}
+		if play.Name == "" {
+			// Single-play recipes without a name keep the legacy
+			// "tasks" header so existing recipes do not see a
+			// visual diff after #208. Multi-play recipes get
+			// numbered auto-names so each play header is distinct.
+			if singleUnnamed {
+				play.Name = "tasks"
+			} else {
+				play.Name = fmt.Sprintf("play #%d", i+1)
+			}
+		}
+
+		if raw.Tags != nil {
+			tags, err := decodeTags(raw.Tags)
+			if err != nil {
+				return nil, fmt.Errorf("play parse error: play #%d %q: %s", i+1, play.Name, err)
+			}
+			play.Tags = tags
+		}
+
+		if play.When != "" {
+			prog, err := CompilePredicate(play.When)
+			if err != nil {
+				return nil, fmt.Errorf("play parse error: play #%d %q: when compile error: %s", i+1, play.Name, err)
+			}
+			play.whenProgram = prog
+		}
+
+		playCtx := BuildPerPlayContext(context, play.Inputs, userSet)
+		perPlayRecipe, err := renderRecipe(data, playCtx)
+		if err != nil {
+			return nil, err
+		}
+		if i >= len(perPlayRecipe) {
+			return nil, fmt.Errorf("play parse error: play #%d %q: per-play render produced fewer plays than the structure pass", i+1, play.Name)
+		}
+
+		exprCtx := buildExprContext(playCtx)
+		play.Tasks = OrderedStringEnvelopeMap{}
+		for j, t := range perPlayRecipe[i].Tasks {
+			envelopes, err := buildEnvelopesForEntry(j+1, t, playCtx, exprCtx)
+			if err != nil {
+				return nil, err
+			}
+			for _, env := range envelopes {
+				if len(play.Tags) > 0 {
+					env.Tags = mergePlayTags(env.Tags, play.Tags)
+				}
+				play.Tasks.Set(env.Name, env)
+			}
+		}
+
+		plays = append(plays, play)
+	}
+
+	return plays, nil
+}
+
+// renderRecipeBytes runs the loop-var-safe sigil render over data with the
+// given context and returns the rendered bytes. Pulled out of the legacy
+// GetTasks so GetPlays can reuse it across the structure pass and per-play
+// passes.
+func renderRecipeBytes(data []byte, context map[string]interface{}) ([]byte, error) {
 	escaped, captured := escapeLoopVars(data)
-
 	render, err := sigil.Execute(escaped, context, "tasks")
 	if err != nil {
-		return tasks, fmt.Errorf("re-render error: %v", err.Error())
+		return nil, fmt.Errorf("re-render error: %v", err.Error())
 	}
-
 	rendered, err := io.ReadAll(&render)
 	if err != nil {
-		return tasks, fmt.Errorf("read error: %v", err.Error())
+		return nil, fmt.Errorf("read error: %v", err.Error())
 	}
+	return unescapeLoopVars(rendered, captured), nil
+}
 
-	out := unescapeLoopVars(rendered, captured)
-
+// renderRecipe is the convenience wrapper that renders data with context
+// and unmarshals the result into a Recipe.
+func renderRecipe(data []byte, context map[string]interface{}) (Recipe, error) {
+	rendered, err := renderRecipeBytes(data, context)
+	if err != nil {
+		return nil, err
+	}
 	recipe := Recipe{}
-	if err := yaml.Unmarshal([]byte(out), &recipe); err != nil {
-		return tasks, fmt.Errorf("unmarshal error: %v", err.Error())
+	if err := yaml.Unmarshal(rendered, &recipe); err != nil {
+		return nil, fmt.Errorf("unmarshal error: %v", err.Error())
 	}
+	return recipe, nil
+}
 
-	if len(recipe) == 0 {
-		return tasks, fmt.Errorf("parse error: no recipe found in tasks file")
+// BuildPerPlayContext layers the play's `inputs:` defaults above the
+// file-level base context, but only for keys the user has not explicitly
+// overridden via --vars-file or CLI flags. The userSet map carries the
+// names of user-overridden inputs; nil disables the layering, which is
+// the GetTasks back-compat behaviour. Per-play defaults with an empty
+// Default string are skipped so they cannot accidentally shadow a real
+// file-level value with "".
+//
+// Exported because the apply / plan executors need to build the same
+// per-play context the loader used so per-task `when:` predicates see
+// the same values as the rendered task bodies.
+func BuildPerPlayContext(base map[string]interface{}, playInputs []Input, userSet map[string]bool) map[string]interface{} {
+	out := make(map[string]interface{}, len(base)+len(playInputs))
+	for k, v := range base {
+		out[k] = v
 	}
-
-	exprContext := buildExprContext(context)
-
-	for i, t := range recipe[0].Tasks {
-		envelopes, err := buildEnvelopesForEntry(i+1, t, context, exprContext)
-		if err != nil {
-			return tasks, err
+	for _, in := range playInputs {
+		if in.Name == "" {
+			continue
 		}
-		for _, env := range envelopes {
-			tasks.Set(env.Name, env)
+		if userSet[in.Name] {
+			continue
 		}
+		if in.Default == "" {
+			continue
+		}
+		out[in.Name] = in.Default
 	}
+	return out
+}
 
-	return tasks, nil
+// mergePlayTags appends playTags onto envTags, dropping duplicates so a
+// task that declares the same tag as the enclosing play does not see it
+// twice. envTags' original order is preserved; new tags from playTags
+// land at the end.
+func mergePlayTags(envTags, playTags []string) []string {
+	if len(playTags) == 0 {
+		return envTags
+	}
+	seen := make(map[string]bool, len(envTags))
+	for _, t := range envTags {
+		seen[t] = true
+	}
+	out := append([]string(nil), envTags...)
+	for _, t := range playTags {
+		if seen[t] {
+			continue
+		}
+		out = append(out, t)
+		seen[t] = true
+	}
+	return out
 }
 
 // buildEnvelopesForEntry walks a single task entry, partitions envelope

--- a/tasks/play.go
+++ b/tasks/play.go
@@ -1,0 +1,95 @@
+package tasks
+
+import (
+	"github.com/expr-lang/expr/vm"
+)
+
+// Play is one entry in a docket recipe's top-level YAML list. A recipe may
+// declare any number of plays; the executor walks them in order and bounds
+// per-task state to the play's own context.
+//
+// The envelope keys (Name, Tags, When, Inputs) sit alongside the per-play
+// Tasks. Per-play Inputs override file-level defaults within their play but
+// not across plays; CLI --name=value and --vars-file always win. Per-play
+// Tags are inherited by every task in the play (additive with per-task tags
+// already on the envelope).
+//
+// The play's own When predicate is evaluated against the file-level merged
+// context only - the play's own Inputs are not visible to its own When (the
+// spec calls this circular). Per-task When inside the play does see the
+// play's Inputs.
+type Play struct {
+	// Name is the user-supplied label for the play. Auto-generated as
+	// "play #N" when the entry omits a name (see GetPlays).
+	Name string
+
+	// Tags is the play's tag list. Folded into every task envelope's Tags
+	// at parse time so the existing FilterByTags helper keeps working
+	// without a per-play branch.
+	Tags []string
+
+	// When is the raw expr-lang/expr source for the play-level conditional.
+	// An empty string means "always run". When non-empty, whenProgram caches
+	// the compiled form so the executor can re-evaluate cheaply.
+	When string
+
+	// Inputs is the play's own inputs declaration. Defaults layer above
+	// file-level defaults but below --vars-file / CLI overrides.
+	Inputs []Input
+
+	// Tasks is the per-play envelope map populated by GetPlays. Insertion
+	// order mirrors the play's tasks: source order.
+	Tasks OrderedStringEnvelopeMap
+
+	// whenProgram is the pre-compiled expr program for When. Set by
+	// GetPlays so the executor does not re-compile per evaluation.
+	whenProgram *vm.Program
+}
+
+// HasWhen reports whether the play carries a non-empty `when:` predicate
+// that must be evaluated before the play's tasks run.
+func (p *Play) HasWhen() bool {
+	return p != nil && p.When != ""
+}
+
+// WhenProgram returns the pre-compiled expr program for the play's When,
+// or nil when no `when:` predicate is present.
+func (p *Play) WhenProgram() *vm.Program {
+	if p == nil {
+		return nil
+	}
+	return p.whenProgram
+}
+
+// IsFileLevel reports whether this play is an inputs-only entry rather
+// than a task play. The convention: a play with no tasks acts purely as
+// a file-level inputs declaration (its `inputs:` are visible to every
+// play's `when:` and to every task body); a play with tasks treats its
+// inputs as play-local (visible to its tasks only).
+func (p *Play) IsFileLevel() bool {
+	return p != nil && len(p.Tasks.Keys()) == 0
+}
+
+// FileLevelInputNames returns the set of input names declared on
+// "inputs-only" plays (plays with no tasks). Inputs on plays with
+// tasks are play-local: their defaults are visible to that play's
+// tasks but not to any play's `when:` and not to other plays' tasks.
+//
+// Used by the apply / plan executors to build the file-level context
+// the spec requires for per-play `when:` evaluation: file-level input
+// defaults plus user overrides only, without play-local defaults
+// leaking in.
+func FileLevelInputNames(plays []*Play) map[string]bool {
+	out := map[string]bool{}
+	for _, p := range plays {
+		if !p.IsFileLevel() {
+			continue
+		}
+		for _, in := range p.Inputs {
+			if in.Name != "" {
+				out[in.Name] = true
+			}
+		}
+	}
+	return out
+}

--- a/tasks/play_test.go
+++ b/tasks/play_test.go
@@ -1,0 +1,319 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+
+	_ "github.com/gliderlabs/sigil/builtin"
+)
+
+// TestGetPlaysSinglePlayBackCompat ensures a single-play file - the legacy
+// shape - produces one Play with the expected name/tasks. This is the
+// shape every existing tasks/*_test.go file relies on through the
+// GetTasks back-compat shim.
+func TestGetPlaysSinglePlayBackCompat(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: create app
+      dokku_app:
+        app: test-app
+`)
+	plays, err := GetPlays(data, map[string]interface{}{}, nil)
+	if err != nil {
+		t.Fatalf("GetPlays: %v", err)
+	}
+	if len(plays) != 1 {
+		t.Fatalf("expected 1 play, got %d", len(plays))
+	}
+	if plays[0].Name != "tasks" {
+		t.Errorf("auto-name = %q, want %q (single-play files keep the legacy header)", plays[0].Name, "tasks")
+	}
+	if len(plays[0].Tasks.Keys()) != 1 {
+		t.Errorf("expected 1 task in play, got %d", len(plays[0].Tasks.Keys()))
+	}
+	if plays[0].Tasks.Get("create app") == nil {
+		t.Error("task 'create app' missing")
+	}
+}
+
+func TestGetPlaysMultiPlayBuildsBoth(t *testing.T) {
+	data := []byte(`---
+- name: api
+  tasks:
+    - name: create api
+      dokku_app:
+        app: api
+- name: worker
+  tasks:
+    - name: create worker
+      dokku_app:
+        app: worker
+`)
+	plays, err := GetPlays(data, map[string]interface{}{}, nil)
+	if err != nil {
+		t.Fatalf("GetPlays: %v", err)
+	}
+	if len(plays) != 2 {
+		t.Fatalf("expected 2 plays, got %d", len(plays))
+	}
+	if plays[0].Name != "api" || plays[1].Name != "worker" {
+		t.Errorf("play names = [%q, %q], want [api, worker]", plays[0].Name, plays[1].Name)
+	}
+	if plays[0].Tasks.Get("create api") == nil {
+		t.Error("api play missing 'create api' task")
+	}
+	if plays[1].Tasks.Get("create worker") == nil {
+		t.Error("worker play missing 'create worker' task")
+	}
+}
+
+// TestGetPlaysPerPlayInputsScopeAcrossPlays is the spec's headline example:
+// two plays both declare an `app` input with different defaults; the task
+// in each play must see its own play's value.
+func TestGetPlaysPerPlayInputsScopeAcrossPlays(t *testing.T) {
+	data := []byte(`---
+- name: api
+  inputs:
+    - name: app
+      default: api
+  tasks:
+    - name: create
+      dokku_app:
+        app: "{{ .app }}"
+- name: worker
+  inputs:
+    - name: app
+      default: worker
+  tasks:
+    - name: create
+      dokku_app:
+        app: "{{ .app }}"
+`)
+	plays, err := GetPlays(data, map[string]interface{}{}, nil)
+	if err != nil {
+		t.Fatalf("GetPlays: %v", err)
+	}
+	if len(plays) != 2 {
+		t.Fatalf("expected 2 plays, got %d", len(plays))
+	}
+
+	apiTask, ok := plays[0].Tasks.Get("create").(*AppTask)
+	if !ok {
+		t.Fatalf("api task is %T, want *AppTask", plays[0].Tasks.Get("create"))
+	}
+	if apiTask.App != "api" {
+		t.Errorf("api task app = %q, want %q (per-play default must win in play scope)", apiTask.App, "api")
+	}
+
+	workerTask, ok := plays[1].Tasks.Get("create").(*AppTask)
+	if !ok {
+		t.Fatalf("worker task is %T, want *AppTask", plays[1].Tasks.Get("create"))
+	}
+	if workerTask.App != "worker" {
+		t.Errorf("worker task app = %q, want %q (per-play default must win in play scope)", workerTask.App, "worker")
+	}
+}
+
+// TestGetPlaysUserOverrideBeatsPlayInputs pins the precedence rule that
+// CLI / vars-file overrides win over play-level inputs even when both
+// declare the same key. The userSet map carries the user-overridden keys.
+func TestGetPlaysUserOverrideBeatsPlayInputs(t *testing.T) {
+	data := []byte(`---
+- name: api
+  inputs:
+    - name: app
+      default: api
+  tasks:
+    - name: create
+      dokku_app:
+        app: "{{ .app }}"
+`)
+	context := map[string]interface{}{"app": "from-cli"}
+	userSet := map[string]bool{"app": true}
+
+	plays, err := GetPlays(data, context, userSet)
+	if err != nil {
+		t.Fatalf("GetPlays: %v", err)
+	}
+	task, ok := plays[0].Tasks.Get("create").(*AppTask)
+	if !ok {
+		t.Fatalf("task is %T, want *AppTask", plays[0].Tasks.Get("create"))
+	}
+	if task.App != "from-cli" {
+		t.Errorf("app = %q, want %q (user override must beat play default)", task.App, "from-cli")
+	}
+}
+
+func TestGetPlaysAutoNamesPlay(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - dokku_app:
+        app: a
+- tasks:
+    - dokku_app:
+        app: b
+`)
+	plays, err := GetPlays(data, map[string]interface{}{}, nil)
+	if err != nil {
+		t.Fatalf("GetPlays: %v", err)
+	}
+	want := []string{"play #1", "play #2"}
+	for i, p := range plays {
+		if p.Name != want[i] {
+			t.Errorf("plays[%d].Name = %q, want %q", i, p.Name, want[i])
+		}
+	}
+}
+
+func TestGetPlaysWhenCompiledAndExposed(t *testing.T) {
+	data := []byte(`---
+- name: api
+  when: 'env == "prod"'
+  tasks:
+    - dokku_app:
+        app: api
+`)
+	plays, err := GetPlays(data, map[string]interface{}{"env": "prod"}, nil)
+	if err != nil {
+		t.Fatalf("GetPlays: %v", err)
+	}
+	if !plays[0].HasWhen() {
+		t.Fatal("HasWhen should be true")
+	}
+	if plays[0].WhenProgram() == nil {
+		t.Error("WhenProgram should be non-nil after compile")
+	}
+}
+
+func TestGetPlaysInvalidWhenReturnsParseError(t *testing.T) {
+	data := []byte(`---
+- name: api
+  when: 'this is not valid expr ('
+  tasks:
+    - dokku_app:
+        app: api
+`)
+	_, err := GetPlays(data, map[string]interface{}{}, nil)
+	if err == nil {
+		t.Fatal("expected parse error for malformed when:")
+	}
+	if !strings.Contains(err.Error(), "when compile error") {
+		t.Errorf("expected when compile error, got: %v", err)
+	}
+}
+
+// TestGetPlaysTagsPropagateToEnvelopes verifies that the play's tags get
+// folded into every task envelope so the existing FilterByTags helper
+// treats them uniformly. The api play's task ends up with both its
+// per-task tag (`deploy`) and the play tag (`api`).
+func TestGetPlaysTagsPropagateToEnvelopes(t *testing.T) {
+	data := []byte(`---
+- name: api
+  tags: [api]
+  tasks:
+    - name: create
+      tags: [deploy]
+      dokku_app:
+        app: api
+`)
+	plays, err := GetPlays(data, map[string]interface{}{}, nil)
+	if err != nil {
+		t.Fatalf("GetPlays: %v", err)
+	}
+	env := plays[0].Tasks.GetEnvelope("create")
+	if env == nil {
+		t.Fatal("envelope missing")
+	}
+	if !env.HasTag("api") || !env.HasTag("deploy") {
+		t.Errorf("envelope tags = %v, want both api and deploy", env.Tags)
+	}
+}
+
+func TestGetPlaysTagsScalarFormDecodes(t *testing.T) {
+	data := []byte(`---
+- name: api
+  tags: api
+  tasks:
+    - dokku_app:
+        app: api
+`)
+	plays, err := GetPlays(data, map[string]interface{}{}, nil)
+	if err != nil {
+		t.Fatalf("GetPlays: %v", err)
+	}
+	if len(plays[0].Tags) != 1 || plays[0].Tags[0] != "api" {
+		t.Errorf("tags = %v, want [api]", plays[0].Tags)
+	}
+}
+
+// TestGetPlaysEmptyRecipe maps the legacy GetTasks "no recipe found"
+// error onto the new entrypoint.
+func TestGetPlaysEmptyRecipe(t *testing.T) {
+	_, err := GetPlays([]byte("---\n"), map[string]interface{}{}, nil)
+	if err == nil {
+		t.Fatal("expected error for empty recipe")
+	}
+	if !strings.Contains(err.Error(), "no recipe found") {
+		t.Errorf("expected 'no recipe found' error, got: %v", err)
+	}
+}
+
+// TestBuildPerPlayContextRespectsUserSet covers the precedence merge in
+// isolation: file-level value stays when no play override; play override
+// wins when key is unset by user; user override always wins.
+func TestBuildPerPlayContextRespectsUserSet(t *testing.T) {
+	base := map[string]interface{}{
+		"file_only": "file_value",
+		"shared":    "file_shared",
+		"user_set":  "from_cli",
+	}
+	playInputs := []Input{
+		{Name: "shared", Default: "play_shared"},
+		{Name: "user_set", Default: "play_user_set"},
+		{Name: "play_only", Default: "play_only_value"},
+	}
+	userSet := map[string]bool{"user_set": true}
+
+	out := BuildPerPlayContext(base, playInputs, userSet)
+
+	cases := map[string]string{
+		"file_only": "file_value",      // untouched
+		"shared":    "play_shared",     // play overrides file default
+		"user_set":  "from_cli",        // user override beats play default
+		"play_only": "play_only_value", // play-only value layers in
+	}
+	for k, want := range cases {
+		if got, _ := out[k].(string); got != want {
+			t.Errorf("ctx[%q] = %v, want %q", k, out[k], want)
+		}
+	}
+
+	// Base must not be mutated.
+	if base["shared"] != "file_shared" {
+		t.Errorf("base mutated: shared = %v", base["shared"])
+	}
+	if _, ok := base["play_only"]; ok {
+		t.Errorf("base must not gain play_only key; got %v", base["play_only"])
+	}
+}
+
+func TestMergePlayTagsDedupsAndPreservesOrder(t *testing.T) {
+	got := mergePlayTags([]string{"deploy"}, []string{"api", "deploy"})
+	want := []string{"deploy", "api"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d (got %v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestMergePlayTagsEmptyPlay(t *testing.T) {
+	in := []string{"a", "b"}
+	got := mergePlayTags(in, nil)
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf("got %v, want %v unchanged", got, in)
+	}
+}

--- a/tasks/sensitive.go
+++ b/tasks/sensitive.go
@@ -38,6 +38,20 @@ func CollectSensitiveValues(tasks OrderedStringEnvelopeMap) []string {
 	return out
 }
 
+// CollectPlaySensitiveValues is the multi-play sibling of
+// CollectSensitiveValues. It walks every task across every play and
+// returns the union of sensitive values, in play-then-task order.
+func CollectPlaySensitiveValues(plays []*Play) []string {
+	var out []string
+	for _, play := range plays {
+		if play == nil {
+			continue
+		}
+		out = append(out, CollectSensitiveValues(play.Tasks)...)
+	}
+	return out
+}
+
 // sensitiveValuesFromTask returns the masked-value set for a single task.
 func sensitiveValuesFromTask(t Task) []string {
 	var out []string

--- a/tasks/validate.go
+++ b/tasks/validate.go
@@ -68,6 +68,21 @@ var activeEnvelopeKeys = map[string]bool{
 	"loop": true,
 }
 
+// allowedPlayKeys is the set of play-level mapping keys the validator
+// admits without flagging as unexpected. #208 extends the legacy
+// inputs/tasks pair with name/tags/when at the play envelope.
+var allowedPlayKeys = map[string]bool{
+	"name":   true,
+	"tags":   true,
+	"when":   true,
+	"inputs": true,
+	"tasks":  true,
+}
+
+// allowedPlayKeysList is the comma-separated form rendered into the
+// "unexpected play key" diagnostic so users see the full allowlist.
+const allowedPlayKeysList = "name, tags, when, inputs, tasks"
+
 // Validate parses data as a docket recipe and returns every problem it finds.
 // It is offline by contract: the implementation must never invoke
 // subprocess.CallExecCommand.
@@ -190,13 +205,29 @@ func validatePlay(play *yaml.Node, label string, inputs []inputWithNode, opts Va
 
 	for i := 0; i < len(play.Content); i += 2 {
 		key := play.Content[i].Value
-		if key != "inputs" && key != "tasks" {
+		if !allowedPlayKeys[key] {
 			problems = append(problems, Problem{
 				Code:    "recipe_shape",
 				Play:    label,
 				Line:    play.Content[i].Line,
 				Column:  play.Content[i].Column,
-				Message: fmt.Sprintf("unexpected play key %q (expected: inputs, tasks)", key),
+				Message: fmt.Sprintf("unexpected play key %q (expected: %s)", key, allowedPlayKeysList),
+			})
+		}
+	}
+
+	// Compile the play-level when: predicate so a typo surfaces at validate
+	// time. The play's when: sees the file-level merged context only - the
+	// play's own inputs are not visible to its own when - but for parse
+	// validation we only care that the source compiles.
+	if whenNode := mappingValue(play, "when"); whenNode != nil && whenNode.Kind == yaml.ScalarNode && whenNode.Value != "" {
+		if _, err := CompilePredicate(whenNode.Value); err != nil {
+			problems = append(problems, Problem{
+				Code:    "expr_compile",
+				Play:    label,
+				Line:    whenNode.Line,
+				Column:  whenNode.Column,
+				Message: fmt.Sprintf("play when expression compile error: %v", err),
 			})
 		}
 	}

--- a/tests/bats/plays.bats
+++ b/tests/bats/plays.bats
@@ -1,0 +1,344 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+# plays.bats covers the #208 multi-play surface end-to-end against the
+# docket binary: a tasks.yml with multiple top-level plays runs every
+# play in order, --play <name> filters to one play, --fail-fast reverts
+# to the abort-entire-run semantics, and a play-level when: predicate
+# skips the entire play. Variable-visibility scoping for play-level
+# when: is exercised against the plan path so tests do not require a
+# Dokku server.
+
+setup() {
+  docket_build
+  dokku_clean_app docket-test-play-first
+  dokku_clean_app docket-test-play-second
+  dokku_clean_app docket-test-playfilter-first
+  dokku_clean_app docket-test-playfilter-second
+  dokku_clean_app docket-test-play-skipped
+  dokku_clean_app docket-test-play-kept
+  dokku_clean_app docket-test-play-bail-ok
+  dokku_clean_app docket-test-play-failfast
+}
+
+teardown() {
+  dokku_clean_app docket-test-play-first
+  dokku_clean_app docket-test-play-second
+  dokku_clean_app docket-test-playfilter-first
+  dokku_clean_app docket-test-playfilter-second
+  dokku_clean_app docket-test-play-skipped
+  dokku_clean_app docket-test-play-kept
+  dokku_clean_app docket-test-play-bail-ok
+  dokku_clean_app docket-test-play-failfast
+}
+
+@test "plays: multi-play tasks.yml runs all plays in order" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- name: first
+  tasks:
+    - dokku_app:
+        app: docket-test-play-first
+- name: second
+  tasks:
+    - dokku_app:
+        app: docket-test-play-second
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "==> Play: first"
+  assert_output --partial "==> Play: second"
+  run dokku apps:exists docket-test-play-first
+  assert_success
+  run dokku apps:exists docket-test-play-second
+  assert_success
+}
+
+@test "plays: --play filter runs only the named play" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- name: first
+  tasks:
+    - dokku_app:
+        app: docket-test-playfilter-first
+- name: second
+  tasks:
+    - dokku_app:
+        app: docket-test-playfilter-second
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --play first
+  assert_success
+  assert_output --partial "==> Play: first"
+  refute_output --partial "==> Play: second"
+  run dokku apps:exists docket-test-playfilter-first
+  assert_success
+  run dokku apps:exists docket-test-playfilter-second
+  assert_failure
+}
+
+@test "plays: --play with unknown name reports available plays" {
+  write_tasks_file <<EOF
+---
+- name: first
+  tasks:
+    - dokku_app:
+        app: docket-test-playfilter-first
+- name: second
+  tasks:
+    - dokku_app:
+        app: docket-test-playfilter-second
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --play missing
+  assert_failure
+  assert_output --partial '--play "missing"'
+  assert_output --partial '"first"'
+  assert_output --partial '"second"'
+}
+
+@test "plays: play with when:false is skipped" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- name: skipped-play
+  when: 'false'
+  tasks:
+    - dokku_app:
+        app: docket-test-play-skipped
+- name: kept-play
+  tasks:
+    - dokku_app:
+        app: docket-test-play-kept
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "(skipped:"
+  assert_output --partial "1 play skipped"
+  run dokku apps:exists docket-test-play-skipped
+  assert_failure
+  run dokku apps:exists docket-test-play-kept
+  assert_success
+}
+
+@test "plays: task error in play 1 does not abort play 2" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- name: failing
+  tasks:
+    - dokku_ports:
+        app: nonexistent-app-xyz
+        port_mappings:
+          - { scheme: http, host: 80, container: 5000 }
+        state: present
+- name: ok
+  tasks:
+    - dokku_app:
+        app: docket-test-play-bail-ok
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_failure
+  run dokku apps:exists docket-test-play-bail-ok
+  assert_success
+}
+
+@test "plays: --fail-fast aborts entire run on first error" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- name: failing
+  tasks:
+    - dokku_ports:
+        app: nonexistent-app-xyz
+        port_mappings:
+          - { scheme: http, host: 80, container: 5000 }
+        state: present
+- name: would-run
+  tasks:
+    - dokku_app:
+        app: docket-test-play-failfast
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --fail-fast
+  assert_failure
+  run dokku apps:exists docket-test-play-failfast
+  assert_failure
+}
+
+@test "plays: invalid play-level when: reported by validate" {
+  write_tasks_file <<EOF
+---
+- name: bad
+  when: 'this is not valid expr ('
+  tasks:
+    - dokku_app:
+        app: docket-test-noop
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "play when expression compile error"
+}
+
+@test "plays: unknown play-level key reported by validate" {
+  write_tasks_file <<EOF
+---
+- name: bad
+  invalidkey: foo
+  tasks:
+    - dokku_app:
+        app: docket-test-noop
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial 'unexpected play key "invalidkey"'
+}
+
+# Variable-visibility tests for play-level when: drive the plan path so
+# they do not require a Dokku server. The pattern is:
+#  - file-level input default is visible to play when: (truthy makes the
+#    play run; falsy makes it skip).
+#  - CLI / vars-file overrides win.
+#  - play-local input defaults are NOT visible to a play's own when:
+#    nor to other plays' when:.
+
+@test "plays: play when: sees file-level input default (truthy)" {
+  write_tasks_file <<EOF
+---
+- inputs:
+    - name: env
+      default: prod
+- name: api
+  when: 'env == "prod"'
+  tasks:
+    - dokku_app:
+        app: docket-test-noop
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "==> Play: api"
+  refute_output --partial "==> Play: api  (skipped"
+}
+
+@test "plays: play when: sees file-level input default (falsy)" {
+  write_tasks_file <<EOF
+---
+- inputs:
+    - name: env
+      default: staging
+- name: api
+  when: 'env == "prod"'
+  tasks:
+    - dokku_app:
+        app: docket-test-noop
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial '==> Play: api  (skipped: when "env == \"prod\"")'
+}
+
+@test "plays: CLI input override wins for play when:" {
+  write_tasks_file <<EOF
+---
+- inputs:
+    - name: env
+      default: staging
+- name: api
+  when: 'env == "prod"'
+  tasks:
+    - dokku_app:
+        app: docket-test-noop
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --env prod
+  assert_success
+  assert_output --partial "==> Play: api"
+  refute_output --partial "==> Play: api  (skipped"
+}
+
+@test "plays: --vars-file value flows into play when:" {
+  write_tasks_file <<EOF
+---
+- inputs:
+    - name: env
+      default: staging
+- name: api
+  when: 'env == "prod"'
+  tasks:
+    - dokku_app:
+        app: docket-test-noop
+EOF
+  cat >"$BATS_TEST_TMPDIR/vars.yml" <<EOF
+env: prod
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --vars-file "$BATS_TEST_TMPDIR/vars.yml"
+  assert_success
+  assert_output --partial "==> Play: api"
+  refute_output --partial "==> Play: api  (skipped"
+}
+
+@test "plays: play own input is NOT visible to its own when:" {
+  write_tasks_file <<EOF
+---
+- name: api
+  inputs:
+    - name: enabled
+      default: "true"
+  when: 'enabled == "true"'
+  tasks:
+    - dokku_app:
+        app: docket-test-noop
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial '(skipped:'
+}
+
+@test "plays: sibling play input is NOT visible to other play's when:" {
+  write_tasks_file <<EOF
+---
+- name: api
+  inputs:
+    - name: app
+      default: api
+  tasks:
+    - name: api-noop
+      dokku_app:
+        app: docket-test-noop-api
+- name: worker
+  when: 'app == "api"'
+  tasks:
+    - name: worker-noop
+      dokku_app:
+        app: docket-test-noop-worker
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "==> Play: api"
+  assert_output --partial '==> Play: worker  (skipped'
+}
+
+@test "plays: per-play inputs scope to their own play in task body" {
+  write_tasks_file <<EOF
+---
+- name: api
+  inputs:
+    - name: app
+      default: docket-test-noop-api
+  tasks:
+    - name: noop
+      dokku_app:
+        app: "{{ .app }}"
+- name: worker
+  inputs:
+    - name: app
+      default: docket-test-noop-worker
+  tasks:
+    - name: noop
+      dokku_app:
+        app: "{{ .app }}"
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "docket-test-noop-api"
+  assert_output --partial "docket-test-noop-worker"
+}


### PR DESCRIPTION
Each entry in tasks.yml now executes as its own play with optional name, tags, when, and inputs. Apply and plan gain --play to scope a run to a single play; apply gains --fail-fast to revert to the legacy abort-entire-run semantics so the default becomes "abort the current play and continue to the next." Per-play inputs slot into the variable precedence chain between file-level defaults and --vars-file values. The per-play when: predicate evaluates against the file-level merged context only, so a play cannot see its own or sibling plays' play-local inputs. Single-play files keep the legacy ==> Play: tasks header unchanged.

Closes #208.