### PR TITLE
feat: add dokku_service_backup task

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -55,6 +55,7 @@ Reference for every task type docket can run inside a recipe. Each page lists th
 - [dokku_scheduler_docker_local_property](dokku_scheduler_docker_local_property.md) - Manages the scheduler-docker-local configuration for a given dokku application
 - [dokku_scheduler_k3s_property](dokku_scheduler_k3s_property.md) - Manages the scheduler-k3s configuration for a given dokku application
 - [dokku_scheduler_property](dokku_scheduler_property.md) - Manages the scheduler configuration for a given dokku application
+- [dokku_service_backup](dokku_service_backup.md) - Manages the S3 backup schedule, authentication, and encryption for a dokku service
 - [dokku_service_create](dokku_service_create.md) - Creates or destroys a dokku service
 - [dokku_service_expose](dokku_service_expose.md) - Exposes or unexposes a dokku service on host ports
 - [dokku_service_link](dokku_service_link.md) - Links or unlinks a dokku service to an app

--- a/docs/tasks/dokku_service_backup.md
+++ b/docs/tasks/dokku_service_backup.md
@@ -1,0 +1,77 @@
+# dokku_service_backup
+
+## Synopsis
+
+Manages the S3 backup schedule, authentication, and encryption for a dokku service
+
+## Requirements
+
+- a dokku datastore service plugin matching the service type (e.g. dokku-postgres, dokku-redis, dokku-mysql)
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `service` | string | yes |  |  | Type of service to back up (e.g. redis, postgres, mysql) |
+| `name` | string | yes |  |  | Name of the service instance |
+| `schedule` | string | no |  |  | Cron schedule for backups (requires bucket) |
+| `bucket` | string | no |  |  | S3 bucket backups are written to (requires schedule) |
+| `use_iam` | bool | no |  |  | Use the instance IAM profile instead of static credentials |
+| `aws_access_key_id` | string | no |  |  | AWS access key id for backup auth (requires aws_secret_access_key) |
+| `aws_secret_access_key` | string | no |  |  | AWS secret access key for backup auth (requires aws_access_key_id) (sensitive) |
+| `aws_default_region` | string | no |  |  | AWS region used for backup auth |
+| `aws_signature_version` | string | no |  |  | AWS signature version used for backup auth |
+| `endpoint_url` | string | no |  |  | S3-compatible endpoint url used for backup auth |
+| `encryption_passphrase` | string | no |  |  | Passphrase used to encrypt future backups (sensitive) |
+| `state` | string | no | present | present, absent | Desired state of the backup configuration |
+
+## Examples
+
+### Schedule daily backups of a postgres service to S3
+
+```yaml
+dokku_service_backup:
+    service: postgres
+    name: my-db
+    schedule: 0 3 * * *
+    bucket: my-backup-bucket
+    aws_access_key_id: AKIAEXAMPLE
+    aws_secret_access_key: examplesecret
+    aws_default_region: us-east-1
+    encryption_passphrase: correct-horse-battery-staple
+```
+
+### Schedule backups using the instance IAM profile
+
+```yaml
+dokku_service_backup:
+    service: postgres
+    name: my-db
+    schedule: 0 3 * * *
+    bucket: my-backup-bucket
+    use_iam: true
+```
+
+### Remove the backup configuration for a postgres service
+
+```yaml
+dokku_service_backup:
+    service: postgres
+    name: my-db
+    state: absent
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -487,7 +487,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 61
+	expected := 62
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}

--- a/tasks/service_backup_task.go
+++ b/tasks/service_backup_task.go
@@ -1,0 +1,293 @@
+package tasks
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// ServiceBackupTask manages the S3 backup configuration for a dokku
+// datastore service: the backup schedule, the S3 authentication, and the
+// backup encryption passphrase.
+//
+// Only the schedule is idempotent: dokku can read it back via
+// <service>:backup-schedule-cat. The auth and encryption pieces have no
+// read command, so when those fields are provided they are applied
+// unconditionally and the task reports Changed=true, mirroring the
+// no-probe pattern used by dokku_git_auth and dokku_registry_auth.
+type ServiceBackupTask struct {
+	// Service is the type of service to back up (e.g. redis, postgres, mysql)
+	Service string `required:"true" yaml:"service" description:"Type of service to back up (e.g. redis, postgres, mysql)"`
+
+	// Name is the name of the service instance
+	Name string `required:"true" yaml:"name" description:"Name of the service instance"`
+
+	// Schedule is the cron schedule for backups. Requires bucket.
+	Schedule string `required:"false" yaml:"schedule,omitempty" description:"Cron schedule for backups (requires bucket)"`
+
+	// Bucket is the S3 bucket backups are written to. Requires schedule.
+	Bucket string `required:"false" yaml:"bucket,omitempty" description:"S3 bucket backups are written to (requires schedule)"`
+
+	// UseIam configures the schedule to use the instance IAM profile instead of static credentials.
+	UseIam bool `required:"false" yaml:"use_iam,omitempty" description:"Use the instance IAM profile instead of static credentials"`
+
+	// AwsAccessKeyID is the AWS access key id used for backup auth. Requires aws_secret_access_key.
+	AwsAccessKeyID string `required:"false" yaml:"aws_access_key_id,omitempty" description:"AWS access key id for backup auth (requires aws_secret_access_key)"`
+
+	// AwsSecretAccessKey is the AWS secret access key used for backup auth. Requires aws_access_key_id.
+	AwsSecretAccessKey string `required:"false" sensitive:"true" yaml:"aws_secret_access_key,omitempty" description:"AWS secret access key for backup auth (requires aws_access_key_id)"`
+
+	// AwsDefaultRegion is the AWS region used for backup auth.
+	AwsDefaultRegion string `required:"false" yaml:"aws_default_region,omitempty" description:"AWS region used for backup auth"`
+
+	// AwsSignatureVersion is the AWS signature version used for backup auth.
+	AwsSignatureVersion string `required:"false" yaml:"aws_signature_version,omitempty" description:"AWS signature version used for backup auth"`
+
+	// EndpointURL is the S3-compatible endpoint url used for backup auth.
+	EndpointURL string `required:"false" yaml:"endpoint_url,omitempty" description:"S3-compatible endpoint url used for backup auth"`
+
+	// EncryptionPassphrase is the passphrase used to encrypt future backups.
+	EncryptionPassphrase string `required:"false" sensitive:"true" yaml:"encryption_passphrase,omitempty" description:"Passphrase used to encrypt future backups"`
+
+	// State is the desired state of the backup configuration
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the backup configuration"`
+}
+
+// ServiceBackupTaskExample contains an example of a ServiceBackupTask
+type ServiceBackupTaskExample struct {
+	// Name is the task name holding the ServiceBackupTask description
+	Name string `yaml:"-"`
+
+	// ServiceBackupTask is the ServiceBackupTask configuration
+	ServiceBackupTask ServiceBackupTask `yaml:"dokku_service_backup"`
+}
+
+// GetName returns the name of the example
+func (e ServiceBackupTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the service backup task
+func (t ServiceBackupTask) Doc() string {
+	return "Manages the S3 backup schedule, authentication, and encryption for a dokku service"
+}
+
+// Requirements lists the non-core dokku plugins this task depends on.
+func (t ServiceBackupTask) Requirements() []string {
+	return []string{"a dokku datastore service plugin matching the service type (e.g. dokku-postgres, dokku-redis, dokku-mysql)"}
+}
+
+// Examples returns a list of ServiceBackupTaskExamples as yaml
+func (t ServiceBackupTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]ServiceBackupTaskExample{
+		{
+			Name: "Schedule daily backups of a postgres service to S3",
+			ServiceBackupTask: ServiceBackupTask{
+				Service:              "postgres",
+				Name:                 "my-db",
+				Schedule:             "0 3 * * *",
+				Bucket:               "my-backup-bucket",
+				AwsAccessKeyID:       "AKIAEXAMPLE",
+				AwsSecretAccessKey:   "examplesecret",
+				AwsDefaultRegion:     "us-east-1",
+				EncryptionPassphrase: "correct-horse-battery-staple",
+			},
+		},
+		{
+			Name: "Schedule backups using the instance IAM profile",
+			ServiceBackupTask: ServiceBackupTask{
+				Service:  "postgres",
+				Name:     "my-db",
+				Schedule: "0 3 * * *",
+				Bucket:   "my-backup-bucket",
+				UseIam:   true,
+			},
+		},
+		{
+			Name: "Remove the backup configuration for a postgres service",
+			ServiceBackupTask: ServiceBackupTask{
+				Service: "postgres",
+				Name:    "my-db",
+				State:   StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute manages the backup configuration for a dokku service
+func (t ServiceBackupTask) Execute() TaskOutputState {
+	return ExecutePlan(t.Plan())
+}
+
+// hasAuth reports whether any AWS credential field was provided.
+func (t ServiceBackupTask) hasAuth() bool {
+	return t.AwsAccessKeyID != "" || t.AwsSecretAccessKey != ""
+}
+
+// Plan reports the drift the ServiceBackupTask would produce.
+func (t ServiceBackupTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if t.Schedule != "" && t.Bucket == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'bucket' is required when 'schedule' is set")}
+			}
+			if t.Bucket != "" && t.Schedule == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'schedule' is required when 'bucket' is set")}
+			}
+			if t.hasAuth() && (t.AwsAccessKeyID == "" || t.AwsSecretAccessKey == "") {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'aws_access_key_id' and 'aws_secret_access_key' are both required to configure backup auth")}
+			}
+			if t.Schedule == "" && !t.hasAuth() && t.EncryptionPassphrase == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("at least one of 'schedule', aws credentials, or 'encryption_passphrase' is required when state is 'present'")}
+			}
+			exists, err := serviceExists(t.Service, t.Name)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !exists {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("service %s %s does not exist", t.Service, t.Name)}
+			}
+
+			inputs := []subprocess.ExecCommandInput{}
+			mutations := []string{}
+
+			// auth and encryption have no read command, so they always run
+			// when provided. Keep secrets out of the mutation strings; the
+			// resolved Commands mask registered sensitive values.
+			if t.hasAuth() {
+				authArgs := []string{"--quiet", fmt.Sprintf("%s:backup-auth", t.Service), t.Name, t.AwsAccessKeyID, t.AwsSecretAccessKey}
+				for _, opt := range []string{t.AwsDefaultRegion, t.AwsSignatureVersion, t.EndpointURL} {
+					if opt == "" {
+						break
+					}
+					authArgs = append(authArgs, opt)
+				}
+				inputs = append(inputs, subprocess.ExecCommandInput{Command: "dokku", Args: authArgs})
+				mutations = append(mutations, fmt.Sprintf("%s:backup-auth %s", t.Service, t.Name))
+			}
+
+			if t.EncryptionPassphrase != "" {
+				inputs = append(inputs, subprocess.ExecCommandInput{
+					Command: "dokku",
+					Args:    []string{"--quiet", fmt.Sprintf("%s:backup-set-encryption", t.Service), t.Name, t.EncryptionPassphrase},
+				})
+				mutations = append(mutations, fmt.Sprintf("%s:backup-set-encryption %s", t.Service, t.Name))
+			}
+
+			if t.Schedule != "" {
+				content, scheduled, err := serviceBackupScheduled(t.Service, t.Name)
+				if err != nil {
+					return PlanResult{Status: PlanStatusError, Error: err}
+				}
+				inSync := scheduled && strings.Contains(content, t.Schedule) && strings.Contains(content, t.Bucket)
+				if !inSync {
+					schedArgs := []string{"--quiet", fmt.Sprintf("%s:backup-schedule", t.Service), t.Name, t.Schedule, t.Bucket}
+					mutation := fmt.Sprintf("%s:backup-schedule %s %s %s", t.Service, t.Name, t.Schedule, t.Bucket)
+					if t.UseIam {
+						schedArgs = append(schedArgs, "--use-iam")
+						mutation += " --use-iam"
+					}
+					inputs = append(inputs, subprocess.ExecCommandInput{Command: "dokku", Args: schedArgs})
+					mutations = append(mutations, mutation)
+				}
+			}
+
+			if len(inputs) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusModify,
+				Reason:    "backup configuration not in sync",
+				Mutations: mutations,
+				Commands:  resolveCommands(inputs),
+				apply: func() TaskOutputState {
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			exists, err := serviceExists(t.Service, t.Name)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !exists {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("service %s %s does not exist", t.Service, t.Name)}
+			}
+
+			inputs := []subprocess.ExecCommandInput{}
+			mutations := []string{}
+
+			_, scheduled, err := serviceBackupScheduled(t.Service, t.Name)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if scheduled {
+				inputs = append(inputs, subprocess.ExecCommandInput{
+					Command: "dokku",
+					Args:    []string{"--quiet", fmt.Sprintf("%s:backup-unschedule", t.Service), t.Name},
+				})
+				mutations = append(mutations, fmt.Sprintf("%s:backup-unschedule %s", t.Service, t.Name))
+			}
+			if t.hasAuth() {
+				inputs = append(inputs, subprocess.ExecCommandInput{
+					Command: "dokku",
+					Args:    []string{"--quiet", fmt.Sprintf("%s:backup-deauth", t.Service), t.Name},
+				})
+				mutations = append(mutations, fmt.Sprintf("%s:backup-deauth %s", t.Service, t.Name))
+			}
+			if t.EncryptionPassphrase != "" {
+				inputs = append(inputs, subprocess.ExecCommandInput{
+					Command: "dokku",
+					Args:    []string{"--quiet", fmt.Sprintf("%s:backup-unset-encryption", t.Service), t.Name},
+				})
+				mutations = append(mutations, fmt.Sprintf("%s:backup-unset-encryption %s", t.Service, t.Name))
+			}
+
+			if len(inputs) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "backup configuration present",
+				Mutations: mutations,
+				Commands:  resolveCommands(inputs),
+				apply: func() TaskOutputState {
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				},
+			}
+		},
+	})
+}
+
+// serviceBackupScheduled reports whether a dokku service has a backup
+// schedule and returns the cron file contents for comparison. A
+// transport-level failure (`*subprocess.SSHError`) is propagated; a
+// dokku-level non-zero exit (no schedule configured) is treated as
+// "not scheduled."
+func serviceBackupScheduled(service, name string) (string, bool, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args: []string{
+			"--quiet",
+			fmt.Sprintf("%s:backup-schedule-cat", service),
+			name,
+		},
+	})
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return "", false, err
+		}
+		return "", false, nil
+	}
+	return result.StdoutContents(), true, nil
+}
+
+// init registers the ServiceBackupTask with the task registry
+func init() {
+	RegisterTask(&ServiceBackupTask{})
+}

--- a/tasks/service_backup_task_test.go
+++ b/tasks/service_backup_task_test.go
@@ -1,0 +1,140 @@
+package tasks
+
+import (
+	"testing"
+
+	_ "github.com/gliderlabs/sigil/builtin"
+)
+
+func TestServiceBackupTaskInvalidState(t *testing.T) {
+	task := ServiceBackupTask{Service: "postgres", Name: "my-db", Schedule: "0 3 * * *", Bucket: "b", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestServiceBackupTaskScheduleRequiresBucket(t *testing.T) {
+	task := ServiceBackupTask{Service: "postgres", Name: "my-db", Schedule: "0 3 * * *"}
+	result := task.Plan()
+	if result.Error == nil {
+		t.Fatal("Plan with schedule and no bucket should return an error")
+	}
+}
+
+func TestServiceBackupTaskBucketRequiresSchedule(t *testing.T) {
+	task := ServiceBackupTask{Service: "postgres", Name: "my-db", Bucket: "my-bucket"}
+	result := task.Plan()
+	if result.Error == nil {
+		t.Fatal("Plan with bucket and no schedule should return an error")
+	}
+}
+
+func TestServiceBackupTaskPartialAuthRejected(t *testing.T) {
+	task := ServiceBackupTask{Service: "postgres", Name: "my-db", AwsAccessKeyID: "AKIA"}
+	result := task.Plan()
+	if result.Error == nil {
+		t.Fatal("Plan with only an access key id should return an error")
+	}
+}
+
+func TestServiceBackupTaskPresentRequiresSomething(t *testing.T) {
+	task := ServiceBackupTask{Service: "postgres", Name: "my-db"}
+	result := task.Plan()
+	if result.Error == nil {
+		t.Fatal("Plan with nothing to configure should return an error")
+	}
+}
+
+func TestGetTasksServiceBackupTaskParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: schedule postgres backups
+      dokku_service_backup:
+        service: postgres
+        name: my-db
+        schedule: "0 3 * * *"
+        bucket: my-backup-bucket
+        aws_access_key_id: AKIAEXAMPLE
+        aws_secret_access_key: examplesecret
+        aws_default_region: us-east-1
+        encryption_passphrase: hunter2
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("schedule postgres backups")
+	if task == nil {
+		t.Fatal("task 'schedule postgres backups' not found")
+	}
+
+	sbTask, ok := task.(*ServiceBackupTask)
+	if !ok {
+		st, ok2 := task.(ServiceBackupTask)
+		if !ok2 {
+			t.Fatalf("task is not a ServiceBackupTask (type is %T)", task)
+		}
+		sbTask = &st
+	}
+
+	if sbTask.Service != "postgres" {
+		t.Errorf("Service = %q, want %q", sbTask.Service, "postgres")
+	}
+	if sbTask.Name != "my-db" {
+		t.Errorf("Name = %q, want %q", sbTask.Name, "my-db")
+	}
+	if sbTask.Schedule != "0 3 * * *" {
+		t.Errorf("Schedule = %q, want %q", sbTask.Schedule, "0 3 * * *")
+	}
+	if sbTask.Bucket != "my-backup-bucket" {
+		t.Errorf("Bucket = %q, want %q", sbTask.Bucket, "my-backup-bucket")
+	}
+	if sbTask.AwsSecretAccessKey != "examplesecret" {
+		t.Errorf("AwsSecretAccessKey = %q, want %q", sbTask.AwsSecretAccessKey, "examplesecret")
+	}
+	if sbTask.EncryptionPassphrase != "hunter2" {
+		t.Errorf("EncryptionPassphrase = %q, want %q", sbTask.EncryptionPassphrase, "hunter2")
+	}
+	if sbTask.State != StatePresent {
+		t.Errorf("expected default state 'present', got %q", sbTask.State)
+	}
+}
+
+func TestServiceBackupTaskSensitiveValuesCollected(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: schedule postgres backups
+      dokku_service_backup:
+        service: postgres
+        name: my-db
+        schedule: "0 3 * * *"
+        bucket: my-backup-bucket
+        aws_access_key_id: AKIAEXAMPLE
+        aws_secret_access_key: topsecret
+        encryption_passphrase: hunter2
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	values := CollectSensitiveValues(tasks)
+	for _, want := range []string{"topsecret", "hunter2"} {
+		found := false
+		for _, v := range values {
+			if v == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected sensitive value %q to be collected, got %v", want, values)
+		}
+	}
+}


### PR DESCRIPTION
Manages a dokku datastore service's S3 backup configuration: the cron schedule, the S3 authentication, and the encryption passphrase. The schedule is probed via `backup-schedule-cat` for idempotency, while auth and encryption have no read command and are applied unconditionally like the other credential tasks.