### PR TITLE
feat: add dokku_plugin task

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -42,6 +42,7 @@ Reference for every task type docket can run inside a recipe. Each page lists th
 - [dokku_network_property](dokku_network_property.md) - Manages the network property for a given dokku application
 - [dokku_nginx_property](dokku_nginx_property.md) - Manages the nginx configuration for a given dokku application
 - [dokku_openresty_property](dokku_openresty_property.md) - Manages the openresty configuration for a given dokku application
+- [dokku_plugin](dokku_plugin.md) - Installs or uninstalls a third-party dokku plugin.
 - [dokku_ports](dokku_ports.md) - Manages the ports for a given dokku application
 - [dokku_proxy_property](dokku_proxy_property.md) - Manages the proxy configuration for a given dokku application
 - [dokku_proxy_toggle](dokku_proxy_toggle.md) - Enables or disables the proxy plugin for a given dokku application

--- a/docs/tasks/dokku_plugin.md
+++ b/docs/tasks/dokku_plugin.md
@@ -1,0 +1,56 @@
+# dokku_plugin
+
+## Synopsis
+
+Installs or uninstalls a third-party dokku plugin. Installation is a root-level operation, so this task must run over the SSH transport (where dokku wraps privilege server-side) or as root locally. Idempotency is by plugin name only - a changed `url` or `committish` on an already-installed plugin is not detected.
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `name` | string | yes |  |  | Plugin name as it appears in plugin:list |
+| `url` | string | no |  |  | Git URL to install the plugin from. Required when state is present. |
+| `committish` | string | no |  |  | Optional git ref (branch, tag, or commit) to install |
+| `state` | string | no | present | present, absent | Desired state of the plugin |
+
+## Examples
+
+### Install a plugin from a git URL
+
+```yaml
+dokku_plugin:
+    name: redis
+    url: https://github.com/dokku/dokku-redis.git
+```
+
+### Install a plugin pinned to a committish
+
+```yaml
+dokku_plugin:
+    name: letsencrypt
+    url: https://github.com/dokku/dokku-letsencrypt.git
+    committish: 0.25.0
+```
+
+### Uninstall a plugin
+
+```yaml
+dokku_plugin:
+    name: redis
+    state: absent
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/tasks/integration_shard_test.go
+++ b/tasks/integration_shard_test.go
@@ -65,6 +65,7 @@ var integrationTestWeights = map[string]float64{
 	"TestIntegrationPlanDetectsMissingApp":                  3.0,
 	"TestIntegrationPlanDoesNotMutate":                      0.5,
 	"TestIntegrationPlanInSyncAfterApply":                   5.9,
+	"TestIntegrationPlugin":                                 60.0,
 	"TestIntegrationPortsAddAndRemove":                      11.3,
 	"TestIntegrationProxyPropertyAll":                       10.0,
 	"TestIntegrationProxyToggle":                            7.7,

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -487,7 +487,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 58
+	expected := 59
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}

--- a/tasks/plugin_task.go
+++ b/tasks/plugin_task.go
@@ -1,0 +1,170 @@
+package tasks
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// PluginTask installs or uninstalls a third-party dokku plugin.
+//
+// plugin:install and plugin:uninstall are root-level operations: over the SSH
+// transport dokku wraps privilege server-side, and run locally docket must
+// already be root. Idempotency is by plugin name only - a changed url or
+// committish on an already-installed plugin is not detected.
+type PluginTask struct {
+	// Name is the plugin name as it appears in plugin:list
+	Name string `required:"true" yaml:"name" description:"Plugin name as it appears in plugin:list"`
+
+	// URL is the git URL to install from. Required when state is present.
+	URL string `required:"false" yaml:"url,omitempty" description:"Git URL to install the plugin from. Required when state is present."`
+
+	// Committish is an optional git ref (branch, tag, or commit) to install
+	Committish string `required:"false" yaml:"committish,omitempty" description:"Optional git ref (branch, tag, or commit) to install"`
+
+	// State is the desired state of the plugin
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the plugin"`
+}
+
+// PluginTaskExample contains an example of a PluginTask
+type PluginTaskExample struct {
+	// Name is the task name holding the PluginTask description
+	Name string `yaml:"-"`
+
+	// PluginTask is the PluginTask configuration
+	PluginTask PluginTask `yaml:"dokku_plugin"`
+}
+
+// GetName returns the name of the example
+func (e PluginTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the plugin task
+func (t PluginTask) Doc() string {
+	return "Installs or uninstalls a third-party dokku plugin. Installation is a " +
+		"root-level operation, so this task must run over the SSH transport (where " +
+		"dokku wraps privilege server-side) or as root locally. Idempotency is by " +
+		"plugin name only - a changed `url` or `committish` on an already-installed " +
+		"plugin is not detected."
+}
+
+// Examples returns the examples for the plugin task
+func (t PluginTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]PluginTaskExample{
+		{
+			Name: "Install a plugin from a git URL",
+			PluginTask: PluginTask{
+				Name: "redis",
+				URL:  "https://github.com/dokku/dokku-redis.git",
+			},
+		},
+		{
+			Name: "Install a plugin pinned to a committish",
+			PluginTask: PluginTask{
+				Name:       "letsencrypt",
+				URL:        "https://github.com/dokku/dokku-letsencrypt.git",
+				Committish: "0.25.0",
+			},
+		},
+		{
+			Name: "Uninstall a plugin",
+			PluginTask: PluginTask{
+				Name:  "redis",
+				State: StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute installs or uninstalls the plugin
+func (t PluginTask) Execute() TaskOutputState {
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the PluginTask would produce.
+func (t PluginTask) Plan() PlanResult {
+	if t.Name == "" {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'name' is required")}
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if t.URL == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'url' is required when state is 'present'")}
+			}
+			installed, err := pluginInstalled(t.Name)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if installed {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			args := []string{"--quiet", "plugin:install", t.URL}
+			if t.Committish != "" {
+				args = append(args, "--committish", t.Committish)
+			}
+			args = append(args, t.Name)
+			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    "plugin not installed",
+				Mutations: []string{fmt.Sprintf("install plugin %s", t.Name)},
+				Commands:  resolveCommands(inputs),
+				apply: func() TaskOutputState {
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			installed, err := pluginInstalled(t.Name)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !installed {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", "plugin:uninstall", t.Name},
+			}}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "plugin installed",
+				Mutations: []string{fmt.Sprintf("uninstall plugin %s", t.Name)},
+				Commands:  resolveCommands(inputs),
+				apply: func() TaskOutputState {
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				},
+			}
+		},
+	})
+}
+
+// pluginInstalled reports whether a plugin is installed by parsing
+// `dokku plugin:list`, whose first whitespace-delimited field per line is the
+// plugin name (mirrors dokku's own plugin:installed check).
+func pluginInstalled(name string) (bool, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "plugin:list"},
+	})
+	if err != nil {
+		return false, err
+	}
+
+	for _, line := range strings.Split(result.StdoutContents(), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) > 0 && fields[0] == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// init registers the PluginTask with the task registry
+func init() {
+	RegisterTask(&PluginTask{})
+}

--- a/tasks/plugin_task_integration_test.go
+++ b/tasks/plugin_task_integration_test.go
@@ -1,0 +1,86 @@
+package tasks
+
+import (
+	"testing"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+func TestIntegrationPlugin(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	// smoke-test-plugin is dokku's purpose-built plugin for exercising the
+	// install/uninstall flow. Pinned to a tag for reproducibility.
+	pluginName := "smoke-test-plugin"
+	pluginURL := "https://github.com/dokku/smoke-test-plugin.git"
+	pluginCommittish := "v0.9.0"
+
+	uninstallPlugin := func() {
+		subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", "plugin:uninstall", pluginName},
+		})
+	}
+
+	uninstallPlugin()
+	defer uninstallPlugin()
+
+	assertInstalled := func(t *testing.T, label string, want bool) {
+		t.Helper()
+		got, err := pluginInstalled(pluginName)
+		if err != nil {
+			t.Fatalf("%s: pluginInstalled failed: %v", label, err)
+		}
+		if got != want {
+			t.Errorf("%s: plugin installed = %v, want %v", label, got, want)
+		}
+	}
+
+	assertInstalled(t, "initial", false)
+
+	// install the plugin
+	installTask := PluginTask{Name: pluginName, URL: pluginURL, Committish: pluginCommittish, State: StatePresent}
+	result := installTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to install plugin: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first install")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+	assertInstalled(t, "after install", true)
+
+	// install again - idempotent
+	result = installTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second install: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent install")
+	}
+
+	// uninstall the plugin
+	uninstallTask := PluginTask{Name: pluginName, State: StateAbsent}
+	result = uninstallTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to uninstall plugin: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first uninstall")
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+	assertInstalled(t, "after uninstall", false)
+
+	// uninstall again - idempotent
+	result = uninstallTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second uninstall: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent uninstall")
+	}
+}

--- a/tasks/plugin_task_test.go
+++ b/tasks/plugin_task_test.go
@@ -1,0 +1,27 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestPluginTaskInvalidState(t *testing.T) {
+	task := PluginTask{Name: "redis", URL: "https://github.com/dokku/dokku-redis.git", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestPluginTaskRequiresName(t *testing.T) {
+	result := PluginTask{URL: "https://github.com/dokku/dokku-redis.git", State: StatePresent}.Plan()
+	if result.Error == nil {
+		t.Fatal("Plan without 'name' should return an error")
+	}
+}
+
+func TestPluginTaskRequiresURLWhenPresent(t *testing.T) {
+	result := PluginTask{Name: "redis", State: StatePresent}.Plan()
+	if result.Error == nil {
+		t.Fatal("Plan with state 'present' and no 'url' should return an error")
+	}
+}


### PR DESCRIPTION
Adds a `dokku_plugin` task that installs or uninstalls a third-party dokku plugin via `plugin:install`/`plugin:uninstall`, probing `plugin:list` for idempotency by plugin name. Installation is a root-level operation, so the task runs over the SSH transport (where dokku wraps privilege server-side) or as root locally; a changed `url` or `committish` on an already-installed plugin is not detected. The integration test installs and uninstalls `dokku/smoke-test-plugin` pinned to `v0.9.0`.

This is stacked on #241; review that first.