### PR TITLE
feat: add block, rescue, and always for task groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ Each task entry in `tasks.yml` admits a small set of cross-cutting envelope keys
 | `changed_when` | active | expr override for the task's "changed" verdict. |
 | `failed_when` | active | expr override for the task's "failed" verdict. |
 | `ignore_errors` | active | Continue on task failure (apply only). |
+| `block` | active | Try clause: list of child task entries that run in order; the first error triggers `rescue`. |
+| `rescue` | active | Catch clause: list of child task entries that run on the first uncaught error in `block`. |
+| `always` | active | Finally clause: list of child task entries that run unconditionally after `block` / `rescue`. |
 
 Unknown envelope keys are rejected at parse time with a "did you mean" suggestion against the closest valid key.
 
@@ -307,6 +310,38 @@ When `register:` is used with `loop:`, the registered value carries an additiona
 ```
 
 `ignore_errors` is meaningful only for `apply`. `plan` never aborts a run, so the flag is a no-op there.
+
+#### `block:` / `rescue:` / `always:` structured error handling
+
+A task entry that carries `block:` becomes a *group entry*: try/catch/finally over a list of nested task entries. The wrapping envelope (`name`, `tags`, `when`, `loop`, `register`, `changed_when`, `failed_when`, `ignore_errors`) applies to the whole group; children execute in order under the group's umbrella.
+
+```yaml
+- tasks:
+    - name: deploy with rollback
+      block:
+        - dokku_app_clone:    { source_app: api, app: api-candidate }
+        - dokku_git_sync:     { app: api-candidate, repository: "{{ .repo }}" }
+        - dokku_checks_toggle: { app: api-candidate, state: enabled }
+      rescue:
+        - dokku_app: { app: api-candidate, state: absent }
+      always:
+        - dokku_config:
+            app: api
+            config:
+              LAST_DEPLOY_ATTEMPT: "now"
+```
+
+Execution rules:
+
+- `block:` children run in source order. The first child whose post-override verdict is failed and whose own `ignore_errors` is false stops the block.
+- When `rescue:` is non-empty, a stopped block triggers every `rescue:` child in order. Rescue children run with the failing block child's `TaskOutputState` bound under `.failed_task`, so a rescue can branch on the actual cause: `when: 'failed_task.Stderr contains "..."'` is the standard idiom.
+- `always:` children run unconditionally after `block:` / `rescue:`, even if rescue itself errored.
+- The group's own envelope predicates (`failed_when`, `changed_when`, `register`, `ignore_errors`) apply to the synthesized group outcome - `register: <name>` snapshots the post-rescue, post-always result; `ignore_errors: true` on the group swallows any residual error after rescue + always.
+- `ignore_errors: true` on a *child* of `block:` swallows that child's error and execution continues; it does NOT trigger `rescue:`. Rescue is the "handle" path; `ignore_errors` is the "swallow" path.
+- `loop:` on a group runs the entire group once per item, with `.item` / `.index` shared across every nested child.
+- Groups nest: a group entry can appear inside another group's `block:` / `rescue:` / `always:` lists.
+
+`plan` reports drift for `block:` children unconditionally. `rescue:` and `always:` children plan only when at least one block child reports drift or a probe error, since `Plan()` cannot fail the way `Execute()` can. Group children render with a `[block]` / `[rescue]` / `[always]` prefix on their event line; the group's own summary line carries a `(group)` annotation.
 
 ### Scaffolding with `init`
 

--- a/commands/apply.go
+++ b/commands/apply.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -221,136 +222,33 @@ playLoop:
 
 		playExprCtx := buildEnvelopeExprContext(tasks.BuildPerPlayContext(context, play.Inputs, userSet))
 
+		ac := &applyContext{
+			play:        play,
+			playExprCtx: playExprCtx,
+			registered:  registered,
+			loopAccum:   loopAccum,
+			emitter:     emitter,
+			counts:      &counts,
+			failFast:    c.failFast,
+		}
+
 		failed := false
 		for _, name := range tasks.FilterByTags(play.Tasks, c.tags, c.skipTags) {
 			env := play.Tasks.GetEnvelope(name)
-			taskStart := time.Now()
-
-			if env.HasWhen() {
-				ok, err := tasks.EvalBool(env.WhenProgram(), envelopeExprContext(playExprCtx, env, nil, registered))
-				if err != nil {
-					counts.Tasks++
-					counts.Errors++
-					failed = true
-					hasError = true
-					emitter.ApplyTask(ApplyTaskEvent{
-						Play:      play.Name,
-						Name:      name,
-						WhenError: err,
-						Duration:  time.Since(taskStart),
-						Timestamp: time.Now().UTC(),
-					})
-					if c.failFast {
-						emitter.ApplySummary(counts, time.Since(start))
-						return 1
-					}
-					break
-				}
-				if !ok {
-					counts.Tasks++
-					counts.Skipped++
-					emitter.ApplyTask(ApplyTaskEvent{
-						Play:      play.Name,
-						Name:      name,
-						Skipped:   true,
-						Duration:  time.Since(taskStart),
-						Timestamp: time.Now().UTC(),
-					})
-					continue
-				}
+			outcome := c.executeTask(env, name, ac, nil, "")
+			if outcome.abort {
+				emitter.ApplySummary(counts, time.Since(start))
+				return 1
 			}
-
-			state := env.Task.Execute()
-			counts.Tasks++
-
-			postState, overrideErr := applyEnvelopeOverrides(env, state, playExprCtx, registered)
-			if overrideErr != nil {
-				counts.Errors++
+			if outcome.failed {
 				failed = true
 				hasError = true
-				emitter.ApplyTask(ApplyTaskEvent{
-					Play:      play.Name,
-					Name:      name,
-					WhenError: overrideErr,
-					Duration:  time.Since(taskStart),
-					Timestamp: time.Now().UTC(),
-				})
-				if c.failFast {
-					emitter.ApplySummary(counts, time.Since(start))
-					return 1
-				}
-				break
-			}
-			state = postState
-
-			recordRegister(env, state, loopAccum, registered)
-
-			switch {
-			case state.Error != nil:
-				ignored := env.IgnoreErrors
-				if !ignored {
-					counts.Errors++
-					failed = true
-					hasError = true
-				}
-				emitter.ApplyTask(ApplyTaskEvent{
-					Play:      play.Name,
-					Name:      name,
-					State:     state,
-					Ignored:   ignored,
-					Duration:  time.Since(taskStart),
-					Timestamp: time.Now().UTC(),
-				})
-				if c.failFast && !ignored {
-					emitter.ApplySummary(counts, time.Since(start))
-					return 1
-				}
-			case state.State != state.DesiredState:
-				ignored := env.IgnoreErrors
-				if !ignored {
-					counts.Errors++
-					failed = true
-					hasError = true
-				}
-				emitter.ApplyTask(ApplyTaskEvent{
-					Play:         play.Name,
-					Name:         name,
-					State:        state,
-					InvalidState: true,
-					Ignored:      ignored,
-					Duration:     time.Since(taskStart),
-					Timestamp:    time.Now().UTC(),
-				})
-				if c.failFast && !ignored {
-					emitter.ApplySummary(counts, time.Since(start))
-					return 1
-				}
-			case state.Changed:
-				counts.Changed++
-				emitter.ApplyTask(ApplyTaskEvent{
-					Play:      play.Name,
-					Name:      name,
-					State:     state,
-					Duration:  time.Since(taskStart),
-					Timestamp: time.Now().UTC(),
-				})
-			default:
-				counts.OK++
-				emitter.ApplyTask(ApplyTaskEvent{
-					Play:      play.Name,
-					Name:      name,
-					State:     state,
-					Duration:  time.Since(taskStart),
-					Timestamp: time.Now().UTC(),
-				})
-			}
-
-			if failed {
 				// Without --fail-fast, an error in this play aborts the
 				// rest of this play but the next play still runs.
 				break
 			}
 		}
+		_ = failed
 	}
 
 	emitter.ApplySummary(counts, time.Since(start))
@@ -358,6 +256,369 @@ playLoop:
 		return 1
 	}
 	return 0
+}
+
+// applyContext bundles the run-wide state apply's per-task helpers
+// share so the function signatures stay tractable.
+type applyContext struct {
+	play        *tasks.Play
+	playExprCtx map[string]interface{}
+	registered  map[string]tasks.RegisteredValue
+	loopAccum   loopRegisterAccumulator
+	emitter     EventEmitter
+	counts      *ApplyCounts
+	failFast    bool
+}
+
+// applyTaskOutcome is the per-task verdict the apply loop reads back
+// from executeTask. failed reports whether the task's failure should
+// abort the current play (false when ignore_errors swallowed the
+// error). abort reports --fail-fast triggered. state carries the
+// post-override TaskOutputState so a group walker can propagate the
+// failing child's state into rescue's `.failed_task` binding.
+type applyTaskOutcome struct {
+	state   tasks.TaskOutputState
+	failed  bool
+	abort   bool
+	skipped bool
+}
+
+// executeTask runs one envelope - leaf or group. The phase string
+// labels child events emitted from a group walk ("block", "rescue",
+// "always"); top-level callers pass "". failedTask is non-nil only
+// when called from a rescue walker so the rescue child's predicates
+// can reference `.failed_task`.
+func (c *ApplyCommand) executeTask(env *tasks.TaskEnvelope, name string, ac *applyContext, failedTask interface{}, phase string) applyTaskOutcome {
+	if env.IsGroup() {
+		return c.executeGroup(env, name, ac, failedTask, phase)
+	}
+	return c.executeLeafTask(env, name, ac, failedTask, phase)
+}
+
+// executeLeafTask runs a single non-group task envelope through the
+// when -> execute -> overrides -> register -> classify pipeline that
+// pre-#211 lived inline inside Run.
+func (c *ApplyCommand) executeLeafTask(env *tasks.TaskEnvelope, name string, ac *applyContext, failedTask interface{}, phase string) applyTaskOutcome {
+	taskStart := time.Now()
+
+	if env.HasWhen() {
+		ok, err := tasks.EvalBool(env.WhenProgram(), envelopeExprContext(ac.playExprCtx, env, nil, ac.registered, failedTask))
+		if err != nil {
+			ac.counts.Tasks++
+			ac.counts.Errors++
+			ac.emitter.ApplyTask(ApplyTaskEvent{
+				Play:      ac.play.Name,
+				Name:      name,
+				Phase:     phase,
+				WhenError: err,
+				Duration:  time.Since(taskStart),
+				Timestamp: time.Now().UTC(),
+			})
+			return applyTaskOutcome{failed: true, abort: c.failFast}
+		}
+		if !ok {
+			ac.counts.Tasks++
+			ac.counts.Skipped++
+			ac.emitter.ApplyTask(ApplyTaskEvent{
+				Play:      ac.play.Name,
+				Name:      name,
+				Phase:     phase,
+				Skipped:   true,
+				Duration:  time.Since(taskStart),
+				Timestamp: time.Now().UTC(),
+			})
+			return applyTaskOutcome{skipped: true}
+		}
+	}
+
+	state := env.Task.Execute()
+	ac.counts.Tasks++
+
+	postState, overrideErr := applyEnvelopeOverrides(env, state, ac.playExprCtx, ac.registered, failedTask)
+	if overrideErr != nil {
+		ac.counts.Errors++
+		ac.emitter.ApplyTask(ApplyTaskEvent{
+			Play:      ac.play.Name,
+			Name:      name,
+			Phase:     phase,
+			WhenError: overrideErr,
+			Duration:  time.Since(taskStart),
+			Timestamp: time.Now().UTC(),
+		})
+		return applyTaskOutcome{failed: true, abort: c.failFast}
+	}
+	state = postState
+
+	recordRegister(env, state, ac.loopAccum, ac.registered)
+
+	switch {
+	case state.Error != nil:
+		ignored := env.IgnoreErrors
+		if !ignored {
+			ac.counts.Errors++
+		}
+		ac.emitter.ApplyTask(ApplyTaskEvent{
+			Play:      ac.play.Name,
+			Name:      name,
+			Phase:     phase,
+			State:     state,
+			Ignored:   ignored,
+			Duration:  time.Since(taskStart),
+			Timestamp: time.Now().UTC(),
+		})
+		return applyTaskOutcome{state: state, failed: !ignored, abort: c.failFast && !ignored}
+	case state.State != state.DesiredState:
+		ignored := env.IgnoreErrors
+		if !ignored {
+			ac.counts.Errors++
+		}
+		ac.emitter.ApplyTask(ApplyTaskEvent{
+			Play:         ac.play.Name,
+			Name:         name,
+			Phase:        phase,
+			State:        state,
+			InvalidState: true,
+			Ignored:      ignored,
+			Duration:     time.Since(taskStart),
+			Timestamp:    time.Now().UTC(),
+		})
+		return applyTaskOutcome{state: state, failed: !ignored, abort: c.failFast && !ignored}
+	case state.Changed:
+		ac.counts.Changed++
+		ac.emitter.ApplyTask(ApplyTaskEvent{
+			Play:      ac.play.Name,
+			Name:      name,
+			Phase:     phase,
+			State:     state,
+			Duration:  time.Since(taskStart),
+			Timestamp: time.Now().UTC(),
+		})
+		return applyTaskOutcome{state: state}
+	default:
+		ac.counts.OK++
+		ac.emitter.ApplyTask(ApplyTaskEvent{
+			Play:      ac.play.Name,
+			Name:      name,
+			Phase:     phase,
+			State:     state,
+			Duration:  time.Since(taskStart),
+			Timestamp: time.Now().UTC(),
+		})
+		return applyTaskOutcome{state: state}
+	}
+}
+
+// executeGroup runs a try/catch/finally group entry (#211): block ->
+// (rescue if a block child errored) -> always. Children execute via
+// executeTask so nested groups recurse naturally. The synthesized
+// group state is passed through the group's own envelope overrides
+// (failed_when / changed_when / register / ignore_errors) so the
+// group itself participates in the same predicate chain leaf tasks do.
+func (c *ApplyCommand) executeGroup(env *tasks.TaskEnvelope, name string, ac *applyContext, failedTask interface{}, phase string) applyTaskOutcome {
+	taskStart := time.Now()
+
+	if env.HasWhen() {
+		ok, err := tasks.EvalBool(env.WhenProgram(), envelopeExprContext(ac.playExprCtx, env, nil, ac.registered, failedTask))
+		if err != nil {
+			ac.counts.Tasks++
+			ac.counts.Errors++
+			ac.emitter.ApplyTask(ApplyTaskEvent{
+				Play:      ac.play.Name,
+				Name:      name,
+				Phase:     phase,
+				Group:     true,
+				WhenError: err,
+				Duration:  time.Since(taskStart),
+				Timestamp: time.Now().UTC(),
+			})
+			return applyTaskOutcome{failed: true, abort: c.failFast}
+		}
+		if !ok {
+			ac.counts.Tasks++
+			ac.counts.Skipped++
+			ac.emitter.ApplyTask(ApplyTaskEvent{
+				Play:      ac.play.Name,
+				Name:      name,
+				Phase:     phase,
+				Group:     true,
+				Skipped:   true,
+				Duration:  time.Since(taskStart),
+				Timestamp: time.Now().UTC(),
+			})
+			return applyTaskOutcome{skipped: true}
+		}
+	}
+
+	// Walk block children. Stop at the first child whose post-override
+	// outcome is failed AND ignore_errors did not swallow it. A
+	// swallowed (ignored) child does NOT trigger rescue per #210 rule:
+	// ignore_errors is the "swallow" path; rescue is the "handle" path.
+	var (
+		anyChanged       bool
+		blockFailedState *tasks.TaskOutputState
+		lastChildState   tasks.TaskOutputState
+	)
+	for i, child := range env.Block {
+		childName := child.Name
+		if childName == "" {
+			childName = fmt.Sprintf("%s.block[%d]", name, i)
+		}
+		outcome := c.executeTask(child, childName, ac, nil, "block")
+		if outcome.abort {
+			return applyTaskOutcome{abort: true}
+		}
+		if outcome.state.Changed {
+			anyChanged = true
+		}
+		lastChildState = outcome.state
+		if outcome.failed {
+			s := outcome.state
+			blockFailedState = &s
+			break
+		}
+	}
+
+	// Run rescue children when block failed.
+	rescueErr := error(nil)
+	if blockFailedState != nil {
+		for i, child := range env.Rescue {
+			childName := child.Name
+			if childName == "" {
+				childName = fmt.Sprintf("%s.rescue[%d]", name, i)
+			}
+			outcome := c.executeTask(child, childName, ac, *blockFailedState, "rescue")
+			if outcome.abort {
+				return applyTaskOutcome{abort: true}
+			}
+			if outcome.state.Changed {
+				anyChanged = true
+			}
+			lastChildState = outcome.state
+			if outcome.failed && rescueErr == nil {
+				if outcome.state.Error != nil {
+					rescueErr = outcome.state.Error
+				} else {
+					rescueErr = errors.New("rescue child failed")
+				}
+			}
+		}
+	}
+
+	// Always children run unconditionally.
+	alwaysErr := error(nil)
+	for i, child := range env.Always {
+		childName := child.Name
+		if childName == "" {
+			childName = fmt.Sprintf("%s.always[%d]", name, i)
+		}
+		outcome := c.executeTask(child, childName, ac, nil, "always")
+		if outcome.abort {
+			return applyTaskOutcome{abort: true}
+		}
+		if outcome.state.Changed {
+			anyChanged = true
+		}
+		lastChildState = outcome.state
+		if outcome.failed && alwaysErr == nil {
+			if outcome.state.Error != nil {
+				alwaysErr = outcome.state.Error
+			} else {
+				alwaysErr = errors.New("always child failed")
+			}
+		}
+	}
+
+	// Synthesize the group's TaskOutputState. Rescue clearing the
+	// block error implies the group succeeded unless always itself
+	// errored. always errors take precedence over a cleared block
+	// error; if block errored and rescue also errored, the rescue
+	// error is the group's verdict (most recent uncaught failure).
+	groupState := tasks.TaskOutputState{
+		Changed:      anyChanged,
+		DesiredState: lastChildState.DesiredState,
+		State:        lastChildState.DesiredState,
+		Stdout:       lastChildState.Stdout,
+		Stderr:       lastChildState.Stderr,
+		ExitCode:     lastChildState.ExitCode,
+		Commands:     lastChildState.Commands,
+		Message:      lastChildState.Message,
+	}
+	switch {
+	case alwaysErr != nil:
+		groupState.Error = alwaysErr
+		groupState.State = ""
+	case rescueErr != nil:
+		groupState.Error = rescueErr
+		groupState.State = ""
+	case blockFailedState != nil && len(env.Rescue) == 0:
+		// Block errored and there is no rescue clause; the original
+		// error propagates as the group's verdict.
+		groupState.Error = blockFailedState.Error
+		groupState.State = blockFailedState.State
+		groupState.DesiredState = blockFailedState.DesiredState
+	}
+
+	postState, overrideErr := applyEnvelopeOverrides(env, groupState, ac.playExprCtx, ac.registered, failedTask)
+	if overrideErr != nil {
+		ac.counts.Errors++
+		ac.emitter.ApplyTask(ApplyTaskEvent{
+			Play:      ac.play.Name,
+			Name:      name,
+			Phase:     phase,
+			Group:     true,
+			WhenError: overrideErr,
+			Duration:  time.Since(taskStart),
+			Timestamp: time.Now().UTC(),
+		})
+		return applyTaskOutcome{failed: true, abort: c.failFast}
+	}
+	groupState = postState
+
+	recordRegister(env, groupState, ac.loopAccum, ac.registered)
+	ac.counts.Tasks++
+
+	switch {
+	case groupState.Error != nil:
+		ignored := env.IgnoreErrors
+		if !ignored {
+			ac.counts.Errors++
+		}
+		ac.emitter.ApplyTask(ApplyTaskEvent{
+			Play:      ac.play.Name,
+			Name:      name,
+			Phase:     phase,
+			Group:     true,
+			State:     groupState,
+			Ignored:   ignored,
+			Duration:  time.Since(taskStart),
+			Timestamp: time.Now().UTC(),
+		})
+		return applyTaskOutcome{state: groupState, failed: !ignored, abort: c.failFast && !ignored}
+	case groupState.Changed:
+		ac.counts.Changed++
+		ac.emitter.ApplyTask(ApplyTaskEvent{
+			Play:      ac.play.Name,
+			Name:      name,
+			Phase:     phase,
+			Group:     true,
+			State:     groupState,
+			Duration:  time.Since(taskStart),
+			Timestamp: time.Now().UTC(),
+		})
+		return applyTaskOutcome{state: groupState}
+	default:
+		ac.counts.OK++
+		ac.emitter.ApplyTask(ApplyTaskEvent{
+			Play:      ac.play.Name,
+			Name:      name,
+			Phase:     phase,
+			Group:     true,
+			State:     groupState,
+			Duration:  time.Since(taskStart),
+			Timestamp: time.Now().UTC(),
+		})
+		return applyTaskOutcome{state: groupState}
+	}
 }
 
 // filterPlaysByName narrows plays to the single play whose Name matches

--- a/commands/apply_envelope_test.go
+++ b/commands/apply_envelope_test.go
@@ -321,7 +321,7 @@ func TestApplyEnvelopeOverridesUnitFailedWhen(t *testing.T) {
 		State:        tasks.StateAbsent,
 		DesiredState: tasks.StatePresent,
 	}
-	got, err := applyEnvelopeOverrides(env, state, map[string]interface{}{}, nil)
+	got, err := applyEnvelopeOverrides(env, state, map[string]interface{}{}, nil, nil)
 	if err != nil {
 		t.Fatalf("applyEnvelopeOverrides: %v", err)
 	}
@@ -342,7 +342,7 @@ func TestApplyEnvelopeOverridesUnitChangedWhen(t *testing.T) {
 		t.Fatalf("compile: %v", err)
 	}
 	state := tasks.TaskOutputState{Changed: true}
-	got, err := applyEnvelopeOverrides(env, state, map[string]interface{}{}, nil)
+	got, err := applyEnvelopeOverrides(env, state, map[string]interface{}{}, nil, nil)
 	if err != nil {
 		t.Fatalf("applyEnvelopeOverrides: %v", err)
 	}

--- a/commands/apply_test.go
+++ b/commands/apply_test.go
@@ -35,7 +35,7 @@ func TestApplyCommandHelpDoesNotPanic(t *testing.T) {
 func TestEnvelopeExprContextSkipsNonLoopEnvelopes(t *testing.T) {
 	base := map[string]interface{}{"env": "prod"}
 	env := &tasks.TaskEnvelope{Name: "x"}
-	got := envelopeExprContext(base, env, nil, nil)
+	got := envelopeExprContext(base, env, nil, nil, nil)
 	if !reflect.DeepEqual(got, base) {
 		t.Errorf("non-loop envelope must return base context unchanged; got %v", got)
 	}
@@ -44,7 +44,7 @@ func TestEnvelopeExprContextSkipsNonLoopEnvelopes(t *testing.T) {
 func TestEnvelopeExprContextInjectsLoopVars(t *testing.T) {
 	base := map[string]interface{}{"env": "prod"}
 	env := &tasks.TaskEnvelope{Name: "x", IsLoopExpansion: true, LoopItem: "api", LoopIndex: 2}
-	got := envelopeExprContext(base, env, nil, nil)
+	got := envelopeExprContext(base, env, nil, nil, nil)
 	if got["item"] != "api" {
 		t.Errorf("item = %v, want api", got["item"])
 	}
@@ -67,7 +67,7 @@ func TestEnvelopeExprContextExposesResultAndRegistered(t *testing.T) {
 	base := map[string]interface{}{"env": "prod"}
 	env := &tasks.TaskEnvelope{Name: "x"}
 
-	got := envelopeExprContext(base, env, nil, nil)
+	got := envelopeExprContext(base, env, nil, nil, nil)
 	if _, ok := got["result"]; ok {
 		t.Errorf("result should be omitted when nil; got %v", got)
 	}
@@ -77,7 +77,7 @@ func TestEnvelopeExprContextExposesResultAndRegistered(t *testing.T) {
 
 	state := tasks.TaskOutputState{Changed: true}
 	registered := map[string]tasks.RegisteredValue{"foo": {TaskOutputState: state}}
-	got = envelopeExprContext(base, env, state, registered)
+	got = envelopeExprContext(base, env, state, registered, nil)
 	if got["result"] == nil {
 		t.Errorf("result should be exposed when non-nil; got %v", got)
 	}

--- a/commands/envelope_context.go
+++ b/commands/envelope_context.go
@@ -25,19 +25,27 @@ func buildEnvelopeExprContext(inputs map[string]interface{}) map[string]interfac
 // post-execute `changed_when` / `failed_when` evaluation phase; pass
 // nil from `when:` call sites so predicates running before the task
 // fires do not see a stale result.
+//
+// failedTask is non-nil only inside a #211 rescue child's predicate
+// evaluation; it is bound under `.failed_task` so a rescue handler can
+// inspect the failing block child's TaskOutputState (e.g.
+// `failed_task.Stderr contains "..."`). Outside rescue scope the key is
+// absent.
 func envelopeExprContext(
 	base map[string]interface{},
 	env *tasks.TaskEnvelope,
 	result interface{},
 	registered map[string]tasks.RegisteredValue,
+	failedTask interface{},
 ) map[string]interface{} {
 	hasLoopVars := env != nil && env.IsLoopExpansion
 	hasResult := result != nil
 	hasRegistered := len(registered) > 0
-	if !hasLoopVars && !hasResult && !hasRegistered {
+	hasFailedTask := failedTask != nil
+	if !hasLoopVars && !hasResult && !hasRegistered && !hasFailedTask {
 		return base
 	}
-	out := make(map[string]interface{}, len(base)+3)
+	out := make(map[string]interface{}, len(base)+4)
 	for k, v := range base {
 		out[k] = v
 	}
@@ -56,6 +64,9 @@ func envelopeExprContext(
 			registeredCopy[k] = v
 		}
 		out["registered"] = registeredCopy
+	}
+	if hasFailedTask {
+		out["failed_task"] = failedTask
 	}
 	return out
 }

--- a/commands/envelope_overrides.go
+++ b/commands/envelope_overrides.go
@@ -31,13 +31,14 @@ func applyEnvelopeOverrides(
 	state tasks.TaskOutputState,
 	playExprCtx map[string]interface{},
 	registered map[string]tasks.RegisteredValue,
+	failedTask interface{},
 ) (tasks.TaskOutputState, error) {
 	if env == nil {
 		return state, nil
 	}
 
 	if env.HasFailedWhen() {
-		ctx := envelopeExprContext(playExprCtx, env, state, registered)
+		ctx := envelopeExprContext(playExprCtx, env, state, registered, failedTask)
 		ok, err := tasks.EvalBool(env.FailedWhenProgram(), ctx)
 		if err != nil {
 			return state, fmt.Errorf("failed_when expression error: %w", err)
@@ -55,7 +56,7 @@ func applyEnvelopeOverrides(
 	}
 
 	if env.HasChangedWhen() {
-		ctx := envelopeExprContext(playExprCtx, env, state, registered)
+		ctx := envelopeExprContext(playExprCtx, env, state, registered, failedTask)
 		ok, err := tasks.EvalBool(env.ChangedWhenProgram(), ctx)
 		if err != nil {
 			return state, fmt.Errorf("changed_when expression error: %w", err)

--- a/commands/group_test.go
+++ b/commands/group_test.go
@@ -1,0 +1,284 @@
+package commands
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestApplyGroupAllChildrenSucceed: a group with all-passing block
+// children and no rescue/always reports OK at the group level and
+// each child renders its own line.
+func TestApplyGroupAllChildrenSucceed(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{Changed: true})
+	stubSet("b", StubFixture{Changed: false})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: deploy
+      block:
+        - name: ensure first
+          dokku_stub: { key: a }
+        - name: ensure second
+          dokku_stub: { key: b }
+`)
+	stdout, stderr, exit := runApply(t, path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s; stderr=%s", exit, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "[block] ensure first") {
+		t.Errorf("expected [block] ensure first in stdout; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "[block] ensure second") {
+		t.Errorf("expected [block] ensure second in stdout; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "deploy  (group)") {
+		t.Errorf("expected group summary line; got:\n%s", stdout)
+	}
+}
+
+// TestApplyGroupBlockErrorTriggersRescue: the first block child errors,
+// rescue runs and clears the failure, group reports OK.
+func TestApplyGroupBlockErrorTriggersRescue(t *testing.T) {
+	defer stubReset()
+	stubSet("bad", StubFixture{ExecuteError: errors.New("block boom")})
+	stubSet("rescue", StubFixture{Changed: true})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: deploy
+      block:
+        - name: errors
+          dokku_stub: { key: bad }
+        - name: should-not-run
+          dokku_stub: { key: bad }
+      rescue:
+        - name: cleanup
+          dokku_stub: { key: rescue }
+`)
+	stdout, stderr, exit := runApply(t, path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0 (rescue cleared); stdout=%s; stderr=%s", exit, stdout, stderr)
+	}
+	combined := stdout + stderr
+	if !strings.Contains(combined, "[block] errors") {
+		t.Errorf("expected [block] errors line; combined=\n%s", combined)
+	}
+	if !strings.Contains(stdout, "[rescue] cleanup") {
+		t.Errorf("expected [rescue] cleanup line; got:\n%s", stdout)
+	}
+	if strings.Contains(combined, "[block] should-not-run") {
+		t.Errorf("post-error block child should not run; combined=\n%s", combined)
+	}
+}
+
+// TestApplyGroupRescueFailureFailsGroup: when rescue itself errors,
+// the group's verdict is failed and the run exits non-zero.
+func TestApplyGroupRescueFailureFailsGroup(t *testing.T) {
+	defer stubReset()
+	stubSet("blockboom", StubFixture{ExecuteError: errors.New("block boom")})
+	stubSet("rescueboom", StubFixture{ExecuteError: errors.New("rescue boom")})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: deploy
+      block:
+        - dokku_stub: { key: blockboom }
+      rescue:
+        - dokku_stub: { key: rescueboom }
+`)
+	stdout, _, exit := runApply(t, path)
+	if exit == 0 {
+		t.Fatalf("expected non-zero exit when rescue errors; stdout=%s", stdout)
+	}
+}
+
+// TestApplyGroupAlwaysRunsAfterSuccessAndRescue: always children run
+// regardless of block success or rescue failure paths.
+func TestApplyGroupAlwaysRunsAfterSuccess(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{Changed: true})
+	stubSet("marker", StubFixture{Changed: true})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: with-always
+      block:
+        - dokku_stub: { key: a }
+      always:
+        - name: stamp
+          dokku_stub: { key: marker }
+`)
+	stdout, _, exit := runApply(t, path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if !strings.Contains(stdout, "[always] stamp") {
+		t.Errorf("expected [always] stamp line; got:\n%s", stdout)
+	}
+}
+
+func TestApplyGroupAlwaysRunsAfterRescue(t *testing.T) {
+	defer stubReset()
+	stubSet("blockboom", StubFixture{ExecuteError: errors.New("block boom")})
+	stubSet("rescue", StubFixture{Changed: true})
+	stubSet("marker", StubFixture{Changed: true})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: with-rescue-and-always
+      block:
+        - dokku_stub: { key: blockboom }
+      rescue:
+        - dokku_stub: { key: rescue }
+      always:
+        - name: stamp
+          dokku_stub: { key: marker }
+`)
+	stdout, _, exit := runApply(t, path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if !strings.Contains(stdout, "[always] stamp") {
+		t.Errorf("expected [always] stamp line after rescue; got:\n%s", stdout)
+	}
+}
+
+// TestApplyGroupIgnoreErrorsOnChildDoesNotTriggerRescue mirrors the
+// #210 rule: ignore_errors swallows a child's error and does NOT
+// trigger rescue. The next block child still runs; rescue stays cold.
+func TestApplyGroupIgnoreErrorsOnChildDoesNotTriggerRescue(t *testing.T) {
+	defer stubReset()
+	stubSet("bad", StubFixture{ExecuteError: errors.New("ignored boom")})
+	stubSet("after", StubFixture{Changed: true})
+	stubSet("rescue", StubFixture{Changed: true})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: swallow
+      block:
+        - name: errors quietly
+          ignore_errors: true
+          dokku_stub: { key: bad }
+        - name: still runs
+          dokku_stub: { key: after }
+      rescue:
+        - name: rescue should not run
+          dokku_stub: { key: rescue }
+`)
+	stdout, _, exit := runApply(t, path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if !strings.Contains(stdout, "[block] still runs") {
+		t.Errorf("post-ignored block child should run; got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "[rescue]") {
+		t.Errorf("rescue must not trigger when ignore_errors swallowed the error; got:\n%s", stdout)
+	}
+}
+
+// TestApplyGroupFailedTaskBoundInRescue: a rescue child's `when:`
+// references `.failed_task` and uses it to gate behaviour. The rescue
+// should run because the predicate sees the failing block child's
+// state.
+func TestApplyGroupFailedTaskBoundInRescue(t *testing.T) {
+	defer stubReset()
+	stubSet("bad", StubFixture{ExecuteError: errors.New("triggered boom")})
+	stubSet("cleanup", StubFixture{Changed: true})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: deploy
+      block:
+        - dokku_stub: { key: bad }
+      rescue:
+        - name: clean if real
+          when: 'failed_task.Error != nil'
+          dokku_stub: { key: cleanup }
+`)
+	stdout, _, exit := runApply(t, path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if !strings.Contains(stdout, "[rescue] clean if real") {
+		t.Errorf("rescue should run since failed_task.Error != nil; got:\n%s", stdout)
+	}
+}
+
+// TestApplyGroupIgnoreErrorsOnGroup: a residual error after rescue +
+// always is suppressed when the group itself carries ignore_errors.
+func TestApplyGroupIgnoreErrorsOnGroup(t *testing.T) {
+	defer stubReset()
+	stubSet("blockboom", StubFixture{ExecuteError: errors.New("block boom")})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: deploy
+      ignore_errors: true
+      block:
+        - dokku_stub: { key: blockboom }
+`)
+	stdout, _, exit := runApply(t, path)
+	if exit != 0 {
+		t.Fatalf("ignore_errors on group should swallow the residual error; exit=%d stdout=%s", exit, stdout)
+	}
+}
+
+// TestApplyGroupRegisterSnapshotsAggregateState: register on a group
+// captures the synthesized post-override outcome and exposes it to a
+// later task's predicate.
+func TestApplyGroupRegisterSnapshotsAggregateState(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{Changed: true})
+	stubSet("b", StubFixture{Changed: false})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: deploy
+      register: deploy_outcome
+      block:
+        - dokku_stub: { key: a }
+    - name: follow-up
+      when: 'registered.deploy_outcome.Changed'
+      dokku_stub: { key: b }
+`)
+	stdout, _, exit := runApply(t, path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if strings.Contains(stdout, "[skipped] follow-up") {
+		t.Errorf("follow-up must run because the group reported changed; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "follow-up") {
+		t.Errorf("follow-up event missing; got:\n%s", stdout)
+	}
+}
+
+// TestApplyGroupNestedFailureReachesOuterRescue: an inner block's
+// error bubbles up and triggers the outer block's rescue.
+func TestApplyGroupNestedFailureReachesOuterRescue(t *testing.T) {
+	defer stubReset()
+	stubSet("inner-boom", StubFixture{ExecuteError: errors.New("inner boom")})
+	stubSet("outer-rescue", StubFixture{Changed: true})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: outer
+      block:
+        - name: inner
+          block:
+            - dokku_stub: { key: inner-boom }
+      rescue:
+        - name: outer rescue
+          dokku_stub: { key: outer-rescue }
+`)
+	stdout, _, exit := runApply(t, path)
+	if exit != 0 {
+		t.Fatalf("outer rescue should clear the failure; exit=%d stdout=%s", exit, stdout)
+	}
+	if !strings.Contains(stdout, "[rescue] outer rescue") {
+		t.Errorf("outer rescue should fire; got:\n%s", stdout)
+	}
+}

--- a/commands/output.go
+++ b/commands/output.go
@@ -63,6 +63,17 @@ type ApplyTaskEvent struct {
 	// but the run continues and the error does not count toward the
 	// summary.
 	Ignored bool
+	// Phase labels group children (#211): "block", "rescue", or
+	// "always". Empty for top-level tasks and for the group's own
+	// summary event. The formatter indents children one level and
+	// surfaces the phase as a marker on the continuation line; the
+	// JSON emitter exposes the same value under a `phase` key.
+	Phase string
+	// Group, when true, marks the event as a group summary (#211)
+	// rather than a leaf or child task. The formatter renders these
+	// with a `(group)` annotation so the user can spot the group's
+	// own outcome at a glance.
+	Group bool
 	// Duration is the wall-clock time Execute took (or zero for the
 	// when-skipped / when-error branches).
 	Duration time.Duration
@@ -78,6 +89,12 @@ type PlanTaskEvent struct {
 	Result    tasks.PlanResult
 	WhenError error
 	Skipped   bool
+	// Phase labels group children (#211): "block", "rescue", or
+	// "always". Empty for top-level tasks and for the group's own
+	// summary event.
+	Phase string
+	// Group, when true, marks the event as a group summary (#211).
+	Group bool
 	Duration  time.Duration
 	Timestamp time.Time
 }
@@ -211,18 +228,19 @@ func (f *Formatter) PlaySkipped(name, whenSrc string) {
 // ApplyTask renders one apply task line plus optional continuations,
 // matching the legacy formatter dispatch in commands/apply.go.
 func (f *Formatter) ApplyTask(ev ApplyTaskEvent) {
+	displayName := decoratePhaseName(ev.Name, ev.Phase, ev.Group)
 	switch {
 	case ev.WhenError != nil:
-		f.TaskLine(MarkerError, ev.Name, "")
+		f.TaskLine(MarkerError, displayName, "")
 		f.Continuation('!', fmt.Sprintf("when expression error: %v", ev.WhenError))
 	case ev.Skipped:
-		f.TaskLine(MarkerSkipped, ev.Name, "")
+		f.TaskLine(MarkerSkipped, displayName, "")
 	case ev.State.Error != nil:
 		suffix := ""
 		if ev.Ignored {
 			suffix = "(ignored)"
 		}
-		f.TaskLine(MarkerError, ev.Name, suffix)
+		f.TaskLine(MarkerError, displayName, suffix)
 		f.ErrorContinuation(ev.State.Error)
 		// Stderr already surfaces via the dokku-prefixed continuation:
 		// subprocess.CallExecCommand wraps stderr into the error itself.
@@ -240,17 +258,17 @@ func (f *Formatter) ApplyTask(ev ApplyTaskEvent) {
 		if ev.Ignored {
 			suffix = "(ignored)"
 		}
-		f.TaskLine(MarkerError, ev.Name, suffix)
+		f.TaskLine(MarkerError, displayName, suffix)
 		f.Continuation('!', fmt.Sprintf("invalid state: expected=%v actual=%v", ev.State.DesiredState, ev.State.State))
 	case ev.State.Changed:
-		f.TaskLine(MarkerChanged, ev.Name, "")
+		f.TaskLine(MarkerChanged, displayName, "")
 		if f.verbose {
 			for _, cmd := range ev.State.Commands {
 				f.Continuation('\u2192', cmd)
 			}
 		}
 	default:
-		f.TaskLine(MarkerOK, ev.Name, "")
+		f.TaskLine(MarkerOK, displayName, "")
 		if f.verbose {
 			for _, cmd := range ev.State.Commands {
 				f.Continuation('\u2192', cmd)
@@ -262,15 +280,16 @@ func (f *Formatter) ApplyTask(ev ApplyTaskEvent) {
 // PlanTask renders one plan task line plus optional continuations,
 // matching the legacy formatter dispatch in commands/plan.go.
 func (f *Formatter) PlanTask(ev PlanTaskEvent) {
+	displayName := decoratePhaseName(ev.Name, ev.Phase, ev.Group)
 	switch {
 	case ev.WhenError != nil:
-		f.TaskLine(MarkerProbeError, ev.Name, fmt.Sprintf("(when expression error: %v)", ev.WhenError))
+		f.TaskLine(MarkerProbeError, displayName, fmt.Sprintf("(when expression error: %v)", ev.WhenError))
 	case ev.Skipped:
-		f.TaskLine(MarkerSkipped, ev.Name, "(when: false)")
+		f.TaskLine(MarkerSkipped, displayName, "(when: false)")
 	case ev.Result.Error != nil:
-		f.TaskLine(MarkerProbeError, ev.Name, fmt.Sprintf("(%s)", PrefixErrorMessage(ev.Result.Error)))
+		f.TaskLine(MarkerProbeError, displayName, fmt.Sprintf("(%s)", PrefixErrorMessage(ev.Result.Error)))
 	case ev.Result.InSync:
-		f.TaskLine(MarkerOK, ev.Name, "(in sync)")
+		f.TaskLine(MarkerOK, displayName, "(in sync)")
 	default:
 		marker := Marker(ev.Result.Status)
 		if marker == "" {
@@ -280,11 +299,25 @@ func (f *Formatter) PlanTask(ev PlanTaskEvent) {
 		if ev.Result.Reason != "" {
 			suffix = "(" + ev.Result.Reason + ")"
 		}
-		f.TaskLine(marker, ev.Name, suffix)
+		f.TaskLine(marker, displayName, suffix)
 		for _, m := range ev.Result.Mutations {
 			f.Continuation('-', m)
 		}
 	}
+}
+
+// decoratePhaseName prefixes a group child's display name with its
+// clause label and tags a group's own summary line with `(group)` so
+// the user can distinguish nested events from the rest of the play.
+// Top-level non-group tasks pass through unchanged.
+func decoratePhaseName(name, phase string, group bool) string {
+	if phase != "" {
+		name = fmt.Sprintf("[%s] %s", phase, name)
+	}
+	if group {
+		name = name + "  (group)"
+	}
+	return name
 }
 
 // ErrorContinuation emits an `! <prefix>: <body>` continuation line

--- a/commands/output_json.go
+++ b/commands/output_json.go
@@ -105,6 +105,12 @@ func (e *JSONEmitter) ApplyTask(ev ApplyTaskEvent) {
 	if cmds := maskedCommands(ev.State.Commands); len(cmds) > 0 {
 		out["commands"] = cmds
 	}
+	if ev.Phase != "" {
+		out["phase"] = ev.Phase
+	}
+	if ev.Group {
+		out["group"] = true
+	}
 	e.write(out)
 }
 
@@ -150,6 +156,12 @@ func (e *JSONEmitter) PlanTask(ev PlanTaskEvent) {
 		if cmds := maskedCommands(ev.Result.Commands); len(cmds) > 0 {
 			out["commands"] = cmds
 		}
+	}
+	if ev.Phase != "" {
+		out["phase"] = ev.Phase
+	}
+	if ev.Group {
+		out["group"] = true
 	}
 	e.write(out)
 }

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -231,102 +231,24 @@ func (c *PlanCommand) Run(args []string) int {
 
 		playExprCtx := buildEnvelopeExprContext(tasks.BuildPerPlayContext(context, play.Inputs, userSet))
 
+		pc := &planContext{
+			play:        play,
+			playExprCtx: playExprCtx,
+			registered:  registered,
+			loopAccum:   loopAccum,
+			emitter:     emitter,
+			counts:      &counts,
+		}
+
 		for _, name := range tasks.FilterByTags(play.Tasks, c.tags, c.skipTags) {
 			env := play.Tasks.GetEnvelope(name)
-			taskStart := time.Now()
-
-			if env.HasWhen() {
-				ok, err := tasks.EvalBool(env.WhenProgram(), envelopeExprContext(playExprCtx, env, nil, registered))
-				if err != nil {
-					counts.Tasks++
-					counts.Errors++
-					hasError = true
-					emitter.PlanTask(PlanTaskEvent{
-						Play:      play.Name,
-						Name:      name,
-						WhenError: err,
-						Duration:  time.Since(taskStart),
-						Timestamp: time.Now().UTC(),
-					})
-					continue
-				}
-				if !ok {
-					counts.Tasks++
-					counts.Skipped++
-					emitter.PlanTask(PlanTaskEvent{
-						Play:      play.Name,
-						Name:      name,
-						Skipped:   true,
-						Duration:  time.Since(taskStart),
-						Timestamp: time.Now().UTC(),
-					})
-					continue
-				}
-			}
-
-			result := env.Task.Plan()
-			counts.Tasks++
-
-			// Synthesize a TaskOutputState from the PlanResult so the
-			// changed_when / failed_when / register phases see a
-			// consistent shape across plan and apply. Plan probes do
-			// not run subprocesses on their drift / in-sync paths, so
-			// Stdout/Stderr/ExitCode are non-zero only on probe-error
-			// paths (#210 plumbed those through PlanResult).
-			synth := tasks.TaskOutputState{
-				Changed:      !result.InSync,
-				Error:        result.Error,
-				State:        result.DesiredState,
-				DesiredState: result.DesiredState,
-				Commands:     result.Commands,
-				Stdout:       result.Stdout,
-				Stderr:       result.Stderr,
-				ExitCode:     result.ExitCode,
-			}
-			postState, overrideErr := applyEnvelopeOverrides(env, synth, playExprCtx, registered)
-			if overrideErr != nil {
-				counts.Errors++
+			outcome := planTask(env, name, pc, nil, "")
+			if outcome.errored {
 				hasError = true
-				emitter.PlanTask(PlanTaskEvent{
-					Play:      play.Name,
-					Name:      name,
-					WhenError: overrideErr,
-					Duration:  time.Since(taskStart),
-					Timestamp: time.Now().UTC(),
-				})
-				continue
 			}
-			synth = postState
-			recordRegister(env, synth, loopAccum, registered)
-
-			// Reflect the post-override verdict back onto the
-			// PlanResult so the existing classifier and the formatter
-			// / JSON output reflect the override. Falsy `failed_when`
-			// clears Error; truthy installs one. Truthy `changed_when`
-			// converts an in-sync probe to drift, while falsy
-			// `changed_when` makes drift look in-sync (the plan event
-			// continues to render via the same code path).
-			result.Error = synth.Error
-			result.InSync = !synth.Changed && synth.Error == nil
-
-			switch {
-			case result.Error != nil:
-				counts.Errors++
-				hasError = true
-			case result.InSync:
-				counts.InSync++
-			default:
-				counts.WouldChange++
+			if outcome.drift {
 				hasDrift = true
 			}
-
-			emitter.PlanTask(PlanTaskEvent{
-				Play:      play.Name,
-				Name:      name,
-				Result:    result,
-				Duration:  time.Since(taskStart),
-				Timestamp: time.Now().UTC(),
-			})
 		}
 	}
 
@@ -348,4 +270,295 @@ func (c *PlanCommand) newEmitter() EventEmitter {
 		return NewJSONEmitter(c.Ui)
 	}
 	return NewFormatter(c.Ui, false)
+}
+
+// planContext bundles the run-wide plan state per-task helpers share so
+// planTask / planLeaf / planGroup signatures stay tractable.
+type planContext struct {
+	play        *tasks.Play
+	playExprCtx map[string]interface{}
+	registered  map[string]tasks.RegisteredValue
+	loopAccum   loopRegisterAccumulator
+	emitter     EventEmitter
+	counts      *PlanCounts
+}
+
+// planTaskOutcome is the per-task verdict the plan loop reads back. The
+// errored / drift flags drive the run-level hasError / hasDrift booleans
+// the executor uses to compute the exit code; the synthesized state is
+// propagated up to a parent group walker so a rescue child's predicates
+// can reference `.failed_task`.
+type planTaskOutcome struct {
+	state   tasks.TaskOutputState
+	errored bool
+	drift   bool
+	skipped bool
+}
+
+// planTask plans one envelope - leaf or group. The phase string labels
+// child events emitted from a group walk ("block", "rescue", "always");
+// top-level callers pass "". failedTask is non-nil only when called
+// from a rescue walker so the rescue child's predicates can reference
+// `.failed_task`.
+func planTask(env *tasks.TaskEnvelope, name string, pc *planContext, failedTask interface{}, phase string) planTaskOutcome {
+	if env.IsGroup() {
+		return planGroup(env, name, pc, failedTask, phase)
+	}
+	return planLeaf(env, name, pc, failedTask, phase)
+}
+
+// planLeaf runs a single non-group envelope through Plan() with the
+// post-override pipeline mirroring apply.
+func planLeaf(env *tasks.TaskEnvelope, name string, pc *planContext, failedTask interface{}, phase string) planTaskOutcome {
+	taskStart := time.Now()
+
+	if env.HasWhen() {
+		ok, err := tasks.EvalBool(env.WhenProgram(), envelopeExprContext(pc.playExprCtx, env, nil, pc.registered, failedTask))
+		if err != nil {
+			pc.counts.Tasks++
+			pc.counts.Errors++
+			pc.emitter.PlanTask(PlanTaskEvent{
+				Play:      pc.play.Name,
+				Name:      name,
+				Phase:     phase,
+				WhenError: err,
+				Duration:  time.Since(taskStart),
+				Timestamp: time.Now().UTC(),
+			})
+			return planTaskOutcome{errored: true}
+		}
+		if !ok {
+			pc.counts.Tasks++
+			pc.counts.Skipped++
+			pc.emitter.PlanTask(PlanTaskEvent{
+				Play:      pc.play.Name,
+				Name:      name,
+				Phase:     phase,
+				Skipped:   true,
+				Duration:  time.Since(taskStart),
+				Timestamp: time.Now().UTC(),
+			})
+			return planTaskOutcome{skipped: true}
+		}
+	}
+
+	result := env.Task.Plan()
+	pc.counts.Tasks++
+
+	synth := tasks.TaskOutputState{
+		Changed:      !result.InSync,
+		Error:        result.Error,
+		State:        result.DesiredState,
+		DesiredState: result.DesiredState,
+		Commands:     result.Commands,
+		Stdout:       result.Stdout,
+		Stderr:       result.Stderr,
+		ExitCode:     result.ExitCode,
+	}
+	postState, overrideErr := applyEnvelopeOverrides(env, synth, pc.playExprCtx, pc.registered, failedTask)
+	if overrideErr != nil {
+		pc.counts.Errors++
+		pc.emitter.PlanTask(PlanTaskEvent{
+			Play:      pc.play.Name,
+			Name:      name,
+			Phase:     phase,
+			WhenError: overrideErr,
+			Duration:  time.Since(taskStart),
+			Timestamp: time.Now().UTC(),
+		})
+		return planTaskOutcome{errored: true}
+	}
+	synth = postState
+	recordRegister(env, synth, pc.loopAccum, pc.registered)
+
+	result.Error = synth.Error
+	result.InSync = !synth.Changed && synth.Error == nil
+
+	out := planTaskOutcome{state: synth}
+	switch {
+	case result.Error != nil:
+		pc.counts.Errors++
+		out.errored = true
+	case result.InSync:
+		pc.counts.InSync++
+	default:
+		pc.counts.WouldChange++
+		out.drift = true
+	}
+
+	pc.emitter.PlanTask(PlanTaskEvent{
+		Play:      pc.play.Name,
+		Name:      name,
+		Phase:     phase,
+		Result:    result,
+		Duration:  time.Since(taskStart),
+		Timestamp: time.Now().UTC(),
+	})
+	return out
+}
+
+// planGroup plans a try/catch/finally group entry (#211). Block
+// children plan unconditionally. Rescue and always children only plan
+// when at least one block child reports drift or a probe error, since
+// Plan() never triggers an apply-time error and walking
+// rescue/always when no block child is going to change is misleading
+// noise. The group's own envelope predicates apply to the synthesized
+// outcome the same way they do for a leaf task.
+func planGroup(env *tasks.TaskEnvelope, name string, pc *planContext, failedTask interface{}, phase string) planTaskOutcome {
+	taskStart := time.Now()
+
+	if env.HasWhen() {
+		ok, err := tasks.EvalBool(env.WhenProgram(), envelopeExprContext(pc.playExprCtx, env, nil, pc.registered, failedTask))
+		if err != nil {
+			pc.counts.Tasks++
+			pc.counts.Errors++
+			pc.emitter.PlanTask(PlanTaskEvent{
+				Play:      pc.play.Name,
+				Name:      name,
+				Phase:     phase,
+				Group:     true,
+				WhenError: err,
+				Duration:  time.Since(taskStart),
+				Timestamp: time.Now().UTC(),
+			})
+			return planTaskOutcome{errored: true}
+		}
+		if !ok {
+			pc.counts.Tasks++
+			pc.counts.Skipped++
+			pc.emitter.PlanTask(PlanTaskEvent{
+				Play:      pc.play.Name,
+				Name:      name,
+				Phase:     phase,
+				Group:     true,
+				Skipped:   true,
+				Duration:  time.Since(taskStart),
+				Timestamp: time.Now().UTC(),
+			})
+			return planTaskOutcome{skipped: true}
+		}
+	}
+
+	var (
+		anyChanged       bool
+		anyDrift         bool
+		blockFailedState tasks.TaskOutputState
+		blockFailed      bool
+		lastChildState   tasks.TaskOutputState
+	)
+	for i, child := range env.Block {
+		childName := child.Name
+		if childName == "" {
+			childName = fmt.Sprintf("%s.block[%d]", name, i)
+		}
+		childOutcome := planTask(child, childName, pc, nil, "block")
+		if childOutcome.state.Changed {
+			anyChanged = true
+		}
+		lastChildState = childOutcome.state
+		if childOutcome.errored && !blockFailed {
+			blockFailed = true
+			blockFailedState = childOutcome.state
+		}
+		if childOutcome.drift {
+			anyDrift = true
+		}
+	}
+
+	walkRescueAlways := blockFailed || anyDrift
+	if walkRescueAlways {
+		var failedTaskCtx interface{}
+		if blockFailed {
+			failedTaskCtx = blockFailedState
+		}
+		for i, child := range env.Rescue {
+			childName := child.Name
+			if childName == "" {
+				childName = fmt.Sprintf("%s.rescue[%d]", name, i)
+			}
+			childOutcome := planTask(child, childName, pc, failedTaskCtx, "rescue")
+			if childOutcome.state.Changed {
+				anyChanged = true
+			}
+			lastChildState = childOutcome.state
+		}
+		for i, child := range env.Always {
+			childName := child.Name
+			if childName == "" {
+				childName = fmt.Sprintf("%s.always[%d]", name, i)
+			}
+			childOutcome := planTask(child, childName, pc, nil, "always")
+			if childOutcome.state.Changed {
+				anyChanged = true
+			}
+			lastChildState = childOutcome.state
+		}
+	}
+
+	groupSynth := tasks.TaskOutputState{
+		Changed:      anyChanged,
+		DesiredState: lastChildState.DesiredState,
+		State:        lastChildState.DesiredState,
+		Stdout:       lastChildState.Stdout,
+		Stderr:       lastChildState.Stderr,
+		ExitCode:     lastChildState.ExitCode,
+		Commands:     lastChildState.Commands,
+	}
+	if blockFailed && len(env.Rescue) == 0 {
+		groupSynth.Error = blockFailedState.Error
+	}
+
+	postState, overrideErr := applyEnvelopeOverrides(env, groupSynth, pc.playExprCtx, pc.registered, failedTask)
+	if overrideErr != nil {
+		pc.counts.Errors++
+		pc.emitter.PlanTask(PlanTaskEvent{
+			Play:      pc.play.Name,
+			Name:      name,
+			Phase:     phase,
+			Group:     true,
+			WhenError: overrideErr,
+			Duration:  time.Since(taskStart),
+			Timestamp: time.Now().UTC(),
+		})
+		return planTaskOutcome{errored: true}
+	}
+	groupSynth = postState
+	recordRegister(env, groupSynth, pc.loopAccum, pc.registered)
+	pc.counts.Tasks++
+
+	result := tasks.PlanResult{
+		Error:        groupSynth.Error,
+		InSync:       !groupSynth.Changed && groupSynth.Error == nil,
+		DesiredState: groupSynth.DesiredState,
+		Commands:     groupSynth.Commands,
+		Stdout:       groupSynth.Stdout,
+		Stderr:       groupSynth.Stderr,
+		ExitCode:     groupSynth.ExitCode,
+	}
+	if !result.InSync && result.Error == nil {
+		result.Status = tasks.PlanStatusModify
+		result.Reason = "block: would mutate state"
+	}
+	out := planTaskOutcome{state: groupSynth}
+	switch {
+	case result.Error != nil:
+		pc.counts.Errors++
+		out.errored = true
+	case result.InSync:
+		pc.counts.InSync++
+	default:
+		pc.counts.WouldChange++
+		out.drift = true
+	}
+
+	pc.emitter.PlanTask(PlanTaskEvent{
+		Play:      pc.play.Name,
+		Name:      name,
+		Phase:     phase,
+		Group:     true,
+		Result:    result,
+		Duration:  time.Since(taskStart),
+		Timestamp: time.Now().UTC(),
+	})
+	return out
 }

--- a/tasks/envelope.go
+++ b/tasks/envelope.go
@@ -45,8 +45,20 @@ type TaskEnvelope struct {
 	FailedWhen   string
 	IgnoreErrors bool
 
-	// Task is the decoded task body. Always non-nil for envelopes the
-	// loader produces.
+	// Block / Rescue / Always carry the nested child envelopes for a
+	// try/catch/finally group entry (#211). When Block is non-empty the
+	// envelope is a group: Task is nil, TypeName is empty, and the
+	// executor walks the three child slices instead of dispatching to a
+	// task body. The wrapping envelope's `name`, `tags`, `when`, `loop`,
+	// `register`, `changed_when`, `failed_when`, and `ignore_errors`
+	// apply to the whole group.
+	Block  []*TaskEnvelope
+	Rescue []*TaskEnvelope
+	Always []*TaskEnvelope
+
+	// Task is the decoded task body. Non-nil for leaf envelopes the
+	// loader produces; nil for group envelopes (#211) where Block /
+	// Rescue / Always carry the nested children instead.
 	Task Task
 
 	// TypeName is the registered task name (e.g. "dokku_app") that
@@ -80,6 +92,15 @@ type TaskEnvelope struct {
 // predicate that must be evaluated before execution.
 func (e *TaskEnvelope) HasWhen() bool {
 	return e != nil && e.When != ""
+}
+
+// IsGroup reports whether the envelope is a try/catch/finally group
+// entry (#211). Group envelopes carry their children in Block / Rescue
+// / Always; their Task is nil. The executor uses this flag as the
+// dispatch boundary between the leaf-task code path and the group
+// walker.
+func (e *TaskEnvelope) IsGroup() bool {
+	return e != nil && len(e.Block) > 0
 }
 
 // WhenProgram returns the pre-compiled expr program for When, or nil if

--- a/tasks/loop.go
+++ b/tasks/loop.go
@@ -83,6 +83,122 @@ func expandLoop(base *TaskEnvelope, body interface{}, registered Task, sigilCont
 	return out, nil
 }
 
+// expandLoopGroup produces one group TaskEnvelope per iteration the
+// envelope's loop resolves to. The base envelope already carries the
+// resolved Loop value; blockBody / rescueBody / alwaysBody are the raw
+// YAML lists of nested task entries decoded once at the file level.
+//
+// For each iteration, the three lists are YAML-marshalled, sigil-rendered
+// with `.item` / `.index` set, then unmarshalled back into
+// []map[string]interface{} and recursed through buildEnvelopesForEntry
+// so child envelopes inherit the iteration's `.item` / `.index` in
+// every nested task body. The expanded group envelope inherits Tags /
+// When / Register from the base; LoopItem / LoopIndex carry the
+// iteration value so the per-group `when:` evaluation can see them.
+func expandLoopGroup(base *TaskEnvelope, blockBody, rescueBody, alwaysBody interface{}, sigilContext, exprContext map[string]interface{}) ([]*TaskEnvelope, error) {
+	items, err := resolveLoopList(base.Loop, exprContext)
+	if err != nil {
+		return nil, err
+	}
+
+	blockBytes, err := yaml.Marshal(blockBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal block body: %w", err)
+	}
+	var rescueBytes, alwaysBytes []byte
+	if rescueBody != nil {
+		rescueBytes, err = yaml.Marshal(rescueBody)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal rescue body: %w", err)
+		}
+	}
+	if alwaysBody != nil {
+		alwaysBytes, err = yaml.Marshal(alwaysBody)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal always body: %w", err)
+		}
+	}
+
+	out := make([]*TaskEnvelope, 0, len(items))
+	for i, item := range items {
+		iterCtx := make(map[string]interface{}, len(sigilContext)+2)
+		for k, v := range sigilContext {
+			iterCtx[k] = v
+		}
+		iterCtx["item"] = item
+		iterCtx["index"] = i
+
+		blockChildren, err := renderAndDecodeGroupClause(blockBytes, "block", iterCtx, sigilContext, exprContext, base.Name, i)
+		if err != nil {
+			return nil, err
+		}
+		if len(blockChildren) == 0 {
+			return nil, fmt.Errorf("loop iteration %d: block: must contain at least one child task", i)
+		}
+
+		var rescueChildren []*TaskEnvelope
+		if rescueBytes != nil {
+			rescueChildren, err = renderAndDecodeGroupClause(rescueBytes, "rescue", iterCtx, sigilContext, exprContext, base.Name, i)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		var alwaysChildren []*TaskEnvelope
+		if alwaysBytes != nil {
+			alwaysChildren, err = renderAndDecodeGroupClause(alwaysBytes, "always", iterCtx, sigilContext, exprContext, base.Name, i)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		expanded := *base
+		expanded.Loop = nil
+		expanded.LoopItem = item
+		expanded.LoopIndex = i
+		expanded.IsLoopExpansion = true
+		expanded.Block = blockChildren
+		expanded.Rescue = rescueChildren
+		expanded.Always = alwaysChildren
+		expanded.Name = loopExpansionName(base.Name, item, i)
+
+		out = append(out, &expanded)
+	}
+	return out, nil
+}
+
+// renderAndDecodeGroupClause renders a single group clause's YAML for
+// one loop iteration and decodes the result into child envelopes. The
+// per-iteration sigil context carries `.item` / `.index` so every nested
+// task body sees the iteration value (per #211: each group iteration's
+// `.item` / `.index` is shared across all its children). The file-level
+// sigilContext stays available so other inputs continue to render.
+func renderAndDecodeGroupClause(body []byte, clause string, iterCtx, sigilContext, exprContext map[string]interface{}, baseName string, iter int) ([]*TaskEnvelope, error) {
+	rendered, err := sigil.Execute(body, iterCtx, "loop")
+	if err != nil {
+		return nil, fmt.Errorf("loop iteration %d %s: render error: %w", iter, clause, err)
+	}
+	renderedBytes, err := io.ReadAll(&rendered)
+	if err != nil {
+		return nil, fmt.Errorf("loop iteration %d %s: read error: %w", iter, clause, err)
+	}
+
+	var rawList []map[string]interface{}
+	if err := yaml.Unmarshal(renderedBytes, &rawList); err != nil {
+		return nil, fmt.Errorf("loop iteration %d %s: decode error: %w", iter, clause, err)
+	}
+
+	out := make([]*TaskEnvelope, 0, len(rawList))
+	for i, entry := range rawList {
+		envelopes, err := buildEnvelopesForEntry(i+1, entry, sigilContext, exprContext)
+		if err != nil {
+			return nil, fmt.Errorf("loop iteration %d %s[%d]: %s", iter, clause, i, err)
+		}
+		out = append(out, envelopes...)
+	}
+	return out, nil
+}
+
 // resolveLoopList normalises a loop value into a concrete list. Strings
 // are compiled and evaluated as expr programs; lists are returned
 // directly. Any other type yields an error.

--- a/tasks/loop_test.go
+++ b/tasks/loop_test.go
@@ -173,3 +173,46 @@ func TestLoopVarOutsideLoopRejectedAtParse(t *testing.T) {
 		t.Errorf("got: %v", err)
 	}
 }
+
+// TestLoopOnGroupExpandsEntireGroup pins #211: a `loop:` on a group
+// duplicates the whole group N times so each iteration's children
+// share that iteration's `.item` / `.index`.
+func TestLoopOnGroupExpandsEntireGroup(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: deploy each
+      loop: [api, worker, web]
+      block:
+        - dokku_app:
+            app: "deploy-{{ .item }}"
+`)
+	out, err := GetTasks(data, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetTasks: %v", err)
+	}
+	keys := out.Keys()
+	if len(keys) != 3 {
+		t.Fatalf("expected 3 group expansions, got %d (%v)", len(keys), keys)
+	}
+	wantApps := []string{"deploy-api", "deploy-worker", "deploy-web"}
+	for i, k := range keys {
+		env := out.GetEnvelope(k)
+		if !env.IsGroup() {
+			t.Errorf("expansion %d %q must be a group", i, k)
+			continue
+		}
+		if !env.IsLoopExpansion {
+			t.Errorf("expansion %d %q must carry IsLoopExpansion", i, k)
+		}
+		if len(env.Block) != 1 {
+			t.Fatalf("expansion %d block: want 1 child, got %d", i, len(env.Block))
+		}
+		appTask, ok := env.Block[0].Task.(*AppTask)
+		if !ok {
+			t.Fatalf("expansion %d block[0] task type %T, want *AppTask", i, env.Block[0].Task)
+		}
+		if appTask.App != wantApps[i] {
+			t.Errorf("expansion %d block[0] app = %q, want %q", i, appTask.App, wantApps[i])
+		}
+	}
+}

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -257,6 +257,9 @@ var envelopeAllowlistKeys = []string{
 	"changed_when",
 	"failed_when",
 	"ignore_errors",
+	"block",
+	"rescue",
+	"always",
 }
 
 // envelopeAllowlistSet is envelopeAllowlistKeys as a lookup set.
@@ -575,7 +578,10 @@ func mergePlayTags(envTags, playTags []string) []string {
 // buildEnvelopesForEntry walks a single task entry, partitions envelope
 // keys vs the task-type key, decodes the body, pre-compiles `when:`, and
 // expands `loop:` if present. Returns one or more envelopes ready for
-// insertion into the ordered map.
+// insertion into the ordered map. When the entry carries `block:`, it is
+// decoded as a try/catch/finally group: child envelopes are produced
+// recursively from the block / rescue / always lists and the wrapping
+// envelope's Task is left nil.
 func buildEnvelopesForEntry(index int, entry map[string]interface{}, sigilContext, exprContext map[string]interface{}) ([]*TaskEnvelope, error) {
 	envelope := &TaskEnvelope{}
 
@@ -584,6 +590,12 @@ func buildEnvelopesForEntry(index int, entry map[string]interface{}, sigilContex
 		taskBody     interface{}
 		taskTypeKeys []string
 		unknownKeys  []string
+		blockRaw     interface{}
+		rescueRaw    interface{}
+		alwaysRaw    interface{}
+		hasBlock     bool
+		hasRescue    bool
+		hasAlways    bool
 	)
 
 	for key, value := range entry {
@@ -630,6 +642,15 @@ func buildEnvelopesForEntry(index int, entry map[string]interface{}, sigilContex
 				return nil, fmt.Errorf("task parse error: task #%d: ignore_errors must be a bool, got %T", index, value)
 			}
 			envelope.IgnoreErrors = b
+		case "block":
+			blockRaw = value
+			hasBlock = true
+		case "rescue":
+			rescueRaw = value
+			hasRescue = true
+		case "always":
+			alwaysRaw = value
+			hasAlways = true
 		default:
 			if _, registered := RegisteredTasks[key]; registered {
 				taskTypeKeys = append(taskTypeKeys, key)
@@ -653,19 +674,25 @@ func buildEnvelopesForEntry(index int, entry map[string]interface{}, sigilContex
 		return nil, unknownKeyError(index, envelope.Name, unknownKeys)
 	}
 
-	if len(taskTypeKeys) == 0 {
-		return nil, fmt.Errorf("task parse error: task #%d %q was not a valid task - valid_tasks=%v", index, envelope.Name, registeredTaskNamesSorted())
+	isGroup := hasBlock
+	if hasRescue && !hasBlock {
+		return nil, fmt.Errorf("task parse error: task #%d %q has rescue: without block:", index, envelope.Name)
 	}
-	if len(taskTypeKeys) > 1 {
-		return nil, fmt.Errorf("task parse error: task #%d %q has %d task-type keys (%s); exactly one is allowed", index, envelope.Name, len(taskTypeKeys), strings.Join(taskTypeKeys, ", "))
+	if hasAlways && !hasBlock {
+		return nil, fmt.Errorf("task parse error: task #%d %q has always: without block:", index, envelope.Name)
 	}
 
-	envelope.TypeName = taskTypeKey
-	registered := RegisteredTasks[taskTypeKey]
-
-	bodyBytes, err := yaml.Marshal(taskBody)
-	if err != nil {
-		return nil, fmt.Errorf("task parse error: task #%d %q failed to marshal config to yaml - %s", index, envelope.Name, err)
+	if isGroup {
+		if len(taskTypeKeys) > 0 {
+			return nil, fmt.Errorf("task parse error: task #%d %q is a block: group and cannot also carry task-type key %q", index, envelope.Name, taskTypeKeys[0])
+		}
+	} else {
+		if len(taskTypeKeys) == 0 {
+			return nil, fmt.Errorf("task parse error: task #%d %q was not a valid task - valid_tasks=%v", index, envelope.Name, registeredTaskNamesSorted())
+		}
+		if len(taskTypeKeys) > 1 {
+			return nil, fmt.Errorf("task parse error: task #%d %q has %d task-type keys (%s); exactly one is allowed", index, envelope.Name, len(taskTypeKeys), strings.Join(taskTypeKeys, ", "))
+		}
 	}
 
 	if envelope.When != "" {
@@ -690,6 +717,51 @@ func buildEnvelopesForEntry(index int, entry map[string]interface{}, sigilContex
 			return nil, fmt.Errorf("task parse error: task #%d %q: failed_when compile error: %s", index, envelope.Name, err)
 		}
 		envelope.failedWhenProgram = prog
+	}
+
+	if isGroup {
+		if envelope.Loop != nil {
+			expanded, err := expandLoopGroup(envelope, blockRaw, rescueRaw, alwaysRaw, sigilContext, exprContext)
+			if err != nil {
+				return nil, fmt.Errorf("task parse error: task #%d %q: %s", index, envelope.Name, err)
+			}
+			return expanded, nil
+		}
+
+		envelope.TypeName = ""
+		blockChildren, err := decodeGroupClause(blockRaw, "block", envelope.Name, sigilContext, exprContext)
+		if err != nil {
+			return nil, fmt.Errorf("task parse error: task #%d %q: %s", index, envelope.Name, err)
+		}
+		if len(blockChildren) == 0 {
+			return nil, fmt.Errorf("task parse error: task #%d %q: block: must contain at least one child task", index, envelope.Name)
+		}
+		envelope.Block = blockChildren
+
+		if hasRescue {
+			rescueChildren, err := decodeGroupClause(rescueRaw, "rescue", envelope.Name, sigilContext, exprContext)
+			if err != nil {
+				return nil, fmt.Errorf("task parse error: task #%d %q: %s", index, envelope.Name, err)
+			}
+			envelope.Rescue = rescueChildren
+		}
+		if hasAlways {
+			alwaysChildren, err := decodeGroupClause(alwaysRaw, "always", envelope.Name, sigilContext, exprContext)
+			if err != nil {
+				return nil, fmt.Errorf("task parse error: task #%d %q: %s", index, envelope.Name, err)
+			}
+			envelope.Always = alwaysChildren
+		}
+
+		return []*TaskEnvelope{envelope}, nil
+	}
+
+	envelope.TypeName = taskTypeKey
+	registered := RegisteredTasks[taskTypeKey]
+
+	bodyBytes, err := yaml.Marshal(taskBody)
+	if err != nil {
+		return nil, fmt.Errorf("task parse error: task #%d %q failed to marshal config to yaml - %s", index, envelope.Name, err)
 	}
 
 	if envelope.Loop != nil {
@@ -718,6 +790,62 @@ func buildEnvelopesForEntry(index int, entry map[string]interface{}, sigilContex
 	}
 
 	return []*TaskEnvelope{envelope}, nil
+}
+
+// decodeGroupClause decodes one of `block:` / `rescue:` / `always:` into
+// a flat slice of child envelopes. The clause value must be a sequence
+// of YAML mappings (`[]interface{}` of `map[string]interface{}` after
+// the YAML unmarshal); each mapping is recursed through
+// buildEnvelopesForEntry so child entries themselves may carry envelope
+// keys, loop expansions, or nested groups.
+func decodeGroupClause(raw interface{}, clause, parentName string, sigilContext, exprContext map[string]interface{}) ([]*TaskEnvelope, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	rawList, ok := raw.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("%s: must be a list of task entries, got %T", clause, raw)
+	}
+	out := make([]*TaskEnvelope, 0, len(rawList))
+	for i, item := range rawList {
+		entry, ok := item.(map[string]interface{})
+		if !ok {
+			if mapped, mapOk := coerceStringKeyMap(item); mapOk {
+				entry = mapped
+			} else {
+				return nil, fmt.Errorf("%s[%d]: child entry must be a yaml mapping, got %T", clause, i, item)
+			}
+		}
+		childEnvelopes, err := buildEnvelopesForEntry(i+1, entry, sigilContext, exprContext)
+		if err != nil {
+			return nil, fmt.Errorf("%s[%d]: %s", clause, i, err)
+		}
+		out = append(out, childEnvelopes...)
+	}
+	return out, nil
+}
+
+// coerceStringKeyMap converts a yaml-decoded map[interface{}]interface{}
+// into a map[string]interface{} so nested entries match the shape
+// buildEnvelopesForEntry expects. yaml.v3 produces map[string]interface{}
+// out of the box, but defensive code keeps the loader robust against
+// custom unmarshallers.
+func coerceStringKeyMap(item interface{}) (map[string]interface{}, bool) {
+	if entry, ok := item.(map[string]interface{}); ok {
+		return entry, true
+	}
+	if entry, ok := item.(map[interface{}]interface{}); ok {
+		out := make(map[string]interface{}, len(entry))
+		for k, v := range entry {
+			ks, ok := k.(string)
+			if !ok {
+				return nil, false
+			}
+			out[ks] = v
+		}
+		return out, true
+	}
+	return nil, false
 }
 
 // decodeTags coerces a yaml-parsed tags value into a []string. Supports

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -695,3 +695,164 @@ func TestTaskDocStrings(t *testing.T) {
 		}
 	}
 }
+
+func TestGetTasksGroupBlockOnly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: deploy
+      block:
+        - name: ensure app
+          dokku_app:
+            app: my-app
+        - name: also ensure
+          dokku_app:
+            app: my-other-app
+`)
+	got, err := GetTasks(data, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetTasks should not error for block-only group, got: %v", err)
+	}
+	keys := got.Keys()
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 envelope (the group), got %d: %v", len(keys), keys)
+	}
+	env := got.GetEnvelope("deploy")
+	if env == nil {
+		t.Fatal("expected envelope named 'deploy'")
+	}
+	if !env.IsGroup() {
+		t.Fatal("expected envelope to be a group")
+	}
+	if len(env.Block) != 2 {
+		t.Errorf("expected 2 block children, got %d", len(env.Block))
+	}
+	if len(env.Rescue) != 0 {
+		t.Errorf("expected 0 rescue children, got %d", len(env.Rescue))
+	}
+	if len(env.Always) != 0 {
+		t.Errorf("expected 0 always children, got %d", len(env.Always))
+	}
+	if env.Task != nil {
+		t.Errorf("group envelope must have nil Task, got %T", env.Task)
+	}
+	if env.TypeName != "" {
+		t.Errorf("group envelope TypeName must be empty, got %q", env.TypeName)
+	}
+}
+
+func TestGetTasksGroupAllClauses(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: deploy with rollback
+      block:
+        - dokku_app:
+            app: candidate
+      rescue:
+        - dokku_app:
+            app: candidate
+            state: absent
+      always:
+        - dokku_config:
+            app: existing
+            config:
+              LAST_ATTEMPT: now
+`)
+	got, err := GetTasks(data, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetTasks: %v", err)
+	}
+	env := got.GetEnvelope("deploy with rollback")
+	if env == nil {
+		t.Fatal("expected envelope named 'deploy with rollback'")
+	}
+	if len(env.Block) != 1 || len(env.Rescue) != 1 || len(env.Always) != 1 {
+		t.Errorf("expected 1/1/1 block/rescue/always, got %d/%d/%d", len(env.Block), len(env.Rescue), len(env.Always))
+	}
+}
+
+func TestGetTasksRejectsEmptyBlock(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: empty
+      block: []
+`)
+	_, err := GetTasks(data, map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected error for empty block, got nil")
+	}
+	if !strings.Contains(err.Error(), "block: must contain at least one child task") {
+		t.Errorf("expected 'block: must contain at least one child task' error, got: %v", err)
+	}
+}
+
+func TestGetTasksRejectsRescueWithoutBlock(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: orphan
+      rescue:
+        - dokku_app:
+            app: x
+`)
+	_, err := GetTasks(data, map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected error for rescue without block, got nil")
+	}
+	if !strings.Contains(err.Error(), "rescue: without block:") {
+		t.Errorf("expected 'rescue: without block:' error, got: %v", err)
+	}
+}
+
+func TestGetTasksRejectsBlockAlongsideTaskType(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: hybrid
+      block:
+        - dokku_app:
+            app: x
+      dokku_app:
+        app: y
+`)
+	_, err := GetTasks(data, map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected error for block alongside task-type, got nil")
+	}
+	if !strings.Contains(err.Error(), "is a block: group and cannot also carry task-type key") {
+		t.Errorf("expected block+task-type error, got: %v", err)
+	}
+}
+
+func TestGetTasksNestedGroup(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: outer
+      block:
+        - name: inner
+          block:
+            - dokku_app:
+                app: deepest
+          rescue:
+            - dokku_app:
+                app: rescued
+`)
+	got, err := GetTasks(data, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetTasks for nested group: %v", err)
+	}
+	outer := got.GetEnvelope("outer")
+	if outer == nil || !outer.IsGroup() {
+		t.Fatal("expected outer group envelope")
+	}
+	if len(outer.Block) != 1 {
+		t.Fatalf("outer.Block: want 1 child, got %d", len(outer.Block))
+	}
+	inner := outer.Block[0]
+	if !inner.IsGroup() {
+		t.Fatal("expected inner envelope to be a group")
+	}
+	if len(inner.Block) != 1 {
+		t.Errorf("inner.Block: want 1, got %d", len(inner.Block))
+	}
+	if len(inner.Rescue) != 1 {
+		t.Errorf("inner.Rescue: want 1, got %d", len(inner.Rescue))
+	}
+}

--- a/tasks/validate.go
+++ b/tasks/validate.go
@@ -47,12 +47,10 @@ const validatePlaceholder = "__docket_validate_placeholder__"
 // reservedEnvelopeKeys lists the per-task keys that are recognised at the
 // envelope level but not yet activated. They live here so a typo in a real
 // task-type name (e.g. dokku_appp) is reported as "unknown task type" rather
-// than getting silently swallowed by an envelope allowlist.
-var reservedEnvelopeKeys = map[string]string{
-	"block":  "#211",
-	"rescue": "#211",
-	"always": "#211",
-}
+// than getting silently swallowed by an envelope allowlist. Empty today
+// because #211 promoted block / rescue / always to active; kept around so
+// future issues can reserve names without revisiting validateTaskEntry.
+var reservedEnvelopeKeys = map[string]string{}
 
 // activeEnvelopeKeys are the envelope keys the validator recognises and
 // passes through to the loader without generating an "envelope key
@@ -67,7 +65,15 @@ var activeEnvelopeKeys = map[string]bool{
 	"changed_when":  true,
 	"failed_when":   true,
 	"ignore_errors": true,
+	"block":         true,
+	"rescue":        true,
+	"always":        true,
 }
+
+// groupClauseKeys is the subset of envelope keys that carry a list of
+// nested task entries for a try/catch/finally group (#211). Used by the
+// loader and validator to recognise group entries.
+var groupClauseKeys = []string{"block", "rescue", "always"}
 
 // allowedPlayKeys is the set of play-level mapping keys the validator
 // admits without flagging as unexpected. #208 extends the legacy
@@ -279,7 +285,9 @@ func validatePlay(play *yaml.Node, label string, inputs []inputWithNode, opts Va
 }
 
 // validateTaskEntry covers checks 3-5: envelope shape, registered task type,
-// and required-field decode.
+// and required-field decode. For group entries (those carrying `block:`),
+// it recurses through every child of block / rescue / always so nested
+// entries surface the same diagnostics.
 func validateTaskEntry(task *yaml.Node, playLabel string, idx int) []Problem {
 	var problems []Problem
 	taskLabel := fmt.Sprintf("task #%d", idx)
@@ -342,6 +350,15 @@ func validateTaskEntry(task *yaml.Node, playLabel string, idx int) []Problem {
 		taskLabel = fmt.Sprintf("task #%d %q", idx, nameValue)
 	}
 
+	blockNode := mappingValue(task, "block")
+	rescueNode := mappingValue(task, "rescue")
+	alwaysNode := mappingValue(task, "always")
+
+	if blockNode != nil || rescueNode != nil || alwaysNode != nil {
+		problems = append(problems, validateGroupEntry(task, blockNode, rescueNode, alwaysNode, taskTypeKeys, taskTypeNode, playLabel, taskLabel)...)
+		return problems
+	}
+
 	if len(taskTypeKeys) == 0 {
 		return append(problems, Problem{
 			Code:    "task_entry_shape",
@@ -381,6 +398,35 @@ func validateTaskEntry(task *yaml.Node, playLabel string, idx int) []Problem {
 	}
 
 	problems = append(problems, validateTaskBody(registered, taskTypeKey, taskBodyNode, playLabel, taskLabel)...)
+	return problems
+}
+
+// validateGroupEntry recurses through block / rescue / always children
+// of a try/catch/finally group (#211) entry so each nested entry
+// receives the per-task validation (envelope shape, registered task
+// type, required-field decode). The group's structural diagnostics
+// (empty block, orphan rescue/always, block alongside a task-type
+// key) live in validateBlockStructure so they are emitted exactly
+// once per recipe walk.
+func validateGroupEntry(task *yaml.Node, blockNode, rescueNode, alwaysNode *yaml.Node, taskTypeKeys []string, taskTypeNode *yaml.Node, playLabel, taskLabel string) []Problem {
+	var problems []Problem
+
+	if blockNode != nil && blockNode.Kind == yaml.SequenceNode {
+		for i, child := range blockNode.Content {
+			problems = append(problems, validateTaskEntry(child, playLabel, i+1)...)
+		}
+	}
+	if rescueNode != nil && rescueNode.Kind == yaml.SequenceNode {
+		for i, child := range rescueNode.Content {
+			problems = append(problems, validateTaskEntry(child, playLabel, i+1)...)
+		}
+	}
+	if alwaysNode != nil && alwaysNode.Kind == yaml.SequenceNode {
+		for i, child := range alwaysNode.Content {
+			problems = append(problems, validateTaskEntry(child, playLabel, i+1)...)
+		}
+	}
+
 	return problems
 }
 
@@ -505,11 +551,103 @@ func validateStrictInputs(inputs []inputWithNode, overrides map[string]bool, lab
 	return problems
 }
 
-// validateBlockStructure is a stub. #211 will populate it with checks that
-// block:/rescue:/always: children are valid task entries.
-func validateBlockStructure(_ *yaml.Node, _ string) []Problem {
-	// TODO(#211): walk block/rescue/always children once they are activated.
-	return nil
+// validateBlockStructure walks every task entry under tasksNode and
+// flags malformed try/catch/finally groups: empty `block:`, `rescue:` /
+// `always:` without a sibling `block:`, a group entry that also carries
+// a task-type key, and non-sequence clause values. Per-child structural
+// checks are handled by validateTaskEntry through its recursion into
+// group children, so this helper only emits the group-level diagnostics.
+func validateBlockStructure(tasksNode *yaml.Node, playLabel string) []Problem {
+	if tasksNode == nil || tasksNode.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var problems []Problem
+	walkGroupEntries(tasksNode, playLabel, func(task *yaml.Node, label string) {
+		blockNode := mappingValue(task, "block")
+		rescueNode := mappingValue(task, "rescue")
+		alwaysNode := mappingValue(task, "always")
+		if blockNode == nil && rescueNode == nil && alwaysNode == nil {
+			return
+		}
+		if blockNode == nil {
+			clauseNode := rescueNode
+			clauseName := "rescue"
+			if rescueNode == nil {
+				clauseNode = alwaysNode
+				clauseName = "always"
+			}
+			problems = append(problems, Problem{
+				Code:    "block_orphan_clause",
+				Play:    playLabel,
+				Task:    label,
+				Line:    clauseNode.Line,
+				Column:  clauseNode.Column,
+				Message: fmt.Sprintf("%s: requires a block: in the same task entry", clauseName),
+			})
+			return
+		}
+		if blockNode.Kind != yaml.SequenceNode {
+			problems = append(problems, Problem{
+				Code:    "block_shape",
+				Play:    playLabel,
+				Task:    label,
+				Line:    blockNode.Line,
+				Column:  blockNode.Column,
+				Message: "block: must be a yaml list of task entries",
+			})
+			return
+		}
+		if len(blockNode.Content) == 0 {
+			problems = append(problems, Problem{
+				Code:    "block_empty",
+				Play:    playLabel,
+				Task:    label,
+				Line:    blockNode.Line,
+				Column:  blockNode.Column,
+				Message: "block: must contain at least one child task",
+			})
+		}
+		for i := 0; i < len(task.Content); i += 2 {
+			key := task.Content[i].Value
+			keyNode := task.Content[i]
+			if activeEnvelopeKeys[key] || key == "name" {
+				continue
+			}
+			if _, registered := RegisteredTasks[key]; registered {
+				problems = append(problems, Problem{
+					Code:    "block_with_task_type",
+					Play:    playLabel,
+					Task:    label,
+					Line:    keyNode.Line,
+					Column:  keyNode.Column,
+					Message: fmt.Sprintf("block: group entry cannot also carry task-type key %q", key),
+				})
+			}
+		}
+	})
+	return problems
+}
+
+// walkGroupEntries calls visit on every task entry mapping reachable
+// from tasksNode, including children inside block / rescue / always
+// clauses. Children inherit the parent's task label (no per-child
+// breadcrumb) so diagnostics align with the on-disk source position.
+func walkGroupEntries(tasksNode *yaml.Node, playLabel string, visit func(task *yaml.Node, label string)) {
+	if tasksNode == nil || tasksNode.Kind != yaml.SequenceNode {
+		return
+	}
+	for i, task := range tasksNode.Content {
+		if task.Kind != yaml.MappingNode {
+			continue
+		}
+		label := taskLabelForNode(task, i+1)
+		visit(task, label)
+		for _, clause := range groupClauseKeys {
+			if child := mappingValue(task, clause); child != nil && child.Kind == yaml.SequenceNode {
+				walkGroupEntries(child, playLabel, visit)
+			}
+		}
+	}
 }
 
 // validateExprPredicates compiles each scalar `when:` / `changed_when:` /
@@ -526,18 +664,14 @@ func validateExprPredicates(tasksNode *yaml.Node, label string) []Problem {
 		return nil
 	}
 	var problems []Problem
-	for i, task := range tasksNode.Content {
-		if task.Kind != yaml.MappingNode {
-			continue
-		}
-		taskLabel := taskLabelForNode(task, i+1)
+	walkGroupEntries(tasksNode, label, func(task *yaml.Node, taskLabel string) {
 		problems = append(problems, compileExprNode(mappingValue(task, "when"), "when", label, taskLabel)...)
 		problems = append(problems, compileExprNode(mappingValue(task, "changed_when"), "changed_when", label, taskLabel)...)
 		problems = append(problems, compileExprNode(mappingValue(task, "failed_when"), "failed_when", label, taskLabel)...)
 		if loop := mappingValue(task, "loop"); loop != nil && loop.Kind == yaml.ScalarNode {
 			problems = append(problems, compileExprNode(loop, "loop", label, taskLabel)...)
 		}
-	}
+	})
 	return problems
 }
 
@@ -588,16 +722,12 @@ func validateRegisterReferences(tasksNode *yaml.Node, playLabel string, register
 		return nil
 	}
 	var problems []Problem
-	for i, task := range tasksNode.Content {
-		if task.Kind != yaml.MappingNode {
-			continue
-		}
+	walkGroupEntries(tasksNode, playLabel, func(task *yaml.Node, taskLabel string) {
 		regNode := mappingValue(task, "register")
 		if regNode == nil || regNode.Kind != yaml.ScalarNode || regNode.Value == "" {
-			continue
+			return
 		}
 		name := regNode.Value
-		taskLabel := taskLabelForNode(task, i+1)
 		if prior, ok := registerSeen[name]; ok {
 			hint := fmt.Sprintf("first declared in %s at line %d", prior.Play, prior.Line)
 			if prior.Task != "" {
@@ -612,22 +742,22 @@ func validateRegisterReferences(tasksNode *yaml.Node, playLabel string, register
 				Message: fmt.Sprintf("register name %q is already declared", name),
 				Hint:    hint,
 			})
-			continue
+			return
 		}
 		registerSeen[name] = registerHit{
 			Play: playLabel,
 			Task: taskLabel,
 			Line: regNode.Line,
 		}
-	}
+	})
 	return problems
 }
 
 // validateTargetReferences guards `.item` / `.index` references. They
 // are loop-iteration variables and are only meaningful inside a task
-// entry that carries a `loop:` key. Any non-loop entry whose body still
-// references the placeholder tokens is reported here. #208 / #212 will
-// extend this stub for --start-at-task and --play target validation.
+// entry that carries a `loop:` key, or inside a child of a group entry
+// (#211) whose ancestor carries a `loop:`. Any reference outside such a
+// scope is reported here.
 func validateTargetReferences(tasksNode *yaml.Node, label string) []Problem {
 	if tasksNode == nil || tasksNode.Kind != yaml.SequenceNode {
 		return nil
@@ -637,11 +767,44 @@ func validateTargetReferences(tasksNode *yaml.Node, label string) []Problem {
 		if task.Kind != yaml.MappingNode {
 			continue
 		}
-		if mappingValue(task, "loop") != nil {
+		taskLabel := taskLabelForNode(task, i+1)
+		problems = append(problems, walkLoopVarScope(task, label, taskLabel, false)...)
+	}
+	return problems
+}
+
+// walkLoopVarScope walks one task entry, tracking whether an ancestor
+// has `loop:` so descendants inside a group's block / rescue / always
+// see the parent loop's `.item` / `.index`. When loopActive is false at
+// a given task, scanForLoopVars flags any `.item` / `.index` reference
+// in the task's envelope and body. When loopActive is true (or the
+// current task carries its own `loop:`), the scan is skipped for that
+// entry's own envelope and body, and the recursion into nested group
+// children continues with loopActive set.
+func walkLoopVarScope(task *yaml.Node, playLabel, taskLabel string, loopActive bool) []Problem {
+	if task == nil || task.Kind != yaml.MappingNode {
+		return nil
+	}
+	var problems []Problem
+	thisLoop := mappingValue(task, "loop") != nil
+	scopeActive := loopActive || thisLoop
+
+	if !scopeActive {
+		problems = append(problems, scanForLoopVars(task, playLabel, taskLabel, true)...)
+	}
+
+	for _, clause := range groupClauseKeys {
+		clauseNode := mappingValue(task, clause)
+		if clauseNode == nil || clauseNode.Kind != yaml.SequenceNode {
 			continue
 		}
-		taskLabel := taskLabelForNode(task, i+1)
-		problems = append(problems, scanForLoopVars(task, label, taskLabel)...)
+		for j, child := range clauseNode.Content {
+			if child.Kind != yaml.MappingNode {
+				continue
+			}
+			childLabel := taskLabelForNode(child, j+1)
+			problems = append(problems, walkLoopVarScope(child, playLabel, childLabel, scopeActive)...)
+		}
 	}
 	return problems
 }
@@ -649,8 +812,12 @@ func validateTargetReferences(tasksNode *yaml.Node, label string) []Problem {
 // scanForLoopVars walks every scalar value reachable from node and
 // reports a Problem for each `{{ .item }}` / `{{ .index }}` reference.
 // Scalars are matched against the placeholder substrings the loader
-// injects at file-level render time.
-func scanForLoopVars(node *yaml.Node, playLabel, taskLabel string) []Problem {
+// injects at file-level render time. When skipGroupChildren is true,
+// recursion stops at block / rescue / always sequence values so the
+// caller can scan the envelope and leaf body without re-scanning child
+// task entries (which walkLoopVarScope handles separately so per-child
+// loop scope is honored).
+func scanForLoopVars(node *yaml.Node, playLabel, taskLabel string, skipGroupChildren bool) []Problem {
 	if node == nil {
 		return nil
 	}
@@ -668,9 +835,20 @@ func scanForLoopVars(node *yaml.Node, playLabel, taskLabel string) []Problem {
 				Hint:    "wrap the task with `loop:` or remove the reference",
 			})
 		}
-	case yaml.SequenceNode, yaml.MappingNode, yaml.DocumentNode:
+	case yaml.MappingNode:
+		for i := 0; i < len(node.Content); i += 2 {
+			keyNode := node.Content[i]
+			valueNode := node.Content[i+1]
+			if skipGroupChildren {
+				if keyNode.Value == "block" || keyNode.Value == "rescue" || keyNode.Value == "always" {
+					continue
+				}
+			}
+			problems = append(problems, scanForLoopVars(valueNode, playLabel, taskLabel, skipGroupChildren)...)
+		}
+	case yaml.SequenceNode, yaml.DocumentNode:
 		for _, child := range node.Content {
-			problems = append(problems, scanForLoopVars(child, playLabel, taskLabel)...)
+			problems = append(problems, scanForLoopVars(child, playLabel, taskLabel, skipGroupChildren)...)
 		}
 	}
 	return problems

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -296,11 +296,11 @@ func TestValidateLevenshtein(t *testing.T) {
 	}
 }
 
-func TestValidateReservedEnvelopeKeyFlagged(t *testing.T) {
-	// register / changed_when / failed_when / ignore_errors are now
-	// activated by #210; block / rescue / always remain reserved for
-	// #211, so use `block:` to pin the diagnostic to a key whose
-	// semantics have not landed yet.
+func TestValidateBlockGroupRejectsTaskTypeKey(t *testing.T) {
+	// block / rescue / always are activated by #211; an entry that
+	// carries `block:` must not also carry a task-type key. The
+	// validator's diagnostic surfaces at the task-type key node so the
+	// editor can jump to the offending key.
 	data := []byte(`---
 - tasks:
     - dokku_app:
@@ -308,8 +308,11 @@ func TestValidateReservedEnvelopeKeyFlagged(t *testing.T) {
       block: []
 `)
 	problems := Validate(data, ValidateOptions{})
-	if p := findProblem(problems, "envelope_key_unsupported"); p == nil {
-		t.Fatalf("expected envelope_key_unsupported problem, got: %+v", problems)
+	if p := findProblem(problems, "block_with_task_type"); p == nil {
+		t.Fatalf("expected block_with_task_type problem, got: %+v", problems)
+	}
+	if p := findProblem(problems, "block_empty"); p == nil {
+		t.Fatalf("expected block_empty problem, got: %+v", problems)
 	}
 }
 
@@ -525,5 +528,85 @@ func TestValidateChangedWhenCompileError(t *testing.T) {
 	problems := Validate(data, ValidateOptions{})
 	if p := findProblem(problems, "expr_compile"); p == nil {
 		t.Fatalf("expected expr_compile problem, got: %+v", problems)
+	}
+}
+
+func TestValidateBlockEmptyEmitsBlockEmpty(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: empty
+      block: []
+`)
+	problems := Validate(data, ValidateOptions{})
+	if p := findProblem(problems, "block_empty"); p == nil {
+		t.Fatalf("expected block_empty problem, got: %+v", problems)
+	}
+}
+
+func TestValidateBlockOrphanRescueEmitsBlockOrphanClause(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: orphan
+      rescue:
+        - dokku_app: { app: x }
+`)
+	problems := Validate(data, ValidateOptions{})
+	if p := findProblem(problems, "block_orphan_clause"); p == nil {
+		t.Fatalf("expected block_orphan_clause problem, got: %+v", problems)
+	}
+}
+
+func TestValidateBlockChildExprCompileError(t *testing.T) {
+	// Compile errors inside block children must still surface so a typo
+	// in a nested `when:` does not silently slip through.
+	data := []byte(`---
+- tasks:
+    - name: outer
+      block:
+        - name: inner
+          when: 'this is not valid expr ('
+          dokku_app:
+            app: x
+`)
+	problems := Validate(data, ValidateOptions{})
+	if p := findProblem(problems, "expr_compile"); p == nil {
+		t.Fatalf("expected expr_compile problem, got: %+v", problems)
+	}
+}
+
+func TestValidateRegisterDuplicateInsideGroup(t *testing.T) {
+	// A duplicate `register:` between a top-level task and a child of a
+	// block should surface as register_duplicate so the executor's
+	// run-wide registered map cannot be silently overwritten.
+	data := []byte(`---
+- tasks:
+    - register: same_name
+      dokku_app:
+        app: a
+    - block:
+        - register: same_name
+          dokku_app:
+            app: b
+`)
+	problems := Validate(data, ValidateOptions{})
+	if p := findProblem(problems, "register_duplicate"); p == nil {
+		t.Fatalf("expected register_duplicate problem, got: %+v", problems)
+	}
+}
+
+func TestValidateLoopVarInsideGroupIsAllowed(t *testing.T) {
+	// `.item` references in a group child are valid when an ancestor
+	// group entry carries `loop:`, even though the child entry itself
+	// has no `loop:`. Validate must not flag those.
+	data := []byte(`---
+- tasks:
+    - loop: [a, b]
+      block:
+        - dokku_app:
+            app: "{{ .item }}"
+`)
+	problems := Validate(data, ValidateOptions{})
+	if p := findProblem(problems, "loop_var_outside_loop"); p != nil {
+		t.Fatalf("did not expect loop_var_outside_loop, got: %+v", *p)
 	}
 }

--- a/tests/bats/block.bats
+++ b/tests/bats/block.bats
@@ -136,7 +136,7 @@ EOF
 EOF
   run "$(docket_bin)" validate --tasks "$TASKS_FILE"
   assert_failure
-  assert_output --partial "block_empty"
+  assert_output --partial "block: must contain at least one child task"
 }
 
 @test "validate flags rescue without block" {
@@ -149,5 +149,5 @@ EOF
 EOF
   run "$(docket_bin)" validate --tasks "$TASKS_FILE"
   assert_failure
-  assert_output --partial "block_orphan_clause"
+  assert_output --partial "rescue: requires a block: in the same task entry"
 }

--- a/tests/bats/block.bats
+++ b/tests/bats/block.bats
@@ -1,0 +1,153 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+# block.bats covers the #211 try/catch/finally surface end-to-end
+# against the docket binary: block runs all children when none error,
+# rescue handles the first error, always runs unconditionally,
+# ignore_errors on a child does not trigger rescue, and loop on a
+# block expands the entire group N times.
+#
+# Tests that mutate live Dokku state gate on require_dokku.
+
+setup() {
+  docket_build
+}
+
+teardown() {
+  dokku_clean_app docket-test-block-1
+  dokku_clean_app docket-test-block-2
+  dokku_clean_app docket-test-block-rescue
+  dokku_clean_app docket-test-block-rescued
+  dokku_clean_app docket-test-block-rescued-zzz
+  dokku_clean_app docket-test-block-always-1
+  dokku_clean_app docket-test-block-always-marker
+  dokku_clean_app docket-test-block-swallowed-after
+  dokku_clean_app docket-test-loop-block-api
+  dokku_clean_app docket-test-loop-block-worker
+  dokku_clean_app docket-test-loop-block-web
+}
+
+@test "block runs all children when none error" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: deploy
+      block:
+        - dokku_app: { app: docket-test-block-1 }
+        - dokku_app: { app: docket-test-block-2 }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  run dokku apps:exists docket-test-block-1
+  assert_success
+  run dokku apps:exists docket-test-block-2
+  assert_success
+}
+
+@test "rescue runs on block error" {
+  require_dokku
+  dokku apps:create docket-test-block-rescue || true
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: try
+      block:
+        - dokku_ports:
+            app: nonexistent-block-target-zzz
+            port_mappings: [{ scheme: http, host_port: 80, container_port: 5000 }]
+            state: present
+      rescue:
+        - dokku_app: { app: docket-test-block-rescue, state: absent }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  run dokku apps:exists docket-test-block-rescue
+  assert_failure
+}
+
+@test "always runs after success" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: with-always
+      block:
+        - dokku_app: { app: docket-test-block-always-1 }
+      always:
+        - dokku_app: { app: docket-test-block-always-marker }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  run dokku apps:exists docket-test-block-always-marker
+  assert_success
+}
+
+@test "ignore_errors on a block child does not trigger rescue" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: swallow
+      block:
+        - name: errors quietly
+          ignore_errors: true
+          dokku_ports:
+            app: nonexistent-block-swallow-zzz
+            port_mappings: [{ scheme: http, host_port: 80, container_port: 5000 }]
+            state: present
+        - dokku_app: { app: docket-test-block-swallowed-after }
+      rescue:
+        - dokku_app: { app: docket-test-block-rescued-zzz }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  run dokku apps:exists docket-test-block-swallowed-after
+  assert_success
+  run dokku apps:exists docket-test-block-rescued-zzz
+  assert_failure
+}
+
+@test "loop on a block runs entire group N times" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: deploy each
+      loop: [api, worker, web]
+      block:
+        - dokku_app: { app: "docket-test-loop-block-{{ .item }}" }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+  for app in api worker web; do
+    run dokku apps:exists "docket-test-loop-block-$app"
+    assert_success
+  done
+}
+
+@test "validate flags empty block" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: empty
+      block: []
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "block_empty"
+}
+
+@test "validate flags rescue without block" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: orphan
+      rescue:
+        - dokku_app: { app: x }
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "block_orphan_clause"
+}


### PR DESCRIPTION
## Summary

Adds three envelope keys that turn a task entry into a try/catch/finally group: `block:` is the protected child list, `rescue:` runs on the first uncaught error, and `always:` runs unconditionally afterward. The wrapping envelope's `name`, `tags`, `when`, `loop`, `register`, `changed_when`, `failed_when`, and `ignore_errors` apply to the whole group, and rescue children see the failed block child's `TaskOutputState` bound under `.failed_task`. `loop:` on a group duplicates the entire group N times. `ignore_errors` on a child swallows the error without triggering rescue, mirroring the rule from #210.

Closes #211.