### PR TITLE
feat: add dokku_service_property task

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -58,6 +58,7 @@ Reference for every task type docket can run inside a recipe. Each page lists th
 - [dokku_service_create](dokku_service_create.md) - Creates or destroys a dokku service
 - [dokku_service_expose](dokku_service_expose.md) - Exposes or unexposes a dokku service on host ports
 - [dokku_service_link](dokku_service_link.md) - Links or unlinks a dokku service to an app
+- [dokku_service_property](dokku_service_property.md) - Manages a property for a given dokku service
 - [dokku_ssh_key](dokku_ssh_key.md) - Manages an SSH public key for git push access via dokku's ssh-keys plugin
 - [dokku_storage_ensure](dokku_storage_ensure.md) - Ensures the storage for a given dokku application
 - [dokku_storage_mount](dokku_storage_mount.md) - Mounts or unmounts the storage for a given dokku application

--- a/docs/tasks/dokku_service_property.md
+++ b/docs/tasks/dokku_service_property.md
@@ -1,0 +1,56 @@
+# dokku_service_property
+
+## Synopsis
+
+Manages a property for a given dokku service
+
+## Requirements
+
+- a dokku datastore service plugin matching the service type (e.g. dokku-postgres, dokku-redis, dokku-mysql)
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `service` | string | yes |  |  | Type of service to configure (e.g. redis, postgres, mysql) |
+| `name` | string | yes |  |  | Name of the service instance |
+| `property` | string | yes |  |  | Name of the property to set |
+| `value` | string | no |  |  | Value to set the property to. Required when state is present. |
+| `state` | string | no | present | present, absent | Desired state of the property |
+
+## Examples
+
+### Set the restart-policy for a postgres service
+
+```yaml
+dokku_service_property:
+    service: postgres
+    name: my-db
+    property: restart-policy
+    value: always
+```
+
+### Clear the restart-policy for a postgres service
+
+```yaml
+dokku_service_property:
+    service: postgres
+    name: my-db
+    property: restart-policy
+    state: absent
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -487,7 +487,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 60
+	expected := 61
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}

--- a/tasks/service_property_task.go
+++ b/tasks/service_property_task.go
@@ -1,0 +1,155 @@
+package tasks
+
+import (
+	"fmt"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// ServicePropertyTask manages a single dokku service property via
+// <service>:set.
+//
+// Idempotency is intentionally skipped here because dokku service plugins
+// expose no uniform way to read back an arbitrary set key: there is no
+// per-service report JSON, and the `<service>:info` flags do not correspond
+// one-to-one to settable keys (e.g. restart-policy, shm-size, and image are
+// settable but not readable via info). The plan therefore reports drift
+// unconditionally. Once a no-change read is available, this task should
+// switch to probing instead of always reporting Changed=true.
+type ServicePropertyTask struct {
+	// Service is the type of service to configure (e.g. redis, postgres, mysql)
+	Service string `required:"true" yaml:"service" description:"Type of service to configure (e.g. redis, postgres, mysql)"`
+
+	// Name is the name of the service instance
+	Name string `required:"true" yaml:"name" description:"Name of the service instance"`
+
+	// Property is the name of the property to set
+	Property string `required:"true" yaml:"property" description:"Name of the property to set"`
+
+	// Value is the value to set the property to. Required when state is present.
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set the property to. Required when state is present."`
+
+	// State is the desired state of the property
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the property"`
+}
+
+// ServicePropertyTaskExample contains an example of a ServicePropertyTask
+type ServicePropertyTaskExample struct {
+	// Name is the task name holding the ServicePropertyTask description
+	Name string `yaml:"-"`
+
+	// ServicePropertyTask is the ServicePropertyTask configuration
+	ServicePropertyTask ServicePropertyTask `yaml:"dokku_service_property"`
+}
+
+// GetName returns the name of the example
+func (e ServicePropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the service property task
+func (t ServicePropertyTask) Doc() string {
+	return "Manages a property for a given dokku service"
+}
+
+// Requirements lists the non-core dokku plugins this task depends on.
+func (t ServicePropertyTask) Requirements() []string {
+	return []string{"a dokku datastore service plugin matching the service type (e.g. dokku-postgres, dokku-redis, dokku-mysql)"}
+}
+
+// Examples returns a list of ServicePropertyTaskExamples as yaml
+func (t ServicePropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]ServicePropertyTaskExample{
+		{
+			Name: "Set the restart-policy for a postgres service",
+			ServicePropertyTask: ServicePropertyTask{
+				Service:  "postgres",
+				Name:     "my-db",
+				Property: "restart-policy",
+				Value:    "always",
+			},
+		},
+		{
+			Name: "Clear the restart-policy for a postgres service",
+			ServicePropertyTask: ServicePropertyTask{
+				Service:  "postgres",
+				Name:     "my-db",
+				Property: "restart-policy",
+				State:    StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute sets or clears the dokku service property
+func (t ServicePropertyTask) Execute() TaskOutputState {
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the ServicePropertyTask would produce. dokku has no
+// reliable way to read back a service set key, so the plan reports drift
+// unconditionally once the service is confirmed to exist.
+func (t ServicePropertyTask) Plan() PlanResult {
+	if t.Property == "" {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'property' is required")}
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if t.Value == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'value' is required when state is 'present'")}
+			}
+			exists, err := serviceExists(t.Service, t.Name)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !exists {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("service %s %s does not exist", t.Service, t.Name)}
+			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", fmt.Sprintf("%s:set", t.Service), t.Name, t.Property, t.Value},
+			}}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    "service property state not probed",
+				Mutations: []string{fmt.Sprintf("%s:set %s %s %s", t.Service, t.Name, t.Property, t.Value)},
+				Commands:  resolveCommands(inputs),
+				apply: func() TaskOutputState {
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			if t.Value != "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'value' must not be set when state is 'absent'")}
+			}
+			exists, err := serviceExists(t.Service, t.Name)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !exists {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("service %s %s does not exist", t.Service, t.Name)}
+			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", fmt.Sprintf("%s:set", t.Service), t.Name, t.Property},
+			}}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "service property state not probed",
+				Mutations: []string{fmt.Sprintf("%s:set %s %s (clear)", t.Service, t.Name, t.Property)},
+				Commands:  resolveCommands(inputs),
+				apply: func() TaskOutputState {
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				},
+			}
+		},
+	})
+}
+
+// init registers the ServicePropertyTask with the task registry
+func init() {
+	RegisterTask(&ServicePropertyTask{})
+}

--- a/tasks/service_property_task_test.go
+++ b/tasks/service_property_task_test.go
@@ -1,0 +1,87 @@
+package tasks
+
+import (
+	"testing"
+
+	_ "github.com/gliderlabs/sigil/builtin"
+)
+
+func TestServicePropertyTaskInvalidState(t *testing.T) {
+	task := ServicePropertyTask{Service: "redis", Name: "test-service", Property: "restart-policy", Value: "always", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestServicePropertyTaskPresentRequiresValue(t *testing.T) {
+	task := ServicePropertyTask{Service: "redis", Name: "test-service", Property: "restart-policy"}
+	result := task.Plan()
+	if result.Error == nil {
+		t.Fatal("Plan with present state and no value should return an error")
+	}
+}
+
+func TestServicePropertyTaskAbsentRejectsValue(t *testing.T) {
+	task := ServicePropertyTask{Service: "redis", Name: "test-service", Property: "restart-policy", Value: "always", State: StateAbsent}
+	result := task.Plan()
+	if result.Error == nil {
+		t.Fatal("Plan with absent state and a value should return an error")
+	}
+}
+
+func TestServicePropertyTaskRequiresProperty(t *testing.T) {
+	task := ServicePropertyTask{Service: "redis", Name: "test-service", Value: "always"}
+	result := task.Plan()
+	if result.Error == nil {
+		t.Fatal("Plan with no property should return an error")
+	}
+}
+
+func TestGetTasksServicePropertyTaskParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: set postgres restart policy
+      dokku_service_property:
+        service: postgres
+        name: my-db
+        property: restart-policy
+        value: always
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("set postgres restart policy")
+	if task == nil {
+		t.Fatal("task 'set postgres restart policy' not found")
+	}
+
+	spTask, ok := task.(*ServicePropertyTask)
+	if !ok {
+		st, ok2 := task.(ServicePropertyTask)
+		if !ok2 {
+			t.Fatalf("task is not a ServicePropertyTask (type is %T)", task)
+		}
+		spTask = &st
+	}
+
+	if spTask.Service != "postgres" {
+		t.Errorf("Service = %q, want %q", spTask.Service, "postgres")
+	}
+	if spTask.Name != "my-db" {
+		t.Errorf("Name = %q, want %q", spTask.Name, "my-db")
+	}
+	if spTask.Property != "restart-policy" {
+		t.Errorf("Property = %q, want %q", spTask.Property, "restart-policy")
+	}
+	if spTask.Value != "always" {
+		t.Errorf("Value = %q, want %q", spTask.Value, "always")
+	}
+	if spTask.State != StatePresent {
+		t.Errorf("expected default state 'present', got %q", spTask.State)
+	}
+}


### PR DESCRIPTION
Sets or clears a single property on a dokku datastore service via `<service>:set`. Service plugins expose no reliable read for set keys, so the task reports drift unconditionally, matching the existing no-probe credential tasks.