### PR TITLE
ci: shard integration tests into 4 balanced parallel jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,10 @@ jobs:
   integration-test:
     name: integration-test
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -58,8 +62,8 @@ jobs:
         run: sudo dokku plugin:install https://github.com/dokku/dokku-letsencrypt.git --committish 0.25.0 letsencrypt
       - name: install dokku acl plugin
         run: sudo dokku plugin:install https://github.com/dokku-community/dokku-acl.git acl
-      - name: run integration tests
-        run: sudo go test -v -count=1 -timeout 40m -run TestIntegration ./tasks/
+      - name: run integration tests (shard ${{ matrix.shard }} of 4)
+        run: sudo DOKKU_TEST_SHARD=${{ matrix.shard }} DOKKU_TEST_SHARDS=4 go test -v -count=1 -timeout 20m -run TestIntegration ./tasks/
 
   bats-test:
     name: bats-test

--- a/tasks/integration_helpers_test.go
+++ b/tasks/integration_helpers_test.go
@@ -23,6 +23,7 @@ func dokkuAvailable() bool {
 
 func skipIfNoDokkuT(t *testing.T) {
 	t.Helper()
+	skipIfNotInShardT(t)
 	if !dokkuAvailable() {
 		t.Skip("skipping integration test: dokku not available")
 	}

--- a/tasks/integration_shard_test.go
+++ b/tasks/integration_shard_test.go
@@ -1,0 +1,173 @@
+package tasks
+
+import (
+	"hash/fnv"
+	"os"
+	"sort"
+	"strconv"
+	"testing"
+)
+
+// integrationTestWeights holds the approximate per-test runtime (seconds) of
+// every TestIntegration* top-level function, used to bin-pack the suite into
+// balanced shards (see computeShards). Values come from a CI run; a few
+// fast/late tests are estimated. Keep this list in sync with the test
+// functions: a test not listed here still runs (it falls back to a hash-based
+// shard assignment in skipIfNotInShardT), it just isn't accounted for when
+// balancing, so add new heavy tests here when CI timings drift.
+var integrationTestWeights = map[string]float64{
+	"TestIntegrationAclApp":                                 9.1,
+	"TestIntegrationAclService":                             5.8,
+	"TestIntegrationAppClone":                               12.6,
+	"TestIntegrationAppCreateAndDestroy":                    6.0,
+	"TestIntegrationAppJsonPropertyAll":                     7.2,
+	"TestIntegrationAppLock":                                7.0,
+	"TestIntegrationBuilderDockerfilePropertyAll":           7.5,
+	"TestIntegrationBuilderHerokuishPropertyAll":            7.5,
+	"TestIntegrationBuilderLambdaPropertyAll":               7.5,
+	"TestIntegrationBuilderNixpacksPropertyAll":             7.5,
+	"TestIntegrationBuilderPackPropertyAll":                 7.5,
+	"TestIntegrationBuilderPropertyAll":                     10.0,
+	"TestIntegrationBuilderRailpackPropertyAll":             7.5,
+	"TestIntegrationBuildpacks":                             7.8,
+	"TestIntegrationBuildpacksPropertyAll":                  7.8,
+	"TestIntegrationBuildsPropertyAll":                      7.2,
+	"TestIntegrationCaddyPropertyAll":                       15.2,
+	"TestIntegrationCertsApp":                               12.6,
+	"TestIntegrationCertsGlobal":                            3.0,
+	"TestIntegrationChecksPropertyAll":                      7.5,
+	"TestIntegrationChecksToggle":                           6.3,
+	"TestIntegrationConfigMultipleKeys":                     6.7,
+	"TestIntegrationConfigSetAndUnset":                      6.5,
+	"TestIntegrationCronPropertyAll":                        10.9,
+	"TestIntegrationDockerOptions":                          6.8,
+	"TestIntegrationDomainsAddAndRemove":                    19.2,
+	"TestIntegrationDomainsToggle":                          10.0,
+	"TestIntegrationExecuteIdempotent":                      5.9,
+	"TestIntegrationGetTasksFullWorkflow":                   5.9,
+	"TestIntegrationGitAuth":                                0.6,
+	"TestIntegrationGitFromArchive":                         40.4,
+	"TestIntegrationGitFromImage":                           39.8,
+	"TestIntegrationGitPropertyAll":                         15.7,
+	"TestIntegrationGitSync":                                7.3,
+	"TestIntegrationHaproxyPropertyAll":                     6.7,
+	"TestIntegrationHttpAuth":                               8.3,
+	"TestIntegrationLetsencrypt":                            6.9,
+	"TestIntegrationLetsencryptPropertyAll":                 32.6,
+	"TestIntegrationLogsPropertyAll":                        11.9,
+	"TestIntegrationMultiTaskWorkflow":                      6.5,
+	"TestIntegrationNetworkCreateAndDestroy":                1.2,
+	"TestIntegrationNetworkPropertyAll":                     13.8,
+	"TestIntegrationNginxPropertyAll":                       249.7,
+	"TestIntegrationOpenrestyPropertyAll":                   254.0,
+	"TestIntegrationPlanCommandsPopulatedOnDrift":           0.4,
+	"TestIntegrationPlanConfigItemizes":                     5.9,
+	"TestIntegrationPlanDetectsMissingApp":                  3.0,
+	"TestIntegrationPlanDoesNotMutate":                      0.5,
+	"TestIntegrationPlanInSyncAfterApply":                   5.9,
+	"TestIntegrationPortsAddAndRemove":                      11.3,
+	"TestIntegrationProxyPropertyAll":                       10.0,
+	"TestIntegrationProxyToggle":                            7.7,
+	"TestIntegrationPsPropertyAll":                          21.3,
+	"TestIntegrationPsScale":                                72.7,
+	"TestIntegrationPsScaleSkipDeploy":                      6.2,
+	"TestIntegrationRegistryAuthApp":                        7.9,
+	"TestIntegrationRegistryAuthGlobal":                     0.9,
+	"TestIntegrationRegistryAuthPasswordNotInArgs":          6.4,
+	"TestIntegrationRegistryPropertyAll":                    12.1,
+	"TestIntegrationResourceLimit":                          6.5,
+	"TestIntegrationResourceLimitProcessType":               6.7,
+	"TestIntegrationResourceReserve":                        6.5,
+	"TestIntegrationResourceReserveProcessType":             6.7,
+	"TestIntegrationRunExecInputsCapturesFailureOutput":     0.2,
+	"TestIntegrationRunExecInputsPopulatesExitCodeAndStdout": 0.2,
+	"TestIntegrationSchedulerDockerLocalPropertyAll":        7.7,
+	"TestIntegrationSchedulerK3sPropertyAll":                21.3,
+	"TestIntegrationSchedulerPropertyAll":                   8.6,
+	"TestIntegrationServiceCreateAndDestroy":                2.9,
+	"TestIntegrationServiceLinkAndUnlink":                   32.0,
+	"TestIntegrationStorageEnsure":                          6.0,
+	"TestIntegrationStorageMount":                           6.0,
+	"TestIntegrationTraefikPropertyAll":                     12.0,
+	"TestIntegrationValidateRunsOffline":                    1.0,
+}
+
+var (
+	// shardIndex is the 1-based shard this process runs (0 = sharding off).
+	shardIndex int
+	// shardTotal is the number of shards (0 = sharding off).
+	shardTotal int
+	// shardOf maps a test name to its 1-based shard for the weighted tests.
+	shardOf map[string]int
+)
+
+func init() {
+	idx, err1 := strconv.Atoi(os.Getenv("DOKKU_TEST_SHARD"))
+	tot, err2 := strconv.Atoi(os.Getenv("DOKKU_TEST_SHARDS"))
+	if err1 != nil || err2 != nil || tot < 1 || idx < 1 || idx > tot {
+		return // sharding disabled: run everything
+	}
+	shardIndex = idx
+	shardTotal = tot
+	shardOf = computeShards(integrationTestWeights, tot)
+}
+
+// computeShards assigns each weighted test to one of n shards using the
+// longest-processing-time greedy heuristic: process tests heaviest-first and
+// drop each into the currently-lightest shard. Deterministic for a given
+// weights map and n. Returns a map of test name to 1-based shard.
+func computeShards(weights map[string]float64, n int) map[string]int {
+	type item struct {
+		name string
+		w    float64
+	}
+	items := make([]item, 0, len(weights))
+	for name, w := range weights {
+		items = append(items, item{name, w})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].w != items[j].w {
+			return items[i].w > items[j].w
+		}
+		return items[i].name < items[j].name
+	})
+
+	loads := make([]float64, n)
+	out := make(map[string]int, len(items))
+	for _, it := range items {
+		lightest := 0
+		for b := 1; b < n; b++ {
+			if loads[b] < loads[lightest] {
+				lightest = b
+			}
+		}
+		loads[lightest] += it.w
+		out[it.name] = lightest + 1
+	}
+	return out
+}
+
+// shardForTest returns the 1-based shard a test belongs to. Listed tests use
+// the bin-packed assignment; unlisted tests fall back to an FNV hash so they
+// still run in exactly one shard.
+func shardForTest(name string) int {
+	if s, ok := shardOf[name]; ok {
+		return s
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(name))
+	return int(h.Sum32()%uint32(shardTotal)) + 1
+}
+
+// skipIfNotInShardT skips the test unless it belongs to the shard this process
+// is running. When sharding is disabled (DOKKU_TEST_SHARD/DOKKU_TEST_SHARDS
+// unset) it is a no-op, so local runs execute the whole suite.
+func skipIfNotInShardT(t *testing.T) {
+	t.Helper()
+	if shardTotal == 0 {
+		return
+	}
+	if got := shardForTest(t.Name()); got != shardIndex {
+		t.Skipf("skipping: test assigned to shard %d/%d, running shard %d", got, shardTotal, shardIndex)
+	}
+}

--- a/tasks/integration_shard_unit_test.go
+++ b/tasks/integration_shard_unit_test.go
@@ -1,0 +1,78 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestComputeShardsBalances(t *testing.T) {
+	const n = 4
+	assignment := computeShards(integrationTestWeights, n)
+
+	if len(assignment) != len(integrationTestWeights) {
+		t.Fatalf("computeShards assigned %d tests; want %d", len(assignment), len(integrationTestWeights))
+	}
+
+	loads := make([]float64, n)
+	counts := make([]int, n)
+	var total float64
+	for name, w := range integrationTestWeights {
+		shard, ok := assignment[name]
+		if !ok {
+			t.Errorf("test %q not assigned to a shard", name)
+			continue
+		}
+		if shard < 1 || shard > n {
+			t.Errorf("test %q assigned to out-of-range shard %d", name, shard)
+			continue
+		}
+		loads[shard-1] += w
+		counts[shard-1]++
+		total += w
+	}
+
+	for i := 0; i < n; i++ {
+		if counts[i] == 0 {
+			t.Errorf("shard %d is empty", i+1)
+		}
+	}
+
+	// Every shard's load should be close to the mean. With two ~250s
+	// outliers the best achievable max is bounded by the largest single
+	// test, so allow generous headroom but still catch gross imbalance.
+	mean := total / n
+	var maxLoad float64
+	for _, l := range loads {
+		if l > maxLoad {
+			maxLoad = l
+		}
+	}
+	if maxLoad > mean*1.25 {
+		t.Errorf("shard imbalance: max load %.0fs exceeds 1.25x mean %.0fs (loads=%v)", maxLoad, mean, loads)
+	}
+}
+
+func TestShardForTestDeterministic(t *testing.T) {
+	// With sharding configured, every weighted test resolves to a stable
+	// shard in [1, n] and unlisted tests hash into range too.
+	saveOf, saveTotal := shardOf, shardTotal
+	defer func() { shardOf, shardTotal = saveOf, saveTotal }()
+
+	shardTotal = 4
+	shardOf = computeShards(integrationTestWeights, shardTotal)
+
+	for name := range integrationTestWeights {
+		if got := shardForTest(name); got < 1 || got > shardTotal {
+			t.Fatalf("shardForTest(%q) = %d, out of range", name, got)
+		}
+	}
+
+	unlisted := "TestIntegrationSomethingBrandNew"
+	a := shardForTest(unlisted)
+	b := shardForTest(unlisted)
+	if a != b {
+		t.Errorf("shardForTest(%q) not deterministic: %d != %d", unlisted, a, b)
+	}
+	if a < 1 || a > shardTotal {
+		t.Errorf("shardForTest(%q) = %d, out of range", unlisted, a)
+	}
+}

--- a/tasks/validate_integration_test.go
+++ b/tasks/validate_integration_test.go
@@ -45,6 +45,7 @@ func TestValidateDoesNotImportSubprocess(t *testing.T) {
 // the import-graph guard above by exercising the actual function at
 // runtime.
 func TestIntegrationValidateRunsOffline(t *testing.T) {
+	skipIfNotInShardT(t)
 	original := os.Getenv("PATH")
 	if err := os.Setenv("PATH", ""); err != nil {
 		t.Fatalf("os.Setenv: %v", err)


### PR DESCRIPTION
The per-property suite runs ~20 min serially. A weighted longest-processing-time bin-pack (driven by `DOKKU_TEST_SHARD`/`DOKKU_TEST_SHARDS`) splits the 74 integration tests into 4 shards of ~308s each, gated in `skipIfNoDokkuT`, and the workflow runs them as a 4-job matrix. Sharding is a no-op when the env vars are unset, so local runs execute the whole suite.