### PR TITLE
feat: add dokku_maintenance task

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,8 @@ jobs:
         run: sudo dokku plugin:install https://github.com/dokku/dokku-letsencrypt.git --committish 0.25.0 letsencrypt
       - name: install dokku acl plugin
         run: sudo dokku plugin:install https://github.com/dokku-community/dokku-acl.git acl
+      - name: install dokku maintenance plugin
+        run: sudo dokku plugin:install https://github.com/dokku/dokku-maintenance.git maintenance
       - name: run integration tests (shard ${{ matrix.shard }} of 4)
         run: sudo DOKKU_TEST_SHARD=${{ matrix.shard }} DOKKU_TEST_SHARDS=4 go test -v -count=1 -timeout 20m -run TestIntegration ./tasks/
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -37,6 +37,7 @@ Reference for every task type docket can run inside a recipe. Each page lists th
 - [dokku_letsencrypt](dokku_letsencrypt.md) - Enables or disables letsencrypt SSL certificates for a dokku application
 - [dokku_letsencrypt_property](dokku_letsencrypt_property.md) - Manages the letsencrypt configuration for a given dokku application
 - [dokku_logs_property](dokku_logs_property.md) - Manages the logs configuration for a given dokku application
+- [dokku_maintenance](dokku_maintenance.md) - Enables or disables maintenance mode for a given dokku application
 - [dokku_network](dokku_network.md) - Creates or destroys a Docker network
 - [dokku_network_property](dokku_network_property.md) - Manages the network property for a given dokku application
 - [dokku_nginx_property](dokku_nginx_property.md) - Manages the nginx configuration for a given dokku application

--- a/docs/tasks/dokku_maintenance.md
+++ b/docs/tasks/dokku_maintenance.md
@@ -1,0 +1,48 @@
+# dokku_maintenance
+
+## Synopsis
+
+Enables or disables maintenance mode for a given dokku application
+
+## Requirements
+
+- dokku-maintenance plugin
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `state` | string | no | present | present, absent | Desired state of maintenance mode |
+
+## Examples
+
+### Enable maintenance mode for an app
+
+```yaml
+dokku_maintenance:
+    app: node-js-app
+```
+
+### Disable maintenance mode for an app
+
+```yaml
+dokku_maintenance:
+    app: node-js-app
+    state: absent
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -487,7 +487,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 56
+	expected := 57
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}

--- a/tasks/maintenance_task.go
+++ b/tasks/maintenance_task.go
@@ -1,0 +1,88 @@
+package tasks
+
+import (
+	"strings"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// maintenanceEnabled probes whether maintenance mode is enabled for an app via
+// `dokku --quiet maintenance:report <app> --maintenance-enabled`. Output is
+// "true"/"false".
+func maintenanceEnabled(ctx ToggleContext) (bool, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "maintenance:report", ctx.App, "--maintenance-enabled"},
+	})
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(result.StdoutContents()) == "true", nil
+}
+
+// MaintenanceTask enables or disables maintenance mode for a given dokku application
+type MaintenanceTask struct {
+	// App is the name of the app
+	App string `required:"true" yaml:"app" description:"Name of the app"`
+
+	// State is the desired state of maintenance mode
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of maintenance mode"`
+}
+
+// MaintenanceTaskExample contains an example of a MaintenanceTask
+type MaintenanceTaskExample struct {
+	// Name is the task name holding the MaintenanceTask description
+	Name string `yaml:"-"`
+
+	// MaintenanceTask is the MaintenanceTask configuration
+	MaintenanceTask MaintenanceTask `yaml:"dokku_maintenance"`
+}
+
+// GetName returns the name of the example
+func (e MaintenanceTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the maintenance task
+func (t MaintenanceTask) Doc() string {
+	return "Enables or disables maintenance mode for a given dokku application"
+}
+
+// Requirements lists the non-core dokku plugins this task depends on.
+func (t MaintenanceTask) Requirements() []string {
+	return []string{"dokku-maintenance plugin"}
+}
+
+// Examples returns the examples for the maintenance task
+func (t MaintenanceTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]MaintenanceTaskExample{
+		{
+			Name: "Enable maintenance mode for an app",
+			MaintenanceTask: MaintenanceTask{
+				App: "node-js-app",
+			},
+		},
+		{
+			Name: "Disable maintenance mode for an app",
+			MaintenanceTask: MaintenanceTask{
+				App:   "node-js-app",
+				State: StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute enables or disables maintenance mode
+func (t MaintenanceTask) Execute() TaskOutputState {
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the MaintenanceTask would produce.
+func (t MaintenanceTask) Plan() PlanResult {
+	return planToggle(t.State, t.App, false, false, "maintenance:enable", "maintenance:disable", maintenanceEnabled)
+}
+
+// init registers the MaintenanceTask with the task registry
+func init() {
+	RegisterTask(&MaintenanceTask{})
+}

--- a/tasks/maintenance_task_integration_test.go
+++ b/tasks/maintenance_task_integration_test.go
@@ -1,0 +1,54 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationMaintenance(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "maintenance")
+
+	appName := "docket-test-maintenance"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// enable maintenance mode
+	enableTask := MaintenanceTask{App: appName, State: StatePresent}
+	result := enableTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to enable maintenance: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// enable again - idempotent
+	result = enableTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second enable: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent enable")
+	}
+
+	// disable maintenance mode
+	disableTask := MaintenanceTask{App: appName, State: StateAbsent}
+	result = disableTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to disable maintenance: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+
+	// disable again - idempotent
+	result = disableTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second disable: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent disable")
+	}
+}

--- a/tasks/maintenance_task_test.go
+++ b/tasks/maintenance_task_test.go
@@ -1,0 +1,13 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestMaintenanceTaskInvalidState(t *testing.T) {
+	task := MaintenanceTask{App: "test-app", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}


### PR DESCRIPTION
Adds a `dokku_maintenance` task that toggles maintenance mode for an app via the `dokku-maintenance` community plugin. It reuses the shared `planToggle` helper and probes `maintenance:report --maintenance-enabled` so repeated applies are no-ops. The integration-test workflow installs the `dokku-maintenance` plugin so the new integration test runs instead of skipping.