### PR TITLE
feat: add dokku_ssh_key task

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -56,6 +56,7 @@ Reference for every task type docket can run inside a recipe. Each page lists th
 - [dokku_scheduler_property](dokku_scheduler_property.md) - Manages the scheduler configuration for a given dokku application
 - [dokku_service_create](dokku_service_create.md) - Creates or destroys a dokku service
 - [dokku_service_link](dokku_service_link.md) - Links or unlinks a dokku service to an app
+- [dokku_ssh_key](dokku_ssh_key.md) - Manages an SSH public key for git push access via dokku's ssh-keys plugin
 - [dokku_storage_ensure](dokku_storage_ensure.md) - Ensures the storage for a given dokku application
 - [dokku_storage_mount](dokku_storage_mount.md) - Mounts or unmounts the storage for a given dokku application
 - [dokku_traefik_property](dokku_traefik_property.md) - Manages the traefik configuration for a given dokku application

--- a/docs/tasks/dokku_ssh_key.md
+++ b/docs/tasks/dokku_ssh_key.md
@@ -1,0 +1,46 @@
+# dokku_ssh_key
+
+## Synopsis
+
+Manages an SSH public key for git push access via dokku's ssh-keys plugin
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `name` | string | yes |  |  | Name that identifies the key in dokku |
+| `key` | string | no |  |  | Public key contents. Required when state is present. |
+| `state` | string | no | present | present, absent | Desired state of the SSH key |
+
+## Examples
+
+### Add a deploy key
+
+```yaml
+dokku_ssh_key:
+    name: deploy-bot
+    key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINioKrRalhe/VF8s43pjp8jpl6LGwv6tF0F5FvKPjUer deploy-bot
+```
+
+### Remove a key by name
+
+```yaml
+dokku_ssh_key:
+    name: deploy-bot
+    state: absent
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -487,7 +487,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 57
+	expected := 58
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}

--- a/tasks/ssh_key_task.go
+++ b/tasks/ssh_key_task.go
@@ -1,0 +1,203 @@
+package tasks
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/dokku/docket/subprocess"
+	"golang.org/x/crypto/ssh"
+)
+
+// SshKeyTask manages an SSH public key for git push access via dokku's
+// core ssh-keys plugin.
+type SshKeyTask struct {
+	// Name identifies the key in dokku
+	Name string `required:"true" yaml:"name" description:"Name that identifies the key in dokku"`
+
+	// Key is the public key contents. Required when state is present.
+	Key string `required:"false" yaml:"key,omitempty" description:"Public key contents. Required when state is present."`
+
+	// State is the desired state of the SSH key
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the SSH key"`
+}
+
+// SshKeyTaskExample contains an example of a SshKeyTask
+type SshKeyTaskExample struct {
+	// Name is the task name holding the SshKeyTask description
+	Name string `yaml:"-"`
+
+	// SshKeyTask is the SshKeyTask configuration
+	SshKeyTask SshKeyTask `yaml:"dokku_ssh_key"`
+}
+
+// GetName returns the name of the example
+func (e SshKeyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the ssh key task
+func (t SshKeyTask) Doc() string {
+	return "Manages an SSH public key for git push access via dokku's ssh-keys plugin"
+}
+
+// Examples returns the examples for the ssh key task
+func (t SshKeyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]SshKeyTaskExample{
+		{
+			Name: "Add a deploy key",
+			SshKeyTask: SshKeyTask{
+				Name: "deploy-bot",
+				Key:  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINioKrRalhe/VF8s43pjp8jpl6LGwv6tF0F5FvKPjUer deploy-bot",
+			},
+		},
+		{
+			Name: "Remove a key by name",
+			SshKeyTask: SshKeyTask{
+				Name:  "deploy-bot",
+				State: StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute adds or removes the SSH key
+func (t SshKeyTask) Execute() TaskOutputState {
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the SshKeyTask would produce.
+func (t SshKeyTask) Plan() PlanResult {
+	if t.Name == "" {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'name' is required")}
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if t.Key == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'key' is required when state is 'present'")}
+			}
+			pub, _, _, _, err := ssh.ParseAuthorizedKey([]byte(t.Key))
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("invalid public key: %v", err)}
+			}
+			keys, err := sshKeysList()
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			addInput := subprocess.ExecCommandInput{
+				Command: "dokku",
+				Args:    []string{"--quiet", "ssh-keys:add", t.Name},
+				Stdin:   strings.NewReader(t.Key + "\n"),
+			}
+			if existing, found := keys[t.Name]; found {
+				if sshKeyMatches(existing, pub) {
+					return PlanResult{InSync: true, Status: PlanStatusOK}
+				}
+				// The name is taken by a different key; ssh-keys:add refuses to
+				// clobber, so remove the stale entry first then re-add.
+				inputs := []subprocess.ExecCommandInput{
+					{Command: "dokku", Args: []string{"--quiet", "ssh-keys:remove", t.Name}},
+					addInput,
+				}
+				return PlanResult{
+					InSync:    false,
+					Status:    PlanStatusModify,
+					Reason:    "key contents changed",
+					Mutations: []string{fmt.Sprintf("rotate ssh key %s", t.Name)},
+					Commands:  resolveCommands(inputs),
+					apply: func() TaskOutputState {
+						return runExecInputs(TaskOutputState{State: StatePresent}, StatePresent, inputs)
+					},
+				}
+			}
+			inputs := []subprocess.ExecCommandInput{addInput}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    "key missing",
+				Mutations: []string{fmt.Sprintf("add ssh key %s", t.Name)},
+				Commands:  resolveCommands(inputs),
+				apply: func() TaskOutputState {
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			keys, err := sshKeysList()
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if _, found := keys[t.Name]; !found {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			inputs := []subprocess.ExecCommandInput{
+				{Command: "dokku", Args: []string{"--quiet", "ssh-keys:remove", t.Name}},
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "key present",
+				Mutations: []string{fmt.Sprintf("remove ssh key %s", t.Name)},
+				Commands:  resolveCommands(inputs),
+				apply: func() TaskOutputState {
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				},
+			}
+		},
+	})
+}
+
+// sshKeyEntry is the subset of `dokku ssh-keys:list --format json` this task
+// reads. dokku emits one object per key with name, fingerprint, and the raw
+// public key (see dokku/sshcommand's list output).
+type sshKeyEntry struct {
+	Name        string `json:"name"`
+	Fingerprint string `json:"fingerprint"`
+	PublicKey   string `json:"public-key"`
+}
+
+// sshKeysList returns the installed ssh keys keyed by name. A dokku-level
+// non-zero exit (e.g. no keys configured) is treated as an empty set; only a
+// transport-level failure (*subprocess.SSHError) is propagated.
+func sshKeysList() (map[string]sshKeyEntry, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "ssh-keys:list", "--format", "json"},
+	})
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return nil, err
+		}
+		return map[string]sshKeyEntry{}, nil
+	}
+
+	var entries []sshKeyEntry
+	if err := json.Unmarshal(result.StdoutBytes(), &entries); err != nil {
+		return map[string]sshKeyEntry{}, nil
+	}
+
+	out := make(map[string]sshKeyEntry, len(entries))
+	for _, e := range entries {
+		out[e.Name] = e
+	}
+	return out, nil
+}
+
+// sshKeyMatches reports whether a dokku-reported entry refers to the same
+// public key as pub. The raw key is compared first (comment-insensitive via
+// Marshal); when absent it falls back to dokku's SHA256 fingerprint.
+func sshKeyMatches(entry sshKeyEntry, pub ssh.PublicKey) bool {
+	if raw := strings.TrimSpace(entry.PublicKey); raw != "" {
+		if reported, _, _, _, err := ssh.ParseAuthorizedKey([]byte(raw)); err == nil {
+			return string(reported.Marshal()) == string(pub.Marshal())
+		}
+	}
+	return strings.TrimSpace(entry.Fingerprint) == ssh.FingerprintSHA256(pub)
+}
+
+// init registers the SshKeyTask with the task registry
+func init() {
+	RegisterTask(&SshKeyTask{})
+}

--- a/tasks/ssh_key_task_integration_test.go
+++ b/tasks/ssh_key_task_integration_test.go
@@ -1,0 +1,102 @@
+package tasks
+
+import (
+	"testing"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+func TestIntegrationSshKey(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	keyName := "docket-test-ssh-key"
+
+	removeSSHKey := func() {
+		subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", "ssh-keys:remove", keyName},
+		})
+	}
+
+	removeSSHKey()
+	defer removeSSHKey()
+
+	assertPresent := func(t *testing.T, label string, want bool) {
+		t.Helper()
+		keys, err := sshKeysList()
+		if err != nil {
+			t.Fatalf("%s: sshKeysList failed: %v", label, err)
+		}
+		if _, found := keys[keyName]; found != want {
+			t.Errorf("%s: key present = %v, want %v", label, found, want)
+		}
+	}
+
+	assertPresent(t, "initial", false)
+
+	// add the key
+	addTask := SshKeyTask{Name: keyName, Key: testSSHKey1, State: StatePresent}
+	result := addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to add key: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first add")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+	assertPresent(t, "after add", true)
+
+	// add the same key again - idempotent
+	result = addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second add: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent add")
+	}
+
+	// rotate to a different key under the same name
+	rotateTask := SshKeyTask{Name: keyName, Key: testSSHKey2, State: StatePresent}
+	result = rotateTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to rotate key: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on rotation")
+	}
+	assertPresent(t, "after rotate", true)
+
+	// rotation is now idempotent
+	result = rotateTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second rotate: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent rotation")
+	}
+
+	// remove the key
+	removeTask := SshKeyTask{Name: keyName, State: StateAbsent}
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to remove key: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first remove")
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+	assertPresent(t, "after remove", false)
+
+	// remove again - idempotent
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second remove: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent remove")
+	}
+}

--- a/tasks/ssh_key_task_test.go
+++ b/tasks/ssh_key_task_test.go
@@ -1,0 +1,79 @@
+package tasks
+
+import (
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// Test fixtures: two distinct ed25519 public keys and their SHA256
+// fingerprints (as emitted by `ssh-keygen -lf`). Shared with the integration
+// test.
+const (
+	testSSHKey1 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINioKrRalhe/VF8s43pjp8jpl6LGwv6tF0F5FvKPjUer docket-test-key-1"
+	testSSHKey2 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJdrDTcBfAuO6HLQwr43xeidcwfLDiKNUDcxEMxqo0tx docket-test-key-2"
+
+	testSSHKey1Fingerprint = "SHA256:LstajP5Ikfsl+VCQw4ZtoPvox4TMWs+3LIo11pXEr4o"
+	testSSHKey2Fingerprint = "SHA256:SgMboxwxpDfXLgOoyoyD/nAgTlCzvcZMMS3r+IyKi1o"
+)
+
+func TestSshKeyTaskInvalidState(t *testing.T) {
+	task := SshKeyTask{Name: "deploy-bot", Key: testSSHKey1, State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestSshKeyTaskRequiresName(t *testing.T) {
+	result := SshKeyTask{Key: testSSHKey1, State: StatePresent}.Plan()
+	if result.Error == nil {
+		t.Fatal("Plan without 'name' should return an error")
+	}
+}
+
+func TestSshKeyTaskRequiresKeyWhenPresent(t *testing.T) {
+	result := SshKeyTask{Name: "deploy-bot", State: StatePresent}.Plan()
+	if result.Error == nil {
+		t.Fatal("Plan with state 'present' and no 'key' should return an error")
+	}
+}
+
+func TestSshKeyTaskInvalidKey(t *testing.T) {
+	result := SshKeyTask{Name: "deploy-bot", Key: "not-a-key", State: StatePresent}.Plan()
+	if result.Error == nil {
+		t.Fatal("Plan with an unparseable key should return an error")
+	}
+}
+
+func TestSshKeyMatches(t *testing.T) {
+	pub, _, _, _, err := ssh.ParseAuthorizedKey([]byte(testSSHKey1))
+	if err != nil {
+		t.Fatalf("failed to parse fixture key: %v", err)
+	}
+
+	// Sanity-check the fixture fingerprint against the crypto/ssh computation
+	// so the comparison the task relies on stays correct.
+	if got := ssh.FingerprintSHA256(pub); got != testSSHKey1Fingerprint {
+		t.Fatalf("fixture fingerprint mismatch: got %q, want %q", got, testSSHKey1Fingerprint)
+	}
+
+	cases := []struct {
+		name  string
+		entry sshKeyEntry
+		want  bool
+	}{
+		{"matching fingerprint only", sshKeyEntry{Fingerprint: testSSHKey1Fingerprint}, true},
+		{"different fingerprint only", sshKeyEntry{Fingerprint: testSSHKey2Fingerprint}, false},
+		{"matching raw key, different comment", sshKeyEntry{PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINioKrRalhe/VF8s43pjp8jpl6LGwv6tF0F5FvKPjUer other-comment"}, true},
+		{"different raw key", sshKeyEntry{PublicKey: testSSHKey2}, false},
+		{"empty entry", sshKeyEntry{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sshKeyMatches(tc.entry, pub); got != tc.want {
+				t.Errorf("sshKeyMatches = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a `dokku_ssh_key` task that manages a named SSH public key for git push access via dokku's core `ssh-keys` plugin. The key contents are piped to `ssh-keys:add` over stdin so the task works identically over the SSH transport, and `ssh-keys:list --format json` is probed to stay idempotent and to detect key rotation (a changed key under the same name is removed and re-added). Idempotency is verified against the `name`, `fingerprint`, and `public-key` fields dokku emits, with the fingerprint comparison cross-checked against `crypto/ssh` in a unit test.

This is stacked on #240; review that first.