### PR TITLE
feat: add dokku_service_expose task

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -56,6 +56,7 @@ Reference for every task type docket can run inside a recipe. Each page lists th
 - [dokku_scheduler_k3s_property](dokku_scheduler_k3s_property.md) - Manages the scheduler-k3s configuration for a given dokku application
 - [dokku_scheduler_property](dokku_scheduler_property.md) - Manages the scheduler configuration for a given dokku application
 - [dokku_service_create](dokku_service_create.md) - Creates or destroys a dokku service
+- [dokku_service_expose](dokku_service_expose.md) - Exposes or unexposes a dokku service on host ports
 - [dokku_service_link](dokku_service_link.md) - Links or unlinks a dokku service to an app
 - [dokku_ssh_key](dokku_ssh_key.md) - Manages an SSH public key for git push access via dokku's ssh-keys plugin
 - [dokku_storage_ensure](dokku_storage_ensure.md) - Ensures the storage for a given dokku application

--- a/docs/tasks/dokku_service_expose.md
+++ b/docs/tasks/dokku_service_expose.md
@@ -1,0 +1,64 @@
+# dokku_service_expose
+
+## Synopsis
+
+Exposes or unexposes a dokku service on host ports
+
+## Requirements
+
+- a dokku datastore service plugin matching the service type (e.g. dokku-postgres, dokku-redis, dokku-mysql)
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `service` | string | yes |  |  | Type of service to expose (e.g. redis, postgres, mysql) |
+| `name` | string | yes |  |  | Name of the service instance |
+| `ports` | list | no |  |  | Host ports to expose the service on. Required when state is present. |
+| `state` | string | no | present | present, absent | Desired state of the service exposure |
+
+## Examples
+
+### Expose a postgres service named my-db on host port 5432
+
+```yaml
+dokku_service_expose:
+    service: postgres
+    name: my-db
+    ports:
+        - "5432"
+```
+
+### Expose a redis service named my-redis on host port 6379
+
+```yaml
+dokku_service_expose:
+    service: redis
+    name: my-redis
+    ports:
+        - "6379"
+```
+
+### Unexpose a postgres service named my-db
+
+```yaml
+dokku_service_expose:
+    service: postgres
+    name: my-db
+    state: absent
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -487,7 +487,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 59
+	expected := 60
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}

--- a/tasks/service_expose_task.go
+++ b/tasks/service_expose_task.go
@@ -1,0 +1,219 @@
+package tasks
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// ServiceExposeTask exposes or unexposes a dokku service on host ports
+type ServiceExposeTask struct {
+	// Service is the type of service to expose (e.g. redis, postgres, mysql)
+	Service string `required:"true" yaml:"service" description:"Type of service to expose (e.g. redis, postgres, mysql)"`
+
+	// Name is the name of the service instance
+	Name string `required:"true" yaml:"name" description:"Name of the service instance"`
+
+	// Ports are the host ports to expose the service on. Required when state is present.
+	Ports []string `required:"false" yaml:"ports,omitempty" description:"Host ports to expose the service on. Required when state is present."`
+
+	// State is the desired state of the service exposure
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the service exposure"`
+}
+
+// ServiceExposeTaskExample contains an example of a ServiceExposeTask
+type ServiceExposeTaskExample struct {
+	// Name is the task name holding the ServiceExposeTask description
+	Name string `yaml:"-"`
+
+	// ServiceExposeTask is the ServiceExposeTask configuration
+	ServiceExposeTask ServiceExposeTask `yaml:"dokku_service_expose"`
+}
+
+// GetName returns the name of the example
+func (e ServiceExposeTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the service expose task
+func (t ServiceExposeTask) Doc() string {
+	return "Exposes or unexposes a dokku service on host ports"
+}
+
+// Requirements lists the non-core dokku plugins this task depends on.
+func (t ServiceExposeTask) Requirements() []string {
+	return []string{"a dokku datastore service plugin matching the service type (e.g. dokku-postgres, dokku-redis, dokku-mysql)"}
+}
+
+// Examples returns a list of ServiceExposeTaskExamples as yaml
+func (t ServiceExposeTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]ServiceExposeTaskExample{
+		{
+			Name: "Expose a postgres service named my-db on host port 5432",
+			ServiceExposeTask: ServiceExposeTask{
+				Service: "postgres",
+				Name:    "my-db",
+				Ports:   []string{"5432"},
+			},
+		},
+		{
+			Name: "Expose a redis service named my-redis on host port 6379",
+			ServiceExposeTask: ServiceExposeTask{
+				Service: "redis",
+				Name:    "my-redis",
+				Ports:   []string{"6379"},
+			},
+		},
+		{
+			Name: "Unexpose a postgres service named my-db",
+			ServiceExposeTask: ServiceExposeTask{
+				Service: "postgres",
+				Name:    "my-db",
+				State:   StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute exposes or unexposes a dokku service
+func (t ServiceExposeTask) Execute() TaskOutputState {
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the ServiceExposeTask would produce.
+func (t ServiceExposeTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if len(t.Ports) == 0 {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'ports' is required when state is 'present'")}
+			}
+			exists, err := serviceExists(t.Service, t.Name)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !exists {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("service %s %s does not exist", t.Service, t.Name)}
+			}
+			current, err := serviceExposedPorts(t.Service, t.Name)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			desired := map[string]bool{}
+			for _, p := range t.Ports {
+				desired[p] = true
+			}
+			if portSetEqual(current, desired) {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			inputs := []subprocess.ExecCommandInput{}
+			mutations := []string{}
+			status := PlanStatusCreate
+			// dokku rejects expose when the service is already exposed, so a
+			// change of ports must unexpose first, then re-expose the full set.
+			if len(current) > 0 {
+				status = PlanStatusModify
+				inputs = append(inputs, subprocess.ExecCommandInput{
+					Command: "dokku",
+					Args:    []string{"--quiet", fmt.Sprintf("%s:unexpose", t.Service), t.Name},
+				})
+				mutations = append(mutations, fmt.Sprintf("%s:unexpose %s", t.Service, t.Name))
+			}
+			exposeArgs := []string{"--quiet", fmt.Sprintf("%s:expose", t.Service), t.Name}
+			exposeArgs = append(exposeArgs, t.Ports...)
+			inputs = append(inputs, subprocess.ExecCommandInput{Command: "dokku", Args: exposeArgs})
+			mutations = append(mutations, fmt.Sprintf("%s:expose %s %s", t.Service, t.Name, strings.Join(t.Ports, " ")))
+			return PlanResult{
+				InSync:    false,
+				Status:    status,
+				Reason:    fmt.Sprintf("%s service %s not exposed on %s", t.Service, t.Name, strings.Join(t.Ports, " ")),
+				Mutations: mutations,
+				Commands:  resolveCommands(inputs),
+				apply: func() TaskOutputState {
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			exists, err := serviceExists(t.Service, t.Name)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !exists {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("service %s %s does not exist", t.Service, t.Name)}
+			}
+			current, err := serviceExposedPorts(t.Service, t.Name)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if len(current) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", fmt.Sprintf("%s:unexpose", t.Service), t.Name},
+			}}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    fmt.Sprintf("%s service %s exposed", t.Service, t.Name),
+				Mutations: []string{fmt.Sprintf("%s:unexpose %s", t.Service, t.Name)},
+				Commands:  resolveCommands(inputs),
+				apply: func() TaskOutputState {
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				},
+			}
+		},
+	})
+}
+
+// serviceExposedPorts returns the set of host ports a dokku service is
+// currently exposed on. A transport-level failure (`*subprocess.SSHError`)
+// is propagated; a dokku-level non-zero exit (e.g. service not exposed) is
+// treated as "no ports exposed."
+func serviceExposedPorts(service, name string) (map[string]bool, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args: []string{
+			"--quiet",
+			fmt.Sprintf("%s:info", service),
+			name,
+			"--exposed-ports",
+		},
+	})
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return nil, err
+		}
+		return map[string]bool{}, nil
+	}
+
+	ports := map[string]bool{}
+	for _, p := range strings.Fields(result.StdoutContents()) {
+		if p == "-" {
+			continue
+		}
+		ports[p] = true
+	}
+	return ports, nil
+}
+
+// portSetEqual reports whether two port sets contain the same elements.
+func portSetEqual(a, b map[string]bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if !b[k] {
+			return false
+		}
+	}
+	return true
+}
+
+// init registers the ServiceExposeTask with the task registry
+func init() {
+	RegisterTask(&ServiceExposeTask{})
+}

--- a/tasks/service_expose_task_test.go
+++ b/tasks/service_expose_task_test.go
@@ -1,0 +1,89 @@
+package tasks
+
+import (
+	"testing"
+
+	_ "github.com/gliderlabs/sigil/builtin"
+)
+
+func TestServiceExposeTaskInvalidState(t *testing.T) {
+	task := ServiceExposeTask{Service: "redis", Name: "test-service", Ports: []string{"6379"}, State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestServiceExposeTaskPresentRequiresPorts(t *testing.T) {
+	task := ServiceExposeTask{Service: "redis", Name: "test-service"}
+	result := task.Plan()
+	if result.Error == nil {
+		t.Fatal("Plan with present state and no ports should return an error")
+	}
+}
+
+func TestGetTasksServiceExposeTaskParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: expose postgres service
+      dokku_service_expose:
+        service: postgres
+        name: my-db
+        ports:
+          - "5432"
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("expose postgres service")
+	if task == nil {
+		t.Fatal("task 'expose postgres service' not found")
+	}
+
+	seTask, ok := task.(*ServiceExposeTask)
+	if !ok {
+		st, ok2 := task.(ServiceExposeTask)
+		if !ok2 {
+			t.Fatalf("task is not a ServiceExposeTask (type is %T)", task)
+		}
+		seTask = &st
+	}
+
+	if seTask.Service != "postgres" {
+		t.Errorf("Service = %q, want %q", seTask.Service, "postgres")
+	}
+	if seTask.Name != "my-db" {
+		t.Errorf("Name = %q, want %q", seTask.Name, "my-db")
+	}
+	if len(seTask.Ports) != 1 || seTask.Ports[0] != "5432" {
+		t.Errorf("Ports = %v, want [5432]", seTask.Ports)
+	}
+	if seTask.State != StatePresent {
+		t.Errorf("expected default state 'present', got %q", seTask.State)
+	}
+}
+
+func TestServiceExposePortSetEqual(t *testing.T) {
+	cases := []struct {
+		name string
+		a    map[string]bool
+		b    map[string]bool
+		want bool
+	}{
+		{"empty", map[string]bool{}, map[string]bool{}, true},
+		{"same", map[string]bool{"5432": true}, map[string]bool{"5432": true}, true},
+		{"different-len", map[string]bool{"5432": true}, map[string]bool{}, false},
+		{"different-members", map[string]bool{"5432": true}, map[string]bool{"6379": true}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := portSetEqual(tc.a, tc.b); got != tc.want {
+				t.Errorf("portSetEqual(%v, %v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Exposes or unexposes a dokku datastore service on host ports, probing the currently exposed ports via the service `info` command so repeated applies are idempotent.