### PR TITLE
feat: add --list-tasks and --start-at-task for inspection and resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,8 @@ The flags are:
 | `--vars-file <path>` | Load input values from a YAML or JSON file. Repeatable; later files override earlier files for the same key. CLI `--name=value` flags always win. See "Layered input variables with `--vars-file`" below. |
 | `--play <name>` | Run only the play with this name. Matches the play's `name:` field; auto-named plays use `play #N`. Composes with `--tags`. |
 | `--fail-fast` | Abort the entire run on the first task error. Without this flag, an error aborts only the current play and the next play still runs. |
+| `--list-tasks` | Print the resolved task plan and exit without running. Honors `--play` / `--tags` / `--skip-tags` and shows expanded loop iterations and `[skipped]` markers for `when:`-skipped tasks. See "Inspecting and resuming" below. |
+| `--start-at-task <name>` | Skip every task before the matched name (rendered as `[skipped] ... (before --start-at-task)`); the matched task and successors run normally. Filter order: `--start-at-task` -> `--tags`/`--skip-tags` -> per-task `when:` at execution. The name search walks every play in source order, narrowed by `--play`. |
 
 For example, a multi-command task renders one continuation per invocation:
 
@@ -439,6 +441,40 @@ For example, a multi-command task renders one continuation per invocation:
 ```
 
 Color output respects [`NO_COLOR`](https://no-color.org/): set `NO_COLOR=1` to disable ANSI escapes, or pipe to a non-TTY (output is plain in that case automatically).
+
+#### Inspecting and resuming with `--list-tasks` / `--start-at-task`
+
+Two flags help when a recipe grows long: `--list-tasks` previews the resolved task plan without running, and `--start-at-task <name>` resumes a partially-applied recipe from a specific task.
+
+`--list-tasks` walks the resolved plan (post `--play` / `--tags` filtering, post `loop:` expansion, post `when:` evaluation against inputs) and prints one line per envelope:
+
+```text
+$ docket apply --list-tasks
+==> Play: api
+[0] dokku apps:create api  [tags=core]
+[1] dokku git:sync api  [tags=deploy]
+[2] dokku config:set api  [tags=core,deploy]
+[3] dokku ports:add api  [tags=deploy]
+```
+
+`when:` predicates that evaluate false against the inputs render as `[skipped]`. Predicates that reference `.registered.<name>` cannot be decided without running prior tasks, so they render as `[unknown]` rather than misreporting a skip. `block:` groups print the group line followed by indented `[block]` / `[rescue]` / `[always]` children.
+
+`--start-at-task <name>` takes the exact envelope name (matching `name:` in the recipe). Earlier tasks render as `[skipped]` with a `(before --start-at-task)` reason and do not run; the matched task and every task after it run normally:
+
+```text
+$ docket apply --start-at-task "dokku config:set api"
+==> Play: api
+[skipped] dokku apps:create api    (before --start-at-task)
+[skipped] dokku git:sync api       (before --start-at-task)
+[ok]      dokku config:set api
+[changed] dokku ports:add api
+
+Summary: 4 tasks * 1 changed * 1 ok * 2 skipped * 0 errors  (took 1.1s)
+```
+
+Resolution order is: `--start-at-task` selects first, then `--tags` / `--skip-tags` filter, then per-task `when:` at execution time. A task can be selected by `--start-at-task` and still be filtered out by `--tags`. Inside a `block:`, matching a child does not unwind the group: the executor enters the block, skips earlier children, runs from the matched child onward, and continues with `rescue` / `always` per normal block semantics. For multi-play files the search walks every play in source order; `--play` narrows it.
+
+If `--start-at-task` does not match any task name, the run exits 1 with the available names listed so the typo can be fixed quickly.
 
 ### Remote execution over SSH
 
@@ -512,6 +548,7 @@ The flags are:
 | `--detailed-exitcode` | Exit `0` when no drift is detected, `2` when at least one task reports drift, `1` on read or probe error. Errors win over drift. Without this flag, plan exits `0` regardless of drift. Mirrors the `git diff --exit-code` / `terraform plan -detailed-exitcode` convention. |
 | `--vars-file <path>` | Load input values from a YAML or JSON file. Repeatable; later files override earlier files for the same key. CLI `--name=value` flags always win. See "Layered input variables with `--vars-file`" below. |
 | `--play <name>` | Plan only the play with this name. Matches the play's `name:` field; auto-named plays use `play #N`. Composes with `--tags`. |
+| `--list-tasks` | Print the resolved task plan and exit without contacting the server. Honors `--play` / `--tags` / `--skip-tags` and shows expanded loop iterations and `[skipped]` markers for `when:`-skipped tasks. See "Inspecting and resuming" under `apply` for the full output shape. |
 
 ```shell
 # CI gate: fail the job if any task would change the server.
@@ -551,11 +588,13 @@ The shipping checks cover: YAML parses, recipe shape (top-level list of plays wi
 docket validate --tasks path/to/tasks.yml
 ```
 
-Exit codes are `0` when no problems are found and `1` otherwise. Three flags are available:
+Exit codes are `0` when no problems are found and `1` otherwise. Five flags are available:
 
 - `--json` emits one JSON-lines event per problem with a stable `version: 1` schema (`{"type":"validate_problem","code":"unknown_task_type", ...}`), suitable for piping into a CI annotator.
-- `--strict` additionally flags any input declared `required: true` that has no `default` and no value supplied via a CLI flag or `--vars-file` - useful in CI to ensure the recipe can be applied without runtime overrides.
+- `--strict` additionally flags any input declared `required: true` that has no `default` and no value supplied via a CLI flag or `--vars-file`, and verifies that any `--play` / `--start-at-task` references passed alongside resolve to real names in the file (problem codes `unknown_play_reference` / `unknown_start_at_task`) - useful in CI to ensure the recipe can be applied without runtime overrides or stale CLI invocations.
 - `--vars-file <path>` loads input values from a YAML or JSON file (repeatable; later files override earlier; CLI `--name=value` flags always win). Values fed in through `--vars-file` count as overrides for `--strict`. See "Layered input variables with `--vars-file`" below.
+- `--play <name>` (strict-only) verifies the named play exists in the recipe. Pair with `--strict` so a CI lint job catches stale `docket apply --play <name>` invocations.
+- `--start-at-task <name>` (strict-only) verifies a task with this name exists in the recipe; narrowed by `--play` when both are set. Pair with `--strict` so a CI lint job catches typos in resume invocations before they reach `apply`.
 
 A task file can also be specified via flag, and may be a file retrieved via http:
 

--- a/commands/apply.go
+++ b/commands/apply.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/dokku/docket/subprocess"
@@ -28,6 +29,8 @@ type ApplyCommand struct {
 	varsFiles         []string
 	play              string
 	failFast          bool
+	listTasks         bool
+	startAtTask       string
 	arguments         map[string]*Argument
 }
 
@@ -78,6 +81,8 @@ func (c *ApplyCommand) FlagSet() *flag.FlagSet {
 	f.StringArrayVar(&c.varsFiles, "vars-file", nil, "load input values from a YAML or JSON file (repeatable; later files override earlier; CLI --name=value flags always win). A .json extension parses as JSON; otherwise YAML.")
 	f.StringVar(&c.play, "play", "", "run only the play with this name (matches the play's `name:` field; auto-named plays use `play #N`)")
 	f.BoolVar(&c.failFast, "fail-fast", false, "abort the entire run on the first task error. By default, an error aborts only the current play and the next play still runs.")
+	f.BoolVar(&c.listTasks, "list-tasks", false, "print the resolved task plan and exit without running. Honors --play / --tags / --skip-tags and shows expanded loop iterations and [skipped] markers for when:-skipped tasks.")
+	f.StringVar(&c.startAtTask, "start-at-task", "", "skip every task before the matched name; the matched task and successors run normally. Filter order: --start-at-task -> --tags/--skip-tags -> per-task when: at execution. The name search walks every play in source order, narrowed by --play.")
 
 	taskFile := getTaskYamlFilename(os.Args)
 	data, err := os.ReadFile(taskFile)
@@ -109,6 +114,8 @@ func (c *ApplyCommand) AutocompleteFlags() complete.Flags {
 			"--vars-file":            complete.PredictFiles("*"),
 			"--play":                 complete.PredictAnything,
 			"--fail-fast":            complete.PredictNothing,
+			"--list-tasks":           complete.PredictNothing,
+			"--start-at-task":        complete.PredictAnything,
 		},
 	)
 }
@@ -170,6 +177,28 @@ func (c *ApplyCommand) Run(args []string) int {
 		return 1
 	}
 
+	if c.startAtTask != "" {
+		if !startAtTaskMatches(plays, c.startAtTask) {
+			c.Ui.Error(fmt.Sprintf(
+				"--start-at-task %q: no task matched name; available names: %s",
+				c.startAtTask, formatStartAtTaskNames(plays),
+			))
+			return 1
+		}
+	}
+
+	if c.listTasks {
+		return renderListTasks(c.Ui, listTasksOptions{
+			plays:         plays,
+			includes:      c.tags,
+			skips:         c.skipTags,
+			fileLevelKeys: fileLevelKeys,
+			userSet:       userSet,
+			context:       context,
+			jsonOut:       c.json,
+		})
+	}
+
 	sensitiveValues = append(sensitiveValues, tasks.CollectPlaySensitiveValues(plays)...)
 	subprocess.SetGlobalSensitive(sensitiveValues)
 	defer subprocess.SetGlobalSensitive(nil)
@@ -183,6 +212,11 @@ func (c *ApplyCommand) Run(args []string) int {
 	counts := ApplyCounts{}
 	playWhenExprCtx := buildEnvelopeExprContext(buildPlayWhenContext(context, fileLevelKeys, userSet))
 	hasError := false
+	// startedAtTask gates --start-at-task: false until an envelope name
+	// matches c.startAtTask, at which point every subsequent task runs
+	// normally. Shared by reference across plays so the search spans the
+	// whole filtered play list.
+	startedAtTask := c.startAtTask == ""
 	// registered is the run-wide map predicates reach via
 	// `.registered.<name>`. loopAccum buffers per-iteration states for
 	// loop+register expansions so the running aggregate is exposed to
@@ -230,6 +264,8 @@ playLoop:
 			emitter:     emitter,
 			counts:      &counts,
 			failFast:    c.failFast,
+			startAtTask: c.startAtTask,
+			started:     &startedAtTask,
 		}
 
 		failed := false
@@ -268,6 +304,13 @@ type applyContext struct {
 	emitter     EventEmitter
 	counts      *ApplyCounts
 	failFast    bool
+	// startAtTask is the --start-at-task target, or "" when the flag
+	// was not set. started is a shared pointer flipped to true the
+	// first time an envelope name matches the target; until it flips,
+	// executeTask emits a [skipped] event with the "before
+	// --start-at-task" reason and skips dispatch.
+	startAtTask string
+	started     *bool
 }
 
 // applyTaskOutcome is the per-task verdict the apply loop reads back
@@ -288,7 +331,38 @@ type applyTaskOutcome struct {
 // "always"); top-level callers pass "". failedTask is non-nil only
 // when called from a rescue walker so the rescue child's predicates
 // can reference `.failed_task`.
+//
+// --start-at-task gating sits at the top: until ac.started flips to
+// true, an envelope whose name does not match ac.startAtTask (and
+// whose group descendants also do not) is reported as `[skipped]`
+// with reason "before --start-at-task" and dispatch is skipped. A
+// group whose own name does not match but a descendant does is
+// entered so the recursive executeTask call lands on the matched
+// child.
 func (c *ApplyCommand) executeTask(env *tasks.TaskEnvelope, name string, ac *applyContext, failedTask interface{}, phase string) applyTaskOutcome {
+	if !*ac.started && ac.startAtTask != "" {
+		switch {
+		case name == ac.startAtTask:
+			*ac.started = true
+		case env.IsGroup() && tasks.EnvelopeContainsName(env, ac.startAtTask):
+			// Don't skip; descend into the group so the matching
+			// child runs. The synthesized group state will reflect
+			// only the executed children, not the skipped ones.
+		default:
+			ac.counts.Tasks++
+			ac.counts.Skipped++
+			ac.emitter.ApplyTask(ApplyTaskEvent{
+				Play:       ac.play.Name,
+				Name:       name,
+				Phase:      phase,
+				Group:      env.IsGroup(),
+				Skipped:    true,
+				SkipReason: "before --start-at-task",
+				Timestamp:  time.Now().UTC(),
+			})
+			return applyTaskOutcome{skipped: true}
+		}
+	}
 	if env.IsGroup() {
 		return c.executeGroup(env, name, ac, failedTask, phase)
 	}
@@ -619,6 +693,63 @@ func (c *ApplyCommand) executeGroup(env *tasks.TaskEnvelope, name string, ac *ap
 		})
 		return applyTaskOutcome{state: groupState}
 	}
+}
+
+// startAtTaskMatches reports whether target matches some envelope name
+// across plays, walking each play's task envelopes plus any block /
+// rescue / always children of group entries. Used to validate the
+// --start-at-task flag before the executor begins so a typo errors out
+// up-front instead of silently skipping the entire run.
+func startAtTaskMatches(plays []*tasks.Play, target string) bool {
+	for _, play := range plays {
+		if play == nil {
+			continue
+		}
+		for _, name := range play.Tasks.Keys() {
+			env := play.Tasks.GetEnvelope(name)
+			if name == target {
+				return true
+			}
+			if tasks.EnvelopeContainsName(env, target) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// formatStartAtTaskNames builds the "available names: ..." hint for an
+// unmatched --start-at-task error. Names are deduplicated and rendered
+// in source order, quoted so the user can copy a name verbatim back
+// onto the CLI.
+func formatStartAtTaskNames(plays []*tasks.Play) string {
+	seen := map[string]bool{}
+	var quoted []string
+	for _, play := range plays {
+		if play == nil {
+			continue
+		}
+		for _, name := range play.Tasks.Keys() {
+			if !seen[name] {
+				seen[name] = true
+				quoted = append(quoted, fmt.Sprintf("%q", name))
+			}
+			env := play.Tasks.GetEnvelope(name)
+			for _, descendant := range tasks.CollectEnvelopeNames([]*tasks.TaskEnvelope{env}) {
+				if descendant == "" || descendant == name {
+					continue
+				}
+				if !seen[descendant] {
+					seen[descendant] = true
+					quoted = append(quoted, fmt.Sprintf("%q", descendant))
+				}
+			}
+		}
+	}
+	if len(quoted) == 0 {
+		return "(none)"
+	}
+	return strings.Join(quoted, ", ")
 }
 
 // filterPlaysByName narrows plays to the single play whose Name matches

--- a/commands/list_tasks.go
+++ b/commands/list_tasks.go
@@ -1,0 +1,238 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/dokku/docket/tasks"
+	"github.com/mitchellh/cli"
+)
+
+// listTasksOptions captures everything renderListTasks needs to walk the
+// resolved play set and print one line per envelope. It is constructed by
+// the apply and plan commands once filterPlaysByName has narrowed the
+// run.
+type listTasksOptions struct {
+	plays         []*tasks.Play
+	includes      []string
+	skips         []string
+	fileLevelKeys map[string]bool
+	userSet       map[string]bool
+	context       map[string]interface{}
+	jsonOut       bool
+}
+
+// renderListTasks walks the resolved task plan and prints one line per
+// envelope without executing anything. Honors --tags / --skip-tags via
+// FilterByTags and renders block / rescue / always children indented
+// under their group's line.
+//
+// when: predicates are evaluated against the inputs only - registered
+// values from prior tasks are not available because no task has run.
+// Predicates that reference `.registered.<name>` produce an [unknown]
+// marker since their truth value cannot be determined statically. All
+// other false predicates produce a [skipped] marker.
+func renderListTasks(ui cli.Ui, opts listTasksOptions) int {
+	for _, play := range opts.plays {
+		if play.IsFileLevel() {
+			continue
+		}
+		playWhenSkipped := false
+		if play.HasWhen() {
+			playCtx := buildEnvelopeExprContext(buildPlayWhenContext(opts.context, opts.fileLevelKeys, opts.userSet))
+			ok, err := tasks.EvalBool(play.WhenProgram(), playCtx)
+			if err != nil {
+				if opts.jsonOut {
+					emitListJSON(ui, map[string]interface{}{
+						"type":      "play_skipped",
+						"play":      play.Name,
+						"when":      play.When,
+						"reason":    fmt.Sprintf("when error: %v", err),
+					})
+				} else {
+					ui.Output(fmt.Sprintf("==> Play: %s  (when error: %v)", play.Name, err))
+				}
+				continue
+			}
+			if !ok {
+				playWhenSkipped = true
+				if opts.jsonOut {
+					emitListJSON(ui, map[string]interface{}{
+						"type":   "play_skipped",
+						"play":   play.Name,
+						"when":   play.When,
+						"reason": "when: " + play.When,
+					})
+				} else {
+					ui.Output(fmt.Sprintf("==> Play: %s  (skipped: when %q)", play.Name, play.When))
+				}
+				continue
+			}
+		}
+		_ = playWhenSkipped
+
+		if !opts.jsonOut {
+			ui.Output(fmt.Sprintf("==> Play: %s", play.Name))
+		}
+
+		playExprCtx := buildEnvelopeExprContext(tasks.BuildPerPlayContext(opts.context, play.Inputs, opts.userSet))
+
+		idx := 0
+		for _, name := range tasks.FilterByTags(play.Tasks, opts.includes, opts.skips) {
+			env := play.Tasks.GetEnvelope(name)
+			renderListEnvelope(ui, play.Name, name, env, idx, "", 0, playExprCtx, opts.jsonOut)
+			idx++
+		}
+	}
+	return 0
+}
+
+// renderListEnvelope renders one envelope's line and, for a group,
+// recursively renders its block / rescue / always children indented one
+// level. indent is the leading-space count; phase labels group children
+// (matching the executor's phase decoration).
+func renderListEnvelope(
+	ui cli.Ui,
+	playName, name string,
+	env *tasks.TaskEnvelope,
+	index int,
+	phase string,
+	indent int,
+	playExprCtx map[string]interface{},
+	jsonOut bool,
+) {
+	skipMarker := evaluateListWhen(env, playExprCtx)
+
+	if jsonOut {
+		ev := map[string]interface{}{
+			"type":  "list_task",
+			"play":  playName,
+			"name":  name,
+			"index": index,
+		}
+		if len(env.Tags) > 0 {
+			ev["tags"] = append([]string{}, env.Tags...)
+		}
+		if env.IsGroup() {
+			ev["group"] = true
+		}
+		if phase != "" {
+			ev["phase"] = phase
+		}
+		switch skipMarker {
+		case "skipped":
+			ev["skipped"] = true
+			ev["when"] = env.When
+		case "unknown":
+			ev["unknown"] = true
+			ev["when"] = env.When
+		case "when_error":
+			ev["when_error"] = true
+			ev["when"] = env.When
+		}
+		if env.IsLoopExpansion {
+			ev["loop_index"] = env.LoopIndex
+			if env.LoopItem != nil {
+				ev["loop_item"] = env.LoopItem
+			}
+		}
+		emitListJSON(ui, ev)
+	} else {
+		var b strings.Builder
+		if indent > 0 {
+			b.WriteString(strings.Repeat("  ", indent))
+		}
+		switch skipMarker {
+		case "skipped":
+			b.WriteString("[skipped] ")
+		case "unknown":
+			b.WriteString("[unknown] ")
+		case "when_error":
+			b.WriteString("[when?]   ")
+		default:
+			b.WriteString(fmt.Sprintf("[%d] ", index))
+		}
+		display := name
+		if phase != "" {
+			display = fmt.Sprintf("[%s] %s", phase, name)
+		}
+		b.WriteString(display)
+		if env.IsGroup() {
+			b.WriteString("  (group)")
+		}
+		if len(env.Tags) > 0 {
+			b.WriteString(fmt.Sprintf("  [tags=%s]", strings.Join(env.Tags, ",")))
+		}
+		ui.Output(b.String())
+	}
+
+	if env.IsGroup() {
+		for i, child := range env.Block {
+			childName := child.Name
+			if childName == "" {
+				childName = fmt.Sprintf("%s.block[%d]", name, i)
+			}
+			renderListEnvelope(ui, playName, childName, child, i, "block", indent+1, playExprCtx, jsonOut)
+		}
+		for i, child := range env.Rescue {
+			childName := child.Name
+			if childName == "" {
+				childName = fmt.Sprintf("%s.rescue[%d]", name, i)
+			}
+			renderListEnvelope(ui, playName, childName, child, i, "rescue", indent+1, playExprCtx, jsonOut)
+		}
+		for i, child := range env.Always {
+			childName := child.Name
+			if childName == "" {
+				childName = fmt.Sprintf("%s.always[%d]", name, i)
+			}
+			renderListEnvelope(ui, playName, childName, child, i, "always", indent+1, playExprCtx, jsonOut)
+		}
+	}
+}
+
+// evaluateListWhen returns the marker --list-tasks should print for
+// env's when: predicate. Returns "" when no predicate is present or it
+// evaluates true; "skipped" when it evaluates false; "unknown" when the
+// predicate references `.registered.<name>` (we can't decide without
+// running prior tasks); "when_error" when the predicate compiles but
+// errors at evaluation time against the inputs context.
+func evaluateListWhen(env *tasks.TaskEnvelope, playExprCtx map[string]interface{}) string {
+	if !env.HasWhen() {
+		return ""
+	}
+	if whenReferencesRegistered(env.When) {
+		return "unknown"
+	}
+	ok, err := tasks.EvalBool(env.WhenProgram(), envelopeExprContext(playExprCtx, env, nil, nil, nil))
+	if err != nil {
+		return "when_error"
+	}
+	if !ok {
+		return "skipped"
+	}
+	return ""
+}
+
+// whenReferencesRegistered does a substring check against the raw expr
+// source for `registered.` references. The check is intentionally
+// conservative: any predicate that mentions `registered` is reported as
+// [unknown] in --list-tasks rather than evaluated against an empty map
+// (which would yield a misleading skip).
+func whenReferencesRegistered(src string) bool {
+	return strings.Contains(src, "registered")
+}
+
+// emitListJSON serialises ev as a single JSON-lines event on the Ui's
+// output sink. Errors are routed to Ui.Error so the consumer sees the
+// failure without corrupting the stream.
+func emitListJSON(ui cli.Ui, ev map[string]interface{}) {
+	ev["version"] = jsonSchemaVersion
+	b, err := json.Marshal(ev)
+	if err != nil {
+		ui.Error("json marshal error: " + err.Error())
+		return
+	}
+	ui.Output(string(b))
+}

--- a/commands/list_tasks.go
+++ b/commands/list_tasks.go
@@ -3,11 +3,80 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/dokku/docket/tasks"
 	"github.com/mitchellh/cli"
 )
+
+// autoNameRE matches the auto-generated task name format from
+// tasks/main.go:generateTaskName ("task #<index> <8-byte-hex>"). When a
+// listing line carries an auto-name, the display falls back to the
+// task's TypeName plus an identifying body field so the user sees
+// something meaningful instead of an opaque random suffix.
+var autoNameRE = regexp.MustCompile(`^task #\d+ [0-9A-F]{16}$`)
+
+// listingDisplayName returns the human-friendly label for env in
+// --list-tasks output. User-supplied names pass through untouched. An
+// auto-generated name (the loader's `task #N <hex>` form) is replaced
+// with `<TypeName>` plus the first identifying body field (App, Name,
+// Service, Repository, ...) when one is present, so a recipe with
+// unnamed tasks still reads back the body the user wrote.
+func listingDisplayName(env *tasks.TaskEnvelope, fallback string) string {
+	if env == nil {
+		return fallback
+	}
+	name := env.Name
+	if name == "" {
+		name = fallback
+	}
+	if !autoNameRE.MatchString(name) {
+		return name
+	}
+	if env.TypeName == "" {
+		return name
+	}
+	if id := identifyingBodyField(env.Task); id != "" {
+		return fmt.Sprintf("%s: %s", env.TypeName, id)
+	}
+	return env.TypeName
+}
+
+// identifyingBodyField walks the task struct (via reflection) for the
+// first non-empty string field whose name matches a common identifier
+// (App, Name, Service, Repository, Mount, Url). Returns "" if no such
+// field is present, in which case the caller falls back to TypeName
+// alone.
+func identifyingBodyField(task tasks.Task) string {
+	if task == nil {
+		return ""
+	}
+	v := reflect.ValueOf(task)
+	for v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return ""
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return ""
+	}
+	for _, candidate := range []string{"App", "Name", "Service", "Repository", "Mount", "Url"} {
+		f := v.FieldByName(candidate)
+		if !f.IsValid() {
+			continue
+		}
+		if f.Kind() != reflect.String {
+			continue
+		}
+		if s := f.String(); s != "" {
+			return s
+		}
+	}
+	return ""
+}
 
 // listTasksOptions captures everything renderListTasks needs to walk the
 // resolved play set and print one line per envelope. It is constructed by
@@ -103,12 +172,13 @@ func renderListEnvelope(
 	jsonOut bool,
 ) {
 	skipMarker := evaluateListWhen(env, playExprCtx)
+	display := listingDisplayName(env, name)
 
 	if jsonOut {
 		ev := map[string]interface{}{
 			"type":  "list_task",
 			"play":  playName,
-			"name":  name,
+			"name":  display,
 			"index": index,
 		}
 		if len(env.Tags) > 0 {
@@ -153,11 +223,11 @@ func renderListEnvelope(
 		default:
 			b.WriteString(fmt.Sprintf("[%d] ", index))
 		}
-		display := name
+		decorated := display
 		if phase != "" {
-			display = fmt.Sprintf("[%s] %s", phase, name)
+			decorated = fmt.Sprintf("[%s] %s", phase, display)
 		}
-		b.WriteString(display)
+		b.WriteString(decorated)
 		if env.IsGroup() {
 			b.WriteString("  (group)")
 		}

--- a/commands/list_tasks_test.go
+++ b/commands/list_tasks_test.go
@@ -39,6 +39,32 @@ func TestApplyListTasksPrintsResolvedPlan(t *testing.T) {
 	}
 }
 
+// TestApplyListTasksUnnamedTasksShowBodyIdentifier covers the unnamed
+// task path: a recipe with no `name:` produces an auto-generated name
+// like `task #1 <hex>` from the loader. --list-tasks substitutes a
+// `<TypeName>: <body identifier>` display so the listing stays
+// readable instead of leaking the random hex suffix.
+func TestApplyListTasksUnnamedTasksShowBodyIdentifier(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- tasks:
+    - dokku_app: { app: docket-test-list-1 }
+    - dokku_app: { app: docket-test-list-2 }
+`)
+	stdout, _, exit := runApply(t, path, "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	for _, want := range []string{"dokku_app: docket-test-list-1", "dokku_app: docket-test-list-2"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("listing should include %q; got:\n%s", want, stdout)
+		}
+	}
+	if strings.Contains(stdout, "task #") {
+		t.Errorf("auto-generated task name should be replaced; got:\n%s", stdout)
+	}
+}
+
 // TestApplyListTasksHonorsTags pins the interaction with --tags: the
 // listing should omit tasks the tag filter would drop, just like the
 // executor does.

--- a/commands/list_tasks_test.go
+++ b/commands/list_tasks_test.go
@@ -1,0 +1,281 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestApplyListTasksPrintsResolvedPlan covers the headline path: a
+// recipe with two tagged tasks should print one line per task without
+// invoking the executor. The stub task fixture is intentionally left
+// unset so a stray Execute() call would render as a [changed] line and
+// trip one of the assertions below.
+func TestApplyListTasksPrintsResolvedPlan(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: create api
+      tags: [core]
+      dokku_stub: { key: a }
+    - name: deploy api
+      tags: [deploy]
+      dokku_stub: { key: b }
+`)
+	stdout, _, exit := runApply(t, path, "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if !strings.Contains(stdout, "[0] create api") {
+		t.Errorf("expected '[0] create api' line; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "[1] deploy api") {
+		t.Errorf("expected '[1] deploy api' line; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "[tags=core]") || !strings.Contains(stdout, "[tags=deploy]") {
+		t.Errorf("expected tags suffix on each line; got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "[changed]") || strings.Contains(stdout, "[ok]") {
+		t.Errorf("--list-tasks must not invoke the executor; got:\n%s", stdout)
+	}
+}
+
+// TestApplyListTasksHonorsTags pins the interaction with --tags: the
+// listing should omit tasks the tag filter would drop, just like the
+// executor does.
+func TestApplyListTasksHonorsTags(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: api task
+      tags: [api]
+      dokku_stub: { key: a }
+    - name: worker task
+      tags: [worker]
+      dokku_stub: { key: b }
+`)
+	stdout, _, exit := runApply(t, path, "--list-tasks", "--tags", "api")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if !strings.Contains(stdout, "api task") {
+		t.Errorf("api task should appear; got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "worker task") {
+		t.Errorf("worker task should be filtered; got:\n%s", stdout)
+	}
+}
+
+// TestApplyListTasksLoopExpansion confirms that `loop:` envelopes are
+// expanded in the listing - one line per iteration, with the iteration
+// suffix already rendered into the name.
+func TestApplyListTasksLoopExpansion(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: deploy
+      loop: [api, worker, web]
+      dokku_stub: { key: "{{ .item }}" }
+`)
+	stdout, _, exit := runApply(t, path, "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	for _, want := range []string{"item=api", "item=worker", "item=web"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("listing should include %q; got:\n%s", want, stdout)
+		}
+	}
+}
+
+// TestApplyListTasksWhenFalseShowsSkipped pins the [skipped] marker for
+// envelopes whose static when: predicate evaluates false against the
+// inputs context.
+func TestApplyListTasksWhenFalseShowsSkipped(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: gated
+      when: 'false'
+      dokku_stub: { key: a }
+`)
+	stdout, _, exit := runApply(t, path, "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if !strings.Contains(stdout, "[skipped] gated") {
+		t.Errorf("expected '[skipped] gated' line; got:\n%s", stdout)
+	}
+}
+
+// TestApplyListTasksWhenRegisteredShowsUnknown covers the
+// `.registered.<name>` case: --list-tasks cannot evaluate predicates
+// that depend on prior task state, so the line renders [unknown]
+// rather than [skipped].
+func TestApplyListTasksWhenRegisteredShowsUnknown(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: first
+      register: first
+      dokku_stub: { key: a }
+    - name: depends-on-first
+      when: 'registered.first.Changed'
+      dokku_stub: { key: b }
+`)
+	stdout, _, exit := runApply(t, path, "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if !strings.Contains(stdout, "[unknown] depends-on-first") {
+		t.Errorf("expected '[unknown] depends-on-first' line; got:\n%s", stdout)
+	}
+}
+
+// TestApplyListTasksGroupRendersChildren pins the block / rescue /
+// always rendering: the group's own name appears once, followed by
+// each child indented with the [block] / [rescue] / [always] phase
+// label.
+func TestApplyListTasksGroupRendersChildren(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: deploy with rollback
+      block:
+        - name: clone
+          dokku_stub: { key: a }
+        - name: sync
+          dokku_stub: { key: b }
+      rescue:
+        - name: cleanup
+          dokku_stub: { key: c }
+      always:
+        - name: log
+          dokku_stub: { key: d }
+`)
+	stdout, _, exit := runApply(t, path, "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	for _, want := range []string{"deploy with rollback", "[block] clone", "[block] sync", "[rescue] cleanup", "[always] log"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("listing should include %q; got:\n%s", want, stdout)
+		}
+	}
+}
+
+// TestPlanListTasksWorks covers --list-tasks on the plan path. The
+// listing should appear without any plan-time probe being run. We
+// verify by confirming a stub key's PlanError is never surfaced.
+func TestPlanListTasksWorks(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{PlanError: stubExecError("plan must not run")})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: probe
+      dokku_stub: { key: a }
+`)
+	stdout, stderr, exit := runPlan(t, path, "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "[0] probe") {
+		t.Errorf("expected '[0] probe' line; got:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "plan must not run") || strings.Contains(stderr, "plan must not run") {
+		t.Errorf("Plan() should not have run; got stdout=%s stderr=%s", stdout, stderr)
+	}
+}
+
+// TestApplyStartAtTaskUnknownErrors pins the up-front guard:
+// --start-at-task pointing at a name that does not exist returns 1
+// with the available-names hint.
+func TestApplyStartAtTaskUnknownErrors(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: first
+      dokku_stub: { key: a }
+    - name: second
+      dokku_stub: { key: b }
+`)
+	_, stderr, exit := runApply(t, path, "--start-at-task", "no-such-task")
+	if exit == 0 {
+		t.Fatal("expected non-zero exit when --start-at-task misses")
+	}
+	for _, want := range []string{`--start-at-task "no-such-task"`, `"first"`, `"second"`, "no task matched name"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr missing %q; got:\n%s", want, stderr)
+		}
+	}
+}
+
+// TestApplyStartAtTaskSkipsEarlier confirms the executor renders
+// [skipped] for tasks before the target and runs the matched task plus
+// successors. The stub fixtures track which tasks actually execute.
+func TestApplyStartAtTaskSkipsEarlier(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{Changed: true})
+	stubSet("b", StubFixture{Changed: true})
+	stubSet("c", StubFixture{Changed: true})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: first
+      dokku_stub: { key: a }
+    - name: second
+      dokku_stub: { key: b }
+    - name: third
+      dokku_stub: { key: c }
+`)
+	stdout, stderr, exit := runApply(t, path, "--start-at-task", "second")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "[skipped] first  (before --start-at-task)") {
+		t.Errorf("first should be skipped with reason; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "[changed] second") {
+		t.Errorf("second should run as [changed]; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "[changed] third") {
+		t.Errorf("third should run as [changed]; got:\n%s", stdout)
+	}
+}
+
+// TestApplyStartAtTaskInsideBlock pins the block-child interaction:
+// matching a child of a block enters the group, skips earlier
+// children, runs the matched child onward, and continues with rescue
+// / always per normal block semantics. We verify the matched child
+// runs and the earlier child does not.
+func TestApplyStartAtTaskInsideBlock(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{Changed: true})
+	stubSet("b", StubFixture{Changed: true})
+	stubSet("c", StubFixture{Changed: true})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: group-1
+      block:
+        - name: block-a
+          dokku_stub: { key: a }
+        - name: block-b
+          dokku_stub: { key: b }
+        - name: block-c
+          dokku_stub: { key: c }
+`)
+	stdout, stderr, exit := runApply(t, path, "--start-at-task", "block-b")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "[skipped] [block] block-a  (before --start-at-task)") {
+		t.Errorf("block-a should be skipped with the reason; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "[changed] [block] block-b") {
+		t.Errorf("block-b should run as changed; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "[changed] [block] block-c") {
+		t.Errorf("block-c should run after the match; got:\n%s", stdout)
+	}
+}

--- a/commands/output.go
+++ b/commands/output.go
@@ -53,6 +53,12 @@ type ApplyTaskEvent struct {
 	// Skipped indicates the `when:` predicate evaluated to false and the
 	// task was filtered out. Mutually exclusive with the other branches.
 	Skipped bool
+	// SkipReason carries a short human-readable annotation rendered as a
+	// parenthetical suffix after the [skipped] marker. Set when the
+	// skip is driven by something other than `when:` (e.g.
+	// "before --start-at-task"). Empty for plain `when:`-driven skips so
+	// the line stays terse.
+	SkipReason string
 	// InvalidState, when true, indicates Execute reported success but the
 	// final State did not match DesiredState; treated as an error in
 	// counts and exit logic.
@@ -234,7 +240,11 @@ func (f *Formatter) ApplyTask(ev ApplyTaskEvent) {
 		f.TaskLine(MarkerError, displayName, "")
 		f.Continuation('!', fmt.Sprintf("when expression error: %v", ev.WhenError))
 	case ev.Skipped:
-		f.TaskLine(MarkerSkipped, displayName, "")
+		suffix := ""
+		if ev.SkipReason != "" {
+			suffix = "(" + ev.SkipReason + ")"
+		}
+		f.TaskLine(MarkerSkipped, displayName, suffix)
 	case ev.State.Error != nil:
 		suffix := ""
 		if ev.Ignored {

--- a/commands/output_json.go
+++ b/commands/output_json.go
@@ -78,6 +78,9 @@ func (e *JSONEmitter) ApplyTask(ev ApplyTaskEvent) {
 		out["error"] = subprocess.MaskString(ev.WhenError.Error())
 	case ev.Skipped:
 		out["status"] = "skipped"
+		if ev.SkipReason != "" {
+			out["skip_reason"] = ev.SkipReason
+		}
 	case ev.State.Error != nil:
 		out["status"] = "error"
 		out["error"] = subprocess.MaskString(PrefixErrorMessage(ev.State.Error))

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -29,6 +29,7 @@ type PlanCommand struct {
 	skipTags          []string
 	varsFiles         []string
 	play              string
+	listTasks         bool
 	arguments         map[string]*Argument
 }
 
@@ -78,6 +79,7 @@ func (c *PlanCommand) FlagSet() *flag.FlagSet {
 	f.StringSliceVar(&c.skipTags, "skip-tags", nil, "comma-separated tag list; tasks whose `tags:` set intersects this list are skipped")
 	f.StringArrayVar(&c.varsFiles, "vars-file", nil, "load input values from a YAML or JSON file (repeatable; later files override earlier; CLI --name=value flags always win). A .json extension parses as JSON; otherwise YAML.")
 	f.StringVar(&c.play, "play", "", "plan only the play with this name (matches the play's `name:` field; auto-named plays use `play #N`)")
+	f.BoolVar(&c.listTasks, "list-tasks", false, "print the resolved task plan and exit without contacting the server. Honors --play / --tags / --skip-tags and shows expanded loop iterations and [skipped] markers for when:-skipped tasks.")
 
 	taskFile := getTaskYamlFilename(os.Args)
 	data, err := os.ReadFile(taskFile)
@@ -108,6 +110,7 @@ func (c *PlanCommand) AutocompleteFlags() complete.Flags {
 			"--skip-tags":            complete.PredictAnything,
 			"--vars-file":            complete.PredictFiles("*"),
 			"--play":                 complete.PredictAnything,
+			"--list-tasks":           complete.PredictNothing,
 		},
 	)
 }
@@ -181,6 +184,18 @@ func (c *PlanCommand) Run(args []string) int {
 	if err != nil {
 		c.Ui.Error(err.Error())
 		return 1
+	}
+
+	if c.listTasks {
+		return renderListTasks(c.Ui, listTasksOptions{
+			plays:         plays,
+			includes:      c.tags,
+			skips:         c.skipTags,
+			fileLevelKeys: fileLevelKeys,
+			userSet:       userSet,
+			context:       context,
+			jsonOut:       c.json,
+		})
 	}
 
 	sensitiveValues = append(sensitiveValues, tasks.CollectPlaySensitiveValues(plays)...)

--- a/commands/validate.go
+++ b/commands/validate.go
@@ -19,11 +19,13 @@ import (
 type ValidateCommand struct {
 	command.Meta
 
-	tasksFile string
-	json      bool
-	strict    bool
-	varsFiles []string
-	arguments map[string]*Argument
+	tasksFile   string
+	json        bool
+	strict      bool
+	varsFiles   []string
+	play        string
+	startAtTask string
+	arguments   map[string]*Argument
 }
 
 func (c *ValidateCommand) Name() string {
@@ -64,8 +66,10 @@ func (c *ValidateCommand) FlagSet() *flag.FlagSet {
 	f := c.Meta.FlagSet(c.Name(), command.FlagSetClient)
 	f.StringVar(&c.tasksFile, "tasks", "tasks.yml", "a yaml file containing a task list")
 	f.BoolVar(&c.json, "json", false, "emit one JSON-lines problem event per finding")
-	f.BoolVar(&c.strict, "strict", false, "additionally flag required inputs that have no default and no CLI override")
+	f.BoolVar(&c.strict, "strict", false, "additionally flag required inputs that have no default and no CLI override, and check that --play / --start-at-task references resolve to real names in the file")
 	f.StringArrayVar(&c.varsFiles, "vars-file", nil, "load input values from a YAML or JSON file (repeatable; later files override earlier; CLI --name=value flags always win). A .json extension parses as JSON; otherwise YAML.")
+	f.StringVar(&c.play, "play", "", "(strict) verify the named play exists in the recipe (matches the play's `name:` field; auto-named plays use `play #N`)")
+	f.StringVar(&c.startAtTask, "start-at-task", "", "(strict) verify a task with this name exists in the recipe; narrowed by --play when set")
 
 	taskFile := getTaskYamlFilename(os.Args)
 	data, err := os.ReadFile(taskFile)
@@ -86,10 +90,12 @@ func (c *ValidateCommand) AutocompleteFlags() complete.Flags {
 	return command.MergeAutocompleteFlags(
 		c.Meta.AutocompleteFlags(command.FlagSetClient),
 		complete.Flags{
-			"--tasks":     complete.PredictFiles("*.yml"),
-			"--json":      complete.PredictNothing,
-			"--strict":    complete.PredictNothing,
-			"--vars-file": complete.PredictFiles("*"),
+			"--tasks":         complete.PredictFiles("*.yml"),
+			"--json":          complete.PredictNothing,
+			"--strict":        complete.PredictNothing,
+			"--vars-file":     complete.PredictFiles("*"),
+			"--play":          complete.PredictAnything,
+			"--start-at-task": complete.PredictAnything,
 		},
 	)
 }
@@ -144,6 +150,8 @@ func (c *ValidateCommand) Run(args []string) int {
 	problems := tasks.Validate(data, tasks.ValidateOptions{
 		Strict:         c.strict,
 		InputOverrides: overrides,
+		PlayName:       c.play,
+		StartAtTask:    c.startAtTask,
 	})
 
 	if c.json {

--- a/tasks/envelope.go
+++ b/tasks/envelope.go
@@ -201,3 +201,65 @@ func FilterByTags(m OrderedStringEnvelopeMap, includes, skips []string) []string
 	}
 	return out
 }
+
+// EnvelopeContainsName reports whether env or any of its block / rescue
+// / always descendants has Name == target. Used by --start-at-task
+// gating so the executor enters a group whose child matches the target
+// rather than skipping the entire group.
+func EnvelopeContainsName(env *TaskEnvelope, target string) bool {
+	if env == nil {
+		return false
+	}
+	if env.Name == target {
+		return true
+	}
+	for _, child := range env.Block {
+		if EnvelopeContainsName(child, target) {
+			return true
+		}
+	}
+	for _, child := range env.Rescue {
+		if EnvelopeContainsName(child, target) {
+			return true
+		}
+	}
+	for _, child := range env.Always {
+		if EnvelopeContainsName(child, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// CollectEnvelopeNames returns every leaf and group envelope name
+// reachable from envs, walking block / rescue / always recursively.
+// Names appear in source order and are de-duplicated. Used by the
+// --start-at-task validators (apply.go and tasks/validate.go) to build
+// the "available names" hint shown when no task matched.
+func CollectEnvelopeNames(envs []*TaskEnvelope) []string {
+	seen := map[string]bool{}
+	var out []string
+	var walk func(env *TaskEnvelope)
+	walk = func(env *TaskEnvelope) {
+		if env == nil {
+			return
+		}
+		if env.Name != "" && !seen[env.Name] {
+			seen[env.Name] = true
+			out = append(out, env.Name)
+		}
+		for _, child := range env.Block {
+			walk(child)
+		}
+		for _, child := range env.Rescue {
+			walk(child)
+		}
+		for _, child := range env.Always {
+			walk(child)
+		}
+	}
+	for _, env := range envs {
+		walk(env)
+	}
+	return out
+}

--- a/tasks/envelope_test.go
+++ b/tasks/envelope_test.go
@@ -98,6 +98,55 @@ func TestFilterByTagsCombinedNarrowsThenDrops(t *testing.T) {
 	}
 }
 
+// TestEnvelopeContainsName covers the helper used by --start-at-task
+// gating: a top-level name match, a recursive match through a block /
+// rescue / always child, and a miss.
+func TestEnvelopeContainsName(t *testing.T) {
+	leaf := &TaskEnvelope{Name: "leaf"}
+	if !EnvelopeContainsName(leaf, "leaf") {
+		t.Errorf("leaf should self-match")
+	}
+	if EnvelopeContainsName(leaf, "other") {
+		t.Errorf("leaf should not match unrelated name")
+	}
+
+	group := &TaskEnvelope{
+		Name: "outer",
+		Block: []*TaskEnvelope{
+			{Name: "inner-a"},
+			{Name: "inner-b", Rescue: []*TaskEnvelope{{Name: "deep"}}},
+		},
+		Always: []*TaskEnvelope{{Name: "always-a"}},
+	}
+	for _, want := range []string{"outer", "inner-a", "inner-b", "deep", "always-a"} {
+		if !EnvelopeContainsName(group, want) {
+			t.Errorf("group should contain %q", want)
+		}
+	}
+	if EnvelopeContainsName(group, "missing") {
+		t.Errorf("group must not contain unrelated name")
+	}
+	if EnvelopeContainsName(nil, "anything") {
+		t.Errorf("nil env should never match")
+	}
+}
+
+// TestCollectEnvelopeNames covers the helper that flattens a slice of
+// envelopes into the source-ordered, de-duplicated name list used in
+// the --start-at-task error hint.
+func TestCollectEnvelopeNames(t *testing.T) {
+	envs := []*TaskEnvelope{
+		{Name: "a"},
+		{Name: "b", Block: []*TaskEnvelope{{Name: "b-child"}, {Name: "a"}}},
+		{Name: "c"},
+	}
+	got := CollectEnvelopeNames(envs)
+	want := []string{"a", "b", "b-child", "c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("CollectEnvelopeNames = %v, want %v", got, want)
+	}
+}
+
 func buildEnvelopeMap(spec map[string][]string) OrderedStringEnvelopeMap {
 	// spec maps key -> tag list. Insertion order follows the alphabetical
 	// order of the keys so test assertions remain stable.

--- a/tasks/validate.go
+++ b/tasks/validate.go
@@ -32,9 +32,16 @@ type Problem struct {
 // ValidateOptions controls optional checks. Strict turns on the input-resolution
 // audit; InputOverrides is the set of input names whose values were supplied on
 // the CLI (the same map registerInputFlags fills in for apply/plan).
+//
+// PlayName and StartAtTask carry the values of `validate --play` and
+// `validate --start-at-task` respectively. They power the cross-reference
+// audit that runs under `--strict`: each non-empty value must resolve to a
+// real play / task name in the recipe.
 type ValidateOptions struct {
 	Strict         bool
 	InputOverrides map[string]bool
+	PlayName       string
+	StartAtTask    string
 }
 
 // validatePlaceholder is substituted for any input that has no default during
@@ -197,7 +204,120 @@ func Validate(data []byte, opts ValidateOptions) []Problem {
 		problems = append(problems, validatePlay(play, label, inputs, opts, registerSeen)...)
 	}
 
+	problems = append(problems, validateCLIReferences(doc, opts)...)
+
 	return problems
+}
+
+// validateCLIReferences checks that the values of `validate --play` and
+// `validate --start-at-task` resolve to real play / task names in the
+// recipe. The audit runs only under --strict so casual `validate` runs
+// (without --strict) never error solely on missing CLI references.
+//
+// --start-at-task is checked against task `name:` fields walked through
+// every play's `tasks:` and through the block / rescue / always
+// children of group entries (#211). Loop expansions are not enumerated
+// here because their per-iteration suffix is only resolved at apply
+// time; the runtime check in commands/apply.go is authoritative.
+func validateCLIReferences(doc *yaml.Node, opts ValidateOptions) []Problem {
+	if !opts.Strict {
+		return nil
+	}
+	if opts.PlayName == "" && opts.StartAtTask == "" {
+		return nil
+	}
+
+	var problems []Problem
+	var playNames []string
+	taskNamesByPlay := map[string][]string{}
+	var allTaskNames []string
+	seen := map[string]bool{}
+
+	for i, play := range doc.Content {
+		if play.Kind != yaml.MappingNode {
+			continue
+		}
+		playLabel := scalarChild(play, "name")
+		if playLabel == "" {
+			playLabel = fmt.Sprintf("play #%d", i+1)
+		}
+		playNames = append(playNames, playLabel)
+
+		tasksNode := mappingValue(play, "tasks")
+		if tasksNode == nil || tasksNode.Kind != yaml.SequenceNode {
+			continue
+		}
+		var names []string
+		walkGroupEntries(tasksNode, playLabel, func(task *yaml.Node, _ string) {
+			n := scalarChild(task, "name")
+			if n == "" {
+				return
+			}
+			names = append(names, n)
+			if !seen[n] {
+				seen[n] = true
+				allTaskNames = append(allTaskNames, n)
+			}
+		})
+		taskNamesByPlay[playLabel] = names
+	}
+
+	if opts.PlayName != "" {
+		found := false
+		for _, n := range playNames {
+			if n == opts.PlayName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			problems = append(problems, Problem{
+				Code:    "unknown_play_reference",
+				Message: fmt.Sprintf("--play %q does not match any play in the recipe", opts.PlayName),
+				Hint:    fmt.Sprintf("available plays: %s", quotedNamesOrNone(playNames)),
+			})
+		}
+	}
+
+	if opts.StartAtTask != "" {
+		candidates := allTaskNames
+		if opts.PlayName != "" {
+			if names, ok := taskNamesByPlay[opts.PlayName]; ok {
+				candidates = names
+			}
+		}
+		found := false
+		for _, n := range candidates {
+			if n == opts.StartAtTask {
+				found = true
+				break
+			}
+		}
+		if !found {
+			problems = append(problems, Problem{
+				Code:    "unknown_start_at_task",
+				Message: fmt.Sprintf("--start-at-task %q does not match any task in the recipe", opts.StartAtTask),
+				Hint:    fmt.Sprintf("available tasks: %s", quotedNamesOrNone(candidates)),
+			})
+		}
+	}
+
+	return problems
+}
+
+// quotedNamesOrNone formats a slice of names as a comma-separated list
+// of quoted strings, or "(none)" when the slice is empty. Used to build
+// the Hint text for unknown_play_reference and unknown_start_at_task
+// problems.
+func quotedNamesOrNone(names []string) string {
+	if len(names) == 0 {
+		return "(none)"
+	}
+	out := make([]string, len(names))
+	for i, n := range names {
+		out[i] = fmt.Sprintf("%q", n)
+	}
+	return strings.Join(out, ", ")
 }
 
 // registerHit records the first occurrence of a `register: <name>` so

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -610,3 +610,137 @@ func TestValidateLoopVarInsideGroupIsAllowed(t *testing.T) {
 		t.Fatalf("did not expect loop_var_outside_loop, got: %+v", *p)
 	}
 }
+
+// TestValidateUnknownPlayReferenceUnderStrict pins the
+// unknown_play_reference check: a --strict run with --play that does
+// not match any play in the recipe surfaces a problem with the
+// available plays in the hint.
+func TestValidateUnknownPlayReferenceUnderStrict(t *testing.T) {
+	data := []byte(`---
+- name: api
+  tasks:
+    - dokku_app: { app: a }
+- name: worker
+  tasks:
+    - dokku_app: { app: b }
+`)
+	problems := Validate(data, ValidateOptions{Strict: true, PlayName: "missing"})
+	p := findProblem(problems, "unknown_play_reference")
+	if p == nil {
+		t.Fatalf("expected unknown_play_reference; got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, `"missing"`) {
+		t.Errorf("message should quote the bad reference; got %q", p.Message)
+	}
+	for _, want := range []string{`"api"`, `"worker"`} {
+		if !strings.Contains(p.Hint, want) {
+			t.Errorf("hint missing %q; got %q", want, p.Hint)
+		}
+	}
+}
+
+// TestValidatePlayReferenceMatch confirms a valid --play under
+// --strict produces no unknown_play_reference problem.
+func TestValidatePlayReferenceMatch(t *testing.T) {
+	data := []byte(`---
+- name: api
+  tasks:
+    - dokku_app: { app: a }
+`)
+	problems := Validate(data, ValidateOptions{Strict: true, PlayName: "api"})
+	if p := findProblem(problems, "unknown_play_reference"); p != nil {
+		t.Fatalf("expected no unknown_play_reference; got: %+v", *p)
+	}
+}
+
+// TestValidateUnknownStartAtTaskUnderStrict pins the
+// unknown_start_at_task check across plays.
+func TestValidateUnknownStartAtTaskUnderStrict(t *testing.T) {
+	data := []byte(`---
+- name: api
+  tasks:
+    - name: deploy api
+      dokku_app: { app: a }
+    - name: configure api
+      dokku_app: { app: a }
+`)
+	problems := Validate(data, ValidateOptions{Strict: true, StartAtTask: "missing-task"})
+	p := findProblem(problems, "unknown_start_at_task")
+	if p == nil {
+		t.Fatalf("expected unknown_start_at_task; got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, `"missing-task"`) {
+		t.Errorf("message should quote the bad reference; got %q", p.Message)
+	}
+	for _, want := range []string{`"deploy api"`, `"configure api"`} {
+		if !strings.Contains(p.Hint, want) {
+			t.Errorf("hint missing %q; got %q", want, p.Hint)
+		}
+	}
+}
+
+// TestValidateStartAtTaskNarrowedByPlay confirms that when --play and
+// --start-at-task are both set, the task search is narrowed to the
+// named play. A task name that exists only in another play is treated
+// as missing.
+func TestValidateStartAtTaskNarrowedByPlay(t *testing.T) {
+	data := []byte(`---
+- name: api
+  tasks:
+    - name: deploy api
+      dokku_app: { app: a }
+- name: worker
+  tasks:
+    - name: deploy worker
+      dokku_app: { app: b }
+`)
+	problems := Validate(data, ValidateOptions{
+		Strict:      true,
+		PlayName:    "api",
+		StartAtTask: "deploy worker",
+	})
+	if p := findProblem(problems, "unknown_start_at_task"); p == nil {
+		t.Fatalf("expected unknown_start_at_task when --play narrows the search; got: %+v", problems)
+	}
+}
+
+// TestValidateStartAtTaskMatchesGroupChild confirms the audit
+// recurses into block / rescue / always children so a child name in a
+// group is recognised.
+func TestValidateStartAtTaskMatchesGroupChild(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: group-1
+      block:
+        - name: child-a
+          dokku_app: { app: a }
+        - name: child-b
+          dokku_app: { app: b }
+`)
+	problems := Validate(data, ValidateOptions{Strict: true, StartAtTask: "child-b"})
+	if p := findProblem(problems, "unknown_start_at_task"); p != nil {
+		t.Fatalf("did not expect unknown_start_at_task for a real group child; got: %+v", *p)
+	}
+}
+
+// TestValidateCLIReferencesSkippedWithoutStrict pins the gating
+// behaviour: passing --play/--start-at-task without --strict does not
+// trigger the cross-reference audit, matching the issue's contract
+// that the check is strict-mode-only.
+func TestValidateCLIReferencesSkippedWithoutStrict(t *testing.T) {
+	data := []byte(`---
+- name: api
+  tasks:
+    - dokku_app: { app: a }
+`)
+	problems := Validate(data, ValidateOptions{
+		PlayName:    "missing",
+		StartAtTask: "also-missing",
+	})
+	if p := findProblem(problems, "unknown_play_reference"); p != nil {
+		t.Errorf("non-strict should not surface unknown_play_reference; got: %+v", *p)
+	}
+	if p := findProblem(problems, "unknown_start_at_task"); p != nil {
+		t.Errorf("non-strict should not surface unknown_start_at_task; got: %+v", *p)
+	}
+}

--- a/tests/bats/list_resume.bats
+++ b/tests/bats/list_resume.bats
@@ -1,0 +1,210 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+# list_resume.bats covers the #212 inspection / resume surface end-to-end:
+# --list-tasks on apply and plan renders the resolved task plan without
+# executing or probing, --start-at-task on apply skips earlier tasks and
+# runs from the matched task onward (including the inside-block case),
+# and validate --strict surfaces unknown_play_reference /
+# unknown_start_at_task problems for typo'd CLI references.
+
+setup() {
+  docket_build
+  dokku_clean_app docket-test-list-1
+  dokku_clean_app docket-test-list-2
+  dokku_clean_app docket-test-list-tag-api
+  dokku_clean_app docket-test-list-tag-worker
+  dokku_clean_app docket-test-list-loop-a
+  dokku_clean_app docket-test-list-loop-b
+  dokku_clean_app docket-test-list-loop-c
+  dokku_clean_app docket-test-start-at-first
+  dokku_clean_app docket-test-start-at-second
+  dokku_clean_app docket-test-start-at-third
+  dokku_clean_app docket-test-start-at-unknown
+  dokku_clean_app docket-test-start-block-a
+  dokku_clean_app docket-test-start-block-b
+  dokku_clean_app docket-test-start-block-c
+}
+
+teardown() {
+  dokku_clean_app docket-test-list-1
+  dokku_clean_app docket-test-list-2
+  dokku_clean_app docket-test-list-tag-api
+  dokku_clean_app docket-test-list-tag-worker
+  dokku_clean_app docket-test-list-loop-a
+  dokku_clean_app docket-test-list-loop-b
+  dokku_clean_app docket-test-list-loop-c
+  dokku_clean_app docket-test-start-at-first
+  dokku_clean_app docket-test-start-at-second
+  dokku_clean_app docket-test-start-at-third
+  dokku_clean_app docket-test-start-at-unknown
+  dokku_clean_app docket-test-start-block-a
+  dokku_clean_app docket-test-start-block-b
+  dokku_clean_app docket-test-start-block-c
+}
+
+@test "--list-tasks prints resolved plan without running" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_app: { app: docket-test-list-1 }
+    - dokku_app: { app: docket-test-list-2 }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  assert_output --partial "docket-test-list-1"
+  assert_output --partial "docket-test-list-2"
+  run dokku apps:exists docket-test-list-1
+  assert_failure   # never created
+}
+
+@test "--list-tasks honors --tags filter" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: api task
+      tags: [api]
+      dokku_app: { app: docket-test-list-tag-api }
+    - name: worker task
+      tags: [worker]
+      dokku_app: { app: docket-test-list-tag-worker }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks --tags api
+  assert_success
+  assert_output --partial "api task"
+  refute_output --partial "worker task"
+}
+
+@test "--list-tasks expands loops" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - loop: [a, b, c]
+      dokku_app: { app: "docket-test-list-loop-{{ .item }}" }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  assert_output --partial "item=a"
+  assert_output --partial "item=b"
+  assert_output --partial "item=c"
+}
+
+@test "--list-tasks shows [skipped] for when:false" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: gated
+      when: 'false'
+      dokku_app: { app: docket-test-list-1 }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  assert_output --partial "[skipped] gated"
+}
+
+@test "--list-tasks works on plan as well" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: probe
+      dokku_app: { app: docket-test-list-1 }
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  assert_output --partial "[0] probe"
+}
+
+@test "--start-at-task skips earlier tasks" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: first
+      dokku_app: { app: docket-test-start-at-first }
+    - name: second
+      dokku_app: { app: docket-test-start-at-second }
+    - name: third
+      dokku_app: { app: docket-test-start-at-third }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --start-at-task second
+  assert_success
+  assert_output --partial "[skipped] first"
+  assert_output --partial "before --start-at-task"
+  run dokku apps:exists docket-test-start-at-first
+  assert_failure   # skipped
+  run dokku apps:exists docket-test-start-at-second
+  assert_success
+  run dokku apps:exists docket-test-start-at-third
+  assert_success
+}
+
+@test "--start-at-task with unknown name errors" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: first
+      dokku_app: { app: docket-test-start-at-unknown }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --start-at-task no-such-task
+  assert_failure
+  assert_output --partial "no task matched name"
+  assert_output --partial '"first"'
+}
+
+@test "--start-at-task matching a block child runs from that child" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: deploy-group
+      block:
+        - name: block-a
+          dokku_app: { app: docket-test-start-block-a }
+        - name: block-b
+          dokku_app: { app: docket-test-start-block-b }
+        - name: block-c
+          dokku_app: { app: docket-test-start-block-c }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --start-at-task block-b
+  assert_success
+  assert_output --partial "[skipped] [block] block-a"
+  assert_output --partial "before --start-at-task"
+  run dokku apps:exists docket-test-start-block-a
+  assert_failure
+  run dokku apps:exists docket-test-start-block-b
+  assert_success
+  run dokku apps:exists docket-test-start-block-c
+  assert_success
+}
+
+@test "validate --strict --play missing reports unknown_play_reference" {
+  write_tasks_file <<EOF
+---
+- name: api
+  tasks:
+    - dokku_app: { app: docket-test-list-1 }
+- name: worker
+  tasks:
+    - dokku_app: { app: docket-test-list-2 }
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE" --strict --play missing
+  assert_failure
+  assert_output --partial '--play "missing"'
+  assert_output --partial '"api"'
+  assert_output --partial '"worker"'
+}
+
+@test "validate --strict --start-at-task missing reports unknown_start_at_task" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: deploy
+      dokku_app: { app: docket-test-list-1 }
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE" --strict --start-at-task missing-task
+  assert_failure
+  assert_output --partial '--start-at-task "missing-task"'
+  assert_output --partial '"deploy"'
+}

--- a/tests/bats/list_resume.bats
+++ b/tests/bats/list_resume.bats
@@ -57,7 +57,7 @@ EOF
   assert_output --partial "docket-test-list-1"
   assert_output --partial "docket-test-list-2"
   run dokku apps:exists docket-test-list-1
-  assert_failure   # never created
+  assert_failure # never created
 }
 
 @test "--list-tasks honors --tags filter" {
@@ -133,7 +133,7 @@ EOF
   assert_output --partial "[skipped] first"
   assert_output --partial "before --start-at-task"
   run dokku apps:exists docket-test-start-at-first
-  assert_failure   # skipped
+  assert_failure # skipped
   run dokku apps:exists docket-test-start-at-second
   assert_success
   run dokku apps:exists docket-test-start-at-third


### PR DESCRIPTION
## Summary

`--list-tasks` on `apply` and `plan` walks the resolved task plan post `--play` / `--tags` filtering and post `loop:` expansion and prints one line per envelope without running. `when:` predicates evaluate against inputs only; predicates that reference `.registered` render as `[unknown]`.

`--start-at-task <name>` on `apply` skips earlier tasks (rendered as `[skipped] ... (before --start-at-task)`) and runs from the matched task onward, including descending into a `block:` group when the match lives inside.

`validate --strict` gains cross-reference checks for `--play` and `--start-at-task`, surfacing `unknown_play_reference` / `unknown_start_at_task` problems for typos before they reach `apply`.

Closes #212.