### PR TITLE
feat: add register, changed_when, failed_when, and ignore_errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,10 @@ Each task entry in `tasks.yml` admits a small set of cross-cutting envelope keys
 | `tags` | active | Tag list filtered by `--tags` / `--skip-tags` on `apply` and `plan`. |
 | `when` | active | expr expression. Falsy renders the task as `[skipped]`. |
 | `loop` | active | List literal, or expr returning a list. Expands one entry into N with `.item` / `.index` available in the body. |
-| `register` | reserved (#210) | Bind the task result for downstream tasks. |
-| `changed_when` | reserved (#210) | expr override for the task's "changed" verdict. |
-| `failed_when` | reserved (#210) | expr override for the task's "failed" verdict. |
-| `ignore_errors` | reserved (#210) | Continue on task failure. |
+| `register` | active | Bind the post-override task result for downstream tasks. |
+| `changed_when` | active | expr override for the task's "changed" verdict. |
+| `failed_when` | active | expr override for the task's "failed" verdict. |
+| `ignore_errors` | active | Continue on task failure (apply only). |
 
 Unknown envelope keys are rejected at parse time with a "did you mean" suggestion against the closest valid key.
 
@@ -191,7 +191,7 @@ docket apply --tasks tasks.yml --skip-tags worker  # everything except worker
         state: enabled
 ```
 
-The expression context today carries the file-level inputs plus, for loop expansions, `.item` and `.index`. Other context keys (`.timestamp`, `.host`, `.play.name`, `.result`, `.registered`) are reserved for follow-on issues.
+The expression context today carries the file-level inputs plus, for loop expansions, `.item` and `.index`. Inside `changed_when:` / `failed_when:` the same context also includes `.result` (the just-finished task's `TaskOutputState`). Once any task has registered, every subsequent envelope predicate (including `when:`) sees `.registered.<name>`. Other context keys (`.timestamp`, `.host`, `.play.name`) are reserved for follow-on issues.
 
 #### `loop:` per-task iteration
 
@@ -218,6 +218,95 @@ or an expr expression that returns a list:
 Each iteration renders the body with `.item` (the iterator value) and `.index` (zero-based) injected. Expanded envelope names are suffixed with `(item=<value>)` to keep them unique; complex items fall back to `(item=#<index>)`. `.item` / `.index` references outside a `loop:` body are rejected at parse time so a stray reference does not silently render to an empty value.
 
 `when:` interacts with `loop:`: the predicate is evaluated per expansion, so `loop: [a, b, c]` plus `when: 'item != "b"'` runs only the `a` and `c` expansions.
+
+#### `register:` cross-task data flow
+
+`register: <name>` snapshots the just-finished task's post-override result into a run-wide map keyed by `<name>`. Every subsequent envelope predicate sees the snapshot at `.registered.<name>`:
+
+```yaml
+- tasks:
+    - name: ensure app
+      register: app_result
+      dokku_app:
+        app: api
+    - name: stamp first deploy
+      when: 'registered.app_result.Changed'
+      dokku_config:
+        app: api
+        config:
+          FIRST_RUN_FLAG: "true"
+```
+
+`registered.<name>` exposes the same fields a task's `TaskOutputState` carries: `.Changed`, `.Error`, `.State`, `.DesiredState`, `.Stdout`, `.Stderr`, `.ExitCode`, `.Commands`, `.Message`. Comparisons like `registered.foo.Error != nil` and `registered.foo.Stderr contains "..."` work directly. Reused names are rejected at parse time with `register_duplicate`; the registered map is shared across plays in one `docket apply` / `docket plan` run.
+
+When `register:` is used with `loop:`, the registered value carries an additional `.Results` list of per-iteration `TaskOutputState`s in source order. The embedded fields aggregate Ansible-style: `.Changed` is true if any iteration changed, `.Error` is the first non-nil iteration error, and the rest mirror the last iteration's values:
+
+```yaml
+- tasks:
+    - name: each
+      loop: [api, worker, web]
+      register: deploys
+      dokku_app:
+        app: "{{ .item }}"
+    - name: any-changed
+      when: 'registered.deploys.Changed'
+      dokku_config:
+        app: api
+        config:
+          LAST_DEPLOY_TS: "now"
+    - name: first-iteration-only
+      when: 'registered.deploys.Results[0].Changed'
+      dokku_config:
+        app: api
+        config:
+          API_FIRST_DEPLOY: "true"
+```
+
+#### `changed_when:` and `failed_when:` per-task overrides
+
+`changed_when:` and `failed_when:` are expr predicates that override the task's self-reported verdict. Both evaluate against `.result` (the just-finished `TaskOutputState`) plus the regular context (`.registered`, file-level inputs, loop vars). Phase ordering is `failed_when` → `changed_when` → `register` snapshot, so `register` sees the post-override values.
+
+`failed_when` matches Ansible: a truthy result marks the task as failed (installing a synthetic error if none was reported), and a falsy result fully clears the failure verdict (Error and the state-mismatch path). It is the standard "this exit code is fine" idiom for idempotent operations:
+
+```yaml
+- name: try removing legacy mount
+  register: unmount
+  failed_when: 'result.Error != nil and not (result.Stderr contains "not mounted")'
+  dokku_storage_mount:
+    app: api
+    state: absent
+    mount: /old/path:/var/data
+
+- name: log only if real failure
+  when: 'registered.unmount.Error != nil'
+  dokku_config:
+    app: api
+    config:
+      LAST_UNMOUNT_ATTEMPT_FAILED: "true"
+```
+
+`changed_when` rewrites the `Changed` flag based on truthiness. `changed_when: 'false'` silences a self-reported-changed task; `changed_when: 'true'` makes an in-sync task render as changed.
+
+#### `ignore_errors:` continue past failures
+
+`ignore_errors: true` suppresses the fatal-exit decision when a task errors. The task still appears as `[error]` in the human output (with an `(ignored)` marker) and `status: "error"` in JSON (with `"ignored": true`), but the run does not abort and the error does not count toward the summary. `ignore_errors` is consulted after `failed_when`, so a `failed_when`-cleared task is not re-flagged:
+
+```yaml
+- tasks:
+    - name: try the optional path
+      ignore_errors: true
+      dokku_storage_mount:
+        app: api
+        state: absent
+        mount: /old/path:/var/data
+    - name: continues regardless
+      dokku_config:
+        app: api
+        config:
+          LAST_RUN_TS: "now"
+```
+
+`ignore_errors` is meaningful only for `apply`. `plan` never aborts a run, so the flag is a no-op there.
 
 ### Scaffolding with `init`
 

--- a/commands/apply.go
+++ b/commands/apply.go
@@ -182,6 +182,14 @@ func (c *ApplyCommand) Run(args []string) int {
 	counts := ApplyCounts{}
 	playWhenExprCtx := buildEnvelopeExprContext(buildPlayWhenContext(context, fileLevelKeys, userSet))
 	hasError := false
+	// registered is the run-wide map predicates reach via
+	// `.registered.<name>`. loopAccum buffers per-iteration states for
+	// loop+register expansions so the running aggregate is exposed to
+	// predicates in subsequent iterations and finalized once the loop
+	// finishes. Both maps are scoped to a single docket apply
+	// invocation.
+	registered := map[string]tasks.RegisteredValue{}
+	loopAccum := loopRegisterAccumulator{}
 
 playLoop:
 	for _, play := range plays {
@@ -219,7 +227,7 @@ playLoop:
 			taskStart := time.Now()
 
 			if env.HasWhen() {
-				ok, err := tasks.EvalBool(env.WhenProgram(), envelopeExprContext(playExprCtx, env))
+				ok, err := tasks.EvalBool(env.WhenProgram(), envelopeExprContext(playExprCtx, env, nil, registered))
 				if err != nil {
 					counts.Tasks++
 					counts.Errors++
@@ -255,15 +263,15 @@ playLoop:
 			state := env.Task.Execute()
 			counts.Tasks++
 
-			switch {
-			case state.Error != nil:
+			postState, overrideErr := applyEnvelopeOverrides(env, state, playExprCtx, registered)
+			if overrideErr != nil {
 				counts.Errors++
 				failed = true
 				hasError = true
 				emitter.ApplyTask(ApplyTaskEvent{
 					Play:      play.Name,
 					Name:      name,
-					State:     state,
+					WhenError: overrideErr,
 					Duration:  time.Since(taskStart),
 					Timestamp: time.Now().UTC(),
 				})
@@ -271,19 +279,49 @@ playLoop:
 					emitter.ApplySummary(counts, time.Since(start))
 					return 1
 				}
+				break
+			}
+			state = postState
+
+			recordRegister(env, state, loopAccum, registered)
+
+			switch {
+			case state.Error != nil:
+				ignored := env.IgnoreErrors
+				if !ignored {
+					counts.Errors++
+					failed = true
+					hasError = true
+				}
+				emitter.ApplyTask(ApplyTaskEvent{
+					Play:      play.Name,
+					Name:      name,
+					State:     state,
+					Ignored:   ignored,
+					Duration:  time.Since(taskStart),
+					Timestamp: time.Now().UTC(),
+				})
+				if c.failFast && !ignored {
+					emitter.ApplySummary(counts, time.Since(start))
+					return 1
+				}
 			case state.State != state.DesiredState:
-				counts.Errors++
-				failed = true
-				hasError = true
+				ignored := env.IgnoreErrors
+				if !ignored {
+					counts.Errors++
+					failed = true
+					hasError = true
+				}
 				emitter.ApplyTask(ApplyTaskEvent{
 					Play:         play.Name,
 					Name:         name,
 					State:        state,
 					InvalidState: true,
+					Ignored:      ignored,
 					Duration:     time.Since(taskStart),
 					Timestamp:    time.Now().UTC(),
 				})
-				if c.failFast {
+				if c.failFast && !ignored {
 					emitter.ApplySummary(counts, time.Since(start))
 					return 1
 				}

--- a/commands/apply_envelope_test.go
+++ b/commands/apply_envelope_test.go
@@ -1,0 +1,385 @@
+package commands
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dokku/docket/tasks"
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/mitchellh/cli"
+)
+
+// runApply drives an ApplyCommand against the tasks file at path,
+// returning stdout / stderr / exit code. It mirrors playOutput
+// (commands/play_when_test.go) but for the apply path: the apply
+// command's FlagSet reads --tasks from os.Args, so we stage that here
+// before invoking Run.
+func runApply(t *testing.T, path string, args ...string) (string, string, int) {
+	t.Helper()
+	origArgs := os.Args
+	os.Args = []string{"docket-test", "apply", "--tasks", path}
+	t.Cleanup(func() { os.Args = origArgs })
+
+	c := &ApplyCommand{}
+	c.Meta = command.Meta{Ui: cli.NewMockUi()}
+	all := append([]string{"--tasks", path}, args...)
+	exit := c.Run(all)
+	ui := c.Ui.(*cli.MockUi)
+	return ui.OutputWriter.String(), ui.ErrorWriter.String(), exit
+}
+
+func writeTasksFile(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write tasks.yml: %v", err)
+	}
+	return path
+}
+
+// TestApplyRegisterMakesPriorResultAvailable: a task that registers as
+// `first` is followed by a task whose `when:` references
+// `registered.first.Changed`. The follow-up should run when first
+// changed and skip otherwise.
+func TestApplyRegisterMakesPriorResultAvailable(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{Changed: true})
+	stubSet("b", StubFixture{Changed: false})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: first
+      register: first
+      dokku_stub: { key: a }
+    - name: follow-up
+      when: 'registered.first.Changed'
+      dokku_stub: { key: b }
+`)
+	stdout, _, exit := runApply(t, path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if !strings.Contains(stdout, "follow-up") {
+		t.Errorf("follow-up should run when first.Changed is true; got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "[skipped] follow-up") {
+		t.Errorf("follow-up should not be skipped; got:\n%s", stdout)
+	}
+}
+
+// TestApplyRegisterFalseSkipsFollowUp: when the registered task did
+// not change, the follow-up's when: predicate is falsy and the task
+// renders as [skipped].
+func TestApplyRegisterFalseSkipsFollowUp(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{Changed: false})
+	stubSet("b", StubFixture{Changed: true})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: first
+      register: first
+      dokku_stub: { key: a }
+    - name: follow-up
+      when: 'registered.first.Changed'
+      dokku_stub: { key: b }
+`)
+	stdout, _, exit := runApply(t, path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if !strings.Contains(stdout, "[skipped]") {
+		t.Errorf("follow-up should be skipped; got:\n%s", stdout)
+	}
+}
+
+// TestApplyChangedWhenFalseFlipsToOK: changed_when: false flips a
+// self-reported-changed task to [ok].
+func TestApplyChangedWhenFalseFlipsToOK(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{Changed: true})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: stamp
+      changed_when: 'false'
+      dokku_stub: { key: a }
+`)
+	stdout, _, exit := runApply(t, path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if !strings.Contains(stdout, "[ok]") {
+		t.Errorf("expected [ok] marker; got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "[changed] stamp") {
+		t.Errorf("changed_when:false should suppress [changed]; got:\n%s", stdout)
+	}
+}
+
+// TestApplyChangedWhenTrueFlipsToChanged: changed_when: true converts
+// an in-sync task to [changed].
+func TestApplyChangedWhenTrueFlipsToChanged(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{Changed: false})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: stamp
+      changed_when: 'true'
+      dokku_stub: { key: a }
+`)
+	stdout, _, exit := runApply(t, path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if !strings.Contains(stdout, "[changed]") {
+		t.Errorf("expected [changed] marker; got:\n%s", stdout)
+	}
+}
+
+// TestApplyFailedWhenSuppressesExpectedError: failed_when matching the
+// stderr pattern clears the error, exit is 0.
+func TestApplyFailedWhenSuppressesExpectedError(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{
+		ExecuteError: stubExecError("App nonexistent does not exist"),
+		Stderr:       "App nonexistent does not exist",
+	})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: tolerant
+      failed_when: 'result.Error != nil and not (result.Stderr contains "does not exist")'
+      dokku_stub: { key: a }
+`)
+	stdout, _, exit := runApply(t, path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0 (failed_when should clear the error); stdout=%s", exit, stdout)
+	}
+	if strings.Contains(stdout, "[error]") {
+		t.Errorf("error should be suppressed; got:\n%s", stdout)
+	}
+}
+
+// TestApplyFailedWhenTrueMarksSuccessAsError: failed_when: true on a
+// successful task flips it to [error] and the run aborts (exit 1).
+func TestApplyFailedWhenTrueMarksSuccessAsError(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{Changed: false})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: pessimist
+      failed_when: 'true'
+      dokku_stub: { key: a }
+`)
+	_, stderr, exit := runApply(t, path)
+	if exit == 0 {
+		t.Fatalf("exit = 0, want non-zero (failed_when:true should fail the run)")
+	}
+	if !strings.Contains(stderr, "[error]") {
+		t.Errorf("expected [error] marker in stderr; got:\n%s", stderr)
+	}
+}
+
+// TestApplyFailedWhenFalseClearsStateMismatch: a falsy failed_when
+// also normalizes State to DesiredState so the state-mismatch branch
+// does not re-flag the task.
+func TestApplyFailedWhenFalseClearsStateMismatch(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{MismatchState: true, Changed: true})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: forgiving
+      failed_when: 'false'
+      dokku_stub: { key: a }
+`)
+	stdout, _, exit := runApply(t, path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if strings.Contains(stdout, "[error]") {
+		t.Errorf("state mismatch should be cleared by falsy failed_when; got:\n%s", stdout)
+	}
+}
+
+// TestApplyIgnoreErrorsContinuesPastFailure: ignore_errors:true keeps
+// the run going past an erroring task. The error event is still
+// emitted but the second task runs and the exit code is 0.
+func TestApplyIgnoreErrorsContinuesPastFailure(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{ExecuteError: errors.New("boom")})
+	stubSet("b", StubFixture{Changed: true})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: this errors
+      ignore_errors: true
+      dokku_stub: { key: a }
+    - name: this still runs
+      dokku_stub: { key: b }
+`)
+	stdout, stderr, exit := runApply(t, path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0 (ignore_errors should suppress fatal exit); stderr=%s", exit, stderr)
+	}
+	if !strings.Contains(stdout, "this still runs") {
+		t.Errorf("second task should run; stdout=\n%s", stdout)
+	}
+	if !strings.Contains(stderr+stdout, "[error]") {
+		t.Errorf("error event should still emit; stdout=%s stderr=%s", stdout, stderr)
+	}
+}
+
+// TestApplyIgnoreErrorsNoOpOnSuccess: ignore_errors:true on a
+// successful task is a no-op; the task still renders as [ok] /
+// [changed] and the run exits 0.
+func TestApplyIgnoreErrorsNoOpOnSuccess(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{Changed: true})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: harmless
+      ignore_errors: true
+      dokku_stub: { key: a }
+`)
+	stdout, _, exit := runApply(t, path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if !strings.Contains(stdout, "[changed]") {
+		t.Errorf("expected [changed]; got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "[error]") {
+		t.Errorf("expected no [error]; got:\n%s", stdout)
+	}
+}
+
+// TestApplyLoopRegisterAccumulatesResults: a loop+register task
+// accumulates per-iteration states into Results, and the aggregate
+// Changed reflects "any iteration changed."
+func TestApplyLoopRegisterAccumulatesResults(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{Changed: false})
+	stubSet("b", StubFixture{Changed: true})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: each
+      loop: [a, b]
+      register: each
+      dokku_stub:
+        key: "{{ .item }}"
+    - name: any-changed
+      when: 'registered.each.Changed'
+      dokku_stub: { key: a }
+    - name: first-iter
+      when: 'registered.each.Results[0].Changed'
+      dokku_stub: { key: a }
+    - name: second-iter
+      when: 'registered.each.Results[1].Changed'
+      dokku_stub: { key: a }
+`)
+	stdout, _, exit := runApply(t, path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	// Aggregate Changed should be true (b changed) so any-changed runs.
+	if !strings.Contains(stdout, "any-changed") || strings.Contains(stdout, "[skipped] any-changed") {
+		t.Errorf("any-changed should run because aggregate Changed is true; got:\n%s", stdout)
+	}
+	// First iteration did NOT change, so first-iter is skipped.
+	if !strings.Contains(stdout, "[skipped]") {
+		t.Errorf("first-iter should be skipped; got:\n%s", stdout)
+	}
+	// Second iteration changed, so second-iter runs.
+	if !strings.Contains(stdout, "second-iter") {
+		t.Errorf("second-iter should run; got:\n%s", stdout)
+	}
+}
+
+// TestApplyEnvelopeOverridesUnitFailedWhen pins applyEnvelopeOverrides
+// behavior in isolation so the predicate phase ordering and Ansible
+// failure-verdict semantics are anchored without spinning up Run().
+func TestApplyEnvelopeOverridesUnitFailedWhen(t *testing.T) {
+	env := &tasks.TaskEnvelope{
+		Name:       "x",
+		FailedWhen: "false",
+	}
+	if _, err := compileEnvelope(env); err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	state := tasks.TaskOutputState{
+		Error:        errors.New("boom"),
+		State:        tasks.StateAbsent,
+		DesiredState: tasks.StatePresent,
+	}
+	got, err := applyEnvelopeOverrides(env, state, map[string]interface{}{}, nil)
+	if err != nil {
+		t.Fatalf("applyEnvelopeOverrides: %v", err)
+	}
+	if got.Error != nil {
+		t.Errorf("falsy failed_when should clear Error; got %v", got.Error)
+	}
+	if got.State != got.DesiredState {
+		t.Errorf("falsy failed_when should normalize State to DesiredState; got %v vs %v", got.State, got.DesiredState)
+	}
+}
+
+func TestApplyEnvelopeOverridesUnitChangedWhen(t *testing.T) {
+	env := &tasks.TaskEnvelope{
+		Name:        "x",
+		ChangedWhen: "false",
+	}
+	if _, err := compileEnvelope(env); err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	state := tasks.TaskOutputState{Changed: true}
+	got, err := applyEnvelopeOverrides(env, state, map[string]interface{}{}, nil)
+	if err != nil {
+		t.Fatalf("applyEnvelopeOverrides: %v", err)
+	}
+	if got.Changed {
+		t.Errorf("falsy changed_when should clear Changed; got true")
+	}
+}
+
+// compileEnvelope is a tiny test helper that pre-compiles the
+// envelope's predicate sources via the public CompilePredicate API and
+// stores the programs back through reflection-free package-private
+// fields. The override evaluator only reads from the program getters,
+// so we need the compiled program in place before calling it.
+func compileEnvelope(env *tasks.TaskEnvelope) (*tasks.TaskEnvelope, error) {
+	// CompilePredicate caches by source, and TaskEnvelope.{Changed,Failed}WhenProgram
+	// look up those programs through the unexported fields. Reach them
+	// indirectly by re-parsing through GetTasks: write a minimal recipe
+	// that carries the predicates and let the loader populate them.
+	data := []byte("---\n- tasks:\n    - name: " + env.Name + "\n      dokku_stub: { key: ignored }\n")
+	if env.FailedWhen != "" {
+		data = []byte("---\n- tasks:\n    - name: " + env.Name + "\n      failed_when: " + quoted(env.FailedWhen) + "\n      dokku_stub: { key: ignored }\n")
+	}
+	if env.ChangedWhen != "" {
+		data = []byte("---\n- tasks:\n    - name: " + env.Name + "\n      changed_when: " + quoted(env.ChangedWhen) + "\n      dokku_stub: { key: ignored }\n")
+	}
+	envelopes, err := tasks.GetTasks(data, nil)
+	if err != nil {
+		return nil, err
+	}
+	loaded := envelopes.GetEnvelope(env.Name)
+	if loaded == nil {
+		return nil, errors.New("loaded envelope not found")
+	}
+	*env = *loaded
+	return env, nil
+}
+
+func quoted(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}

--- a/commands/apply_test.go
+++ b/commands/apply_test.go
@@ -35,7 +35,7 @@ func TestApplyCommandHelpDoesNotPanic(t *testing.T) {
 func TestEnvelopeExprContextSkipsNonLoopEnvelopes(t *testing.T) {
 	base := map[string]interface{}{"env": "prod"}
 	env := &tasks.TaskEnvelope{Name: "x"}
-	got := envelopeExprContext(base, env)
+	got := envelopeExprContext(base, env, nil, nil)
 	if !reflect.DeepEqual(got, base) {
 		t.Errorf("non-loop envelope must return base context unchanged; got %v", got)
 	}
@@ -44,7 +44,7 @@ func TestEnvelopeExprContextSkipsNonLoopEnvelopes(t *testing.T) {
 func TestEnvelopeExprContextInjectsLoopVars(t *testing.T) {
 	base := map[string]interface{}{"env": "prod"}
 	env := &tasks.TaskEnvelope{Name: "x", IsLoopExpansion: true, LoopItem: "api", LoopIndex: 2}
-	got := envelopeExprContext(base, env)
+	got := envelopeExprContext(base, env, nil, nil)
 	if got["item"] != "api" {
 		t.Errorf("item = %v, want api", got["item"])
 	}
@@ -56,6 +56,33 @@ func TestEnvelopeExprContextInjectsLoopVars(t *testing.T) {
 	}
 	if base["item"] != nil {
 		t.Errorf("base must not be mutated by envelopeExprContext")
+	}
+}
+
+// TestEnvelopeExprContextExposesResultAndRegistered pins the new keys
+// added by #210: `.result` only when the caller passes a non-nil
+// result, and `.registered` only when the registered map is
+// non-empty.
+func TestEnvelopeExprContextExposesResultAndRegistered(t *testing.T) {
+	base := map[string]interface{}{"env": "prod"}
+	env := &tasks.TaskEnvelope{Name: "x"}
+
+	got := envelopeExprContext(base, env, nil, nil)
+	if _, ok := got["result"]; ok {
+		t.Errorf("result should be omitted when nil; got %v", got)
+	}
+	if _, ok := got["registered"]; ok {
+		t.Errorf("registered should be omitted when empty; got %v", got)
+	}
+
+	state := tasks.TaskOutputState{Changed: true}
+	registered := map[string]tasks.RegisteredValue{"foo": {TaskOutputState: state}}
+	got = envelopeExprContext(base, env, state, registered)
+	if got["result"] == nil {
+		t.Errorf("result should be exposed when non-nil; got %v", got)
+	}
+	if got["registered"] == nil {
+		t.Errorf("registered should be exposed when non-empty; got %v", got)
 	}
 }
 

--- a/commands/envelope_context.go
+++ b/commands/envelope_context.go
@@ -18,17 +18,45 @@ func buildEnvelopeExprContext(inputs map[string]interface{}) map[string]interfac
 
 // envelopeExprContext returns a per-envelope expr context. Loop-expansion
 // envelopes inject `.item` / `.index` so a `when: 'item != "web"'`
-// predicate evaluates against the iteration value.
-func envelopeExprContext(base map[string]interface{}, env *tasks.TaskEnvelope) map[string]interface{} {
-	if env == nil || !env.IsLoopExpansion {
+// predicate evaluates against the iteration value. The run-wide
+// registered map is exposed under `.registered` whenever it carries
+// any entries so a predicate can reference `.registered.<name>` once
+// a prior task has registered. result is non-nil only inside the
+// post-execute `changed_when` / `failed_when` evaluation phase; pass
+// nil from `when:` call sites so predicates running before the task
+// fires do not see a stale result.
+func envelopeExprContext(
+	base map[string]interface{},
+	env *tasks.TaskEnvelope,
+	result interface{},
+	registered map[string]tasks.RegisteredValue,
+) map[string]interface{} {
+	hasLoopVars := env != nil && env.IsLoopExpansion
+	hasResult := result != nil
+	hasRegistered := len(registered) > 0
+	if !hasLoopVars && !hasResult && !hasRegistered {
 		return base
 	}
-	out := make(map[string]interface{}, len(base)+2)
+	out := make(map[string]interface{}, len(base)+3)
 	for k, v := range base {
 		out[k] = v
 	}
-	out["item"] = env.LoopItem
-	out["index"] = env.LoopIndex
+	if hasLoopVars {
+		out["item"] = env.LoopItem
+		out["index"] = env.LoopIndex
+	}
+	if hasResult {
+		out["result"] = result
+	}
+	if hasRegistered {
+		// Copy the registered map per call so a downstream call cannot
+		// mutate the executor's working map by writing into the context.
+		registeredCopy := make(map[string]tasks.RegisteredValue, len(registered))
+		for k, v := range registered {
+			registeredCopy[k] = v
+		}
+		out["registered"] = registeredCopy
+	}
 	return out
 }
 

--- a/commands/envelope_overrides.go
+++ b/commands/envelope_overrides.go
@@ -1,0 +1,111 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/dokku/docket/tasks"
+)
+
+// applyEnvelopeOverrides applies the post-execute predicate phases on
+// state in the order documented in #210: failed_when first, then
+// changed_when, then register snapshot. The post-override state is
+// returned. If either predicate raises an expr runtime error, state is
+// returned unchanged with the wrapped error so the caller surfaces it
+// the same way it surfaces a `when:` evaluation error.
+//
+// `failed_when` truthy installs a synthetic error
+// (`fmt.Errorf("failed_when matched: %s", src)`) when the task's own
+// state.Error is nil; truthy with an existing error keeps the original
+// error. `failed_when` falsy clears state.Error and normalizes
+// state.State to state.DesiredState so the apply classifier's
+// state-mismatch branch does not re-flag the task. This matches
+// Ansible's "failed_when fully overrides the failure verdict"
+// semantics.
+//
+// `changed_when` overrides state.Changed based on truthiness alone; the
+// underlying task's self-reported flag is replaced regardless of its
+// previous value.
+func applyEnvelopeOverrides(
+	env *tasks.TaskEnvelope,
+	state tasks.TaskOutputState,
+	playExprCtx map[string]interface{},
+	registered map[string]tasks.RegisteredValue,
+) (tasks.TaskOutputState, error) {
+	if env == nil {
+		return state, nil
+	}
+
+	if env.HasFailedWhen() {
+		ctx := envelopeExprContext(playExprCtx, env, state, registered)
+		ok, err := tasks.EvalBool(env.FailedWhenProgram(), ctx)
+		if err != nil {
+			return state, fmt.Errorf("failed_when expression error: %w", err)
+		}
+		if ok {
+			if state.Error == nil {
+				state.Error = errors.New("failed_when matched: " + env.FailedWhen)
+			}
+		} else {
+			state.Error = nil
+			if state.DesiredState != "" {
+				state.State = state.DesiredState
+			}
+		}
+	}
+
+	if env.HasChangedWhen() {
+		ctx := envelopeExprContext(playExprCtx, env, state, registered)
+		ok, err := tasks.EvalBool(env.ChangedWhenProgram(), ctx)
+		if err != nil {
+			return state, fmt.Errorf("changed_when expression error: %w", err)
+		}
+		state.Changed = ok
+	}
+
+	return state, nil
+}
+
+// loopRegisterAccumulator buffers per-iteration TaskOutputStates for a
+// loop+register envelope. The apply / plan loop accumulates into it
+// each iteration and recomputes the run-wide registered map after every
+// append so predicates between iterations see the running aggregate.
+type loopRegisterAccumulator map[string][]tasks.TaskOutputState
+
+// remember stores state under name. For the first occurrence it
+// initializes the slice; subsequent calls append in source order.
+func (a loopRegisterAccumulator) remember(name string, state tasks.TaskOutputState) {
+	a[name] = append(a[name], state)
+}
+
+// finalize returns the RegisteredValue for name from the accumulated
+// states. For a single-iteration accumulator this is identical to the
+// non-loop register shape (Results: nil). For multi-iteration accumulators
+// the embedded TaskOutputState aggregates per the documented Ansible
+// semantics and Results carries every iteration's post-override state.
+func (a loopRegisterAccumulator) finalize(name string) tasks.RegisteredValue {
+	return tasks.AggregateRegistered(a[name])
+}
+
+// recordRegister updates the run-wide registered map with the latest
+// state for env.Register, supporting both non-loop and loop expansions.
+// Non-loop envelopes overwrite directly; loop expansions accumulate
+// into the per-name buffer and republish the running aggregate so
+// predicates running between iterations see the in-progress Results
+// list rather than nothing.
+func recordRegister(
+	env *tasks.TaskEnvelope,
+	state tasks.TaskOutputState,
+	accum loopRegisterAccumulator,
+	registered map[string]tasks.RegisteredValue,
+) {
+	if env == nil || env.Register == "" {
+		return
+	}
+	if !env.IsLoopExpansion {
+		registered[env.Register] = tasks.RegisteredValue{TaskOutputState: state}
+		return
+	}
+	accum.remember(env.Register, state)
+	registered[env.Register] = accum.finalize(env.Register)
+}

--- a/commands/output.go
+++ b/commands/output.go
@@ -57,6 +57,12 @@ type ApplyTaskEvent struct {
 	// final State did not match DesiredState; treated as an error in
 	// counts and exit logic.
 	InvalidState bool
+	// Ignored, when true, indicates the task errored but `ignore_errors:
+	// true` suppressed the fatal-exit decision. The event is still
+	// emitted with the `[error]` marker so the user sees what failed,
+	// but the run continues and the error does not count toward the
+	// summary.
+	Ignored bool
 	// Duration is the wall-clock time Execute took (or zero for the
 	// when-skipped / when-error branches).
 	Duration time.Duration
@@ -212,7 +218,11 @@ func (f *Formatter) ApplyTask(ev ApplyTaskEvent) {
 	case ev.Skipped:
 		f.TaskLine(MarkerSkipped, ev.Name, "")
 	case ev.State.Error != nil:
-		f.TaskLine(MarkerError, ev.Name, "")
+		suffix := ""
+		if ev.Ignored {
+			suffix = "(ignored)"
+		}
+		f.TaskLine(MarkerError, ev.Name, suffix)
 		f.ErrorContinuation(ev.State.Error)
 		// Stderr already surfaces via the dokku-prefixed continuation:
 		// subprocess.CallExecCommand wraps stderr into the error itself.
@@ -226,7 +236,11 @@ func (f *Formatter) ApplyTask(ev ApplyTaskEvent) {
 			}
 		}
 	case ev.InvalidState:
-		f.TaskLine(MarkerError, ev.Name, "")
+		suffix := ""
+		if ev.Ignored {
+			suffix = "(ignored)"
+		}
+		f.TaskLine(MarkerError, ev.Name, suffix)
 		f.Continuation('!', fmt.Sprintf("invalid state: expected=%v actual=%v", ev.State.DesiredState, ev.State.State))
 	case ev.State.Changed:
 		f.TaskLine(MarkerChanged, ev.Name, "")

--- a/commands/output_json.go
+++ b/commands/output_json.go
@@ -88,9 +88,15 @@ func (e *JSONEmitter) ApplyTask(ev ApplyTaskEvent) {
 			out["stdout"] = subprocess.MaskString(ev.State.Stdout)
 		}
 		out["exit_code"] = ev.State.ExitCode
+		if ev.Ignored {
+			out["ignored"] = true
+		}
 	case ev.InvalidState:
 		out["status"] = "error"
 		out["error"] = subprocess.MaskString(invalidStateMessage(ev.State))
+		if ev.Ignored {
+			out["ignored"] = true
+		}
 	case ev.State.Changed:
 		out["status"] = "changed"
 	default:

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -197,6 +197,13 @@ func (c *PlanCommand) Run(args []string) int {
 	hasError := false
 	hasDrift := false
 	playWhenExprCtx := buildEnvelopeExprContext(buildPlayWhenContext(context, fileLevelKeys, userSet))
+	// registered + loopAccum carry the same role as in apply: predicates
+	// in plan mode see `.registered.<name>` based on the
+	// post-override synthesized TaskOutputState of prior tasks.
+	// `ignore_errors` is a no-op in plan because plan never aborts the
+	// run.
+	registered := map[string]tasks.RegisteredValue{}
+	loopAccum := loopRegisterAccumulator{}
 
 	for _, play := range plays {
 		if play.IsFileLevel() {
@@ -229,7 +236,7 @@ func (c *PlanCommand) Run(args []string) int {
 			taskStart := time.Now()
 
 			if env.HasWhen() {
-				ok, err := tasks.EvalBool(env.WhenProgram(), envelopeExprContext(playExprCtx, env))
+				ok, err := tasks.EvalBool(env.WhenProgram(), envelopeExprContext(playExprCtx, env, nil, registered))
 				if err != nil {
 					counts.Tasks++
 					counts.Errors++
@@ -259,6 +266,48 @@ func (c *PlanCommand) Run(args []string) int {
 
 			result := env.Task.Plan()
 			counts.Tasks++
+
+			// Synthesize a TaskOutputState from the PlanResult so the
+			// changed_when / failed_when / register phases see a
+			// consistent shape across plan and apply. Plan probes do
+			// not run subprocesses on their drift / in-sync paths, so
+			// Stdout/Stderr/ExitCode are non-zero only on probe-error
+			// paths (#210 plumbed those through PlanResult).
+			synth := tasks.TaskOutputState{
+				Changed:      !result.InSync,
+				Error:        result.Error,
+				State:        result.DesiredState,
+				DesiredState: result.DesiredState,
+				Commands:     result.Commands,
+				Stdout:       result.Stdout,
+				Stderr:       result.Stderr,
+				ExitCode:     result.ExitCode,
+			}
+			postState, overrideErr := applyEnvelopeOverrides(env, synth, playExprCtx, registered)
+			if overrideErr != nil {
+				counts.Errors++
+				hasError = true
+				emitter.PlanTask(PlanTaskEvent{
+					Play:      play.Name,
+					Name:      name,
+					WhenError: overrideErr,
+					Duration:  time.Since(taskStart),
+					Timestamp: time.Now().UTC(),
+				})
+				continue
+			}
+			synth = postState
+			recordRegister(env, synth, loopAccum, registered)
+
+			// Reflect the post-override verdict back onto the
+			// PlanResult so the existing classifier and the formatter
+			// / JSON output reflect the override. Falsy `failed_when`
+			// clears Error; truthy installs one. Truthy `changed_when`
+			// converts an in-sync probe to drift, while falsy
+			// `changed_when` makes drift look in-sync (the plan event
+			// continues to render via the same code path).
+			result.Error = synth.Error
+			result.InSync = !synth.Changed && synth.Error == nil
 
 			switch {
 			case result.Error != nil:

--- a/commands/play_executor_test.go
+++ b/commands/play_executor_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -182,6 +183,58 @@ func TestMultiPlayPlayLevelTagsPropagateToTasks(t *testing.T) {
 	}
 	if strings.Contains(stdout, "deploy-worker") {
 		t.Errorf("deploy-worker should be filtered by --tags; got:\n%s", stdout)
+	}
+}
+
+// TestPlanRegisteredVisibleToFollowUp drives plan against the stub
+// task and asserts that a register: + when: combination behaves the
+// same way it does in apply: the second task's `when:` evaluates
+// against the synthesized TaskOutputState of the first.
+func TestPlanRegisteredVisibleToFollowUp(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{Changed: true})
+	stubSet("b", StubFixture{Changed: false})
+
+	path := writeMultiPlayTasks(t, `---
+- tasks:
+    - name: first
+      register: first
+      dokku_stub: { key: a }
+    - name: follow-up
+      when: 'registered.first.Changed'
+      dokku_stub: { key: b }
+`)
+	stdout, _, exit := runPlan(t, path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if !strings.Contains(stdout, "follow-up") || strings.Contains(stdout, "[skipped] follow-up") {
+		t.Errorf("follow-up should plan because first.Changed is true; got:\n%s", stdout)
+	}
+}
+
+// TestPlanFailedWhenClearsError pins that failed_when in plan mode
+// rewrites the synthesized TaskOutputState's Error so the plan
+// classifier no longer treats the task as a probe error.
+func TestPlanFailedWhenClearsError(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{
+		PlanError: errors.New("App nonexistent does not exist"),
+		Stderr:    "App nonexistent does not exist",
+	})
+
+	path := writeMultiPlayTasks(t, `---
+- tasks:
+    - name: tolerant
+      failed_when: 'result.Error != nil and not (result.Stderr contains "does not exist")'
+      dokku_stub: { key: a }
+`)
+	stdout, _, exit := runPlan(t, path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if strings.Contains(stdout, "[!]") {
+		t.Errorf("probe error should be cleared by failed_when; got:\n%s", stdout)
 	}
 }
 

--- a/commands/stub_task_test.go
+++ b/commands/stub_task_test.go
@@ -1,0 +1,136 @@
+package commands
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/dokku/docket/tasks"
+)
+
+// StubTask is a test-only Task type registered as `dokku_stub` so apply
+// / plan tests can drive the executor without contacting a Dokku
+// server. Each stub instance carries a `Key` field that maps into the
+// per-key fixture in stubFixtures; the test sets the desired
+// TaskOutputState for that key and the executor picks it up via
+// Execute(). Plan() returns a Drift / InSync result based on the
+// fixture's Changed flag plus its Error.
+type StubTask struct {
+	// Key is the lookup into stubFixtures. Required.
+	Key string `yaml:"key" required:"true"`
+}
+
+// Doc / Examples are not exercised by the apply / plan tests. They
+// exist so StubTask satisfies the Task interface.
+func (t StubTask) Doc() string                    { return "stub task for tests" }
+func (t StubTask) Examples() ([]tasks.Doc, error) { return nil, nil }
+
+func (t StubTask) Plan() tasks.PlanResult {
+	fixture := stubGet(t.Key)
+	if fixture.PlanError != nil {
+		return tasks.PlanResult{
+			Status:       tasks.PlanStatusError,
+			Error:        fixture.PlanError,
+			DesiredState: tasks.StatePresent,
+			Stdout:       fixture.Stdout,
+			Stderr:       fixture.Stderr,
+			ExitCode:     fixture.ExitCode,
+		}
+	}
+	if !fixture.Changed && fixture.ExecuteError == nil {
+		return tasks.PlanResult{
+			InSync:       true,
+			Status:       tasks.PlanStatusOK,
+			DesiredState: tasks.StatePresent,
+		}
+	}
+	return tasks.PlanResult{
+		Status:       tasks.PlanStatusModify,
+		DesiredState: tasks.StatePresent,
+	}
+}
+
+func (t StubTask) Execute() tasks.TaskOutputState {
+	fixture := stubGet(t.Key)
+	if fixture.ExecuteError != nil {
+		return tasks.TaskOutputState{
+			Error:        fixture.ExecuteError,
+			Stdout:       fixture.Stdout,
+			Stderr:       fixture.Stderr,
+			ExitCode:     fixture.ExitCode,
+			DesiredState: tasks.StatePresent,
+			State:        tasks.StatePresent,
+		}
+	}
+	if fixture.PlanError != nil {
+		return tasks.TaskOutputState{
+			Error:        fixture.PlanError,
+			Stdout:       fixture.Stdout,
+			Stderr:       fixture.Stderr,
+			ExitCode:     fixture.ExitCode,
+			DesiredState: tasks.StatePresent,
+			State:        tasks.StatePresent,
+		}
+	}
+	if fixture.MismatchState {
+		return tasks.TaskOutputState{
+			DesiredState: tasks.StatePresent,
+			State:        tasks.StateAbsent,
+			Changed:      fixture.Changed,
+		}
+	}
+	return tasks.TaskOutputState{
+		Changed:      fixture.Changed,
+		DesiredState: tasks.StatePresent,
+		State:        tasks.StatePresent,
+		Stdout:       fixture.Stdout,
+		Stderr:       fixture.Stderr,
+		ExitCode:     fixture.ExitCode,
+	}
+}
+
+// StubFixture controls the TaskOutputState a StubTask returns for a
+// given Key. Tests set fields here and the stub task echoes them back
+// from Execute() / Plan().
+type StubFixture struct {
+	Changed       bool
+	ExecuteError  error
+	PlanError     error
+	Stdout        string
+	Stderr        string
+	ExitCode      int
+	MismatchState bool
+}
+
+var (
+	stubMu       sync.Mutex
+	stubFixtures = map[string]StubFixture{}
+)
+
+func stubSet(key string, f StubFixture) {
+	stubMu.Lock()
+	defer stubMu.Unlock()
+	stubFixtures[key] = f
+}
+
+func stubGet(key string) StubFixture {
+	stubMu.Lock()
+	defer stubMu.Unlock()
+	return stubFixtures[key]
+}
+
+func stubReset() {
+	stubMu.Lock()
+	defer stubMu.Unlock()
+	stubFixtures = map[string]StubFixture{}
+}
+
+// stubExecError returns an error that, when threaded through the
+// production ExecutePlan path, would have populated Stderr. Used in
+// tests that exercise `failed_when: result.Stderr contains "..."`.
+func stubExecError(stderr string) error {
+	return errors.New(stderr)
+}
+
+func init() {
+	tasks.RegisterTask(&StubTask{})
+}

--- a/subprocess/exec.go
+++ b/subprocess/exec.go
@@ -63,6 +63,42 @@ type ExecCommandInput struct {
 	Host string
 }
 
+// ExecError wraps a CallExecCommand failure with the underlying
+// response so callers that propagate the error up the stack can later
+// recover Stdout / Stderr / ExitCode without threading the response
+// through every helper signature. The Error() method returns the
+// inner error's text so existing callers that print err.Error() see
+// the same string as before.
+//
+// Callers recover the response with errors.As:
+//
+//	var execErr *subprocess.ExecError
+//	if errors.As(err, &execErr) {
+//	    // execErr.Response.Stderr is available
+//	}
+type ExecError struct {
+	Response ExecCommandResponse
+	Err      error
+}
+
+// Error returns the wrapped error's message so existing string-based
+// comparisons (e.g. fmt.Errorf wrapping) continue to work.
+func (e *ExecError) Error() string {
+	if e == nil || e.Err == nil {
+		return ""
+	}
+	return e.Err.Error()
+}
+
+// Unwrap exposes the wrapped error so errors.Is / errors.As traverse
+// chains of wrapped errors correctly.
+func (e *ExecError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
 // ExecCommandResponse is the response for the ExecCommand function
 type ExecCommandResponse struct {
 	// Command is the resolved command line that was executed, including
@@ -247,23 +283,25 @@ func CallExecCommandWithContext(ctx context.Context, input ExecCommandInput) (Ex
 
 	res, err := cmd.Execute(ctx)
 	if err != nil {
-		return ExecCommandResponse{
+		response := ExecCommandResponse{
 			Command:   resolved,
 			Stdout:    res.Stdout,
 			Stderr:    res.Stderr,
 			ExitCode:  res.ExitCode,
 			Cancelled: res.Cancelled,
-		}, err
+		}
+		return response, &ExecError{Response: response, Err: err}
 	}
 
 	if res.ExitCode != 0 {
-		return ExecCommandResponse{
+		response := ExecCommandResponse{
 			Command:   resolved,
 			Stdout:    res.Stdout,
 			Stderr:    res.Stderr,
 			ExitCode:  res.ExitCode,
 			Cancelled: res.Cancelled,
-		}, errors.New(res.Stderr)
+		}
+		return response, &ExecError{Response: response, Err: errors.New(res.Stderr)}
 	}
 
 	return ExecCommandResponse{

--- a/subprocess/ssh.go
+++ b/subprocess/ssh.go
@@ -375,7 +375,7 @@ func classifySshResult(target sshTarget, remote []string, resp ExecCommandRespon
 		}
 	}
 	if resp.ExitCode != 0 {
-		return resp, errors.New(resp.Stderr)
+		return resp, &ExecError{Response: resp, Err: errors.New(resp.Stderr)}
 	}
 	return resp, nil
 }

--- a/tasks/dispatch.go
+++ b/tasks/dispatch.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/dokku/docket/subprocess"
@@ -92,11 +93,28 @@ func DispatchPlan(state State, funcMap map[State]func() PlanResult) PlanResult {
 //     and a final State that matches DesiredState on success.
 func ExecutePlan(p PlanResult) TaskOutputState {
 	if p.Error != nil {
+		stdout, stderr, exitCode := p.Stdout, p.Stderr, p.ExitCode
+		// Recover the underlying ExecCommandResponse if a probe helper
+		// surfaced its CallExecCommand failure as a *subprocess.ExecError.
+		// This lets `failed_when: 'result.Stderr contains ...'` predicates
+		// match against probe-side stderr without each probe helper having
+		// to thread the response through its return signature.
+		if stdout == "" && stderr == "" && exitCode == 0 {
+			var execErr *subprocess.ExecError
+			if errors.As(p.Error, &execErr) {
+				stdout = execErr.Response.Stdout
+				stderr = execErr.Response.Stderr
+				exitCode = execErr.Response.ExitCode
+			}
+		}
 		return TaskOutputState{
 			Error:        p.Error,
 			Message:      p.Error.Error(),
 			DesiredState: p.DesiredState,
 			State:        p.DesiredState,
+			Stdout:       stdout,
+			Stderr:       stderr,
+			ExitCode:     exitCode,
 		}
 	}
 	if p.InSync {
@@ -118,4 +136,22 @@ func ExecutePlan(p PlanResult) TaskOutputState {
 		out.DesiredState = p.DesiredState
 	}
 	return out
+}
+
+// PlanErrorFromExec wraps a probe-side CallExecCommand failure into a
+// PlanResult that also carries the response's Stdout/Stderr/ExitCode.
+// Probe helpers use it from their `if err != nil` branch so a later
+// failed_when predicate can match `result.Stderr` in plan mode the
+// same way it can in apply mode. desiredState is the state value the
+// caller would have stored in PlanResult.DesiredState; pass the State
+// argument the probe is processing.
+func PlanErrorFromExec(desiredState State, err error, r subprocess.ExecCommandResponse) PlanResult {
+	return PlanResult{
+		Status:       PlanStatusError,
+		Error:        err,
+		DesiredState: desiredState,
+		Stdout:       r.Stdout,
+		Stderr:       r.Stderr,
+		ExitCode:     r.ExitCode,
+	}
 }

--- a/tasks/dispatch_test.go
+++ b/tasks/dispatch_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/dokku/docket/subprocess"
@@ -43,6 +44,66 @@ func TestWithExecResultDoesNotMutateReceiver(t *testing.T) {
 	}
 	if original.ExitCode != 7 {
 		t.Errorf("receiver ExitCode mutated: %d", original.ExitCode)
+	}
+}
+
+// TestExecutePlanProbeErrorPopulatesStderrFromExecError pins the
+// behavior #210 added: when a probe helper bubbles a CallExecCommand
+// failure, the wrapped *subprocess.ExecError carries the response
+// fields, and ExecutePlan recovers them onto the returned
+// TaskOutputState so failed_when predicates can match against
+// `result.Stderr` even on probe-error paths.
+func TestExecutePlanProbeErrorPopulatesStderrFromExecError(t *testing.T) {
+	execErr := &subprocess.ExecError{
+		Response: subprocess.ExecCommandResponse{
+			Stdout:   "stdout text",
+			Stderr:   "App nonexistent does not exist",
+			ExitCode: 20,
+		},
+		Err: errors.New("App nonexistent does not exist"),
+	}
+	got := ExecutePlan(PlanResult{
+		Status:       PlanStatusError,
+		Error:        execErr,
+		DesiredState: StatePresent,
+	})
+	if got.Error == nil {
+		t.Fatalf("expected error to propagate")
+	}
+	if got.Stderr != "App nonexistent does not exist" {
+		t.Errorf("stderr should recover from ExecError; got %q", got.Stderr)
+	}
+	if got.Stdout != "stdout text" {
+		t.Errorf("stdout should recover from ExecError; got %q", got.Stdout)
+	}
+	if got.ExitCode != 20 {
+		t.Errorf("exit code should recover from ExecError; got %d", got.ExitCode)
+	}
+}
+
+// TestExecutePlanExplicitProbeFieldsTakePrecedence pins that PlanResult
+// fields populated by a probe helper that called PlanErrorFromExec
+// directly are not overwritten by the ExecError fallback.
+func TestExecutePlanExplicitProbeFieldsTakePrecedence(t *testing.T) {
+	execErr := &subprocess.ExecError{
+		Response: subprocess.ExecCommandResponse{
+			Stderr:   "from-execerror",
+			ExitCode: 1,
+		},
+		Err: errors.New("boom"),
+	}
+	got := ExecutePlan(PlanResult{
+		Status:       PlanStatusError,
+		Error:        execErr,
+		DesiredState: StatePresent,
+		Stderr:       "explicit",
+		ExitCode:     42,
+	})
+	if got.Stderr != "explicit" {
+		t.Errorf("explicit Stderr should win; got %q", got.Stderr)
+	}
+	if got.ExitCode != 42 {
+		t.Errorf("explicit ExitCode should win; got %d", got.ExitCode)
 	}
 }
 

--- a/tasks/envelope.go
+++ b/tasks/envelope.go
@@ -68,6 +68,12 @@ type TaskEnvelope struct {
 	// whenProgram is the pre-compiled expr program for When. Set by the
 	// loader so loop iterations re-use the same compiled bytecode.
 	whenProgram *vm.Program
+
+	// changedWhenProgram / failedWhenProgram are the pre-compiled expr
+	// programs for ChangedWhen and FailedWhen. Set by the loader so the
+	// apply / plan executor does not re-compile per task.
+	changedWhenProgram *vm.Program
+	failedWhenProgram  *vm.Program
 }
 
 // HasWhen reports whether the envelope carries a non-empty `when:`
@@ -83,6 +89,36 @@ func (e *TaskEnvelope) WhenProgram() *vm.Program {
 		return nil
 	}
 	return e.whenProgram
+}
+
+// HasChangedWhen reports whether the envelope carries a non-empty
+// `changed_when:` predicate.
+func (e *TaskEnvelope) HasChangedWhen() bool {
+	return e != nil && e.ChangedWhen != ""
+}
+
+// ChangedWhenProgram returns the pre-compiled expr program for
+// ChangedWhen, or nil when no `changed_when:` predicate is present.
+func (e *TaskEnvelope) ChangedWhenProgram() *vm.Program {
+	if e == nil {
+		return nil
+	}
+	return e.changedWhenProgram
+}
+
+// HasFailedWhen reports whether the envelope carries a non-empty
+// `failed_when:` predicate.
+func (e *TaskEnvelope) HasFailedWhen() bool {
+	return e != nil && e.FailedWhen != ""
+}
+
+// FailedWhenProgram returns the pre-compiled expr program for
+// FailedWhen, or nil when no `failed_when:` predicate is present.
+func (e *TaskEnvelope) FailedWhenProgram() *vm.Program {
+	if e == nil {
+		return nil
+	}
+	return e.failedWhenProgram
 }
 
 // HasTag reports whether the envelope's tag set contains tag.

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -205,6 +205,16 @@ type PlanResult struct {
 	// Error implies Status == PlanStatusError.
 	Error error
 
+	// Stdout / Stderr / ExitCode capture the underlying subprocess
+	// response that produced a probe error. Populated by probe call
+	// sites that bubble a CallExecCommand failure into a PlanResult so
+	// `failed_when` predicates referencing `result.Stderr` work in plan
+	// mode the same way they do in apply mode. Empty / zero on the
+	// in-sync, drift, and apply-only paths.
+	Stdout   string
+	Stderr   string
+	ExitCode int
+
 	// apply, when non-nil, is the closure ExecutePlan invokes to mutate
 	// server state. nil when InSync. Captures any probed state needed for
 	// the mutation so the apply path does not re-probe. Unexported so
@@ -664,6 +674,22 @@ func buildEnvelopesForEntry(index int, entry map[string]interface{}, sigilContex
 			return nil, fmt.Errorf("task parse error: task #%d %q: when compile error: %s", index, envelope.Name, err)
 		}
 		envelope.whenProgram = prog
+	}
+
+	if envelope.ChangedWhen != "" {
+		prog, err := CompilePredicate(envelope.ChangedWhen)
+		if err != nil {
+			return nil, fmt.Errorf("task parse error: task #%d %q: changed_when compile error: %s", index, envelope.Name, err)
+		}
+		envelope.changedWhenProgram = prog
+	}
+
+	if envelope.FailedWhen != "" {
+		prog, err := CompilePredicate(envelope.FailedWhen)
+		if err != nil {
+			return nil, fmt.Errorf("task parse error: task #%d %q: failed_when compile error: %s", index, envelope.Name, err)
+		}
+		envelope.failedWhenProgram = prog
 	}
 
 	if envelope.Loop != nil {

--- a/tasks/predicate_test.go
+++ b/tasks/predicate_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -100,5 +101,168 @@ func TestEvalListNonListErrors(t *testing.T) {
 	}
 	if _, err := EvalList(prog, nil); err == nil {
 		t.Fatal("expected non-list error, got nil")
+	}
+}
+
+// TestEvalBoolResultStructFields covers the post-execute predicate
+// shape: result is a TaskOutputState struct value passed under the
+// "result" key. expr-lang/expr accesses Go struct fields by name via
+// reflection, so `result.Changed` and `result.Stderr` work directly.
+func TestEvalBoolResultStructFields(t *testing.T) {
+	state := TaskOutputState{Changed: true, Stderr: "expected message"}
+
+	prog, err := CompilePredicate(`result.Changed`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	got, err := EvalBool(prog, map[string]interface{}{"result": state})
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if !got {
+		t.Errorf("result.Changed: got false, want true")
+	}
+
+	prog, err = CompilePredicate(`result.Stderr contains "expected"`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	got, err = EvalBool(prog, map[string]interface{}{"result": state})
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if !got {
+		t.Errorf("result.Stderr contains: got false, want true")
+	}
+}
+
+// TestEvalBoolResultErrorNilCheck covers the `result.Error != nil`
+// pattern from the issue body. A nil error renders as nil under expr's
+// reflection bridge, so the comparison uses the `nil` keyword.
+func TestEvalBoolResultErrorNilCheck(t *testing.T) {
+	prog, err := CompilePredicate(`result.Error != nil`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	noErr := TaskOutputState{}
+	got, err := EvalBool(prog, map[string]interface{}{"result": noErr})
+	if err != nil {
+		t.Fatalf("eval (no error): %v", err)
+	}
+	if got {
+		t.Errorf("result.Error != nil with nil Error: got true, want false")
+	}
+
+	withErr := TaskOutputState{Error: fmt.Errorf("boom")}
+	got, err = EvalBool(prog, map[string]interface{}{"result": withErr})
+	if err != nil {
+		t.Fatalf("eval (with error): %v", err)
+	}
+	if !got {
+		t.Errorf("result.Error != nil with non-nil Error: got false, want true")
+	}
+}
+
+// TestEvalBoolRegisteredLookup covers the `.registered.<name>` shape.
+// The map carries RegisteredValue entries, and expr's struct-field
+// access traverses the embedded TaskOutputState so
+// `registered.foo.Changed` resolves to the aggregate flag.
+func TestEvalBoolRegisteredLookup(t *testing.T) {
+	prog, err := CompilePredicate(`registered.foo.Changed`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	registered := map[string]RegisteredValue{
+		"foo": {TaskOutputState: TaskOutputState{Changed: true}},
+	}
+	got, err := EvalBool(prog, map[string]interface{}{"registered": registered})
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if !got {
+		t.Errorf("got false, want true")
+	}
+}
+
+// TestEvalBoolRegisteredMissingIsFalsy covers AllowUndefinedVariables
+// for nested key access: a predicate referencing a register name that
+// has not been declared yet evaluates to nil at runtime, which is
+// falsy. No expr error is raised.
+func TestEvalBoolRegisteredMissingIsFalsy(t *testing.T) {
+	prog, err := CompilePredicate(`registered.missing.Error != nil`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	registered := map[string]RegisteredValue{}
+	got, err := EvalBool(prog, map[string]interface{}{"registered": registered})
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if got {
+		t.Errorf("missing register key should be nil-comparable; got true")
+	}
+}
+
+// TestEvalBoolRegisteredResultsIndex covers loop-style register access
+// where Results is the per-iteration list.
+func TestEvalBoolRegisteredResultsIndex(t *testing.T) {
+	prog, err := CompilePredicate(`registered.foo.Results[0].Changed`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	registered := map[string]RegisteredValue{
+		"foo": {
+			TaskOutputState: TaskOutputState{Changed: true},
+			Results: []TaskOutputState{
+				{Changed: true},
+				{Changed: false},
+			},
+		},
+	}
+	got, err := EvalBool(prog, map[string]interface{}{"registered": registered})
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if !got {
+		t.Errorf("Results[0].Changed: got false, want true")
+	}
+}
+
+// TestAggregateRegisteredAggregatesAcrossIterations pins the
+// loop-aggregation rules: Changed = any iteration changed, Error =
+// first non-nil error, last-iteration values for the rest.
+func TestAggregateRegisteredAggregatesAcrossIterations(t *testing.T) {
+	iters := []TaskOutputState{
+		{Changed: false, Stderr: "one"},
+		{Changed: true, Stderr: "two", Error: fmt.Errorf("first error")},
+		{Changed: false, Stderr: "three", Error: fmt.Errorf("later error")},
+	}
+	got := AggregateRegistered(iters)
+	if !got.Changed {
+		t.Errorf("aggregate Changed should be true (any iteration changed)")
+	}
+	if got.Error == nil || got.Error.Error() != "first error" {
+		t.Errorf("aggregate Error should be the first non-nil error; got %v", got.Error)
+	}
+	if got.Stderr != "three" {
+		t.Errorf("aggregate Stderr should follow last iteration; got %q", got.Stderr)
+	}
+	if len(got.Results) != 3 {
+		t.Errorf("Results should carry all iterations; got %d", len(got.Results))
+	}
+}
+
+func TestAggregateRegisteredEmptyAndSingle(t *testing.T) {
+	if got := AggregateRegistered(nil); got.Changed || got.Error != nil || len(got.Results) != 0 {
+		t.Errorf("empty aggregate should be zero value; got %+v", got)
+	}
+	single := []TaskOutputState{{Changed: true, Stderr: "only"}}
+	got := AggregateRegistered(single)
+	if !got.Changed || got.Stderr != "only" {
+		t.Errorf("single-element aggregate should mirror the input; got %+v", got)
+	}
+	if got.Results != nil {
+		t.Errorf("single-element aggregate should leave Results nil; got %v", got.Results)
 	}
 }

--- a/tasks/registered.go
+++ b/tasks/registered.go
@@ -1,0 +1,63 @@
+package tasks
+
+// RegisteredValue is the shape stored in the apply / plan run-wide
+// registered map for a `register: <name>` task. Predicates reach it via
+// `.registered.<name>`.
+//
+// For non-loop tasks, the embedded TaskOutputState is the post-override
+// result and Results is nil; predicates use `.registered.foo.Changed`,
+// `.registered.foo.Error`, etc. directly.
+//
+// For loop expansions, every iteration shares the same Register name.
+// Results carries the per-iteration post-override states in source
+// order. The embedded TaskOutputState is an Ansible-style aggregate
+// across the iterations:
+//
+//   - Changed: true when any iteration's Changed is true.
+//   - Error: the first non-nil error among iterations (nil when every
+//     iteration succeeded).
+//   - State / DesiredState / Stdout / Stderr / ExitCode / Commands:
+//     the last iteration's values.
+//
+// Embedded-struct field access works through expr-lang/expr because
+// it uses reflect.Value.FieldByName, which traverses embedded fields.
+type RegisteredValue struct {
+	TaskOutputState
+	Results []TaskOutputState
+}
+
+// AggregateRegistered builds a RegisteredValue from one or more
+// per-iteration TaskOutputStates. Callers use it to roll a loop's
+// expansions into a single registered value. Passing a single state
+// yields a RegisteredValue whose Results is nil and whose embedded
+// fields mirror the input directly.
+func AggregateRegistered(iter []TaskOutputState) RegisteredValue {
+	if len(iter) == 0 {
+		return RegisteredValue{}
+	}
+	if len(iter) == 1 {
+		return RegisteredValue{TaskOutputState: iter[0]}
+	}
+	last := iter[len(iter)-1]
+	out := RegisteredValue{
+		TaskOutputState: TaskOutputState{
+			DesiredState: last.DesiredState,
+			State:        last.State,
+			Stdout:       last.Stdout,
+			Stderr:       last.Stderr,
+			ExitCode:     last.ExitCode,
+			Commands:     last.Commands,
+			Message:      last.Message,
+		},
+		Results: append([]TaskOutputState(nil), iter...),
+	}
+	for _, s := range iter {
+		if s.Changed {
+			out.Changed = true
+		}
+		if out.Error == nil && s.Error != nil {
+			out.Error = s.Error
+		}
+	}
+	return out
+}

--- a/tasks/validate.go
+++ b/tasks/validate.go
@@ -49,23 +49,24 @@ const validatePlaceholder = "__docket_validate_placeholder__"
 // task-type name (e.g. dokku_appp) is reported as "unknown task type" rather
 // than getting silently swallowed by an envelope allowlist.
 var reservedEnvelopeKeys = map[string]string{
-	"block":         "#211",
-	"rescue":        "#211",
-	"always":        "#211",
-	"register":      "#210",
-	"changed_when":  "#210",
-	"failed_when":   "#210",
-	"ignore_errors": "#210",
+	"block":  "#211",
+	"rescue": "#211",
+	"always": "#211",
 }
 
-// activeEnvelopeKeys are the envelope keys this PR (#205) activates. They
-// are recognised by the validator and pass through to the loader without
-// generating an "envelope key reserved" diagnostic.
+// activeEnvelopeKeys are the envelope keys the validator recognises and
+// passes through to the loader without generating an "envelope key
+// reserved" diagnostic. Keep in sync with envelopeAllowlistKeys in
+// tasks/main.go.
 var activeEnvelopeKeys = map[string]bool{
-	"name": true,
-	"tags": true,
-	"when": true,
-	"loop": true,
+	"name":          true,
+	"tags":          true,
+	"when":          true,
+	"loop":          true,
+	"register":      true,
+	"changed_when":  true,
+	"failed_when":   true,
+	"ignore_errors": true,
 }
 
 // allowedPlayKeys is the set of play-level mapping keys the validator
@@ -175,20 +176,34 @@ func Validate(data []byte, opts ValidateOptions) []Problem {
 	}
 
 	var problems []Problem
+	// registerSeen tracks register names across the whole recipe so a
+	// duplicate `register: foo` in two different plays surfaces as a
+	// single register_duplicate problem. The registered map is run-wide
+	// at apply / plan time, so the validator's uniqueness check is
+	// recipe-wide too.
+	registerSeen := map[string]registerHit{}
 	for i, play := range doc.Content {
 		label := fmt.Sprintf("play #%d", i+1)
 		var inputs []inputWithNode
 		if i < len(playsInputs) {
 			inputs = playsInputs[i]
 		}
-		problems = append(problems, validatePlay(play, label, inputs, opts)...)
+		problems = append(problems, validatePlay(play, label, inputs, opts, registerSeen)...)
 	}
 
 	return problems
 }
 
+// registerHit records the first occurrence of a `register: <name>` so
+// later occurrences can quote the prior site in their diagnostic.
+type registerHit struct {
+	Play string
+	Task string
+	Line int
+}
+
 // validatePlay walks one play (one MappingNode within the recipe sequence).
-func validatePlay(play *yaml.Node, label string, inputs []inputWithNode, opts ValidateOptions) []Problem {
+func validatePlay(play *yaml.Node, label string, inputs []inputWithNode, opts ValidateOptions, registerSeen map[string]registerHit) []Problem {
 	var problems []Problem
 
 	if play.Kind != yaml.MappingNode {
@@ -236,11 +251,11 @@ func validatePlay(play *yaml.Node, label string, inputs []inputWithNode, opts Va
 		problems = append(problems, validateStrictInputs(inputs, opts.InputOverrides, label)...)
 	}
 
-	// Stub checks: present so future PRs (#205/#208/#210/#211/#212) can wire
+	// Stub checks: present so future PRs (#205/#208/#211/#212) can wire
 	// real bodies without touching the call site.
 	problems = append(problems, validateBlockStructure(tasksNode, label)...)
 	problems = append(problems, validateExprPredicates(tasksNode, label)...)
-	problems = append(problems, validateRegisterReferences(tasksNode, label)...)
+	problems = append(problems, validateRegisterReferences(tasksNode, label, registerSeen)...)
 	problems = append(problems, validateTargetReferences(tasksNode, label)...)
 
 	if tasksNode == nil {
@@ -556,11 +571,56 @@ func compileExprNode(node *yaml.Node, key, playLabel, taskLabel string) []Proble
 	return nil
 }
 
-// validateRegisterReferences is a stub. #210 will populate it with checks
-// that anything referencing .registered.foo has a prior register: foo.
-func validateRegisterReferences(_ *yaml.Node, _ string) []Problem {
-	// TODO(#210): resolve register references once the registry is wired.
-	return nil
+// validateRegisterReferences enforces uniqueness of `register: <name>`
+// across the whole recipe. registerSeen is the recipe-wide map of names
+// that have already been claimed; each call updates it with the names
+// declared in this play. Re-using a name (within the same play, or
+// across plays) is reported as `register_duplicate`.
+//
+// Cross-reference checking (every `.registered.foo` reference must have
+// a prior `register: foo`) is intentionally out of scope: predicates
+// reference dotted paths like `.registered.foo.Results[0].Stderr`,
+// which would require a tiny expr AST walker per envelope, and the
+// AllowUndefinedVariables compile mode means an unknown reference
+// degrades to nil at runtime rather than blowing up.
+func validateRegisterReferences(tasksNode *yaml.Node, playLabel string, registerSeen map[string]registerHit) []Problem {
+	if tasksNode == nil || tasksNode.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var problems []Problem
+	for i, task := range tasksNode.Content {
+		if task.Kind != yaml.MappingNode {
+			continue
+		}
+		regNode := mappingValue(task, "register")
+		if regNode == nil || regNode.Kind != yaml.ScalarNode || regNode.Value == "" {
+			continue
+		}
+		name := regNode.Value
+		taskLabel := taskLabelForNode(task, i+1)
+		if prior, ok := registerSeen[name]; ok {
+			hint := fmt.Sprintf("first declared in %s at line %d", prior.Play, prior.Line)
+			if prior.Task != "" {
+				hint = fmt.Sprintf("first declared in %s on %s (line %d)", prior.Play, prior.Task, prior.Line)
+			}
+			problems = append(problems, Problem{
+				Code:    "register_duplicate",
+				Play:    playLabel,
+				Task:    taskLabel,
+				Line:    regNode.Line,
+				Column:  regNode.Column,
+				Message: fmt.Sprintf("register name %q is already declared", name),
+				Hint:    hint,
+			})
+			continue
+		}
+		registerSeen[name] = registerHit{
+			Play: playLabel,
+			Task: taskLabel,
+			Line: regNode.Line,
+		}
+	}
+	return problems
 }
 
 // validateTargetReferences guards `.item` / `.index` references. They

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -297,15 +297,15 @@ func TestValidateLevenshtein(t *testing.T) {
 }
 
 func TestValidateReservedEnvelopeKeyFlagged(t *testing.T) {
-	// register / changed_when / failed_when / ignore_errors stay reserved
-	// for #210; the rest of the envelope keys (name, tags, when, loop)
-	// are activated by #205. Using `register:` here pins the assertion to
-	// a key whose semantics have not landed yet.
+	// register / changed_when / failed_when / ignore_errors are now
+	// activated by #210; block / rescue / always remain reserved for
+	// #211, so use `block:` to pin the diagnostic to a key whose
+	// semantics have not landed yet.
 	data := []byte(`---
 - tasks:
     - dokku_app:
         app: my-app
-      register: app_result
+      block: []
 `)
 	problems := Validate(data, ValidateOptions{})
 	if p := findProblem(problems, "envelope_key_unsupported"); p == nil {
@@ -449,5 +449,81 @@ func TestValidateActiveEnvelopeKeysNotReserved(t *testing.T) {
 	problems := Validate(data, ValidateOptions{})
 	if p := findProblem(problems, "envelope_key_unsupported"); p != nil {
 		t.Fatalf("did not expect envelope_key_unsupported, got: %+v", p)
+	}
+}
+
+// TestValidateRegisterUniqueWithinPlay reports a duplicate register
+// name declared twice in the same play.
+func TestValidateRegisterUniqueWithinPlay(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: first
+      register: foo
+      dokku_app:
+        app: app-a
+    - name: second
+      register: foo
+      dokku_app:
+        app: app-b
+`)
+	problems := Validate(data, ValidateOptions{})
+	if got := countProblems(problems, "register_duplicate"); got != 1 {
+		t.Fatalf("expected exactly one register_duplicate, got %d: %+v", got, problems)
+	}
+}
+
+// TestValidateRegisterUniqueAcrossPlays reports a duplicate register
+// name declared in two different plays. The registered map is
+// recipe-wide at apply / plan time, so the validator's check is too.
+func TestValidateRegisterUniqueAcrossPlays(t *testing.T) {
+	data := []byte(`---
+- name: api
+  tasks:
+    - register: foo
+      dokku_app:
+        app: api
+- name: worker
+  tasks:
+    - register: foo
+      dokku_app:
+        app: worker
+`)
+	problems := Validate(data, ValidateOptions{})
+	if got := countProblems(problems, "register_duplicate"); got != 1 {
+		t.Fatalf("expected exactly one register_duplicate, got %d: %+v", got, problems)
+	}
+}
+
+// TestValidateRegisterUniqueAcceptsDistinctNames passes when each
+// register declaration uses a different name.
+func TestValidateRegisterUniqueAcceptsDistinctNames(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - register: alpha
+      dokku_app:
+        app: a
+    - register: beta
+      dokku_app:
+        app: b
+`)
+	problems := Validate(data, ValidateOptions{})
+	if p := findProblem(problems, "register_duplicate"); p != nil {
+		t.Fatalf("did not expect register_duplicate, got: %+v", p)
+	}
+}
+
+// TestValidateChangedWhenCompileError pins that compile errors in
+// changed_when are surfaced via the existing expr_compile diagnostic
+// shape (the validator pre-compiles changed_when / failed_when).
+func TestValidateChangedWhenCompileError(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - changed_when: 'env =='
+      dokku_app:
+        app: x
+`)
+	problems := Validate(data, ValidateOptions{})
+	if p := findProblem(problems, "expr_compile"); p == nil {
+		t.Fatalf("expected expr_compile problem, got: %+v", problems)
 	}
 }

--- a/tests/bats/register.bats
+++ b/tests/bats/register.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+# register.bats covers the #210 envelope features end-to-end against
+# the docket binary: register: cross-task data flow, changed_when /
+# failed_when overrides, and ignore_errors fatal-exit suppression.
+#
+# Tests that mutate live Dokku state gate on require_dokku; the
+# validate-only tests run anywhere because validate is offline by
+# contract.
+
+setup() {
+  docket_build
+}
+
+teardown() {
+  dokku_clean_app docket-test-register
+  dokku_clean_app docket-test-changed-when
+  dokku_clean_app docket-test-ignore-errors-after
+}
+
+@test "register: makes prior task result available to follow-up when:" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure app
+      register: app_result
+      dokku_app:
+        app: docket-test-register
+    - name: only on first run
+      when: 'registered.app_result.Changed'
+      dokku_config:
+        app: docket-test-register
+        config:
+          FIRST_RUN_FLAG: "true"
+EOF
+
+  # First run: app does not exist, so the create changes state and
+  # the follow-up runs.
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  run dokku config:get docket-test-register FIRST_RUN_FLAG
+  assert_output "true"
+
+  # Second run: the app already exists, so register's Changed is
+  # false and the follow-up skips. The flag should not be re-set.
+  dokku config:unset docket-test-register FIRST_RUN_FLAG
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  run dokku config:get docket-test-register FIRST_RUN_FLAG
+  refute_output "true"
+}
+
+@test "changed_when: false silences a self-reported-changed task" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: stamp
+      changed_when: 'false'
+      dokku_config:
+        app: docket-test-changed-when
+        config:
+          LAST_PING: "now"
+EOF
+  # Pre-create the app so dokku_config has somewhere to write.
+  dokku apps:create docket-test-changed-when
+
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "[ok]"
+  refute_output --partial "[changed]"
+}
+
+@test "failed_when: clears the error when stderr matches a known pattern" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: tolerant probe
+      failed_when: 'result.Error != nil and not (result.Stderr contains "does not exist")'
+      dokku_config:
+        app: nonexistent-app-zzz-docket-test
+        state: present
+        config:
+          K: v
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+}
+
+@test "ignore_errors: true continues past errors and exits 0" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: this errors
+      ignore_errors: true
+      dokku_config:
+        app: nonexistent-app-yyy-docket-test
+        state: present
+        config:
+          K: v
+    - name: this still runs
+      dokku_app:
+        app: docket-test-ignore-errors-after
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  run dokku apps:exists docket-test-ignore-errors-after
+  assert_success
+}
+
+@test "register: duplicate name surfaces a validate problem" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - register: dup
+      dokku_app:
+        app: a
+    - register: dup
+      dokku_app:
+        app: b
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "register"
+  assert_output --partial "already declared"
+}


### PR DESCRIPTION
## Summary

Activates the four envelope keys reserved by #205. After each task runs, `failed_when` overrides the failure verdict (clearing both the error and any state-mismatch when falsy, matching Ansible), then `changed_when` overrides the changed flag, then `register` snapshots the post-override result for later tasks to read at `.registered.<name>`. `ignore_errors: true` keeps the run going past an erroring task on the apply path; the error event still emits with `(ignored)` in human output and `ignored: true` in JSON.

Loop expansions accumulate per-iteration states under `Results` and roll up the embedded `Changed` / `Error` fields Ansible-style: `registered.foo.Changed` is true if any iteration changed, while `registered.foo.Results[i]` carries the per-iteration state. The registered map is shared across plays in one docket invocation; duplicate `register:` names surface as a parse-time `register_duplicate` problem in `validate`.

Probe-error stderr is plumbed through a new `*subprocess.ExecError` wrapper so `failed_when: 'result.Stderr contains ...'` works on the plan-probe path too without changing every probe helper signature.

Closes #210.