### PR TITLE
feat: add ansible-style sections to generated task docs

### DIFF
--- a/docs/tasks/dokku_acl_app.md
+++ b/docs/tasks/dokku_acl_app.md
@@ -1,8 +1,24 @@
 # dokku_acl_app
 
+## Synopsis
+
 Manages the dokku-acl access list for a dokku application
 
-## Grant users access to an app
+## Requirements
+
+- dokku-acl plugin
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `users` | list | no |  |  | List of users to add or remove from the ACL |
+| `state` | string | no | present | present, absent | Desired state of the ACL entries |
+
+## Examples
+
+### Grant users access to an app
 
 ```yaml
 dokku_acl_app:
@@ -12,7 +28,7 @@ dokku_acl_app:
         - bob
 ```
 
-## Revoke a user's access to an app
+### Revoke a user's access to an app
 
 ```yaml
 dokku_acl_app:
@@ -22,7 +38,7 @@ dokku_acl_app:
     state: absent
 ```
 
-## Clear the entire ACL for an app
+### Clear the entire ACL for an app
 
 ```yaml
 dokku_acl_app:
@@ -30,3 +46,18 @@ dokku_acl_app:
     users: []
     state: absent
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_acl_service.md
+++ b/docs/tasks/dokku_acl_service.md
@@ -1,8 +1,25 @@
 # dokku_acl_service
 
+## Synopsis
+
 Manages the dokku-acl access list for a dokku service
 
-## Grant users access to a redis service
+## Requirements
+
+- dokku-acl plugin
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `service` | string | yes |  |  | Name of the service instance |
+| `type` | string | yes |  |  | Type of service (e.g. redis, postgres) |
+| `users` | list | no |  |  | List of users to add or remove from the ACL |
+| `state` | string | no | present | present, absent | Desired state of the ACL entries |
+
+## Examples
+
+### Grant users access to a redis service
 
 ```yaml
 dokku_acl_service:
@@ -13,7 +30,7 @@ dokku_acl_service:
         - bob
 ```
 
-## Revoke a user's access to a redis service
+### Revoke a user's access to a redis service
 
 ```yaml
 dokku_acl_service:
@@ -24,7 +41,7 @@ dokku_acl_service:
     state: absent
 ```
 
-## Clear the entire ACL for a redis service
+### Clear the entire ACL for a redis service
 
 ```yaml
 dokku_acl_service:
@@ -33,3 +50,18 @@ dokku_acl_service:
     users: []
     state: absent
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_app.md
+++ b/docs/tasks/dokku_app.md
@@ -1,18 +1,44 @@
 # dokku_app
 
+## Synopsis
+
 Creates or destroys an app
 
-## Create an app named hello-world
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `state` | string | no | present | present, absent | State of the app |
+
+## Examples
+
+### Create an app named hello-world
 
 ```yaml
 dokku_app:
     app: hello-world
 ```
 
-## Destroy the app named hello-world
+### Destroy the app named hello-world
 
 ```yaml
 dokku_app:
     app: hello-world
     state: absent
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_app_clone.md
+++ b/docs/tasks/dokku_app_clone.md
@@ -1,8 +1,21 @@
 # dokku_app_clone
 
+## Synopsis
+
 Clones an existing dokku app to a new app
 
-## Clone an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the new (target) app |
+| `source_app` | string | yes |  |  | Name of the existing app to clone from |
+| `skip_deploy` | bool | no |  |  | Skip deployment of the cloned app |
+| `state` | string | no | present | present | Desired state of the cloned app |
+
+## Examples
+
+### Clone an app
 
 ```yaml
 dokku_app_clone:
@@ -10,7 +23,7 @@ dokku_app_clone:
     source_app: node-js-app
 ```
 
-## Clone an app without deploying
+### Clone an app without deploying
 
 ```yaml
 dokku_app_clone:
@@ -18,3 +31,18 @@ dokku_app_clone:
     source_app: node-js-app
     skip_deploy: true
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_app_json_property.md
+++ b/docs/tasks/dokku_app_json_property.md
@@ -1,8 +1,22 @@
 # dokku_app_json_property
 
+## Synopsis
+
 Manages the app.json configuration for a given dokku application
 
-## Setting the appjson-path for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the app.json configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the app.json property to set |
+| `value` | string | no |  |  | Value to set for the app.json property |
+| `state` | string | no | present | present, absent | Desired state of the app.json configuration |
+
+## Examples
+
+### Setting the appjson-path for an app
 
 ```yaml
 dokku_app_json_property:
@@ -11,7 +25,7 @@ dokku_app_json_property:
     value: app.json
 ```
 
-## Setting the appjson-path globally
+### Setting the appjson-path globally
 
 ```yaml
 dokku_app_json_property:
@@ -21,10 +35,25 @@ dokku_app_json_property:
     value: app.json
 ```
 
-## Clearing the appjson-path for an app
+### Clearing the appjson-path for an app
 
 ```yaml
 dokku_app_json_property:
     app: node-js-app
     property: appjson-path
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_app_lock.md
+++ b/docs/tasks/dokku_app_lock.md
@@ -1,18 +1,44 @@
 # dokku_app_lock
 
+## Synopsis
+
 Locks or unlocks a dokku application from deployment
 
-## Lock an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `state` | string | no | present | present, absent | Desired lock state |
+
+## Examples
+
+### Lock an app
 
 ```yaml
 dokku_app_lock:
     app: node-js-app
 ```
 
-## Unlock an app
+### Unlock an app
 
 ```yaml
 dokku_app_lock:
     app: node-js-app
     state: absent
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_builder_dockerfile_property.md
+++ b/docs/tasks/dokku_builder_dockerfile_property.md
@@ -1,8 +1,22 @@
 # dokku_builder_dockerfile_property
 
+## Synopsis
+
 Manages the builder-dockerfile configuration for a given dokku application
 
-## Setting the dockerfile path for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the builder-dockerfile configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the builder-dockerfile property to set |
+| `value` | string | no |  |  | Value to set for the builder-dockerfile property |
+| `state` | string | no | present | present, absent | Desired state of the builder-dockerfile configuration |
+
+## Examples
+
+### Setting the dockerfile path for an app
 
 ```yaml
 dokku_builder_dockerfile_property:
@@ -11,7 +25,7 @@ dokku_builder_dockerfile_property:
     value: Dockerfile.production
 ```
 
-## Setting the dockerfile path globally
+### Setting the dockerfile path globally
 
 ```yaml
 dokku_builder_dockerfile_property:
@@ -21,10 +35,25 @@ dokku_builder_dockerfile_property:
     value: Dockerfile
 ```
 
-## Clearing the dockerfile path for an app
+### Clearing the dockerfile path for an app
 
 ```yaml
 dokku_builder_dockerfile_property:
     app: node-js-app
     property: dockerfile-path
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_builder_herokuish_property.md
+++ b/docs/tasks/dokku_builder_herokuish_property.md
@@ -1,8 +1,22 @@
 # dokku_builder_herokuish_property
 
+## Synopsis
+
 Manages the builder-herokuish configuration for a given dokku application
 
-## Allowing the herokuish builder for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the builder-herokuish configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the builder-herokuish property to set |
+| `value` | string | no |  |  | Value to set for the builder-herokuish property |
+| `state` | string | no | present | present, absent | Desired state of the builder-herokuish configuration |
+
+## Examples
+
+### Allowing the herokuish builder for an app
 
 ```yaml
 dokku_builder_herokuish_property:
@@ -11,7 +25,7 @@ dokku_builder_herokuish_property:
     value: "true"
 ```
 
-## Allowing the herokuish builder globally
+### Allowing the herokuish builder globally
 
 ```yaml
 dokku_builder_herokuish_property:
@@ -21,10 +35,25 @@ dokku_builder_herokuish_property:
     value: "true"
 ```
 
-## Clearing the allowed property for an app
+### Clearing the allowed property for an app
 
 ```yaml
 dokku_builder_herokuish_property:
     app: node-js-app
     property: allowed
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_builder_lambda_property.md
+++ b/docs/tasks/dokku_builder_lambda_property.md
@@ -1,8 +1,22 @@
 # dokku_builder_lambda_property
 
+## Synopsis
+
 Manages the builder-lambda configuration for a given dokku application
 
-## Setting the lambda.yml path for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the builder-lambda configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the builder-lambda property to set |
+| `value` | string | no |  |  | Value to set for the builder-lambda property |
+| `state` | string | no | present | present, absent | Desired state of the builder-lambda configuration |
+
+## Examples
+
+### Setting the lambda.yml path for an app
 
 ```yaml
 dokku_builder_lambda_property:
@@ -11,7 +25,7 @@ dokku_builder_lambda_property:
     value: config/lambda.yml
 ```
 
-## Setting the lambda.yml path globally
+### Setting the lambda.yml path globally
 
 ```yaml
 dokku_builder_lambda_property:
@@ -21,10 +35,25 @@ dokku_builder_lambda_property:
     value: lambda.yml
 ```
 
-## Clearing the lambda.yml path for an app
+### Clearing the lambda.yml path for an app
 
 ```yaml
 dokku_builder_lambda_property:
     app: node-js-app
     property: lambdayml-path
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_builder_nixpacks_property.md
+++ b/docs/tasks/dokku_builder_nixpacks_property.md
@@ -1,8 +1,22 @@
 # dokku_builder_nixpacks_property
 
+## Synopsis
+
 Manages the builder-nixpacks configuration for a given dokku application
 
-## Setting the nixpacks.toml path for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the builder-nixpacks configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the builder-nixpacks property to set |
+| `value` | string | no |  |  | Value to set for the builder-nixpacks property |
+| `state` | string | no | present | present, absent | Desired state of the builder-nixpacks configuration |
+
+## Examples
+
+### Setting the nixpacks.toml path for an app
 
 ```yaml
 dokku_builder_nixpacks_property:
@@ -11,7 +25,7 @@ dokku_builder_nixpacks_property:
     value: config/nixpacks.toml
 ```
 
-## Setting the nixpacks.toml path globally
+### Setting the nixpacks.toml path globally
 
 ```yaml
 dokku_builder_nixpacks_property:
@@ -21,10 +35,25 @@ dokku_builder_nixpacks_property:
     value: nixpacks.toml
 ```
 
-## Clearing the nixpacks.toml path for an app
+### Clearing the nixpacks.toml path for an app
 
 ```yaml
 dokku_builder_nixpacks_property:
     app: node-js-app
     property: nixpackstoml-path
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_builder_pack_property.md
+++ b/docs/tasks/dokku_builder_pack_property.md
@@ -1,8 +1,22 @@
 # dokku_builder_pack_property
 
+## Synopsis
+
 Manages the builder-pack configuration for a given dokku application
 
-## Setting the project.toml path for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the builder-pack configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the builder-pack property to set |
+| `value` | string | no |  |  | Value to set for the builder-pack property |
+| `state` | string | no | present | present, absent | Desired state of the builder-pack configuration |
+
+## Examples
+
+### Setting the project.toml path for an app
 
 ```yaml
 dokku_builder_pack_property:
@@ -11,7 +25,7 @@ dokku_builder_pack_property:
     value: config/project.toml
 ```
 
-## Setting the project.toml path globally
+### Setting the project.toml path globally
 
 ```yaml
 dokku_builder_pack_property:
@@ -21,10 +35,25 @@ dokku_builder_pack_property:
     value: project.toml
 ```
 
-## Clearing the project.toml path for an app
+### Clearing the project.toml path for an app
 
 ```yaml
 dokku_builder_pack_property:
     app: node-js-app
     property: projecttoml-path
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_builder_property.md
+++ b/docs/tasks/dokku_builder_property.md
@@ -1,8 +1,22 @@
 # dokku_builder_property
 
+## Synopsis
+
 Manages the builder configuration for a given dokku application
 
-## Overriding the auto-selected builder
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the builder configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the builder property to set |
+| `value` | string | no |  |  | Value to set for the builder property |
+| `state` | string | no | present | present, absent | Desired state of the builder configuration |
+
+## Examples
+
+### Overriding the auto-selected builder
 
 ```yaml
 dokku_builder_property:
@@ -11,7 +25,7 @@ dokku_builder_property:
     value: dockerfile
 ```
 
-## Setting the builder to the default value
+### Setting the builder to the default value
 
 ```yaml
 dokku_builder_property:
@@ -19,7 +33,7 @@ dokku_builder_property:
     property: selected
 ```
 
-## Changing the build build directory
+### Changing the build build directory
 
 ```yaml
 dokku_builder_property:
@@ -28,7 +42,7 @@ dokku_builder_property:
     value: backend
 ```
 
-## Overriding the auto-selected builder globally
+### Overriding the auto-selected builder globally
 
 ```yaml
 dokku_builder_property:
@@ -37,3 +51,18 @@ dokku_builder_property:
     property: selected
     value: herokuish
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_builder_railpack_property.md
+++ b/docs/tasks/dokku_builder_railpack_property.md
@@ -1,8 +1,22 @@
 # dokku_builder_railpack_property
 
+## Synopsis
+
 Manages the builder-railpack configuration for a given dokku application
 
-## Setting the railpack.json path for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the builder-railpack configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the builder-railpack property to set |
+| `value` | string | no |  |  | Value to set for the builder-railpack property |
+| `state` | string | no | present | present, absent | Desired state of the builder-railpack configuration |
+
+## Examples
+
+### Setting the railpack.json path for an app
 
 ```yaml
 dokku_builder_railpack_property:
@@ -11,7 +25,7 @@ dokku_builder_railpack_property:
     value: config/railpack.json
 ```
 
-## Setting the railpack.json path globally
+### Setting the railpack.json path globally
 
 ```yaml
 dokku_builder_railpack_property:
@@ -21,10 +35,25 @@ dokku_builder_railpack_property:
     value: railpack.json
 ```
 
-## Clearing the railpack.json path for an app
+### Clearing the railpack.json path for an app
 
 ```yaml
 dokku_builder_railpack_property:
     app: node-js-app
     property: railpackjson-path
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_buildpacks.md
+++ b/docs/tasks/dokku_buildpacks.md
@@ -1,8 +1,20 @@
 # dokku_buildpacks
 
+## Synopsis
+
 Manages the buildpacks for a given dokku application
 
-## Add buildpacks to an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `buildpacks` | list | no |  |  | List of buildpack URLs |
+| `state` | string | no | present | present, absent | Desired state of the buildpacks |
+
+## Examples
+
+### Add buildpacks to an app
 
 ```yaml
 dokku_buildpacks:
@@ -13,7 +25,7 @@ dokku_buildpacks:
     state: ""
 ```
 
-## Remove a buildpack from an app
+### Remove a buildpack from an app
 
 ```yaml
 dokku_buildpacks:
@@ -23,7 +35,7 @@ dokku_buildpacks:
     state: absent
 ```
 
-## Clear all buildpacks from an app
+### Clear all buildpacks from an app
 
 ```yaml
 dokku_buildpacks:
@@ -31,3 +43,18 @@ dokku_buildpacks:
     buildpacks: []
     state: absent
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_buildpacks_property.md
+++ b/docs/tasks/dokku_buildpacks_property.md
@@ -1,8 +1,22 @@
 # dokku_buildpacks_property
 
+## Synopsis
+
 Manages the buildpacks configuration for a given dokku application
 
-## Setting the stack value for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the buildpacks configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the buildpacks property to set |
+| `value` | string | no |  |  | Value to set for the buildpacks property |
+| `state` | string | no | present | present, absent | Desired state of the buildpacks configuration |
+
+## Examples
+
+### Setting the stack value for an app
 
 ```yaml
 dokku_buildpacks_property:
@@ -11,7 +25,7 @@ dokku_buildpacks_property:
     value: gliderlabs/herokuish:latest
 ```
 
-## Setting the stack value globally
+### Setting the stack value globally
 
 ```yaml
 dokku_buildpacks_property:
@@ -21,10 +35,25 @@ dokku_buildpacks_property:
     value: gliderlabs/herokuish:latest
 ```
 
-## Clearing the stack value for an app
+### Clearing the stack value for an app
 
 ```yaml
 dokku_buildpacks_property:
     app: node-js-app
     property: stack
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_builds_property.md
+++ b/docs/tasks/dokku_builds_property.md
@@ -1,8 +1,22 @@
 # dokku_builds_property
 
+## Synopsis
+
 Manages the builds configuration for a given dokku application
 
-## Setting the retention value for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the builds configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the builds property to set |
+| `value` | string | no |  |  | Value to set for the builds property |
+| `state` | string | no | present | present, absent | Desired state of the builds configuration |
+
+## Examples
+
+### Setting the retention value for an app
 
 ```yaml
 dokku_builds_property:
@@ -11,7 +25,7 @@ dokku_builds_property:
     value: "50"
 ```
 
-## Setting the retention value globally
+### Setting the retention value globally
 
 ```yaml
 dokku_builds_property:
@@ -21,10 +35,25 @@ dokku_builds_property:
     value: "50"
 ```
 
-## Clearing the retention value for an app
+### Clearing the retention value for an app
 
 ```yaml
 dokku_builds_property:
     app: node-js-app
     property: retention
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_caddy_property.md
+++ b/docs/tasks/dokku_caddy_property.md
@@ -1,8 +1,22 @@
 # dokku_caddy_property
 
+## Synopsis
+
 Manages the caddy configuration for a given dokku application
 
-## Enabling internal TLS for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the caddy configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the caddy property to set |
+| `value` | string | no |  |  | Value to set for the caddy property |
+| `state` | string | no | present | present, absent | Desired state of the caddy configuration |
+
+## Examples
+
+### Enabling internal TLS for an app
 
 ```yaml
 dokku_caddy_property:
@@ -11,7 +25,7 @@ dokku_caddy_property:
     value: "true"
 ```
 
-## Setting the letsencrypt email globally
+### Setting the letsencrypt email globally
 
 ```yaml
 dokku_caddy_property:
@@ -21,10 +35,25 @@ dokku_caddy_property:
     value: admin@example.com
 ```
 
-## Clearing internal TLS for an app
+### Clearing internal TLS for an app
 
 ```yaml
 dokku_caddy_property:
     app: node-js-app
     property: tls-internal
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_certs.md
+++ b/docs/tasks/dokku_certs.md
@@ -1,8 +1,26 @@
 # dokku_certs
 
+## Synopsis
+
 Manages SSL certificates for a dokku app or globally. The `cert` and `key` fields are paths on the dokku server, so when running with `DOKKU_HOST` set the referenced files must already exist on the remote host - docket does not upload them.
 
-## Add an SSL certificate to an app
+## Requirements
+
+- dokku-global-cert plugin (required only when global: true)
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the certificate should be applied globally via the dokku-global-cert plugin |
+| `cert` | string | no |  |  | Path on the dokku server to the SSL certificate file (sensitive) |
+| `key` | string | no |  |  | Path on the dokku server to the SSL certificate key file (sensitive) |
+| `state` | string | no | present | present, absent | Desired state of the SSL configuration |
+
+## Examples
+
+### Add an SSL certificate to an app
 
 ```yaml
 dokku_certs:
@@ -11,7 +29,7 @@ dokku_certs:
     key: /etc/nginx/ssl/node-js-app.key
 ```
 
-## Remove an SSL certificate from an app
+### Remove an SSL certificate from an app
 
 ```yaml
 dokku_certs:
@@ -19,7 +37,7 @@ dokku_certs:
     state: absent
 ```
 
-## Add a global SSL certificate (requires the dokku-global-cert plugin)
+### Add a global SSL certificate (requires the dokku-global-cert plugin)
 
 ```yaml
 dokku_certs:
@@ -29,7 +47,7 @@ dokku_certs:
     key: /etc/nginx/ssl/global.key
 ```
 
-## Remove the global SSL certificate
+### Remove the global SSL certificate
 
 ```yaml
 dokku_certs:
@@ -37,3 +55,18 @@ dokku_certs:
     global: true
     state: absent
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_checks_property.md
+++ b/docs/tasks/dokku_checks_property.md
@@ -1,8 +1,22 @@
 # dokku_checks_property
 
+## Synopsis
+
 Manages the checks configuration for a given dokku application
 
-## Setting the wait-to-retire value for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the checks configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the checks property to set |
+| `value` | string | no |  |  | Value to set for the checks property |
+| `state` | string | no | present | present, absent | Desired state of the checks configuration |
+
+## Examples
+
+### Setting the wait-to-retire value for an app
 
 ```yaml
 dokku_checks_property:
@@ -11,7 +25,7 @@ dokku_checks_property:
     value: "60"
 ```
 
-## Setting the wait-to-retire value globally
+### Setting the wait-to-retire value globally
 
 ```yaml
 dokku_checks_property:
@@ -21,10 +35,25 @@ dokku_checks_property:
     value: "60"
 ```
 
-## Clearing the wait-to-retire value for an app
+### Clearing the wait-to-retire value for an app
 
 ```yaml
 dokku_checks_property:
     app: node-js-app
     property: wait-to-retire
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_checks_toggle.md
+++ b/docs/tasks/dokku_checks_toggle.md
@@ -1,8 +1,20 @@
 # dokku_checks_toggle
 
+## Synopsis
+
 Enables or disables the checks plugin for a given dokku application
 
-## Disable the zero downtime deployment
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `global` | bool | no |  |  | Flag indicating if the checks plugin should be applied globally |
+| `state` | string | no | present | present, absent | Desired state of the checks plugin |
+
+## Examples
+
+### Disable the zero downtime deployment
 
 ```yaml
 dokku_checks_toggle:
@@ -10,10 +22,25 @@ dokku_checks_toggle:
     state: absent
 ```
 
-## Re-enable the zero downtime deployment (enabled by default)
+### Re-enable the zero downtime deployment (enabled by default)
 
 ```yaml
 dokku_checks_toggle:
     app: hello-world
     state: present
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_config.md
+++ b/docs/tasks/dokku_config.md
@@ -1,8 +1,21 @@
 # dokku_config
 
+## Synopsis
+
 Manages the configuration for a given dokku application
 
-## set KEY=VALUE
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `restart` | bool | no | true |  | Flag indicating if the app should be restarted |
+| `config` | dict | no |  |  | Map of configuration key-value pairs |
+| `state` | string | no | present | present, absent | Desired state of the configuration |
+
+## Examples
+
+### set KEY=VALUE
 
 ```yaml
 dokku_config:
@@ -12,7 +25,7 @@ dokku_config:
         KEY: VALUE_1
 ```
 
-## set KEY=VALUE without restart
+### set KEY=VALUE without restart
 
 ```yaml
 dokku_config:
@@ -21,3 +34,18 @@ dokku_config:
     config:
         KEY: VALUE_1
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_cron_property.md
+++ b/docs/tasks/dokku_cron_property.md
@@ -1,8 +1,22 @@
 # dokku_cron_property
 
+## Synopsis
+
 Manages the cron configuration for a given dokku application
 
-## Enabling maintenance mode for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the cron configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the cron property to set |
+| `value` | string | no |  |  | Value to set for the cron property |
+| `state` | string | no | present | present, absent | Desired state of the cron configuration |
+
+## Examples
+
+### Enabling maintenance mode for an app
 
 ```yaml
 dokku_cron_property:
@@ -11,7 +25,7 @@ dokku_cron_property:
     value: "true"
 ```
 
-## Setting the mailto address globally
+### Setting the mailto address globally
 
 ```yaml
 dokku_cron_property:
@@ -21,10 +35,25 @@ dokku_cron_property:
     value: ops@example.com
 ```
 
-## Clearing the maintenance mode for an app
+### Clearing the maintenance mode for an app
 
 ```yaml
 dokku_cron_property:
     app: node-js-app
     property: maintenance
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_docker_options.md
+++ b/docs/tasks/dokku_docker_options.md
@@ -1,8 +1,21 @@
 # dokku_docker_options
 
+## Synopsis
+
 Manages docker-options for a given dokku application
 
-## Mount the docker socket at deploy
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `phase` | string | yes |  | build, deploy, run | Deployment phase the option applies to |
+| `option` | string | yes |  |  | Docker option string (e.g. '-v /var/run/docker.sock:/var/run/docker.sock') |
+| `state` | string | no | present | present, absent | Desired state of the docker option |
+
+## Examples
+
+### Mount the docker socket at deploy
 
 ```yaml
 dokku_docker_options:
@@ -11,7 +24,7 @@ dokku_docker_options:
     option: -v /var/run/docker.sock:/var/run/docker.sock
 ```
 
-## Remove a docker option from the deploy phase
+### Remove a docker option from the deploy phase
 
 ```yaml
 dokku_docker_options:
@@ -20,3 +33,18 @@ dokku_docker_options:
     option: -v /var/run/docker.sock:/var/run/docker.sock
     state: absent
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_domains.md
+++ b/docs/tasks/dokku_domains.md
@@ -1,8 +1,21 @@
 # dokku_domains
 
+## Synopsis
+
 Manages the domains for a given dokku application or globally
 
-## Add domains to an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app |
+| `global` | bool | no |  |  | Flag indicating if the domains should be applied globally |
+| `domains` | list | no |  |  | List of domain names |
+| `state` | string | no | present | present, absent, set, clear | Desired state of the domains |
+
+## Examples
+
+### Add domains to an app
 
 ```yaml
 dokku_domains:
@@ -13,7 +26,7 @@ dokku_domains:
     state: ""
 ```
 
-## Remove domains from an app
+### Remove domains from an app
 
 ```yaml
 dokku_domains:
@@ -23,7 +36,7 @@ dokku_domains:
     state: absent
 ```
 
-## Set global domains
+### Set global domains
 
 ```yaml
 dokku_domains:
@@ -34,7 +47,7 @@ dokku_domains:
     state: set
 ```
 
-## Clear all domains from an app
+### Clear all domains from an app
 
 ```yaml
 dokku_domains:
@@ -42,3 +55,18 @@ dokku_domains:
     domains: []
     state: clear
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_domains_toggle.md
+++ b/docs/tasks/dokku_domains_toggle.md
@@ -1,3 +1,45 @@
 # dokku_domains_toggle
 
+## Synopsis
+
 Enables or disables the domains plugin for a given dokku application
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `global` | bool | no |  |  | Flag indicating if the domains plugin should be applied globally |
+| `state` | string | no | present | present, absent | Desired state of the domains plugin |
+
+## Examples
+
+### Enable the domains plugin for an app
+
+```yaml
+dokku_domains_toggle:
+    app: node-js-app
+```
+
+### Disable the domains plugin for an app
+
+```yaml
+dokku_domains_toggle:
+    app: node-js-app
+    state: absent
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_git_auth.md
+++ b/docs/tasks/dokku_git_auth.md
@@ -1,8 +1,21 @@
 # dokku_git_auth
 
+## Synopsis
+
 Manages netrc credentials for a git host
 
-## Configure netrc credentials for a git host
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `host` | string | yes |  |  | Git server hostname (e.g. github.com) |
+| `username` | string | no |  |  | Netrc username. Required when state is present. |
+| `password` | string | no |  |  | Netrc password. Required when state is present. (sensitive) |
+| `state` | string | no | present | present, absent | Desired state of the netrc entry |
+
+## Examples
+
+### Configure netrc credentials for a git host
 
 ```yaml
 dokku_git_auth:
@@ -11,10 +24,25 @@ dokku_git_auth:
     password: ghp_examplepat
 ```
 
-## Remove netrc credentials for a git host
+### Remove netrc credentials for a git host
 
 ```yaml
 dokku_git_auth:
     host: github.com
     state: absent
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_git_from_archive.md
+++ b/docs/tasks/dokku_git_from_archive.md
@@ -1,8 +1,23 @@
 # dokku_git_from_archive
 
+## Synopsis
+
 Deploys a git repository from an archive URL
 
-## Deploy a tar archive
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `archive_url` | string | yes |  |  | URL of the archive to deploy (sensitive) |
+| `archive_type` | string | no | tar | tar, tar.gz, zip | Format of the archive |
+| `git_username` | string | no |  |  | Git author username for the synthetic commit |
+| `git_email` | string | no |  |  | Git author email for the synthetic commit |
+| `state` | string | no | deployed | deployed | Desired state of the deployment |
+
+## Examples
+
+### Deploy a tar archive
 
 ```yaml
 dokku_git_from_archive:
@@ -10,7 +25,7 @@ dokku_git_from_archive:
     archive_url: https://example.com/release-1.0.0.tar
 ```
 
-## Deploy a zip archive with author metadata
+### Deploy a zip archive with author metadata
 
 ```yaml
 dokku_git_from_archive:
@@ -20,3 +35,18 @@ dokku_git_from_archive:
     git_username: deploy-bot
     git_email: deploy@example.com
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_git_from_image.md
+++ b/docs/tasks/dokku_git_from_image.md
@@ -1,3 +1,52 @@
 # dokku_git_from_image
 
+## Synopsis
+
 Deploys a git repository from a docker image
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `image` | string | yes |  |  | Docker image to deploy (sensitive) |
+| `build_dir` | string | no |  |  | Directory to build the git repository |
+| `git_username` | string | no |  |  | Username to use for the git repository |
+| `git_email` | string | no |  |  | Email to use for the git repository |
+| `state` | string | no | deployed | deployed | Desired state of the git repository |
+
+## Examples
+
+### Deploy an app from a docker image
+
+```yaml
+dokku_git_from_image:
+    app: node-js-app
+    image: dokku/node-js-app:latest
+```
+
+### Deploy from an image with a build directory and git author
+
+```yaml
+dokku_git_from_image:
+    app: node-js-app
+    image: dokku/node-js-app:latest
+    build_dir: /app
+    git_username: dokku
+    git_email: dokku@example.com
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_git_property.md
+++ b/docs/tasks/dokku_git_property.md
@@ -1,8 +1,22 @@
 # dokku_git_property
 
+## Synopsis
+
 Manages the git configuration for a given dokku application
 
-## Setting the deploy branch for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the git configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the git property to set |
+| `value` | string | no |  |  | Value to set for the git property |
+| `state` | string | no | present | present, absent | Desired state of the git configuration |
+
+## Examples
+
+### Setting the deploy branch for an app
 
 ```yaml
 dokku_git_property:
@@ -11,7 +25,7 @@ dokku_git_property:
     value: main
 ```
 
-## Keeping the .git directory during builds
+### Keeping the .git directory during builds
 
 ```yaml
 dokku_git_property:
@@ -20,7 +34,7 @@ dokku_git_property:
     value: "true"
 ```
 
-## Setting the rev env var globally
+### Setting the rev env var globally
 
 ```yaml
 dokku_git_property:
@@ -30,10 +44,25 @@ dokku_git_property:
     value: GIT_REV
 ```
 
-## Clearing a git property
+### Clearing a git property
 
 ```yaml
 dokku_git_property:
     app: node-js-app
     property: deploy-branch
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_git_sync.md
+++ b/docs/tasks/dokku_git_sync.md
@@ -1,8 +1,24 @@
 # dokku_git_sync
 
+## Synopsis
+
 Syncs a git repository to a dokku application
 
-## Sync a git repository to an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `remote` | string | yes |  |  | Git remote url to sync |
+| `git_ref` | string | no |  |  | Git reference to sync |
+| `build` | bool | no |  |  | Trigger an application build after syncing |
+| `build_if_changes` | bool | no |  |  | Trigger a build only if changes are detected |
+| `skip_deploy_branch` | bool | no |  |  | Skip automatically setting the deploy-branch property |
+| `state` | string | no | present | present | Desired state of the git sync |
+
+## Examples
+
+### Sync a git repository to an app
 
 ```yaml
 dokku_git_sync:
@@ -15,7 +31,7 @@ dokku_git_sync:
     state: ""
 ```
 
-## Sync a git repository with a specific ref and build
+### Sync a git repository with a specific ref and build
 
 ```yaml
 dokku_git_sync:
@@ -27,3 +43,18 @@ dokku_git_sync:
     skip_deploy_branch: false
     state: ""
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_haproxy_property.md
+++ b/docs/tasks/dokku_haproxy_property.md
@@ -1,8 +1,22 @@
 # dokku_haproxy_property
 
+## Synopsis
+
 Manages the haproxy configuration for a given dokku application
 
-## Setting the letsencrypt email for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the haproxy configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the haproxy property to set |
+| `value` | string | no |  |  | Value to set for the haproxy property |
+| `state` | string | no | present | present, absent | Desired state of the haproxy configuration |
+
+## Examples
+
+### Setting the letsencrypt email for an app
 
 ```yaml
 dokku_haproxy_property:
@@ -11,7 +25,7 @@ dokku_haproxy_property:
     value: admin@example.com
 ```
 
-## Setting the log level globally
+### Setting the log level globally
 
 ```yaml
 dokku_haproxy_property:
@@ -21,10 +35,25 @@ dokku_haproxy_property:
     value: INFO
 ```
 
-## Clearing the letsencrypt email for an app
+### Clearing the letsencrypt email for an app
 
 ```yaml
 dokku_haproxy_property:
     app: node-js-app
     property: letsencrypt-email
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_http_auth.md
+++ b/docs/tasks/dokku_http_auth.md
@@ -1,8 +1,25 @@
 # dokku_http_auth
 
+## Synopsis
+
 Manages HTTP authentication for a given dokku application
 
-## Enable HTTP authentication for an app
+## Requirements
+
+- dokku-http-auth plugin
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `username` | string | no |  |  | HTTP auth username |
+| `password` | string | no |  |  | HTTP auth password (sensitive) |
+| `state` | string | no | present | present, absent | State of the HTTP auth |
+
+## Examples
+
+### Enable HTTP authentication for an app
 
 ```yaml
 dokku_http_auth:
@@ -11,10 +28,25 @@ dokku_http_auth:
     password: secret
 ```
 
-## Disable HTTP authentication for an app
+### Disable HTTP authentication for an app
 
 ```yaml
 dokku_http_auth:
     app: hello-world
     state: absent
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_letsencrypt.md
+++ b/docs/tasks/dokku_letsencrypt.md
@@ -1,18 +1,48 @@
 # dokku_letsencrypt
 
+## Synopsis
+
 Enables or disables letsencrypt SSL certificates for a dokku application
 
-## Enable letsencrypt for an app
+## Requirements
+
+- dokku-letsencrypt plugin
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `state` | string | no | present | present, absent | Desired state of the letsencrypt integration |
+
+## Examples
+
+### Enable letsencrypt for an app
 
 ```yaml
 dokku_letsencrypt:
     app: node-js-app
 ```
 
-## Disable letsencrypt for an app
+### Disable letsencrypt for an app
 
 ```yaml
 dokku_letsencrypt:
     app: node-js-app
     state: absent
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_letsencrypt_property.md
+++ b/docs/tasks/dokku_letsencrypt_property.md
@@ -1,8 +1,26 @@
 # dokku_letsencrypt_property
 
+## Synopsis
+
 Manages the letsencrypt configuration for a given dokku application
 
-## Setting the letsencrypt email for an app
+## Requirements
+
+- dokku-letsencrypt plugin
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the letsencrypt configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the letsencrypt property to set |
+| `value` | string | no |  |  | Value to set for the letsencrypt property (sensitive) |
+| `state` | string | no | present | present, absent | Desired state of the letsencrypt configuration |
+
+## Examples
+
+### Setting the letsencrypt email for an app
 
 ```yaml
 dokku_letsencrypt_property:
@@ -11,7 +29,7 @@ dokku_letsencrypt_property:
     value: admin@example.com
 ```
 
-## Setting the dns provider for an app
+### Setting the dns provider for an app
 
 ```yaml
 dokku_letsencrypt_property:
@@ -20,7 +38,7 @@ dokku_letsencrypt_property:
     value: namecheap
 ```
 
-## Setting a dns-provider-* env var globally
+### Setting a dns-provider-* env var globally
 
 ```yaml
 dokku_letsencrypt_property:
@@ -30,10 +48,25 @@ dokku_letsencrypt_property:
     value: deploy-bot
 ```
 
-## Clearing the letsencrypt email for an app
+### Clearing the letsencrypt email for an app
 
 ```yaml
 dokku_letsencrypt_property:
     app: node-js-app
     property: email
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_logs_property.md
+++ b/docs/tasks/dokku_logs_property.md
@@ -1,8 +1,22 @@
 # dokku_logs_property
 
+## Synopsis
+
 Manages the logs configuration for a given dokku application
 
-## Setting the max-size value for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the logs configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the logs property to set |
+| `value` | string | no |  |  | Value to set for the logs property |
+| `state` | string | no | present | present, absent | Desired state of the logs configuration |
+
+## Examples
+
+### Setting the max-size value for an app
 
 ```yaml
 dokku_logs_property:
@@ -11,7 +25,7 @@ dokku_logs_property:
     value: 100m
 ```
 
-## Setting the max-size value globally
+### Setting the max-size value globally
 
 ```yaml
 dokku_logs_property:
@@ -21,10 +35,25 @@ dokku_logs_property:
     value: 100m
 ```
 
-## Clearing the max-size value for an app
+### Clearing the max-size value for an app
 
 ```yaml
 dokku_logs_property:
     app: node-js-app
     property: max-size
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_network.md
+++ b/docs/tasks/dokku_network.md
@@ -1,18 +1,44 @@
 # dokku_network
 
+## Synopsis
+
 Creates or destroys a Docker network
 
-## Create a network named example-network
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `name` | string | yes |  |  | Name of the network |
+| `state` | string | no | present | present, absent | State of the network |
+
+## Examples
+
+### Create a network named example-network
 
 ```yaml
 dokku_network:
     name: example-network
 ```
 
-## Destroy a network named example-network
+### Destroy a network named example-network
 
 ```yaml
 dokku_network:
     name: example-network
     state: absent
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_network_property.md
+++ b/docs/tasks/dokku_network_property.md
@@ -1,8 +1,22 @@
 # dokku_network_property
 
+## Synopsis
+
 Manages the network property for a given dokku application
 
-## Associates a network after a container is created but before it is started
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the network property should be applied globally |
+| `property` | string | yes |  |  | Name of the network property to set |
+| `value` | string | no |  |  | Value of the network property to set |
+| `state` | string | no | present | present, absent | Desired state of the network property |
+
+## Examples
+
+### Associates a network after a container is created but before it is started
 
 ```yaml
 dokku_network_property:
@@ -11,7 +25,7 @@ dokku_network_property:
     value: example-network
 ```
 
-## Associates the network at container creation
+### Associates the network at container creation
 
 ```yaml
 dokku_network_property:
@@ -20,7 +34,7 @@ dokku_network_property:
     value: example-network
 ```
 
-## Setting a global network property
+### Setting a global network property
 
 ```yaml
 dokku_network_property:
@@ -30,10 +44,25 @@ dokku_network_property:
     value: example-network
 ```
 
-## Clearing a network property
+### Clearing a network property
 
 ```yaml
 dokku_network_property:
     app: hello-world
     property: attach-post-create
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_nginx_property.md
+++ b/docs/tasks/dokku_nginx_property.md
@@ -1,8 +1,22 @@
 # dokku_nginx_property
 
+## Synopsis
+
 Manages the nginx configuration for a given dokku application
 
-## Setting the proxy read timeout for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the nginx configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the nginx property to set |
+| `value` | string | no |  |  | Value to set for the nginx property |
+| `state` | string | no | present | present, absent | Desired state of the nginx configuration |
+
+## Examples
+
+### Setting the proxy read timeout for an app
 
 ```yaml
 dokku_nginx_property:
@@ -11,7 +25,7 @@ dokku_nginx_property:
     value: 120s
 ```
 
-## Setting the client max body size for an app
+### Setting the client max body size for an app
 
 ```yaml
 dokku_nginx_property:
@@ -20,7 +34,7 @@ dokku_nginx_property:
     value: 50m
 ```
 
-## Setting a global nginx property
+### Setting a global nginx property
 
 ```yaml
 dokku_nginx_property:
@@ -30,10 +44,25 @@ dokku_nginx_property:
     value: 0.0.0.0
 ```
 
-## Clearing an nginx property
+### Clearing an nginx property
 
 ```yaml
 dokku_nginx_property:
     app: node-js-app
     property: proxy-read-timeout
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_openresty_property.md
+++ b/docs/tasks/dokku_openresty_property.md
@@ -1,8 +1,22 @@
 # dokku_openresty_property
 
+## Synopsis
+
 Manages the openresty configuration for a given dokku application
 
-## Setting the proxy read timeout for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the openresty configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the openresty property to set |
+| `value` | string | no |  |  | Value to set for the openresty property |
+| `state` | string | no | present | present, absent | Desired state of the openresty configuration |
+
+## Examples
+
+### Setting the proxy read timeout for an app
 
 ```yaml
 dokku_openresty_property:
@@ -11,7 +25,7 @@ dokku_openresty_property:
     value: 120s
 ```
 
-## Setting the client max body size for an app
+### Setting the client max body size for an app
 
 ```yaml
 dokku_openresty_property:
@@ -20,7 +34,7 @@ dokku_openresty_property:
     value: 50m
 ```
 
-## Setting a global openresty property
+### Setting a global openresty property
 
 ```yaml
 dokku_openresty_property:
@@ -30,10 +44,25 @@ dokku_openresty_property:
     value: 0.0.0.0
 ```
 
-## Clearing an openresty property
+### Clearing an openresty property
 
 ```yaml
 dokku_openresty_property:
     app: node-js-app
     property: proxy-read-timeout
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_ports.md
+++ b/docs/tasks/dokku_ports.md
@@ -1,3 +1,67 @@
 # dokku_ports
 
+## Synopsis
+
 Manages the ports for a given dokku application
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `port_mappings` | list | yes |  |  | Port mappings to set. Each item has: scheme, host, container. |
+| `state` | string | no | present | present, absent | Desired state of the ports |
+
+## Examples
+
+### Map http port 80 to container port 5000
+
+```yaml
+dokku_ports:
+    app: node-js-app
+    port_mappings:
+        - scheme: http
+          host: 80
+          container: 5000
+```
+
+### Map both http and https ports
+
+```yaml
+dokku_ports:
+    app: node-js-app
+    port_mappings:
+        - scheme: http
+          host: 80
+          container: 5000
+        - scheme: https
+          host: 443
+          container: 5000
+```
+
+### Remove a port mapping
+
+```yaml
+dokku_ports:
+    app: node-js-app
+    port_mappings:
+        - scheme: http
+          host: 80
+          container: 5000
+    state: absent
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_proxy_property.md
+++ b/docs/tasks/dokku_proxy_property.md
@@ -1,8 +1,22 @@
 # dokku_proxy_property
 
+## Synopsis
+
 Manages the proxy configuration for a given dokku application
 
-## Setting the proxy type for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the proxy configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the proxy property to set |
+| `value` | string | no |  |  | Value to set for the proxy property |
+| `state` | string | no | present | present, absent | Desired state of the proxy configuration |
+
+## Examples
+
+### Setting the proxy type for an app
 
 ```yaml
 dokku_proxy_property:
@@ -11,7 +25,7 @@ dokku_proxy_property:
     value: nginx
 ```
 
-## Setting the proxy type globally
+### Setting the proxy type globally
 
 ```yaml
 dokku_proxy_property:
@@ -21,7 +35,7 @@ dokku_proxy_property:
     value: haproxy
 ```
 
-## Setting the proxy port for an app
+### Setting the proxy port for an app
 
 ```yaml
 dokku_proxy_property:
@@ -30,10 +44,25 @@ dokku_proxy_property:
     value: "8080"
 ```
 
-## Clearing the proxy type for an app
+### Clearing the proxy type for an app
 
 ```yaml
 dokku_proxy_property:
     app: node-js-app
     property: type
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_proxy_toggle.md
+++ b/docs/tasks/dokku_proxy_toggle.md
@@ -1,3 +1,45 @@
 # dokku_proxy_toggle
 
+## Synopsis
+
 Enables or disables the proxy plugin for a given dokku application
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `global` | bool | no |  |  | Flag indicating if the proxy should be applied globally |
+| `state` | string | no | present | present, absent | Desired state of the proxy |
+
+## Examples
+
+### Enable the proxy for an app
+
+```yaml
+dokku_proxy_toggle:
+    app: node-js-app
+```
+
+### Disable the proxy for an app
+
+```yaml
+dokku_proxy_toggle:
+    app: node-js-app
+    state: absent
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_ps_property.md
+++ b/docs/tasks/dokku_ps_property.md
@@ -1,8 +1,22 @@
 # dokku_ps_property
 
+## Synopsis
+
 Manages the ps configuration for a given dokku application
 
-## Setting the restart-policy value for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the ps configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the ps property to set |
+| `value` | string | no |  |  | Value to set for the ps property |
+| `state` | string | no | present | present, absent | Desired state of the ps configuration |
+
+## Examples
+
+### Setting the restart-policy value for an app
 
 ```yaml
 dokku_ps_property:
@@ -11,7 +25,7 @@ dokku_ps_property:
     value: on-failure:5
 ```
 
-## Setting the restart-policy value globally
+### Setting the restart-policy value globally
 
 ```yaml
 dokku_ps_property:
@@ -21,10 +35,25 @@ dokku_ps_property:
     value: on-failure:5
 ```
 
-## Clearing the restart-policy value for an app
+### Clearing the restart-policy value for an app
 
 ```yaml
 dokku_ps_property:
     app: node-js-app
     property: restart-policy
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_ps_scale.md
+++ b/docs/tasks/dokku_ps_scale.md
@@ -1,8 +1,21 @@
 # dokku_ps_scale
 
+## Synopsis
+
 Manages the process scale for a given dokku application
 
-## Scale web and worker processes
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `scale` | dict | yes |  |  | Map of process types to quantities |
+| `skip_deploy` | bool | no | false |  | Skip the corresponding deploy |
+| `state` | string | no | present | present | Desired state of the process scale |
+
+## Examples
+
+### Scale web and worker processes
 
 ```yaml
 dokku_ps_scale:
@@ -13,7 +26,7 @@ dokku_ps_scale:
     skip_deploy: false
 ```
 
-## Scale web and worker processes without deploy
+### Scale web and worker processes without deploy
 
 ```yaml
 dokku_ps_scale:
@@ -23,3 +36,18 @@ dokku_ps_scale:
         worker: 4
     skip_deploy: true
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_registry_auth.md
+++ b/docs/tasks/dokku_registry_auth.md
@@ -1,8 +1,23 @@
 # dokku_registry_auth
 
+## Synopsis
+
 Manages docker registry authentication for a dokku application or globally
 
-## Log in to a registry for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the registry credential should be applied globally |
+| `server` | string | yes |  |  | Docker registry hostname (e.g. docker.io, ghcr.io) |
+| `username` | string | no |  |  | Registry username (required when state is present) |
+| `password` | string | no |  |  | Registry password (required when state is present) (sensitive) |
+| `state` | string | no | present | present, absent | Desired state of the registry credential |
+
+## Examples
+
+### Log in to a registry for an app
 
 ```yaml
 dokku_registry_auth:
@@ -12,7 +27,7 @@ dokku_registry_auth:
     password: ghp_examplepat
 ```
 
-## Log in to a registry globally
+### Log in to a registry globally
 
 ```yaml
 dokku_registry_auth:
@@ -23,7 +38,7 @@ dokku_registry_auth:
     password: examplepassword
 ```
 
-## Log out from a registry for an app
+### Log out from a registry for an app
 
 ```yaml
 dokku_registry_auth:
@@ -32,7 +47,7 @@ dokku_registry_auth:
     state: absent
 ```
 
-## Log out from a registry globally
+### Log out from a registry globally
 
 ```yaml
 dokku_registry_auth:
@@ -41,3 +56,18 @@ dokku_registry_auth:
     server: docker.io
     state: absent
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_registry_property.md
+++ b/docs/tasks/dokku_registry_property.md
@@ -1,8 +1,22 @@
 # dokku_registry_property
 
+## Synopsis
+
 Manages the registry configuration for a given dokku application
 
-## Setting the image repo for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the registry configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the registry property to set |
+| `value` | string | no |  |  | Value to set for the registry property |
+| `state` | string | no | present | present, absent | Desired state of the registry configuration |
+
+## Examples
+
+### Setting the image repo for an app
 
 ```yaml
 dokku_registry_property:
@@ -11,7 +25,7 @@ dokku_registry_property:
     value: registry.example.com/node-js-app
 ```
 
-## Enabling push-on-release for an app
+### Enabling push-on-release for an app
 
 ```yaml
 dokku_registry_property:
@@ -20,7 +34,7 @@ dokku_registry_property:
     value: "true"
 ```
 
-## Setting the registry server globally
+### Setting the registry server globally
 
 ```yaml
 dokku_registry_property:
@@ -30,10 +44,25 @@ dokku_registry_property:
     value: registry.example.com
 ```
 
-## Clearing the image repo for an app
+### Clearing the image repo for an app
 
 ```yaml
 dokku_registry_property:
     app: node-js-app
     property: image-repo
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_resource_limit.md
+++ b/docs/tasks/dokku_resource_limit.md
@@ -1,8 +1,22 @@
 # dokku_resource_limit
 
+## Synopsis
+
 Manages the resource limits for a given dokku application
 
-## Set CPU and memory limits
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `process_type` | string | no |  |  | Process type to set resource limits for |
+| `resources` | dict | no |  |  | Map of resource type to quantity |
+| `clear_before` | bool | no | false |  | ClearBefore clears all resource limits before applying new ones |
+| `state` | string | no | present | present, absent | Desired state of the resource limits |
+
+## Examples
+
+### Set CPU and memory limits
 
 ```yaml
 dokku_resource_limit:
@@ -13,7 +27,7 @@ dokku_resource_limit:
     clear_before: false
 ```
 
-## Set memory limit for web process type
+### Set memory limit for web process type
 
 ```yaml
 dokku_resource_limit:
@@ -24,7 +38,7 @@ dokku_resource_limit:
     clear_before: false
 ```
 
-## Clear all resource limits
+### Clear all resource limits
 
 ```yaml
 dokku_resource_limit:
@@ -33,3 +47,18 @@ dokku_resource_limit:
     clear_before: false
     state: absent
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_resource_reserve.md
+++ b/docs/tasks/dokku_resource_reserve.md
@@ -1,8 +1,22 @@
 # dokku_resource_reserve
 
+## Synopsis
+
 Manages the resource reservations for a given dokku application
 
-## Set CPU and memory reservations
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `process_type` | string | no |  |  | Process type to set resource reservations for |
+| `resources` | dict | no |  |  | Map of resource type to quantity |
+| `clear_before` | bool | no | false |  | ClearBefore clears all resource reservations before applying new ones |
+| `state` | string | no | present | present, absent | Desired state of the resource reservations |
+
+## Examples
+
+### Set CPU and memory reservations
 
 ```yaml
 dokku_resource_reserve:
@@ -13,7 +27,7 @@ dokku_resource_reserve:
     clear_before: false
 ```
 
-## Set memory reservation for web process type
+### Set memory reservation for web process type
 
 ```yaml
 dokku_resource_reserve:
@@ -24,7 +38,7 @@ dokku_resource_reserve:
     clear_before: false
 ```
 
-## Clear all resource reservations
+### Clear all resource reservations
 
 ```yaml
 dokku_resource_reserve:
@@ -33,3 +47,18 @@ dokku_resource_reserve:
     clear_before: false
     state: absent
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_scheduler_docker_local_property.md
+++ b/docs/tasks/dokku_scheduler_docker_local_property.md
@@ -1,8 +1,21 @@
 # dokku_scheduler_docker_local_property
 
+## Synopsis
+
 Manages the scheduler-docker-local configuration for a given dokku application
 
-## Enabling the init process for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `property` | string | yes |  |  | Name of the scheduler-docker-local property to set |
+| `value` | string | no |  |  | Value to set for the scheduler-docker-local property |
+| `state` | string | no | present | present, absent | Desired state of the scheduler-docker-local configuration |
+
+## Examples
+
+### Enabling the init process for an app
 
 ```yaml
 dokku_scheduler_docker_local_property:
@@ -11,7 +24,7 @@ dokku_scheduler_docker_local_property:
     value: "true"
 ```
 
-## Setting the parallel schedule count for an app
+### Setting the parallel schedule count for an app
 
 ```yaml
 dokku_scheduler_docker_local_property:
@@ -20,10 +33,25 @@ dokku_scheduler_docker_local_property:
     value: "4"
 ```
 
-## Clearing the init process for an app
+### Clearing the init process for an app
 
 ```yaml
 dokku_scheduler_docker_local_property:
     app: node-js-app
     property: init-process
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_scheduler_k3s_property.md
+++ b/docs/tasks/dokku_scheduler_k3s_property.md
@@ -1,8 +1,22 @@
 # dokku_scheduler_k3s_property
 
+## Synopsis
+
 Manages the scheduler-k3s configuration for a given dokku application
 
-## Setting the deploy timeout for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the scheduler-k3s configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the scheduler-k3s property to set |
+| `value` | string | no |  |  | Value to set for the scheduler-k3s property |
+| `state` | string | no | present | present, absent | Desired state of the scheduler-k3s configuration |
+
+## Examples
+
+### Setting the deploy timeout for an app
 
 ```yaml
 dokku_scheduler_k3s_property:
@@ -11,7 +25,7 @@ dokku_scheduler_k3s_property:
     value: 300s
 ```
 
-## Setting the namespace for an app
+### Setting the namespace for an app
 
 ```yaml
 dokku_scheduler_k3s_property:
@@ -20,7 +34,7 @@ dokku_scheduler_k3s_property:
     value: production
 ```
 
-## Setting the letsencrypt prod email globally
+### Setting the letsencrypt prod email globally
 
 ```yaml
 dokku_scheduler_k3s_property:
@@ -30,10 +44,25 @@ dokku_scheduler_k3s_property:
     value: admin@example.com
 ```
 
-## Clearing the namespace for an app
+### Clearing the namespace for an app
 
 ```yaml
 dokku_scheduler_k3s_property:
     app: node-js-app
     property: namespace
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_scheduler_property.md
+++ b/docs/tasks/dokku_scheduler_property.md
@@ -1,8 +1,22 @@
 # dokku_scheduler_property
 
+## Synopsis
+
 Manages the scheduler configuration for a given dokku application
 
-## Selecting the scheduler for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the scheduler configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the scheduler property to set |
+| `value` | string | no |  |  | Value to set for the scheduler property |
+| `state` | string | no | present | present, absent | Desired state of the scheduler configuration |
+
+## Examples
+
+### Selecting the scheduler for an app
 
 ```yaml
 dokku_scheduler_property:
@@ -11,7 +25,7 @@ dokku_scheduler_property:
     value: docker-local
 ```
 
-## Selecting the scheduler globally
+### Selecting the scheduler globally
 
 ```yaml
 dokku_scheduler_property:
@@ -21,10 +35,25 @@ dokku_scheduler_property:
     value: docker-local
 ```
 
-## Clearing the scheduler property for an app
+### Clearing the scheduler property for an app
 
 ```yaml
 dokku_scheduler_property:
     app: node-js-app
     property: selected
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_service_create.md
+++ b/docs/tasks/dokku_service_create.md
@@ -1,8 +1,24 @@
 # dokku_service_create
 
+## Synopsis
+
 Creates or destroys a dokku service
 
-## Create a redis service named my-redis
+## Requirements
+
+- a dokku datastore service plugin matching the service type (e.g. dokku-postgres, dokku-redis, dokku-mysql)
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `service` | string | yes |  |  | Type of service to create (e.g. redis, postgres, mysql) |
+| `name` | string | yes |  |  | Name of the service instance |
+| `state` | string | no | present | present, absent | Desired state of the service |
+
+## Examples
+
+### Create a redis service named my-redis
 
 ```yaml
 dokku_service_create:
@@ -10,7 +26,7 @@ dokku_service_create:
     name: my-redis
 ```
 
-## Create a postgres service named my-db
+### Create a postgres service named my-db
 
 ```yaml
 dokku_service_create:
@@ -18,7 +34,7 @@ dokku_service_create:
     name: my-db
 ```
 
-## Destroy a redis service named my-redis
+### Destroy a redis service named my-redis
 
 ```yaml
 dokku_service_create:
@@ -26,3 +42,18 @@ dokku_service_create:
     name: my-redis
     state: absent
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_service_link.md
+++ b/docs/tasks/dokku_service_link.md
@@ -1,8 +1,25 @@
 # dokku_service_link
 
+## Synopsis
+
 Links or unlinks a dokku service to an app
 
-## Link a redis service named my-redis to my-app
+## Requirements
+
+- a dokku datastore service plugin matching the service type (e.g. dokku-postgres, dokku-redis, dokku-mysql)
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app to link the service to |
+| `service` | string | yes |  |  | Type of service to link (e.g. redis, postgres, mysql) |
+| `name` | string | yes |  |  | Name of the service instance |
+| `state` | string | no | present | present, absent | Desired state of the service link |
+
+## Examples
+
+### Link a redis service named my-redis to my-app
 
 ```yaml
 dokku_service_link:
@@ -11,7 +28,7 @@ dokku_service_link:
     name: my-redis
 ```
 
-## Link a postgres service named my-db to my-app
+### Link a postgres service named my-db to my-app
 
 ```yaml
 dokku_service_link:
@@ -20,7 +37,7 @@ dokku_service_link:
     name: my-db
 ```
 
-## Unlink a redis service named my-redis from my-app
+### Unlink a redis service named my-redis from my-app
 
 ```yaml
 dokku_service_link:
@@ -29,3 +46,18 @@ dokku_service_link:
     name: my-redis
     state: absent
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_storage_ensure.md
+++ b/docs/tasks/dokku_storage_ensure.md
@@ -1,3 +1,46 @@
 # dokku_storage_ensure
 
+## Synopsis
+
 Ensures the storage for a given dokku application
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `chown` | string | no |  |  | Chown value to set |
+| `state` | string | no | present | present, absent | Desired state of the storage |
+
+## Examples
+
+### Ensure a storage directory owned by the herokuish user
+
+```yaml
+dokku_storage_ensure:
+    app: node-js-app
+    chown: herokuish
+```
+
+### Ensure a storage directory owned by root
+
+```yaml
+dokku_storage_ensure:
+    app: node-js-app
+    chown: root
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_storage_mount.md
+++ b/docs/tasks/dokku_storage_mount.md
@@ -1,3 +1,50 @@
 # dokku_storage_mount
 
+## Synopsis
+
 Mounts or unmounts the storage for a given dokku application
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `host_dir` | string | yes |  |  | Host directory to mount |
+| `container_dir` | string | yes |  |  | Container directory to mount |
+| `state` | string | no | present | present, absent | Desired state of the storage |
+
+## Examples
+
+### Mount a host directory into an app
+
+```yaml
+dokku_storage_mount:
+    app: node-js-app
+    host_dir: /var/lib/dokku/data/storage/node-js-app
+    container_dir: /app/storage
+```
+
+### Unmount a host directory from an app
+
+```yaml
+dokku_storage_mount:
+    app: node-js-app
+    host_dir: /var/lib/dokku/data/storage/node-js-app
+    container_dir: /app/storage
+    state: absent
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_traefik_property.md
+++ b/docs/tasks/dokku_traefik_property.md
@@ -1,8 +1,22 @@
 # dokku_traefik_property
 
+## Synopsis
+
 Manages the traefik configuration for a given dokku application
 
-## Setting the letsencrypt email for an app
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the traefik configuration should be applied globally |
+| `property` | string | yes |  |  | Name of the traefik property to set |
+| `value` | string | no |  |  | Value to set for the traefik property |
+| `state` | string | no | present | present, absent | Desired state of the traefik configuration |
+
+## Examples
+
+### Setting the letsencrypt email for an app
 
 ```yaml
 dokku_traefik_property:
@@ -11,7 +25,7 @@ dokku_traefik_property:
     value: admin@example.com
 ```
 
-## Setting the log level globally
+### Setting the log level globally
 
 ```yaml
 dokku_traefik_property:
@@ -21,10 +35,25 @@ dokku_traefik_property:
     value: INFO
 ```
 
-## Clearing the letsencrypt email for an app
+### Clearing the letsencrypt email for an app
 
 ```yaml
 dokku_traefik_property:
     app: node-js-app
     property: letsencrypt-email
 ```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/writing-tasks.md
+++ b/docs/writing-tasks.md
@@ -30,8 +30,8 @@ named `lollipop`, `tasks/lollipop_task.go` would contain:
 package main
 
 type LollipopTask struct {
-  App   string `required:"true" yaml:"app"`
-  State State  `required:"true" yaml:"state" default:"present"`
+  App   string `required:"true" yaml:"app" description:"Name of the app"`
+  State State  `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the lollipop"`
 }
 
 func (t LollipopTask) Plan() PlanResult {
@@ -69,10 +69,19 @@ A few conventions to follow:
 
 - The struct holds the fields the task needs. The only required field is `State`, the desired state;
   everything else is specific to the task.
+- Give every field a `description:"..."` tag. The docs generator reads it (along with `required`,
+  `default`, and `options`) to build the task's Parameters table, so a field without one renders an
+  empty description cell. Add `,omitempty` to the `yaml` tag of optional fields so example YAML stays
+  clean, and use `required:"false"` whenever a field has a `default` (a defaulted field is never
+  actually required).
 - For a task that performs several atomic changes in one call (such as setting multiple config
   keys), populate `PlanResult.Mutations` with one entry per change, so `plan` can itemize the diff.
 - `DispatchPlan` and `DispatchState` set `DesiredState` on the result automatically.
 - `init()` registers the task with `RegisterTask`, which makes it usable in a recipe.
+- When a task depends on a dokku plugin that is not part of dokku core (for example `dokku-acl` or
+  `dokku-letsencrypt`), implement the optional `Requirements() []string` method. The generator
+  renders the returned entries in a Requirements section on the task's page; tasks without the
+  method simply omit the section.
 
 ## Toggle and property tasks
 
@@ -153,8 +162,11 @@ unconditionally; those are recognized by `isDynamicProperty` in `tasks/propertie
 
 ## Regenerating the task docs
 
-The per-task pages under [`docs/tasks/`](tasks/README.md) are generated from each task's `Doc()` and
-`Examples()` methods - they are not hand-edited. After adding or changing a task, regenerate them:
+The per-task pages under [`docs/tasks/`](tasks/README.md) are generated from each task's `Doc()`,
+`Examples()`, and optional `Requirements()` methods plus its struct field tags - they are not
+hand-edited. Each page carries a Synopsis (from `Doc()`), a Requirements section (when the task
+implements `Requirements()`), a Parameters table (reflected from the field tags), the examples, and
+a shared Return Values table. After adding or changing a task, regenerate them:
 
 ```bash
 make docs

--- a/generate/docs.go
+++ b/generate/docs.go
@@ -4,11 +4,13 @@ package main
 import (
 	"fmt"
 	"log"
-	"github.com/dokku/docket/tasks"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
+
+	"github.com/dokku/docket/tasks"
 )
 
 // summarize reduces a task's docblock to a single-line summary for the index:
@@ -24,77 +26,283 @@ func summarize(doc string) string {
 	return s
 }
 
+// param is one row of a task's Parameters table, derived from a struct field.
+type param struct {
+	Name        string
+	Type        string
+	Required    bool
+	Default     string
+	Choices     string
+	Description string
+}
+
+// displayType maps a Go field type to the doc-facing type name. Named string
+// types such as State render as "string"; slices render as "list" and maps as
+// "dict", mirroring Ansible's type vocabulary.
+func displayType(t reflect.Type) string {
+	switch t.Kind() {
+	case reflect.String:
+		return "string"
+	case reflect.Bool:
+		return "bool"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return "int"
+	case reflect.Slice:
+		return "list"
+	case reflect.Map:
+		return "dict"
+	default:
+		return t.String()
+	}
+}
+
+// yamlName extracts the recipe key for a field from its yaml tag, dropping any
+// ",omitempty"-style suffix. Returns "" when the field is not serialized.
+func yamlName(tag reflect.StructTag, fieldName string) string {
+	name := tag.Get("yaml")
+	if comma := strings.IndexByte(name, ','); comma >= 0 {
+		name = name[:comma]
+	}
+	if name == "-" {
+		return ""
+	}
+	if name == "" {
+		return strings.ToLower(fieldName)
+	}
+	return name
+}
+
+// elementYamlNames returns the recipe keys of the fields of a slice element
+// struct, so a list-of-struct field can describe its item shape inline.
+func elementYamlNames(t reflect.Type) []string {
+	if t.Kind() != reflect.Slice {
+		return nil
+	}
+	el := t.Elem()
+	if el.Kind() != reflect.Struct {
+		return nil
+	}
+	var names []string
+	for i := 0; i < el.NumField(); i++ {
+		f := el.Field(i)
+		if n := yamlName(f.Tag, f.Name); n != "" {
+			names = append(names, n)
+		}
+	}
+	return names
+}
+
+// buildParams reflects over a task struct type and returns its parameters in
+// declaration order.
+func buildParams(rt reflect.Type) []param {
+	var params []param
+	for i := 0; i < rt.NumField(); i++ {
+		field := rt.Field(i)
+		if field.PkgPath != "" { // unexported
+			continue
+		}
+		name := yamlName(field.Tag, field.Name)
+		if name == "" {
+			continue
+		}
+
+		def := field.Tag.Get("default")
+		// A field with a default is effectively optional even if it is
+		// tagged required:"true".
+		required := field.Tag.Get("required") == "true" && def == ""
+
+		desc := field.Tag.Get("description")
+		if items := elementYamlNames(field.Type); len(items) > 0 {
+			desc = strings.TrimSpace(desc)
+			if desc != "" && !strings.HasSuffix(desc, ".") {
+				desc += "."
+			}
+			desc = strings.TrimSpace(desc + " Each item has: " + strings.Join(items, ", ") + ".")
+		}
+		if field.Tag.Get("sensitive") == "true" {
+			desc = strings.TrimSpace(desc + " (sensitive)")
+		}
+
+		choices := ""
+		if opts := field.Tag.Get("options"); opts != "" {
+			choices = strings.Join(strings.Split(opts, ","), ", ")
+		}
+
+		params = append(params, param{
+			Name:        name,
+			Type:        displayType(field.Type),
+			Required:    required,
+			Default:     def,
+			Choices:     choices,
+			Description: desc,
+		})
+	}
+	return params
+}
+
+// escapeCell makes a string safe to embed in a markdown table cell.
+func escapeCell(s string) string {
+	s = strings.ReplaceAll(s, "|", "\\|")
+	return strings.ReplaceAll(s, "\n", " ")
+}
+
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}
+
+// parametersSection renders the Parameters table for a task. Returns "" when
+// the task has no documented parameters.
+func parametersSection(params []param) string {
+	if len(params) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("## Parameters\n\n")
+	b.WriteString("| Parameter | Type | Required | Default | Choices | Description |\n")
+	b.WriteString("| --- | --- | --- | --- | --- | --- |\n")
+	for _, p := range params {
+		b.WriteString(fmt.Sprintf(
+			"| `%s` | %s | %s | %s | %s | %s |\n",
+			p.Name,
+			p.Type,
+			yesNo(p.Required),
+			escapeCell(p.Default),
+			escapeCell(p.Choices),
+			escapeCell(p.Description),
+		))
+	}
+	return b.String()
+}
+
+// requirementsSection renders the Requirements bullet list for a task that
+// declares non-core plugin dependencies. Returns "" otherwise.
+func requirementsSection(task tasks.Task) string {
+	doc, ok := task.(tasks.RequirementsDocer)
+	if !ok {
+		return ""
+	}
+	reqs := doc.Requirements()
+	if len(reqs) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("## Requirements\n\n")
+	for _, r := range reqs {
+		b.WriteString("- " + r + "\n")
+	}
+	return b.String()
+}
+
+// returnValuesSection is the shared Return Values table. Every task returns a
+// tasks.TaskOutputState, so the table is identical across pages. The keys are
+// the Go field names because that is how recipes reference them through
+// `register:` and `result.<Field>`.
+func returnValuesSection() string {
+	rows := [][4]string{
+		{"Changed", "always", "bool", "Whether the task changed server state."},
+		{"State", "always", "string", "Resulting state of the resource."},
+		{"DesiredState", "always", "string", "The state the task targeted."},
+		{"Message", "always", "string", "Human-readable result message (may be empty)."},
+		{"Commands", "when a subprocess ran", "list", "Resolved dokku command lines executed."},
+		{"Stdout", "when a subprocess ran", "string", "Captured stdout of the final command."},
+		{"Stderr", "when a subprocess ran", "string", "Captured stderr of the final command."},
+		{"ExitCode", "when a subprocess ran", "int", "Exit code of the final command."},
+	}
+	var b strings.Builder
+	b.WriteString("## Return Values\n\n")
+	b.WriteString("Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).\n\n")
+	b.WriteString("| Key | Returned | Type | Description |\n")
+	b.WriteString("| --- | --- | --- | --- |\n")
+	for _, r := range rows {
+		b.WriteString(fmt.Sprintf("| `%s` | %s | %s | %s |\n", r[0], r[1], r[2], r[3]))
+	}
+	return b.String()
+}
+
+// examplesSection renders a task's examples under a single Examples header,
+// one H3 subsection per example.
+func examplesSection(taskName string, examples []tasks.Doc) string {
+	if len(examples) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("## Examples\n\n")
+	for _, example := range examples {
+		b.WriteString("### " + example.Name + "\n\n")
+		b.WriteString("```yaml\n")
+		b.WriteString(strings.TrimSpace(example.Codeblock) + "\n")
+		b.WriteString("```\n\n")
+	}
+	return strings.TrimRight(b.String(), "\n") + "\n"
+}
+
+// renderPage builds the full markdown page for one task.
+func renderPage(taskName string, task tasks.Task, examples []tasks.Doc) string {
+	rt := reflect.TypeOf(task)
+	if rt.Kind() == reflect.Ptr {
+		rt = rt.Elem()
+	}
+
+	var sections []string
+	sections = append(sections, "# "+taskName)
+	sections = append(sections, "## Synopsis\n\n"+strings.TrimSpace(task.Doc()))
+	if req := requirementsSection(task); req != "" {
+		sections = append(sections, strings.TrimRight(req, "\n"))
+	}
+	if pt := parametersSection(buildParams(rt)); pt != "" {
+		sections = append(sections, strings.TrimRight(pt, "\n"))
+	}
+	if ex := examplesSection(taskName, examples); ex != "" {
+		sections = append(sections, strings.TrimRight(ex, "\n"))
+	}
+	sections = append(sections, strings.TrimRight(returnValuesSection(), "\n"))
+
+	return strings.Join(sections, "\n\n") + "\n"
+}
+
 func main() {
 	docsFolderName := "../" + os.Args[1]
-	// expand docsFolderName
 	docsFolderName, err := filepath.Abs(docsFolderName)
 	if err != nil {
 		log.Fatalf("failed to expand docs folder name: %v", err)
 	}
 
-	// create docs folder if it doesn't exist
 	if _, err := os.Stat(docsFolderName); os.IsNotExist(err) {
-		err = os.MkdirAll(docsFolderName, 0755)
-		if err != nil {
+		if err = os.MkdirAll(docsFolderName, 0755); err != nil {
 			log.Fatalf("failed to create docs folder: %v", err)
 		}
 	}
 
-	markdownTemplate := `
-# %s
-
-%s
-%s
-`
-
-	sectionTemplate := `
-## %s
-
-%syaml
-%s
-%s`
-
-	codefence := "```"
-
-	// read in all registered tasks
 	registeredTasks := tasks.RegisteredTasks
 
-	// for each registered task, generate a docs file
-	for taskName, task := range registeredTasks {
-		fmt.Println(taskName)
-
-		examples, err := task.Examples()
-		if err != nil {
-			log.Fatalf("failed to get examples for task %s: %v", taskName, err)
-		}
-
-		docblock := task.Doc()
-
-		var exampleSections []string
-		for _, example := range examples {
-			example := fmt.Sprintf(sectionTemplate, example.Name, codefence, strings.TrimSpace(example.Codeblock), codefence)
-			exampleSections = append(exampleSections, example)
-		}
-
-		examplesYaml := strings.Join(exampleSections, "\n")
-		markdown := fmt.Sprintf(markdownTemplate, taskName, docblock, examplesYaml)
-		output := strings.TrimSpace(markdown) + "\n"
-
-		taskDocsFile := filepath.Join(docsFolderName, taskName+".md")
-		err = os.WriteFile(taskDocsFile, []byte(output), 0644)
-		if err != nil {
-			log.Fatalf("failed to write docblock: %v", err)
-		}
-	}
-
-	// Emit an index listing every task with a one-line summary, sorted by name
-	// so the output is stable across runs.
+	// Sorted names keep the generation order (and console output) stable.
 	names := make([]string, 0, len(registeredTasks))
 	for name := range registeredTasks {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 
+	for _, taskName := range names {
+		fmt.Println(taskName)
+		task := registeredTasks[taskName]
+
+		examples, err := task.Examples()
+		if err != nil {
+			log.Fatalf("failed to get examples for task %s: %v", taskName, err)
+		}
+
+		output := renderPage(taskName, task, examples)
+
+		taskDocsFile := filepath.Join(docsFolderName, taskName+".md")
+		if err := os.WriteFile(taskDocsFile, []byte(output), 0644); err != nil {
+			log.Fatalf("failed to write docblock: %v", err)
+		}
+	}
+
+	// Emit an index listing every task with a one-line summary.
 	var index strings.Builder
 	index.WriteString("# Tasks\n\n")
 	index.WriteString("Reference for every task type docket can run inside a recipe. Each page lists the task's fields and example usage. These pages are generated from the task definitions with `make docs`.\n\n")

--- a/tasks/acl_app_task.go
+++ b/tasks/acl_app_task.go
@@ -10,13 +10,13 @@ import (
 // AclAppTask manages the dokku-acl access list for a dokku application
 type AclAppTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// Users is the list of users to add or remove from the ACL
-	Users []string `required:"false" yaml:"users"`
+	Users []string `required:"false" yaml:"users" description:"List of users to add or remove from the ACL"`
 
 	// State is the desired state of the ACL entries
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the ACL entries"`
 }
 
 // AclAppTaskExample contains an example of an AclAppTask
@@ -36,6 +36,11 @@ func (e AclAppTaskExample) GetName() string {
 // Doc returns the docblock for the acl app task
 func (t AclAppTask) Doc() string {
 	return "Manages the dokku-acl access list for a dokku application"
+}
+
+// Requirements lists the non-core dokku plugins this task depends on.
+func (t AclAppTask) Requirements() []string {
+	return []string{"dokku-acl plugin"}
 }
 
 // Examples returns the examples for the acl app task

--- a/tasks/acl_service_task.go
+++ b/tasks/acl_service_task.go
@@ -10,16 +10,16 @@ import (
 // AclServiceTask manages the dokku-acl access list for a dokku service
 type AclServiceTask struct {
 	// Service is the name of the service instance
-	Service string `required:"true" yaml:"service"`
+	Service string `required:"true" yaml:"service" description:"Name of the service instance"`
 
 	// Type is the type of service (e.g. redis, postgres)
-	Type string `required:"true" yaml:"type"`
+	Type string `required:"true" yaml:"type" description:"Type of service (e.g. redis, postgres)"`
 
 	// Users is the list of users to add or remove from the ACL
-	Users []string `required:"false" yaml:"users"`
+	Users []string `required:"false" yaml:"users" description:"List of users to add or remove from the ACL"`
 
 	// State is the desired state of the ACL entries
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the ACL entries"`
 }
 
 // AclServiceTaskExample contains an example of an AclServiceTask
@@ -39,6 +39,11 @@ func (e AclServiceTaskExample) GetName() string {
 // Doc returns the docblock for the acl service task
 func (t AclServiceTask) Doc() string {
 	return "Manages the dokku-acl access list for a dokku service"
+}
+
+// Requirements lists the non-core dokku plugins this task depends on.
+func (t AclServiceTask) Requirements() []string {
+	return []string{"dokku-acl plugin"}
 }
 
 // Examples returns the examples for the acl service task

--- a/tasks/app_clone_task.go
+++ b/tasks/app_clone_task.go
@@ -9,16 +9,16 @@ import (
 // AppCloneTask clones an existing dokku app to a new app
 type AppCloneTask struct {
 	// App is the name of the new (target) app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the new (target) app"`
 
 	// SourceApp is the name of the existing app to clone from
-	SourceApp string `required:"true" yaml:"source_app"`
+	SourceApp string `required:"true" yaml:"source_app" description:"Name of the existing app to clone from"`
 
 	// SkipDeploy skips deployment of the cloned app
-	SkipDeploy bool `required:"false" yaml:"skip_deploy,omitempty"`
+	SkipDeploy bool `required:"false" yaml:"skip_deploy,omitempty" description:"Skip deployment of the cloned app"`
 
 	// State is the desired state of the cloned app
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present" description:"Desired state of the cloned app"`
 }
 
 // AppCloneTaskExample contains an example of an AppCloneTask

--- a/tasks/app_json_property_task.go
+++ b/tasks/app_json_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // AppJsonPropertyTask manages the app.json configuration for a given dokku application
 type AppJsonPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the app.json configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the app.json configuration should be applied globally"`
 
 	// Property is the name of the app.json property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the app.json property to set"`
 
 	// Value is the value to set for the app.json property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the app.json property"`
 
 	// State is the desired state of the app.json configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the app.json configuration"`
 }
 
 // AppJsonPropertyTaskExample contains an example of an AppJsonPropertyTask

--- a/tasks/app_lock_task.go
+++ b/tasks/app_lock_task.go
@@ -9,10 +9,10 @@ import (
 // AppLockTask locks or unlocks a dokku application from deployment
 type AppLockTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// State is the desired lock state
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired lock state"`
 }
 
 // AppLockTaskExample contains an example of an AppLockTask

--- a/tasks/app_task.go
+++ b/tasks/app_task.go
@@ -7,10 +7,10 @@ import (
 // AppTask creates or destroys an app
 type AppTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// State is the state of the app
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"State of the app"`
 }
 
 // AppTaskExample contains an example of an AppTask

--- a/tasks/builder_dockerfile_property_task.go
+++ b/tasks/builder_dockerfile_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // BuilderDockerfilePropertyTask manages the builder-dockerfile configuration for a given dokku application
 type BuilderDockerfilePropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the builder-dockerfile configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the builder-dockerfile configuration should be applied globally"`
 
 	// Property is the name of the builder-dockerfile property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the builder-dockerfile property to set"`
 
 	// Value is the value to set for the builder-dockerfile property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder-dockerfile property"`
 
 	// State is the desired state of the builder-dockerfile configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the builder-dockerfile configuration"`
 }
 
 // BuilderDockerfilePropertyTaskExample contains an example of a BuilderDockerfilePropertyTask

--- a/tasks/builder_herokuish_property_task.go
+++ b/tasks/builder_herokuish_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // BuilderHerokuishPropertyTask manages the builder-herokuish configuration for a given dokku application
 type BuilderHerokuishPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the builder-herokuish configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the builder-herokuish configuration should be applied globally"`
 
 	// Property is the name of the builder-herokuish property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the builder-herokuish property to set"`
 
 	// Value is the value to set for the builder-herokuish property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder-herokuish property"`
 
 	// State is the desired state of the builder-herokuish configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the builder-herokuish configuration"`
 }
 
 // BuilderHerokuishPropertyTaskExample contains an example of a BuilderHerokuishPropertyTask

--- a/tasks/builder_lambda_property_task.go
+++ b/tasks/builder_lambda_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // BuilderLambdaPropertyTask manages the builder-lambda configuration for a given dokku application
 type BuilderLambdaPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the builder-lambda configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the builder-lambda configuration should be applied globally"`
 
 	// Property is the name of the builder-lambda property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the builder-lambda property to set"`
 
 	// Value is the value to set for the builder-lambda property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder-lambda property"`
 
 	// State is the desired state of the builder-lambda configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the builder-lambda configuration"`
 }
 
 // BuilderLambdaPropertyTaskExample contains an example of a BuilderLambdaPropertyTask

--- a/tasks/builder_nixpacks_property_task.go
+++ b/tasks/builder_nixpacks_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // BuilderNixpacksPropertyTask manages the builder-nixpacks configuration for a given dokku application
 type BuilderNixpacksPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the builder-nixpacks configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the builder-nixpacks configuration should be applied globally"`
 
 	// Property is the name of the builder-nixpacks property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the builder-nixpacks property to set"`
 
 	// Value is the value to set for the builder-nixpacks property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder-nixpacks property"`
 
 	// State is the desired state of the builder-nixpacks configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the builder-nixpacks configuration"`
 }
 
 // BuilderNixpacksPropertyTaskExample contains an example of a BuilderNixpacksPropertyTask

--- a/tasks/builder_pack_property_task.go
+++ b/tasks/builder_pack_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // BuilderPackPropertyTask manages the builder-pack configuration for a given dokku application
 type BuilderPackPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the builder-pack configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the builder-pack configuration should be applied globally"`
 
 	// Property is the name of the builder-pack property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the builder-pack property to set"`
 
 	// Value is the value to set for the builder-pack property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder-pack property"`
 
 	// State is the desired state of the builder-pack configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the builder-pack configuration"`
 }
 
 // BuilderPackPropertyTaskExample contains an example of a BuilderPackPropertyTask

--- a/tasks/builder_property_task.go
+++ b/tasks/builder_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // BuilderTask manages the builder configuration for a given dokku application
 type BuilderPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the builder configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the builder configuration should be applied globally"`
 
 	// Property is the name of the builder property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the builder property to set"`
 
 	// Value is the value to set for the builder property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder property"`
 
 	// State is the desired state of the builder configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the builder configuration"`
 }
 
 // BuilderPropertyTaskExample contains an example of a BuilderPropertyTask

--- a/tasks/builder_railpack_property_task.go
+++ b/tasks/builder_railpack_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // BuilderRailpackPropertyTask manages the builder-railpack configuration for a given dokku application
 type BuilderRailpackPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the builder-railpack configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the builder-railpack configuration should be applied globally"`
 
 	// Property is the name of the builder-railpack property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the builder-railpack property to set"`
 
 	// Value is the value to set for the builder-railpack property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builder-railpack property"`
 
 	// State is the desired state of the builder-railpack configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the builder-railpack configuration"`
 }
 
 // BuilderRailpackPropertyTaskExample contains an example of a BuilderRailpackPropertyTask

--- a/tasks/buildpacks_property_task.go
+++ b/tasks/buildpacks_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // BuildpacksPropertyTask manages the buildpacks configuration for a given dokku application
 type BuildpacksPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the buildpacks configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the buildpacks configuration should be applied globally"`
 
 	// Property is the name of the buildpacks property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the buildpacks property to set"`
 
 	// Value is the value to set for the buildpacks property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the buildpacks property"`
 
 	// State is the desired state of the buildpacks configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the buildpacks configuration"`
 }
 
 // BuildpacksPropertyTaskExample contains an example of a BuildpacksPropertyTask

--- a/tasks/buildpacks_task.go
+++ b/tasks/buildpacks_task.go
@@ -10,13 +10,13 @@ import (
 // BuildpacksTask manages the buildpacks for a given dokku application
 type BuildpacksTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// Buildpacks is the list of buildpack URLs
-	Buildpacks []string `required:"false" yaml:"buildpacks"`
+	Buildpacks []string `required:"false" yaml:"buildpacks" description:"List of buildpack URLs"`
 
 	// State is the desired state of the buildpacks
-	State State `required:"false" yaml:"state" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state" default:"present" options:"present,absent" description:"Desired state of the buildpacks"`
 }
 
 // BuildpacksTaskExample contains an example of a BuildpacksTask

--- a/tasks/builds_property_task.go
+++ b/tasks/builds_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // BuildsPropertyTask manages the builds configuration for a given dokku application
 type BuildsPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the builds configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the builds configuration should be applied globally"`
 
 	// Property is the name of the builds property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the builds property to set"`
 
 	// Value is the value to set for the builds property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the builds property"`
 
 	// State is the desired state of the builds configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the builds configuration"`
 }
 
 // BuildsPropertyTaskExample contains an example of a BuildsPropertyTask

--- a/tasks/caddy_property_task.go
+++ b/tasks/caddy_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // CaddyPropertyTask manages the caddy configuration for a given dokku application
 type CaddyPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the caddy configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the caddy configuration should be applied globally"`
 
 	// Property is the name of the caddy property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the caddy property to set"`
 
 	// Value is the value to set for the caddy property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the caddy property"`
 
 	// State is the desired state of the caddy configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the caddy configuration"`
 }
 
 // CaddyPropertyTaskExample contains an example of a CaddyPropertyTask

--- a/tasks/certs_task.go
+++ b/tasks/certs_task.go
@@ -10,20 +10,20 @@ import (
 // CertsTask manages SSL certificates for a dokku app or globally
 type CertsTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the certificate should be applied globally
 	// via the dokku-global-cert plugin
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the certificate should be applied globally via the dokku-global-cert plugin"`
 
 	// Cert is the path on the dokku server to the SSL certificate file
-	Cert string `required:"false" sensitive:"true" yaml:"cert,omitempty"`
+	Cert string `required:"false" sensitive:"true" yaml:"cert,omitempty" description:"Path on the dokku server to the SSL certificate file"`
 
 	// Key is the path on the dokku server to the SSL certificate key file
-	Key string `required:"false" sensitive:"true" yaml:"key,omitempty"`
+	Key string `required:"false" sensitive:"true" yaml:"key,omitempty" description:"Path on the dokku server to the SSL certificate key file"`
 
 	// State is the desired state of the SSL configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the SSL configuration"`
 }
 
 // CertsTaskExample contains an example of a CertsTask
@@ -46,6 +46,11 @@ func (t CertsTask) Doc() string {
 		"and `key` fields are paths on the dokku server, so when running with " +
 		"`DOKKU_HOST` set the referenced files must already exist on the " +
 		"remote host - docket does not upload them."
+}
+
+// Requirements lists the non-core dokku plugins this task depends on.
+func (t CertsTask) Requirements() []string {
+	return []string{"dokku-global-cert plugin (required only when global: true)"}
 }
 
 // Examples returns the examples for the certs task

--- a/tasks/checks_property_task.go
+++ b/tasks/checks_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // ChecksPropertyTask manages the checks configuration for a given dokku application
 type ChecksPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the checks configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the checks configuration should be applied globally"`
 
 	// Property is the name of the checks property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the checks property to set"`
 
 	// Value is the value to set for the checks property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the checks property"`
 
 	// State is the desired state of the checks configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the checks configuration"`
 }
 
 // ChecksPropertyTaskExample contains an example of a ChecksPropertyTask

--- a/tasks/checks_toggle_task.go
+++ b/tasks/checks_toggle_task.go
@@ -31,13 +31,13 @@ func checksEnabled(ctx ToggleContext) (bool, error) {
 // ChecksToggleTask enables or disables the checks plugin for a given dokku application
 type ChecksToggleTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// Global is a flag indicating if the checks plugin should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the checks plugin should be applied globally"`
 
 	// State is the desired state of the checks plugin
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the checks plugin"`
 }
 
 // ChecksToggleTaskExample contains an example of a ChecksToggleTask

--- a/tasks/config_task.go
+++ b/tasks/config_task.go
@@ -10,16 +10,16 @@ import (
 // ConfigTask manages the configuration for a given dokku application
 type ConfigTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// Restart is a flag indicating if the app should be restarted
-	Restart bool `yaml:"restart" default:"true"`
+	Restart bool `yaml:"restart" default:"true" description:"Flag indicating if the app should be restarted"`
 
 	// Config is a map of configuration key-value pairs
-	Config map[string]string `yaml:"config"`
+	Config map[string]string `yaml:"config" description:"Map of configuration key-value pairs"`
 
 	// State is the desired state of the configuration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the configuration"`
 }
 
 // ConfigTaskExample contains an example of a ConfigTask

--- a/tasks/cron_property_task.go
+++ b/tasks/cron_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // CronPropertyTask manages the cron configuration for a given dokku application
 type CronPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the cron configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the cron configuration should be applied globally"`
 
 	// Property is the name of the cron property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the cron property to set"`
 
 	// Value is the value to set for the cron property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the cron property"`
 
 	// State is the desired state of the cron configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the cron configuration"`
 }
 
 // CronPropertyTaskExample contains an example of a CronPropertyTask

--- a/tasks/docker_options_task.go
+++ b/tasks/docker_options_task.go
@@ -11,16 +11,16 @@ import (
 // DockerOptionsTask manages docker-options for a given dokku application
 type DockerOptionsTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// Phase is the deployment phase the option applies to
-	Phase string `required:"true" yaml:"phase" options:"build,deploy,run"`
+	Phase string `required:"true" yaml:"phase" options:"build,deploy,run" description:"Deployment phase the option applies to"`
 
 	// Option is the docker option string (e.g. "-v /var/run/docker.sock:/var/run/docker.sock")
-	Option string `required:"true" yaml:"option"`
+	Option string `required:"true" yaml:"option" description:"Docker option string (e.g. '-v /var/run/docker.sock:/var/run/docker.sock')"`
 
 	// State is the desired state of the docker option
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the docker option"`
 }
 
 // DockerOptionsTaskExample contains an example of a DockerOptionsTask

--- a/tasks/domains_task.go
+++ b/tasks/domains_task.go
@@ -9,16 +9,16 @@ import (
 // DomainsTask manages the domains for a given dokku application or globally
 type DomainsTask struct {
 	// App is the name of the app
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app"`
 
 	// Global is a flag indicating if the domains should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the domains should be applied globally"`
 
 	// Domains is the list of domain names
-	Domains []string `required:"false" yaml:"domains"`
+	Domains []string `required:"false" yaml:"domains" description:"List of domain names"`
 
 	// State is the desired state of the domains
-	State State `required:"false" yaml:"state" default:"present" options:"present,absent,set,clear"`
+	State State `required:"false" yaml:"state" default:"present" options:"present,absent,set,clear" description:"Desired state of the domains"`
 }
 
 // DomainsTaskExample contains an example of a DomainsTask

--- a/tasks/domains_toggle_task.go
+++ b/tasks/domains_toggle_task.go
@@ -29,13 +29,13 @@ func domainsEnabled(ctx ToggleContext) (bool, error) {
 // DomainsToggleTask enables or disables the domains plugin for a given dokku application
 type DomainsToggleTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// Global is a flag indicating if the domains plugin should be applied globally
-	Global bool `required:"false" yaml:"global"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the domains plugin should be applied globally"`
 
 	// State is the desired state of the domains plugin
-	State State `required:"false" yaml:"state" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the domains plugin"`
 }
 
 // DomainsToggleTaskExample contains an example of a DomainsToggleTask
@@ -59,7 +59,21 @@ func (t DomainsToggleTask) Doc() string {
 
 // Examples returns the examples for the domains toggle task
 func (t DomainsToggleTask) Examples() ([]Doc, error) {
-	return MarshalExamples([]DomainsToggleTaskExample{})
+	return MarshalExamples([]DomainsToggleTaskExample{
+		{
+			Name: "Enable the domains plugin for an app",
+			DomainsToggleTask: DomainsToggleTask{
+				App: "node-js-app",
+			},
+		},
+		{
+			Name: "Disable the domains plugin for an app",
+			DomainsToggleTask: DomainsToggleTask{
+				App:   "node-js-app",
+				State: StateAbsent,
+			},
+		},
+	})
 }
 
 // Execute enables or disables the domains plugin

--- a/tasks/git_auth_task.go
+++ b/tasks/git_auth_task.go
@@ -15,16 +15,16 @@ import (
 // instead of always reporting Changed=true.
 type GitAuthTask struct {
 	// Host is the git server hostname (e.g. github.com)
-	Host string `required:"true" yaml:"host"`
+	Host string `required:"true" yaml:"host" description:"Git server hostname (e.g. github.com)"`
 
 	// Username is the netrc username. Required when state is present.
-	Username string `required:"false" yaml:"username,omitempty"`
+	Username string `required:"false" yaml:"username,omitempty" description:"Netrc username. Required when state is present."`
 
 	// Password is the netrc password. Required when state is present.
-	Password string `required:"false" sensitive:"true" yaml:"password,omitempty"`
+	Password string `required:"false" sensitive:"true" yaml:"password,omitempty" description:"Netrc password. Required when state is present."`
 
 	// State is the desired state of the netrc entry
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the netrc entry"`
 }
 
 // GitAuthTaskExample contains an example of a GitAuthTask

--- a/tasks/git_from_archive_task.go
+++ b/tasks/git_from_archive_task.go
@@ -10,23 +10,23 @@ import (
 // GitFromArchiveTask deploys a git repository from an archive URL
 type GitFromArchiveTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// ArchiveURL is the URL of the archive to deploy. Tagged sensitive
 	// because URLs can embed credentials (e.g. https://user:token@host/path).
-	ArchiveURL string `required:"true" sensitive:"true" yaml:"archive_url"`
+	ArchiveURL string `required:"true" sensitive:"true" yaml:"archive_url" description:"URL of the archive to deploy"`
 
 	// ArchiveType is the format of the archive
-	ArchiveType string `required:"false" yaml:"archive_type,omitempty" default:"tar" options:"tar,tar.gz,zip"`
+	ArchiveType string `required:"false" yaml:"archive_type,omitempty" default:"tar" options:"tar,tar.gz,zip" description:"Format of the archive"`
 
 	// GitUsername is the git author username for the synthetic commit
-	GitUsername string `required:"false" yaml:"git_username,omitempty"`
+	GitUsername string `required:"false" yaml:"git_username,omitempty" description:"Git author username for the synthetic commit"`
 
 	// GitEmail is the git author email for the synthetic commit
-	GitEmail string `required:"false" yaml:"git_email,omitempty"`
+	GitEmail string `required:"false" yaml:"git_email,omitempty" description:"Git author email for the synthetic commit"`
 
 	// State is the desired state of the deployment
-	State State `required:"false" yaml:"state,omitempty" default:"deployed" options:"deployed"`
+	State State `required:"false" yaml:"state,omitempty" default:"deployed" options:"deployed" description:"Desired state of the deployment"`
 }
 
 // GitFromArchiveTaskExample contains an example of a GitFromArchiveTask

--- a/tasks/git_from_image_task.go
+++ b/tasks/git_from_image_task.go
@@ -12,23 +12,23 @@ import (
 // GitFromImageTask deploys a git repository from a docker image
 type GitFromImageTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// Image is the docker image to deploy. Tagged sensitive because image
 	// references can embed registry credentials (e.g. user:token@host/repo).
-	Image string `required:"true" sensitive:"true" yaml:"image"`
+	Image string `required:"true" sensitive:"true" yaml:"image" description:"Docker image to deploy"`
 
 	// BuildDir is the directory to build the git repository
-	BuildDir string `required:"false" yaml:"build_dir"`
+	BuildDir string `required:"false" yaml:"build_dir,omitempty" description:"Directory to build the git repository"`
 
 	// GitUsername is the username to use for the git repository
-	GitUsername string `required:"false" yaml:"git_username"`
+	GitUsername string `required:"false" yaml:"git_username,omitempty" description:"Username to use for the git repository"`
 
 	// GitEmail is the email to use for the git repository
-	GitEmail string `required:"false" yaml:"git_email"`
+	GitEmail string `required:"false" yaml:"git_email,omitempty" description:"Email to use for the git repository"`
 
 	// State is the desired state of the git repository
-	State State `required:"false" yaml:"state" default:"deployed" options:"deployed"`
+	State State `required:"false" yaml:"state,omitempty" default:"deployed" options:"deployed" description:"Desired state of the git repository"`
 }
 
 // GitFromImageTaskExample contains an example of a GitFromImageTask
@@ -52,7 +52,25 @@ func (t GitFromImageTask) Doc() string {
 
 // Examples returns the examples for the git from image task
 func (t GitFromImageTask) Examples() ([]Doc, error) {
-	return MarshalExamples([]GitFromImageTaskExample{})
+	return MarshalExamples([]GitFromImageTaskExample{
+		{
+			Name: "Deploy an app from a docker image",
+			GitFromImageTask: GitFromImageTask{
+				App:   "node-js-app",
+				Image: "dokku/node-js-app:latest",
+			},
+		},
+		{
+			Name: "Deploy from an image with a build directory and git author",
+			GitFromImageTask: GitFromImageTask{
+				App:         "node-js-app",
+				Image:       "dokku/node-js-app:latest",
+				BuildDir:    "/app",
+				GitUsername: "dokku",
+				GitEmail:    "dokku@example.com",
+			},
+		},
+	})
 }
 
 // Execute deploys a git repository from a docker image

--- a/tasks/git_property_task.go
+++ b/tasks/git_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // GitPropertyTask manages the git configuration for a given dokku application
 type GitPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the git configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the git configuration should be applied globally"`
 
 	// Property is the name of the git property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the git property to set"`
 
 	// Value is the value to set for the git property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the git property"`
 
 	// State is the desired state of the git configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the git configuration"`
 }
 
 // GitPropertyTaskExample contains an example of a GitPropertyTask

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -10,25 +10,25 @@ import (
 // GitSyncTask syncs a git repository to a dokku application
 type GitSyncTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// Remote is the git remote url to sync
-	Remote string `required:"true" yaml:"remote"`
+	Remote string `required:"true" yaml:"remote" description:"Git remote url to sync"`
 
 	// GitRef is the git reference to sync
-	GitRef string `required:"false" yaml:"git_ref"`
+	GitRef string `required:"false" yaml:"git_ref" description:"Git reference to sync"`
 
 	// Build triggers an application build after syncing
-	Build bool `required:"false" yaml:"build"`
+	Build bool `required:"false" yaml:"build" description:"Trigger an application build after syncing"`
 
 	// BuildIfChanges triggers a build only if changes are detected
-	BuildIfChanges bool `required:"false" yaml:"build_if_changes"`
+	BuildIfChanges bool `required:"false" yaml:"build_if_changes" description:"Trigger a build only if changes are detected"`
 
 	// SkipDeployBranch skips automatically setting the deploy-branch property
-	SkipDeployBranch bool `required:"false" yaml:"skip_deploy_branch"`
+	SkipDeployBranch bool `required:"false" yaml:"skip_deploy_branch" description:"Skip automatically setting the deploy-branch property"`
 
 	// State is the desired state of the git sync
-	State State `required:"false" yaml:"state" default:"present" options:"present"`
+	State State `required:"false" yaml:"state" default:"present" options:"present" description:"Desired state of the git sync"`
 }
 
 // GitSyncTaskExample contains an example of a GitSyncTask

--- a/tasks/haproxy_property_task.go
+++ b/tasks/haproxy_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // HaproxyPropertyTask manages the haproxy configuration for a given dokku application
 type HaproxyPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the haproxy configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the haproxy configuration should be applied globally"`
 
 	// Property is the name of the haproxy property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the haproxy property to set"`
 
 	// Value is the value to set for the haproxy property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the haproxy property"`
 
 	// State is the desired state of the haproxy configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the haproxy configuration"`
 }
 
 // HaproxyPropertyTaskExample contains an example of a HaproxyPropertyTask

--- a/tasks/http_auth_task.go
+++ b/tasks/http_auth_task.go
@@ -11,16 +11,16 @@ import (
 // HttpAuthTask manages HTTP authentication for a dokku application
 type HttpAuthTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// Username is the HTTP auth username
-	Username string `required:"false" yaml:"username,omitempty"`
+	Username string `required:"false" yaml:"username,omitempty" description:"HTTP auth username"`
 
 	// Password is the HTTP auth password
-	Password string `required:"false" sensitive:"true" yaml:"password,omitempty"`
+	Password string `required:"false" sensitive:"true" yaml:"password,omitempty" description:"HTTP auth password"`
 
 	// State is the state of the HTTP auth
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"State of the HTTP auth"`
 }
 
 // HttpAuthTaskExample contains an example of an HttpAuthTask
@@ -40,6 +40,11 @@ func (e HttpAuthTaskExample) GetName() string {
 // Doc returns the docblock for the HTTP auth task
 func (t HttpAuthTask) Doc() string {
 	return "Manages HTTP authentication for a given dokku application"
+}
+
+// Requirements lists the non-core dokku plugins this task depends on.
+func (t HttpAuthTask) Requirements() []string {
+	return []string{"dokku-http-auth plugin"}
 }
 
 // Examples returns a list of HttpAuthTaskExamples as yaml

--- a/tasks/letsencrypt_property_task.go
+++ b/tasks/letsencrypt_property_task.go
@@ -3,21 +3,21 @@ package tasks
 // LetsencryptPropertyTask manages the letsencrypt configuration for a given dokku application
 type LetsencryptPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the letsencrypt configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the letsencrypt configuration should be applied globally"`
 
 	// Property is the name of the letsencrypt property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the letsencrypt property to set"`
 
 	// Value is the value to set for the letsencrypt property. Tagged sensitive
 	// because some letsencrypt properties carry DNS-API credentials; benign
 	// property values get masked too, which is preferable to leaking secrets.
-	Value string `required:"false" sensitive:"true" yaml:"value,omitempty"`
+	Value string `required:"false" sensitive:"true" yaml:"value,omitempty" description:"Value to set for the letsencrypt property"`
 
 	// State is the desired state of the letsencrypt configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the letsencrypt configuration"`
 }
 
 // LetsencryptPropertyTaskExample contains an example of a LetsencryptPropertyTask
@@ -37,6 +37,11 @@ func (e LetsencryptPropertyTaskExample) GetName() string {
 // Doc returns the docblock for the letsencrypt property task
 func (t LetsencryptPropertyTask) Doc() string {
 	return "Manages the letsencrypt configuration for a given dokku application"
+}
+
+// Requirements lists the non-core dokku plugins this task depends on.
+func (t LetsencryptPropertyTask) Requirements() []string {
+	return []string{"dokku-letsencrypt plugin"}
 }
 
 // Examples returns the examples for the letsencrypt property task

--- a/tasks/letsencrypt_task.go
+++ b/tasks/letsencrypt_task.go
@@ -10,10 +10,10 @@ import (
 // LetsencryptTask enables or disables the dokku-letsencrypt plugin for a dokku app
 type LetsencryptTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// State is the desired state of the letsencrypt integration
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the letsencrypt integration"`
 }
 
 // LetsencryptTaskExample contains an example of a LetsencryptTask
@@ -33,6 +33,11 @@ func (e LetsencryptTaskExample) GetName() string {
 // Doc returns the docblock for the letsencrypt task
 func (t LetsencryptTask) Doc() string {
 	return "Enables or disables letsencrypt SSL certificates for a dokku application"
+}
+
+// Requirements lists the non-core dokku plugins this task depends on.
+func (t LetsencryptTask) Requirements() []string {
+	return []string{"dokku-letsencrypt plugin"}
 }
 
 // Examples returns the examples for the letsencrypt task

--- a/tasks/logs_property_task.go
+++ b/tasks/logs_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // LogsPropertyTask manages the logs configuration for a given dokku application
 type LogsPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the logs configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the logs configuration should be applied globally"`
 
 	// Property is the name of the logs property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the logs property to set"`
 
 	// Value is the value to set for the logs property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the logs property"`
 
 	// State is the desired state of the logs configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the logs configuration"`
 }
 
 // LogsPropertyTaskExample contains an example of a LogsPropertyTask

--- a/tasks/network_property_task.go
+++ b/tasks/network_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // NetworkPropertyTask manages the network property for a given dokku application
 type NetworkPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the network property should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the network property should be applied globally"`
 
 	// Property is the name of the network property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the network property to set"`
 
 	// Value is the value of the network property to set
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value of the network property to set"`
 
 	// State is the desired state of the network property
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the network property"`
 }
 
 // NetworkPropertyTaskExample contains an example of a NetworkPropertyTask

--- a/tasks/network_task.go
+++ b/tasks/network_task.go
@@ -7,10 +7,10 @@ import (
 // NetworkTask creates or destroys a Docker network
 type NetworkTask struct {
 	// Name is the name of the network
-	Name string `required:"true" yaml:"name"`
+	Name string `required:"true" yaml:"name" description:"Name of the network"`
 
 	// State is the state of the network
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"State of the network"`
 }
 
 // NetworkTaskExample contains an example of a NetworkTask

--- a/tasks/nginx_property_task.go
+++ b/tasks/nginx_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // NginxPropertyTask manages the nginx configuration for a given dokku application
 type NginxPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the nginx configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the nginx configuration should be applied globally"`
 
 	// Property is the name of the nginx property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the nginx property to set"`
 
 	// Value is the value to set for the nginx property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the nginx property"`
 
 	// State is the desired state of the nginx configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the nginx configuration"`
 }
 
 // NginxPropertyTaskExample contains an example of a NginxPropertyTask

--- a/tasks/openresty_property_task.go
+++ b/tasks/openresty_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // OpenrestyPropertyTask manages the openresty configuration for a given dokku application
 type OpenrestyPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the openresty configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the openresty configuration should be applied globally"`
 
 	// Property is the name of the openresty property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the openresty property to set"`
 
 	// Value is the value to set for the openresty property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the openresty property"`
 
 	// State is the desired state of the openresty configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the openresty configuration"`
 }
 
 // OpenrestyPropertyTaskExample contains an example of an OpenrestyPropertyTask

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -11,13 +11,13 @@ import (
 // PortsTask manages the ports for a given dokku application
 type PortsTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// PortMappings are the port mappings to set
-	PortMappings []PortMapping `required:"true" yaml:"port_mappings"`
+	PortMappings []PortMapping `required:"true" yaml:"port_mappings" description:"Port mappings to set"`
 
 	// State is the desired state of the ports
-	State State `required:"false" yaml:"state" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the ports"`
 }
 
 // PortsTaskExample contains an example of a PortsTask
@@ -37,13 +37,13 @@ func (e PortsTaskExample) GetName() string {
 // PortMapping represents a port mapping
 type PortMapping struct {
 	// Scheme is the scheme of the port mapping
-	Scheme string `required:"true" yaml:"scheme"`
+	Scheme string `required:"true" yaml:"scheme" description:"Scheme of the port mapping"`
 
 	// Host is the host of the port mapping
-	Host int `required:"true" yaml:"host"`
+	Host int `required:"true" yaml:"host" description:"Host of the port mapping"`
 
 	// Container is the container of the port mapping
-	Container int `required:"true" yaml:"container"`
+	Container int `required:"true" yaml:"container" description:"Container of the port mapping"`
 }
 
 // String returns the string representation of the port mapping
@@ -58,7 +58,37 @@ func (t PortsTask) Doc() string {
 
 // Examples returns the examples for the ports task
 func (t PortsTask) Examples() ([]Doc, error) {
-	return MarshalExamples([]PortsTaskExample{})
+	return MarshalExamples([]PortsTaskExample{
+		{
+			Name: "Map http port 80 to container port 5000",
+			PortsTask: PortsTask{
+				App: "node-js-app",
+				PortMappings: []PortMapping{
+					{Scheme: "http", Host: 80, Container: 5000},
+				},
+			},
+		},
+		{
+			Name: "Map both http and https ports",
+			PortsTask: PortsTask{
+				App: "node-js-app",
+				PortMappings: []PortMapping{
+					{Scheme: "http", Host: 80, Container: 5000},
+					{Scheme: "https", Host: 443, Container: 5000},
+				},
+			},
+		},
+		{
+			Name: "Remove a port mapping",
+			PortsTask: PortsTask{
+				App: "node-js-app",
+				PortMappings: []PortMapping{
+					{Scheme: "http", Host: 80, Container: 5000},
+				},
+				State: StateAbsent,
+			},
+		},
+	})
 }
 
 // Execute sets or unsets the ports

--- a/tasks/proxy_property_task.go
+++ b/tasks/proxy_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // ProxyPropertyTask manages the proxy configuration for a given dokku application
 type ProxyPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the proxy configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the proxy configuration should be applied globally"`
 
 	// Property is the name of the proxy property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the proxy property to set"`
 
 	// Value is the value to set for the proxy property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the proxy property"`
 
 	// State is the desired state of the proxy configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the proxy configuration"`
 }
 
 // ProxyPropertyTaskExample contains an example of a ProxyPropertyTask

--- a/tasks/proxy_toggle_task.go
+++ b/tasks/proxy_toggle_task.go
@@ -28,13 +28,13 @@ func proxyEnabled(ctx ToggleContext) (bool, error) {
 // ProxyToggleTask manages the proxy for a given dokku application
 type ProxyToggleTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// Global is a flag indicating if the proxy should be applied globally
-	Global bool `required:"false" yaml:"global"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the proxy should be applied globally"`
 
 	// State is the desired state of the proxy
-	State State `required:"false" yaml:"state" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the proxy"`
 }
 
 // ProxyToggleTaskExample contains an example of a ProxyToggleTask
@@ -58,7 +58,21 @@ func (t ProxyToggleTask) Doc() string {
 
 // Examples returns the examples for the proxy toggle task
 func (t ProxyToggleTask) Examples() ([]Doc, error) {
-	return MarshalExamples([]ProxyToggleTaskExample{})
+	return MarshalExamples([]ProxyToggleTaskExample{
+		{
+			Name: "Enable the proxy for an app",
+			ProxyToggleTask: ProxyToggleTask{
+				App: "node-js-app",
+			},
+		},
+		{
+			Name: "Disable the proxy for an app",
+			ProxyToggleTask: ProxyToggleTask{
+				App:   "node-js-app",
+				State: StateAbsent,
+			},
+		},
+	})
 }
 
 // Execute enables or disables the proxy

--- a/tasks/ps_property_task.go
+++ b/tasks/ps_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // PsPropertyTask manages the ps configuration for a given dokku application
 type PsPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the ps configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the ps configuration should be applied globally"`
 
 	// Property is the name of the ps property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the ps property to set"`
 
 	// Value is the value to set for the ps property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the ps property"`
 
 	// State is the desired state of the ps configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the ps configuration"`
 }
 
 // PsPropertyTaskExample contains an example of a PsPropertyTask

--- a/tasks/ps_scale_task.go
+++ b/tasks/ps_scale_task.go
@@ -10,16 +10,16 @@ import (
 // PsScaleTask manages the process scale for a given dokku application
 type PsScaleTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// Scale is a map of process types to quantities
-	Scale map[string]int `required:"true" yaml:"scale"`
+	Scale map[string]int `required:"true" yaml:"scale" description:"Map of process types to quantities"`
 
 	// SkipDeploy skips the corresponding deploy
-	SkipDeploy bool `yaml:"skip_deploy" default:"false"`
+	SkipDeploy bool `yaml:"skip_deploy" default:"false" description:"Skip the corresponding deploy"`
 
 	// State is the desired state of the process scale
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present" description:"Desired state of the process scale"`
 }
 
 // PsScaleTaskExample contains an example of a PsScaleTask

--- a/tasks/registry_auth_task.go
+++ b/tasks/registry_auth_task.go
@@ -10,23 +10,23 @@ import (
 // RegistryAuthTask manages docker registry authentication for a dokku application or globally
 type RegistryAuthTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the registry credential should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the registry credential should be applied globally"`
 
 	// Server is the docker registry hostname (e.g. docker.io, ghcr.io)
-	Server string `required:"true" yaml:"server"`
+	Server string `required:"true" yaml:"server" description:"Docker registry hostname (e.g. docker.io, ghcr.io)"`
 
 	// Username is the registry username (required when state is present)
-	Username string `required:"false" yaml:"username,omitempty"`
+	Username string `required:"false" yaml:"username,omitempty" description:"Registry username (required when state is present)"`
 
 	// Password is the registry password (required when state is present)
 	// The value is fed to dokku via --password-stdin and never appears on argv
-	Password string `required:"false" sensitive:"true" yaml:"password,omitempty"`
+	Password string `required:"false" sensitive:"true" yaml:"password,omitempty" description:"Registry password (required when state is present)"`
 
 	// State is the desired state of the registry credential
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the registry credential"`
 }
 
 // RegistryAuthTaskExample contains an example of a RegistryAuthTask

--- a/tasks/registry_property_task.go
+++ b/tasks/registry_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // RegistryPropertyTask manages the registry configuration for a given dokku application
 type RegistryPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the registry configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the registry configuration should be applied globally"`
 
 	// Property is the name of the registry property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the registry property to set"`
 
 	// Value is the value to set for the registry property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the registry property"`
 
 	// State is the desired state of the registry configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the registry configuration"`
 }
 
 // RegistryPropertyTaskExample contains an example of a RegistryPropertyTask

--- a/tasks/requirements.go
+++ b/tasks/requirements.go
@@ -1,0 +1,10 @@
+package tasks
+
+// RequirementsDocer is an optional interface a task implements when it
+// depends on a dokku plugin that is not part of dokku core. The docs
+// generator renders the returned entries in a Requirements section on the
+// task's page. Each entry names a plugin and may carry a parenthetical
+// qualifier when the dependency is conditional.
+type RequirementsDocer interface {
+	Requirements() []string
+}

--- a/tasks/resource_limit_task.go
+++ b/tasks/resource_limit_task.go
@@ -3,19 +3,19 @@ package tasks
 // ResourceLimitTask manages the resource limits for a given dokku application
 type ResourceLimitTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// ProcessType is the process type to set resource limits for
-	ProcessType string `required:"false" yaml:"process_type,omitempty"`
+	ProcessType string `required:"false" yaml:"process_type,omitempty" description:"Process type to set resource limits for"`
 
 	// Resources is a map of resource type to quantity
-	Resources map[string]string `yaml:"resources"`
+	Resources map[string]string `yaml:"resources" description:"Map of resource type to quantity"`
 
 	// ClearBefore clears all resource limits before applying new ones
-	ClearBefore bool `yaml:"clear_before" default:"false"`
+	ClearBefore bool `yaml:"clear_before" default:"false" description:"ClearBefore clears all resource limits before applying new ones"`
 
 	// State is the desired state of the resource limits
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the resource limits"`
 }
 
 // ResourceLimitTaskExample contains an example of a ResourceLimitTask

--- a/tasks/resource_reserve_task.go
+++ b/tasks/resource_reserve_task.go
@@ -3,19 +3,19 @@ package tasks
 // ResourceReserveTask manages the resource reservations for a given dokku application
 type ResourceReserveTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// ProcessType is the process type to set resource reservations for
-	ProcessType string `required:"false" yaml:"process_type,omitempty"`
+	ProcessType string `required:"false" yaml:"process_type,omitempty" description:"Process type to set resource reservations for"`
 
 	// Resources is a map of resource type to quantity
-	Resources map[string]string `yaml:"resources"`
+	Resources map[string]string `yaml:"resources" description:"Map of resource type to quantity"`
 
 	// ClearBefore clears all resource reservations before applying new ones
-	ClearBefore bool `yaml:"clear_before" default:"false"`
+	ClearBefore bool `yaml:"clear_before" default:"false" description:"ClearBefore clears all resource reservations before applying new ones"`
 
 	// State is the desired state of the resource reservations
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the resource reservations"`
 }
 
 // ResourceReserveTaskExample contains an example of a ResourceReserveTask

--- a/tasks/scheduler_docker_local_property_task.go
+++ b/tasks/scheduler_docker_local_property_task.go
@@ -3,16 +3,16 @@ package tasks
 // SchedulerDockerLocalPropertyTask manages the scheduler-docker-local configuration for a given dokku application
 type SchedulerDockerLocalPropertyTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// Property is the name of the scheduler-docker-local property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the scheduler-docker-local property to set"`
 
 	// Value is the value to set for the scheduler-docker-local property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the scheduler-docker-local property"`
 
 	// State is the desired state of the scheduler-docker-local configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the scheduler-docker-local configuration"`
 }
 
 // SchedulerDockerLocalPropertyTaskExample contains an example of a SchedulerDockerLocalPropertyTask

--- a/tasks/scheduler_k3s_property_task.go
+++ b/tasks/scheduler_k3s_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // SchedulerK3sPropertyTask manages the scheduler-k3s configuration for a given dokku application
 type SchedulerK3sPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the scheduler-k3s configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the scheduler-k3s configuration should be applied globally"`
 
 	// Property is the name of the scheduler-k3s property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the scheduler-k3s property to set"`
 
 	// Value is the value to set for the scheduler-k3s property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the scheduler-k3s property"`
 
 	// State is the desired state of the scheduler-k3s configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the scheduler-k3s configuration"`
 }
 
 // SchedulerK3sPropertyTaskExample contains an example of a SchedulerK3sPropertyTask

--- a/tasks/scheduler_property_task.go
+++ b/tasks/scheduler_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // SchedulerPropertyTask manages the scheduler configuration for a given dokku application
 type SchedulerPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the scheduler configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the scheduler configuration should be applied globally"`
 
 	// Property is the name of the scheduler property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the scheduler property to set"`
 
 	// Value is the value to set for the scheduler property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the scheduler property"`
 
 	// State is the desired state of the scheduler configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the scheduler configuration"`
 }
 
 // SchedulerPropertyTaskExample contains an example of a SchedulerPropertyTask

--- a/tasks/service_create_task.go
+++ b/tasks/service_create_task.go
@@ -8,13 +8,13 @@ import (
 // ServiceCreateTask creates or destroys a dokku service
 type ServiceCreateTask struct {
 	// Service is the type of service to create (e.g. redis, postgres, mysql)
-	Service string `required:"true" yaml:"service"`
+	Service string `required:"true" yaml:"service" description:"Type of service to create (e.g. redis, postgres, mysql)"`
 
 	// Name is the name of the service instance
-	Name string `required:"true" yaml:"name"`
+	Name string `required:"true" yaml:"name" description:"Name of the service instance"`
 
 	// State is the desired state of the service
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the service"`
 }
 
 // ServiceCreateTaskExample contains an example of a ServiceCreateTask
@@ -34,6 +34,11 @@ func (e ServiceCreateTaskExample) GetName() string {
 // Doc returns the docblock for the service create task
 func (t ServiceCreateTask) Doc() string {
 	return "Creates or destroys a dokku service"
+}
+
+// Requirements lists the non-core dokku plugins this task depends on.
+func (t ServiceCreateTask) Requirements() []string {
+	return []string{"a dokku datastore service plugin matching the service type (e.g. dokku-postgres, dokku-redis, dokku-mysql)"}
 }
 
 // Examples returns a list of ServiceCreateTaskExamples as yaml

--- a/tasks/service_link_task.go
+++ b/tasks/service_link_task.go
@@ -8,16 +8,16 @@ import (
 // ServiceLinkTask links or unlinks a dokku service to an app
 type ServiceLinkTask struct {
 	// App is the name of the app to link the service to
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app to link the service to"`
 
 	// Service is the type of service to link (e.g. redis, postgres, mysql)
-	Service string `required:"true" yaml:"service"`
+	Service string `required:"true" yaml:"service" description:"Type of service to link (e.g. redis, postgres, mysql)"`
 
 	// Name is the name of the service instance
-	Name string `required:"true" yaml:"name"`
+	Name string `required:"true" yaml:"name" description:"Name of the service instance"`
 
 	// State is the desired state of the service link
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the service link"`
 }
 
 // ServiceLinkTaskExample contains an example of a ServiceLinkTask
@@ -37,6 +37,11 @@ func (e ServiceLinkTaskExample) GetName() string {
 // Doc returns the docblock for the service link task
 func (t ServiceLinkTask) Doc() string {
 	return "Links or unlinks a dokku service to an app"
+}
+
+// Requirements lists the non-core dokku plugins this task depends on.
+func (t ServiceLinkTask) Requirements() []string {
+	return []string{"a dokku datastore service plugin matching the service type (e.g. dokku-postgres, dokku-redis, dokku-mysql)"}
 }
 
 // Examples returns a list of ServiceLinkTaskExamples as yaml

--- a/tasks/storage_ensure_task.go
+++ b/tasks/storage_ensure_task.go
@@ -8,13 +8,13 @@ import (
 // StorageEnsureTask manages the storage for a given dokku application
 type StorageEnsureTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// Chown is the chown value to set
-	Chown string `required:"false" yaml:"chown"`
+	Chown string `required:"false" yaml:"chown,omitempty" description:"Chown value to set"`
 
 	// State is the desired state of the storage
-	State State `required:"false" yaml:"state" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the storage"`
 }
 
 // StorageEnsureTaskExample contains an example of a StorageEnsureTask
@@ -38,7 +38,22 @@ func (t StorageEnsureTask) Doc() string {
 
 // Examples returns the examples for the storage ensure task
 func (t StorageEnsureTask) Examples() ([]Doc, error) {
-	return MarshalExamples([]StorageEnsureTaskExample{})
+	return MarshalExamples([]StorageEnsureTaskExample{
+		{
+			Name: "Ensure a storage directory owned by the herokuish user",
+			StorageEnsureTask: StorageEnsureTask{
+				App:   "node-js-app",
+				Chown: "herokuish",
+			},
+		},
+		{
+			Name: "Ensure a storage directory owned by root",
+			StorageEnsureTask: StorageEnsureTask{
+				App:   "node-js-app",
+				Chown: "root",
+			},
+		},
+	})
 }
 
 // Execute ensures the storage for a given app

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -11,16 +11,16 @@ import (
 // StorageMountTask manages the storage for a given dokku application
 type StorageMountTask struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
+	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// HostDir is the host directory to mount
-	HostDir string `required:"true" yaml:"host_dir"`
+	HostDir string `required:"true" yaml:"host_dir" description:"Host directory to mount"`
 
 	// ContainerDir is the container directory to mount
-	ContainerDir string `required:"true" yaml:"container_dir"`
+	ContainerDir string `required:"true" yaml:"container_dir" description:"Container directory to mount"`
 
 	// State is the desired state of the storage
-	State State `required:"false" yaml:"state" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the storage"`
 }
 
 // StorageMountTaskExample contains an example of a StorageMountTask
@@ -44,7 +44,25 @@ func (t StorageMountTask) Doc() string {
 
 // Examples returns the examples for the storage mount task
 func (t StorageMountTask) Examples() ([]Doc, error) {
-	return MarshalExamples([]StorageMountTaskExample{})
+	return MarshalExamples([]StorageMountTaskExample{
+		{
+			Name: "Mount a host directory into an app",
+			StorageMountTask: StorageMountTask{
+				App:          "node-js-app",
+				HostDir:      "/var/lib/dokku/data/storage/node-js-app",
+				ContainerDir: "/app/storage",
+			},
+		},
+		{
+			Name: "Unmount a host directory from an app",
+			StorageMountTask: StorageMountTask{
+				App:          "node-js-app",
+				HostDir:      "/var/lib/dokku/data/storage/node-js-app",
+				ContainerDir: "/app/storage",
+				State:        StateAbsent,
+			},
+		},
+	})
 }
 
 // Execute mounts or unmounts the storage for a given app

--- a/tasks/traefik_property_task.go
+++ b/tasks/traefik_property_task.go
@@ -3,19 +3,19 @@ package tasks
 // TraefikPropertyTask manages the traefik configuration for a given dokku application
 type TraefikPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
-	App string `required:"false" yaml:"app"`
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
 
 	// Global is a flag indicating if the traefik configuration should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty"`
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the traefik configuration should be applied globally"`
 
 	// Property is the name of the traefik property to set
-	Property string `required:"true" yaml:"property"`
+	Property string `required:"true" yaml:"property" description:"Name of the traefik property to set"`
 
 	// Value is the value to set for the traefik property
-	Value string `required:"false" yaml:"value,omitempty"`
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the traefik property"`
 
 	// State is the desired state of the traefik configuration
-	State State `required:"true" yaml:"state,omitempty" default:"present" options:"present,absent"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the traefik configuration"`
 }
 
 // TraefikPropertyTaskExample contains an example of a TraefikPropertyTask


### PR DESCRIPTION
Generated task pages now mirror the layout of an Ansible module page, adding a synopsis, requirements, a parameters reference, and return values so users can author recipes without reading the source.