### PR TITLE
feat: add dokku_storage_entry and richer mount attachments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.10
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.11
           sudo dokku plugin:install-dependencies --core
       - name: install dokku redis plugin
         run: sudo dokku plugin:install https://github.com/dokku/dokku-redis.git redis
@@ -87,7 +87,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.10
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.11
           sudo dokku plugin:install-dependencies --core
       - name: install bats
         run: sudo apt-get install -qq -y bats bats-support bats-assert

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.9
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.10
           sudo dokku plugin:install-dependencies --core
       - name: install dokku redis plugin
         run: sudo dokku plugin:install https://github.com/dokku/dokku-redis.git redis
@@ -87,7 +87,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.9
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.10
           sudo dokku plugin:install-dependencies --core
       - name: install bats
         run: sudo apt-get install -qq -y bats bats-support bats-assert

--- a/commands/apply.go
+++ b/commands/apply.go
@@ -415,6 +415,10 @@ func (c *ApplyCommand) executeLeafTask(env *tasks.TaskEnvelope, name string, ac 
 		}
 	}
 
+	if msg := tasks.TaskDeprecation(env.Task); msg != "" {
+		ac.emitter.TaskWarning(ac.play.Name, name, msg)
+	}
+
 	state := env.Task.Execute()
 	ac.counts.Tasks++
 

--- a/commands/list_tasks.go
+++ b/commands/list_tasks.go
@@ -173,6 +173,10 @@ func renderListEnvelope(
 ) {
 	skipMarker := evaluateListWhen(env, playExprCtx)
 	display := listingDisplayName(env, name)
+	deprecation := ""
+	if env != nil && env.Task != nil {
+		deprecation = tasks.TaskDeprecation(env.Task)
+	}
 
 	if jsonOut {
 		ev := map[string]interface{}{
@@ -189,6 +193,10 @@ func renderListEnvelope(
 		}
 		if phase != "" {
 			ev["phase"] = phase
+		}
+		if deprecation != "" {
+			ev["deprecated"] = true
+			ev["deprecation"] = deprecation
 		}
 		switch skipMarker {
 		case "skipped":
@@ -230,6 +238,9 @@ func renderListEnvelope(
 		b.WriteString(decorated)
 		if env.IsGroup() {
 			b.WriteString("  (group)")
+		}
+		if deprecation != "" {
+			b.WriteString("  (deprecated)")
 		}
 		if len(env.Tags) > 0 {
 			b.WriteString(fmt.Sprintf("  [tags=%s]", strings.Join(env.Tags, ",")))

--- a/commands/output.go
+++ b/commands/output.go
@@ -29,6 +29,11 @@ type EventEmitter interface {
 	ApplyTask(ev ApplyTaskEvent)
 	// PlanTask emits one event per task in a `plan` run.
 	PlanTask(ev PlanTaskEvent)
+	// TaskWarning emits a non-fatal warning associated with a task, such
+	// as a task-type deprecation notice. It does not affect task counts
+	// or exit codes; apply / plan call it before the per-task event so
+	// the warning appears immediately above the task's result line.
+	TaskWarning(play, name, message string)
 	// ApplySummary emits the end-of-run footer for `apply`.
 	ApplySummary(c ApplyCounts, d time.Duration)
 	// PlanSummary emits the end-of-run footer for `plan`.
@@ -123,6 +128,12 @@ const (
 	MarkerModify     Marker = "~"
 	MarkerDestroy    Marker = "-"
 	MarkerProbeError Marker = "!"
+
+	// MarkerDeprecated prefixes a TaskWarning line emitted when a task
+	// type implements DeprecationDocer. Distinct from the apply/plan
+	// markers because the warning is informational and does not feed
+	// the run counts or exit code.
+	MarkerDeprecated Marker = "deprecated"
 )
 
 // markerWidth is the fixed column width that every bracketed marker is
@@ -188,8 +199,21 @@ func NewFormatter(ui cli.Ui, verbose bool) *Formatter {
 			MarkerModify:     color.New(color.FgYellow),
 			MarkerDestroy:    color.New(color.FgRed),
 			MarkerProbeError: color.New(color.FgRed),
+			MarkerDeprecated: color.New(color.FgYellow, color.Faint),
 		},
 	}
+}
+
+// TaskWarning renders a `[deprecated] <name>  (<message>)` line above the
+// task's result line. It is informational, so the line goes to
+// Ui.Output (not Ui.Error) and does not affect counts. The message is
+// masked against the global sensitive set.
+func (f *Formatter) TaskWarning(_, name, message string) {
+	if message == "" {
+		return
+	}
+	suffix := "(" + message + ")"
+	f.TaskLine(MarkerDeprecated, name, suffix)
 }
 
 // Verbose reports whether the formatter is in verbose mode.

--- a/commands/output_json.go
+++ b/commands/output_json.go
@@ -169,6 +169,25 @@ func (e *JSONEmitter) PlanTask(ev PlanTaskEvent) {
 	e.write(out)
 }
 
+// TaskWarning emits a `warning` event keyed by `reason` and tied to a
+// specific task. Today the only reason is "deprecated"; the event is
+// emitted before the task's own `task` event so consumers can correlate
+// by ordering.
+func (e *JSONEmitter) TaskWarning(play, name, message string) {
+	if message == "" {
+		return
+	}
+	e.write(map[string]interface{}{
+		"version": jsonSchemaVersion,
+		"type":    "warning",
+		"play":    play,
+		"name":    name,
+		"reason":  "deprecated",
+		"message": subprocess.MaskString(message),
+		"ts":      nowRFC3339(),
+	})
+}
+
 // ApplySummary emits the end-of-run summary event for apply.
 func (e *JSONEmitter) ApplySummary(c ApplyCounts, d time.Duration) {
 	e.write(map[string]interface{}{

--- a/commands/output_json_test.go
+++ b/commands/output_json_test.go
@@ -403,6 +403,42 @@ func TestJSONEmitterEveryEventHasVersion1(t *testing.T) {
 }
 
 // TestEmitterInterfaceSatisfied compiles iff Formatter and JSONEmitter both
+func TestJSONEmitterTaskWarning(t *testing.T) {
+	e, ui := emitterTestUI()
+	e.TaskWarning("tasks", "ensure storage", "use dokku_storage_entry instead")
+	ev := decodeOnly(t, ui.OutputWriter.String())
+
+	if got, want := ev["version"], float64(1); got != want {
+		t.Errorf("version = %v, want %v", got, want)
+	}
+	if got, want := ev["type"], "warning"; got != want {
+		t.Errorf("type = %v, want %v", got, want)
+	}
+	if got, want := ev["play"], "tasks"; got != want {
+		t.Errorf("play = %v, want %v", got, want)
+	}
+	if got, want := ev["name"], "ensure storage"; got != want {
+		t.Errorf("name = %v, want %v", got, want)
+	}
+	if got, want := ev["reason"], "deprecated"; got != want {
+		t.Errorf("reason = %v, want %v", got, want)
+	}
+	if got, want := ev["message"], "use dokku_storage_entry instead"; got != want {
+		t.Errorf("message = %v, want %v", got, want)
+	}
+	if _, ok := ev["ts"]; !ok {
+		t.Error("ts must be set")
+	}
+}
+
+func TestJSONEmitterTaskWarningEmptyIsNoOp(t *testing.T) {
+	e, ui := emitterTestUI()
+	e.TaskWarning("tasks", "ensure storage", "")
+	if ui.OutputWriter.String() != "" {
+		t.Errorf("expected no output for empty message, got %q", ui.OutputWriter.String())
+	}
+}
+
 // satisfy the EventEmitter contract. Catches signature drift at build time.
 func TestEmitterInterfaceSatisfied(t *testing.T) {
 	var _ EventEmitter = (*Formatter)(nil)

--- a/commands/output_test.go
+++ b/commands/output_test.go
@@ -331,6 +331,32 @@ func TestApplyTaskErrorOmitsEmptyStdout(t *testing.T) {
 	}
 }
 
+func TestFormatterTaskWarningRendersDeprecatedMarker(t *testing.T) {
+	f, ui := newTestFormatter(false)
+	f.TaskWarning("tasks", "ensure storage", "use dokku_storage_entry instead")
+	got := ui.OutputWriter.String()
+	if !strings.Contains(got, "[deprecated]") {
+		t.Errorf("expected [deprecated] marker, got %q", got)
+	}
+	if !strings.Contains(got, "ensure storage") {
+		t.Errorf("expected task name in line, got %q", got)
+	}
+	if !strings.Contains(got, "use dokku_storage_entry instead") {
+		t.Errorf("expected deprecation message in line, got %q", got)
+	}
+	if ui.ErrorWriter.String() != "" {
+		t.Errorf("deprecation warning must not write to stderr, got %q", ui.ErrorWriter.String())
+	}
+}
+
+func TestFormatterTaskWarningEmptyMessageIsNoOp(t *testing.T) {
+	f, ui := newTestFormatter(false)
+	f.TaskWarning("tasks", "ensure storage", "")
+	if ui.OutputWriter.String() != "" {
+		t.Errorf("expected no output for empty message, got %q", ui.OutputWriter.String())
+	}
+}
+
 func TestFormatterVerboseAccessor(t *testing.T) {
 	f, _ := newTestFormatter(true)
 	if !f.Verbose() {

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -367,6 +367,10 @@ func planLeaf(env *tasks.TaskEnvelope, name string, pc *planContext, failedTask 
 		}
 	}
 
+	if msg := tasks.TaskDeprecation(env.Task); msg != "" {
+		pc.emitter.TaskWarning(pc.play.Name, name, msg)
+	}
+
 	result := env.Task.Plan()
 	pc.counts.Tasks++
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,8 +38,9 @@ code into it:
 
 ## Prerequisites
 
-- **Dokku >= 0.38.9.** docket reads each plugin's state through `:report --format json`, and the
-  shape it depends on was finalized across all plugins in 0.38.9.
+- **Dokku >= 0.38.10.** docket reads each plugin's state through `:report --format json`, and the
+  shape it depends on was finalized across all plugins in 0.38.9; 0.38.10 added `--force` to
+  `storage:destroy`, which `dokku_storage_entry` relies on to stay non-interactive.
 - **dokku-letsencrypt >= 0.25.0**, but only if your recipe uses `dokku_letsencrypt_property`
   tasks.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,11 +38,8 @@ code into it:
 
 ## Prerequisites
 
-- **Dokku >= 0.38.10.** docket reads each plugin's state through `:report --format json`, and the
-  shape it depends on was finalized across all plugins in 0.38.9; 0.38.10 added `--force` to
-  `storage:destroy`, which `dokku_storage_entry` relies on to stay non-interactive.
-- **dokku-letsencrypt >= 0.25.0**, but only if your recipe uses `dokku_letsencrypt_property`
-  tasks.
+- **Dokku >= 0.38.11.**
+- **dokku-letsencrypt >= 0.25.0.**
 
 ## Installation
 

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -17,10 +17,18 @@ slightly between `apply` and `plan`:
 |-------|-----------------|-----------------|
 | `play_start` | `version`, `type`, `name`, `ts` | `host` |
 | `play_skipped` | `version`, `type`, `name`, `ts` | `when`, `reason` |
+| `warning` | `version`, `type`, `play`, `name`, `reason`, `message`, `ts` | - |
 | `task` (apply) | `version`, `type`, `play`, `name`, `status` (`ok`/`changed`/`skipped`/`error`), `changed`, `state`, `desired_state`, `duration_ms`, `ts` | `error`, `commands` |
 | `task` (plan) | `version`, `type`, `play`, `name`, `status` (`ok`/`+`/`~`/`-`/`skipped`/`error`), `would_change`, `state`, `desired_state`, `duration_ms`, `ts` | `reason`, `mutations`, `commands`, `error` |
 | `summary` (apply) | `version`, `type`, `tasks`, `changed`, `ok`, `skipped`, `errors`, `plays_skipped`, `duration_ms` | - |
 | `summary` (plan) | `version`, `type`, `tasks`, `would_change`, `in_sync`, `skipped`, `errors`, `plays_skipped`, `duration_ms` | - |
+
+A `warning` event precedes the `task` event it is associated with so consumers can correlate by
+ordering. Today the only `reason` is `deprecated`, emitted when a task whose type implements
+`Deprecation()` is about to run; `message` carries the deprecation notice with sensitive values
+masked. `--list-tasks --json` does not emit a separate `warning` event; instead, the `list_task`
+event for a deprecated task carries `"deprecated": true` and a `deprecation` field with the
+message.
 
 ## Commands
 

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -61,6 +61,7 @@ Reference for every task type docket can run inside a recipe. Each page lists th
 - [dokku_service_link](dokku_service_link.md) - Links or unlinks a dokku service to an app
 - [dokku_service_property](dokku_service_property.md) - Manages a property for a given dokku service
 - [dokku_ssh_key](dokku_ssh_key.md) - Manages an SSH public key for git push access via dokku's ssh-keys plugin
-- [dokku_storage_ensure](dokku_storage_ensure.md) - Ensures the storage for a given dokku application
-- [dokku_storage_mount](dokku_storage_mount.md) - Mounts or unmounts the storage for a given dokku application
+- [dokku_storage_ensure](dokku_storage_ensure.md) - Ensures the storage for a given dokku application (deprecated)
+- [dokku_storage_entry](dokku_storage_entry.md) - Creates or destroys a named storage registry entry
+- [dokku_storage_mount](dokku_storage_mount.md) - Attaches or detaches storage on a dokku application
 - [dokku_traefik_property](dokku_traefik_property.md) - Manages the traefik configuration for a given dokku application

--- a/docs/tasks/dokku_storage_ensure.md
+++ b/docs/tasks/dokku_storage_ensure.md
@@ -4,6 +4,8 @@
 
 Ensures the storage for a given dokku application
 
+> **Deprecated:** use dokku_storage_entry instead; dokku's storage:ensure-directory has been deprecated in favor of storage:create
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_storage_entry.md
+++ b/docs/tasks/dokku_storage_entry.md
@@ -1,0 +1,61 @@
+# dokku_storage_entry
+
+## Synopsis
+
+Creates or destroys a named storage registry entry
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `name` | string | yes |  |  | Name of the storage entry |
+| `path` | string | no |  |  | Host path for the entry (docker-local scheduler; defaults to the dokku storage root joined with the entry name) |
+| `scheduler` | string | no | docker-local |  | Scheduler that backs the entry |
+| `size` | string | no |  |  | Volume size (scheduler-dependent) |
+| `access_mode` | string | no |  |  | Volume access mode (scheduler-dependent) |
+| `storage_class` | string | no |  |  | Storage class name (scheduler-dependent) |
+| `namespace` | string | no |  |  | Namespace (scheduler-dependent) |
+| `chown` | string | no |  |  | Chown value applied when the entry's host directory is created |
+| `reclaim_policy` | string | no |  |  | Reclaim policy (scheduler-dependent) |
+| `state` | string | no | present | present, absent | Desired state of the storage entry |
+
+## Examples
+
+### Create a docker-local storage entry owned by the herokuish user
+
+```yaml
+dokku_storage_entry:
+    name: node-js-app-data
+    chown: herokuish
+```
+
+### Create a storage entry at an explicit host path
+
+```yaml
+dokku_storage_entry:
+    name: node-js-app-data
+    path: /var/lib/dokku/data/storage/node-js-app-data
+```
+
+### Destroy a storage entry
+
+```yaml
+dokku_storage_entry:
+    name: node-js-app-data
+    state: absent
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_storage_mount.md
+++ b/docs/tasks/dokku_storage_mount.md
@@ -2,20 +2,48 @@
 
 ## Synopsis
 
-Mounts or unmounts the storage for a given dokku application
+Attaches or detaches storage on a dokku application
 
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | yes |  |  | Name of the app |
-| `host_dir` | string | yes |  |  | Host directory to mount |
+| `entry_name` | string | no |  |  | Named storage registry entry to attach (mutually exclusive with host_dir) |
+| `host_dir` | string | no |  |  | Host directory to mount in the legacy bind-mount form (mutually exclusive with entry_name) |
 | `container_dir` | string | yes |  |  | Container directory to mount |
+| `phases` | list | no |  |  | Deployment phases the attachment applies to (deploy, run). Empty defers to the dokku default. |
+| `process_type` | string | no |  |  | Process type the attachment applies to |
+| `subpath` | string | no |  |  | Subpath within the entry to mount |
+| `readonly` | bool | no |  |  | Mount the attachment as read-only |
+| `volume_chown` | string | no |  |  | Chown option applied to the volume at mount time |
 | `state` | string | no | present | present, absent | Desired state of the storage |
 
 ## Examples
 
-### Mount a host directory into an app
+### Attach a named storage entry to an app
+
+```yaml
+dokku_storage_mount:
+    app: node-js-app
+    entry_name: node-js-app-data
+    container_dir: /app/storage
+```
+
+### Attach a named entry on deploy only, read-only, for the web process
+
+```yaml
+dokku_storage_mount:
+    app: node-js-app
+    entry_name: node-js-app-data
+    container_dir: /app/storage
+    phases:
+        - deploy
+    process_type: web
+    readonly: true
+```
+
+### Mount a host directory into an app (legacy form)
 
 ```yaml
 dokku_storage_mount:
@@ -24,12 +52,12 @@ dokku_storage_mount:
     container_dir: /app/storage
 ```
 
-### Unmount a host directory from an app
+### Unmount a named entry from an app
 
 ```yaml
 dokku_storage_mount:
     app: node-js-app
-    host_dir: /var/lib/dokku/data/storage/node-js-app
+    entry_name: node-js-app-data
     container_dir: /app/storage
     state: absent
 ```

--- a/docs/writing-tasks.md
+++ b/docs/writing-tasks.md
@@ -82,6 +82,13 @@ A few conventions to follow:
   `dokku-letsencrypt`), implement the optional `Requirements() []string` method. The generator
   renders the returned entries in a Requirements section on the task's page; tasks without the
   method simply omit the section.
+- When a task type is deprecated (typically because the underlying dokku subcommand was deprecated
+  or a richer replacement task exists), implement the optional `Deprecation() string` method.
+  The generator renders the returned message in a Deprecated admonition on the task's page and
+  appends `(deprecated)` to the task's index entry; `apply --list-tasks` marks it the same way;
+  `apply` and `plan` emit a one-time `warning` line above each deprecated task's result line.
+  Keep the message short and name the replacement, e.g.
+  `"use dokku_storage_entry instead; storage:ensure-directory has been deprecated"`.
 
 ## Toggle and property tasks
 

--- a/generate/docs.go
+++ b/generate/docs.go
@@ -196,6 +196,18 @@ func requirementsSection(task tasks.Task) string {
 	return b.String()
 }
 
+// deprecationSection renders the Deprecated admonition for a task that
+// implements DeprecationDocer. The notice sits between the Synopsis and
+// the Requirements/Parameters sections so the reader sees it before
+// scanning the field table.
+func deprecationSection(task tasks.Task) string {
+	msg := tasks.TaskDeprecation(task)
+	if msg == "" {
+		return ""
+	}
+	return "> **Deprecated:** " + strings.TrimSpace(msg)
+}
+
 // returnValuesSection is the shared Return Values table. Every task returns a
 // tasks.TaskOutputState, so the table is identical across pages. The keys are
 // the Go field names because that is how recipes reference them through
@@ -249,6 +261,9 @@ func renderPage(taskName string, task tasks.Task, examples []tasks.Doc) string {
 	var sections []string
 	sections = append(sections, "# "+taskName)
 	sections = append(sections, "## Synopsis\n\n"+strings.TrimSpace(task.Doc()))
+	if dep := deprecationSection(task); dep != "" {
+		sections = append(sections, dep)
+	}
 	if req := requirementsSection(task); req != "" {
 		sections = append(sections, strings.TrimRight(req, "\n"))
 	}
@@ -307,7 +322,11 @@ func main() {
 	index.WriteString("# Tasks\n\n")
 	index.WriteString("Reference for every task type docket can run inside a recipe. Each page lists the task's fields and example usage. These pages are generated from the task definitions with `make docs`.\n\n")
 	for _, name := range names {
-		index.WriteString(fmt.Sprintf("- [%s](%s.md) - %s\n", name, name, summarize(registeredTasks[name].Doc())))
+		suffix := ""
+		if tasks.TaskDeprecation(registeredTasks[name]) != "" {
+			suffix = " (deprecated)"
+		}
+		index.WriteString(fmt.Sprintf("- [%s](%s.md) - %s%s\n", name, name, summarize(registeredTasks[name].Doc()), suffix))
 	}
 
 	indexFile := filepath.Join(docsFolderName, "README.md")

--- a/tasks/deprecation.go
+++ b/tasks/deprecation.go
@@ -1,0 +1,21 @@
+package tasks
+
+// DeprecationDocer is an optional interface a task implements when the task
+// type is deprecated. Deprecation returns a human-readable notice naming
+// the recommended replacement and (optionally) the reason. The docs
+// generator renders the message in a Deprecated section on the task's
+// page; --list-tasks marks the task; apply and plan emit a one-time
+// warning when the task runs.
+type DeprecationDocer interface {
+	Deprecation() string
+}
+
+// TaskDeprecation returns the deprecation notice for t, or "" when t does
+// not implement DeprecationDocer. Centralised so docs generation, the
+// list-tasks renderer, and the apply/plan executors share one read site.
+func TaskDeprecation(t Task) string {
+	if d, ok := t.(DeprecationDocer); ok {
+		return d.Deprecation()
+	}
+	return ""
+}

--- a/tasks/deprecation_test.go
+++ b/tasks/deprecation_test.go
@@ -1,0 +1,30 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestTaskDeprecationEmptyForUndeprecatedTask(t *testing.T) {
+	if got := TaskDeprecation(&AppTask{}); got != "" {
+		t.Errorf("expected empty deprecation for AppTask, got %q", got)
+	}
+}
+
+func TestTaskDeprecationForStorageEnsure(t *testing.T) {
+	got := TaskDeprecation(&StorageEnsureTask{})
+	if got == "" {
+		t.Fatal("expected non-empty deprecation for StorageEnsureTask")
+	}
+	if !contains(got, "dokku_storage_entry") {
+		t.Errorf("expected deprecation message to point to dokku_storage_entry, got %q", got)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/tasks/integration_shard_test.go
+++ b/tasks/integration_shard_test.go
@@ -88,6 +88,7 @@ var integrationTestWeights = map[string]float64{
 	"TestIntegrationServiceCreateAndDestroy":                2.9,
 	"TestIntegrationServiceLinkAndUnlink":                   32.0,
 	"TestIntegrationStorageEnsure":                          6.0,
+	"TestIntegrationStorageEntry":                           6.0,
 	"TestIntegrationStorageMount":                           6.0,
 	"TestIntegrationTraefikPropertyAll":                     12.0,
 	"TestIntegrationValidateRunsOffline":                    1.0,

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -215,6 +215,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_service_create",
 		"dokku_service_link",
 		"dokku_storage_ensure",
+		"dokku_storage_entry",
 		"dokku_storage_mount",
 		"dokku_traefik_property",
 	}
@@ -487,7 +488,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 62
+	expected := 63
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -684,7 +685,8 @@ func TestTaskDocStrings(t *testing.T) {
 		{&ServiceLinkTask{}, "Links or unlinks a dokku service to an app"},
 		{&ProxyToggleTask{}, "Enables or disables the proxy plugin for a given dokku application"},
 		{&StorageEnsureTask{}, "Ensures the storage for a given dokku application"},
-		{&StorageMountTask{}, "Mounts or unmounts the storage for a given dokku application"},
+		{&StorageEntryTask{}, "Creates or destroys a named storage registry entry"},
+		{&StorageMountTask{}, "Attaches or detaches storage on a dokku application"},
 		{&TraefikPropertyTask{}, "Manages the traefik configuration for a given dokku application"},
 	}
 

--- a/tasks/storage_ensure_task.go
+++ b/tasks/storage_ensure_task.go
@@ -36,6 +36,14 @@ func (t StorageEnsureTask) Doc() string {
 	return "Ensures the storage for a given dokku application"
 }
 
+// Deprecation marks dokku_storage_ensure as deprecated. dokku's
+// underlying storage:ensure-directory subcommand has been deprecated in
+// favor of storage:create, which docket exposes through
+// dokku_storage_entry.
+func (t StorageEnsureTask) Deprecation() string {
+	return "use dokku_storage_entry instead; dokku's storage:ensure-directory has been deprecated in favor of storage:create"
+}
+
 // Examples returns the examples for the storage ensure task
 func (t StorageEnsureTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]StorageEnsureTaskExample{

--- a/tasks/storage_entry_task.go
+++ b/tasks/storage_entry_task.go
@@ -1,0 +1,213 @@
+package tasks
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// StorageEntryTask manages a named storage registry entry — the thing
+// `storage:create` produces and `storage:list-entries` reports. Entries
+// exist independently of any single app, and an attachment created via
+// dokku_storage_mount references them by name.
+//
+// Idempotency is keyed on the entry name: when an entry with the given
+// name exists, the task is in sync regardless of the other field
+// values. Attribute changes are therefore not drift-detected; to change
+// scheduler, size, or any other attribute, the recipe must destroy and
+// re-create the entry.
+type StorageEntryTask struct {
+	// Name is the name of the storage entry
+	Name string `required:"true" yaml:"name" description:"Name of the storage entry"`
+
+	// Path is the host path for the entry (docker-local scheduler).
+	// Optional; defaults to the dokku storage root + name.
+	Path string `required:"false" yaml:"path,omitempty" description:"Host path for the entry (docker-local scheduler; defaults to the dokku storage root joined with the entry name)"`
+
+	// Scheduler is the scheduler that backs the entry
+	Scheduler string `required:"false" yaml:"scheduler,omitempty" default:"docker-local" description:"Scheduler that backs the entry"`
+
+	// Size is the volume size (scheduler-dependent)
+	Size string `required:"false" yaml:"size,omitempty" description:"Volume size (scheduler-dependent)"`
+
+	// AccessMode is the volume access mode (scheduler-dependent)
+	AccessMode string `required:"false" yaml:"access_mode,omitempty" description:"Volume access mode (scheduler-dependent)"`
+
+	// StorageClass is the storage class name (scheduler-dependent)
+	StorageClass string `required:"false" yaml:"storage_class,omitempty" description:"Storage class name (scheduler-dependent)"`
+
+	// Namespace is the namespace (scheduler-dependent)
+	Namespace string `required:"false" yaml:"namespace,omitempty" description:"Namespace (scheduler-dependent)"`
+
+	// Chown is the chown value applied when the entry's host directory is created
+	Chown string `required:"false" yaml:"chown,omitempty" description:"Chown value applied when the entry's host directory is created"`
+
+	// ReclaimPolicy is the reclaim policy (scheduler-dependent)
+	ReclaimPolicy string `required:"false" yaml:"reclaim_policy,omitempty" description:"Reclaim policy (scheduler-dependent)"`
+
+	// State is the desired state of the storage entry
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the storage entry"`
+}
+
+// StorageEntryTaskExample contains an example of a StorageEntryTask
+type StorageEntryTaskExample struct {
+	// Name is the task name holding the StorageEntryTask description
+	Name string `yaml:"-"`
+
+	// StorageEntryTask is the StorageEntryTask configuration
+	StorageEntryTask StorageEntryTask `yaml:"dokku_storage_entry"`
+}
+
+// GetName returns the name of the example
+func (e StorageEntryTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the storage entry task
+func (t StorageEntryTask) Doc() string {
+	return "Creates or destroys a named storage registry entry"
+}
+
+// Examples returns the examples for the storage entry task
+func (t StorageEntryTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]StorageEntryTaskExample{
+		{
+			Name: "Create a docker-local storage entry owned by the herokuish user",
+			StorageEntryTask: StorageEntryTask{
+				Name:  "node-js-app-data",
+				Chown: "herokuish",
+			},
+		},
+		{
+			Name: "Create a storage entry at an explicit host path",
+			StorageEntryTask: StorageEntryTask{
+				Name: "node-js-app-data",
+				Path: "/var/lib/dokku/data/storage/node-js-app-data",
+			},
+		},
+		{
+			Name: "Destroy a storage entry",
+			StorageEntryTask: StorageEntryTask{
+				Name:  "node-js-app-data",
+				State: StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute creates or destroys the storage entry
+func (t StorageEntryTask) Execute() TaskOutputState {
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the StorageEntryTask would produce.
+func (t StorageEntryTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			exists, err := storageEntryExists(t.Name)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if exists {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			args := []string{"--quiet", "storage:create"}
+			if t.Scheduler != "" {
+				args = append(args, "--scheduler", t.Scheduler)
+			}
+			if t.Size != "" {
+				args = append(args, "--size", t.Size)
+			}
+			if t.AccessMode != "" {
+				args = append(args, "--access-mode", t.AccessMode)
+			}
+			if t.StorageClass != "" {
+				args = append(args, "--storage-class-name", t.StorageClass)
+			}
+			if t.Namespace != "" {
+				args = append(args, "--namespace", t.Namespace)
+			}
+			if t.Chown != "" {
+				args = append(args, "--chown", t.Chown)
+			}
+			if t.ReclaimPolicy != "" {
+				args = append(args, "--reclaim-policy", t.ReclaimPolicy)
+			}
+			args = append(args, t.Name)
+			if t.Path != "" {
+				args = append(args, t.Path)
+			}
+			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusCreate,
+				Reason:    "entry missing",
+				Mutations: []string{fmt.Sprintf("create storage entry %s", t.Name)},
+				Commands:  resolveCommands(inputs),
+				apply: func() TaskOutputState {
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			exists, err := storageEntryExists(t.Name)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if !exists {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			inputs := []subprocess.ExecCommandInput{{
+				Command: "dokku",
+				Args:    []string{"--quiet", "storage:destroy", "--force", t.Name},
+			}}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    "entry present",
+				Mutations: []string{fmt.Sprintf("destroy storage entry %s", t.Name)},
+				Commands:  resolveCommands(inputs),
+				apply: func() TaskOutputState {
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				},
+			}
+		},
+	})
+}
+
+// storageEntryExists reports whether a named storage registry entry
+// exists. A transport-level failure (`*subprocess.SSHError`) is
+// propagated; a dokku-level non-zero exit is treated as "no entry."
+func storageEntryExists(name string) (bool, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "storage:list-entries", "--format", "json"},
+	})
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return false, err
+		}
+		return false, nil
+	}
+
+	var entries []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(result.StdoutBytes(), &entries); err != nil {
+		return false, nil
+	}
+	for _, entry := range entries {
+		if entry.Name == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// init registers the StorageEntryTask with the task registry
+func init() {
+	RegisterTask(&StorageEntryTask{})
+}

--- a/tasks/storage_entry_task_integration_test.go
+++ b/tasks/storage_entry_task_integration_test.go
@@ -1,0 +1,57 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationStorageEntry(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	name := "docket-test-entry"
+
+	// Start clean.
+	destroy := StorageEntryTask{Name: name, State: StateAbsent}
+	destroy.Execute()
+
+	create := StorageEntryTask{Name: name, Chown: "herokuish", State: StatePresent}
+	result := create.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to create entry: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for new entry")
+	}
+
+	// Re-apply: should be idempotent.
+	result = create.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent create failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false for existing entry")
+	}
+
+	// Destroy.
+	result = destroy.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to destroy entry: %v", result.Error)
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for destroy")
+	}
+
+	// Destroy again: idempotent.
+	result = destroy.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent destroy failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false for already-absent entry")
+	}
+}

--- a/tasks/storage_entry_task_test.go
+++ b/tasks/storage_entry_task_test.go
@@ -1,0 +1,30 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestStorageEntryTaskInvalidState(t *testing.T) {
+	task := StorageEntryTask{Name: "test-entry", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestStorageEntryAbsentStateAllowed(t *testing.T) {
+	// Absent is a valid state, unlike storage_ensure. The task will fail
+	// because dokku isn't reachable, but the failure must not be the
+	// "absent state is not supported" sentinel.
+	task := StorageEntryTask{Name: "test-entry", State: StateAbsent}
+	result := task.Execute()
+	if result.Error != nil && result.Error.Error() == "the absent state is not supported for storage:ensure" {
+		t.Errorf("absent should be supported for storage_entry, got: %v", result.Error)
+	}
+}
+
+func TestStorageEntryRegistered(t *testing.T) {
+	if _, ok := RegisteredTasks["dokku_storage_entry"]; !ok {
+		t.Fatal("expected dokku_storage_entry to be registered")
+	}
+}

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -8,16 +8,52 @@ import (
 	"github.com/dokku/docket/subprocess"
 )
 
-// StorageMountTask manages the storage for a given dokku application
+// StorageMountTask manages a storage attachment for a dokku application.
+// It supports two forms:
+//
+//   - Legacy bind mount: set host_dir + container_dir to pass the colon
+//     form to `storage:mount <app> <host:container>`. Round-tripped with
+//     dokku versions that predate the named-entry registry.
+//   - Named-entry attachment: set entry_name + container_dir and (optionally)
+//     phases, process_type, subpath, readonly, volume_chown. Maps to
+//     `storage:mount <app> <entry_name> --container-dir <container_dir>`
+//     plus the matching attachment flags.
+//
+// Exactly one of entry_name / host_dir must be set. Idempotency is keyed
+// on (source, container_path) using `storage:list <app> --format json`;
+// the richer attachment attributes are applied at mount time only and
+// are not drift-detected (mirroring the partial-probe pattern in
+// service_backup and storage_ensure).
 type StorageMountTask struct {
 	// App is the name of the app
 	App string `required:"true" yaml:"app" description:"Name of the app"`
 
-	// HostDir is the host directory to mount
-	HostDir string `required:"true" yaml:"host_dir" description:"Host directory to mount"`
+	// EntryName is the named storage registry entry to attach. Mutually
+	// exclusive with host_dir.
+	EntryName string `required:"false" yaml:"entry_name,omitempty" description:"Named storage registry entry to attach (mutually exclusive with host_dir)"`
+
+	// HostDir is the host directory to mount (legacy bind-mount form).
+	// Mutually exclusive with entry_name.
+	HostDir string `required:"false" yaml:"host_dir,omitempty" description:"Host directory to mount in the legacy bind-mount form (mutually exclusive with entry_name)"`
 
 	// ContainerDir is the container directory to mount
 	ContainerDir string `required:"true" yaml:"container_dir" description:"Container directory to mount"`
+
+	// Phases is the deployment phases the attachment applies to (deploy, run).
+	// Empty defers to the dokku default (both phases).
+	Phases []string `required:"false" yaml:"phases,omitempty" description:"Deployment phases the attachment applies to (deploy, run). Empty defers to the dokku default."`
+
+	// ProcessType limits the attachment to a specific process type
+	ProcessType string `required:"false" yaml:"process_type,omitempty" description:"Process type the attachment applies to"`
+
+	// Subpath is the subpath within the entry to mount
+	Subpath string `required:"false" yaml:"subpath,omitempty" description:"Subpath within the entry to mount"`
+
+	// Readonly mounts the attachment as read-only when true
+	Readonly bool `required:"false" yaml:"readonly,omitempty" description:"Mount the attachment as read-only"`
+
+	// VolumeChown is the chown option applied to the volume at mount time
+	VolumeChown string `required:"false" yaml:"volume_chown,omitempty" description:"Chown option applied to the volume at mount time"`
 
 	// State is the desired state of the storage
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the storage"`
@@ -39,14 +75,33 @@ func (e StorageMountTaskExample) GetName() string {
 
 // Doc returns the docblock for the storage mount task
 func (t StorageMountTask) Doc() string {
-	return "Mounts or unmounts the storage for a given dokku application"
+	return "Attaches or detaches storage on a dokku application"
 }
 
 // Examples returns the examples for the storage mount task
 func (t StorageMountTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]StorageMountTaskExample{
 		{
-			Name: "Mount a host directory into an app",
+			Name: "Attach a named storage entry to an app",
+			StorageMountTask: StorageMountTask{
+				App:          "node-js-app",
+				EntryName:    "node-js-app-data",
+				ContainerDir: "/app/storage",
+			},
+		},
+		{
+			Name: "Attach a named entry on deploy only, read-only, for the web process",
+			StorageMountTask: StorageMountTask{
+				App:          "node-js-app",
+				EntryName:    "node-js-app-data",
+				ContainerDir: "/app/storage",
+				Phases:       []string{"deploy"},
+				ProcessType:  "web",
+				Readonly:     true,
+			},
+		},
+		{
+			Name: "Mount a host directory into an app (legacy form)",
 			StorageMountTask: StorageMountTask{
 				App:          "node-js-app",
 				HostDir:      "/var/lib/dokku/data/storage/node-js-app",
@@ -54,10 +109,10 @@ func (t StorageMountTask) Examples() ([]Doc, error) {
 			},
 		},
 		{
-			Name: "Unmount a host directory from an app",
+			Name: "Unmount a named entry from an app",
 			StorageMountTask: StorageMountTask{
 				App:          "node-js-app",
-				HostDir:      "/var/lib/dokku/data/storage/node-js-app",
+				EntryName:    "node-js-app-data",
 				ContainerDir: "/app/storage",
 				State:        StateAbsent,
 			},
@@ -65,17 +120,19 @@ func (t StorageMountTask) Examples() ([]Doc, error) {
 	})
 }
 
-// Execute mounts or unmounts the storage for a given app
+// Execute attaches or detaches storage for a given app
 func (t StorageMountTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
 // Plan reports the drift the StorageMountTask would produce.
 func (t StorageMountTask) Plan() PlanResult {
-	mountSpec := fmt.Sprintf("%s:%s", t.HostDir, t.ContainerDir)
+	if err := t.validate(); err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			exists, err := mountExists(t.App, t.HostDir, t.ContainerDir)
+			exists, err := mountExists(t.App, t.EntryName, t.HostDir, t.ContainerDir)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -84,13 +141,13 @@ func (t StorageMountTask) Plan() PlanResult {
 			}
 			inputs := []subprocess.ExecCommandInput{{
 				Command: "dokku",
-				Args:    []string{"--quiet", "storage:mount", t.App, mountSpec},
+				Args:    t.mountArgs(),
 			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusCreate,
 				Reason:    "mount missing",
-				Mutations: []string{fmt.Sprintf("mount %s on %s", mountSpec, t.App)},
+				Mutations: []string{fmt.Sprintf("mount %s on %s", t.describeMount(), t.App)},
 				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
 					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
@@ -98,7 +155,7 @@ func (t StorageMountTask) Plan() PlanResult {
 			}
 		},
 		StateAbsent: func() PlanResult {
-			exists, err := mountExists(t.App, t.HostDir, t.ContainerDir)
+			exists, err := mountExists(t.App, t.EntryName, t.HostDir, t.ContainerDir)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -107,13 +164,13 @@ func (t StorageMountTask) Plan() PlanResult {
 			}
 			inputs := []subprocess.ExecCommandInput{{
 				Command: "dokku",
-				Args:    []string{"--quiet", "storage:unmount", t.App, mountSpec},
+				Args:    t.unmountArgs(),
 			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
 				Reason:    "mount present",
-				Mutations: []string{fmt.Sprintf("unmount %s on %s", mountSpec, t.App)},
+				Mutations: []string{fmt.Sprintf("unmount %s on %s", t.describeMount(), t.App)},
 				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
 					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
@@ -123,10 +180,90 @@ func (t StorageMountTask) Plan() PlanResult {
 	})
 }
 
-// mountExists checks if the storage mount exists. A transport-level
+// validate enforces the cross-field rules that the docs generator's
+// required-field check cannot express: exactly one of entry_name /
+// host_dir is set, and every phases entry is one of deploy / run.
+func (t StorageMountTask) validate() error {
+	if t.EntryName == "" && t.HostDir == "" {
+		return errors.New("exactly one of 'entry_name' or 'host_dir' is required")
+	}
+	if t.EntryName != "" && t.HostDir != "" {
+		return errors.New("'entry_name' and 'host_dir' are mutually exclusive")
+	}
+	for _, phase := range t.Phases {
+		if phase != "deploy" && phase != "run" {
+			return fmt.Errorf("invalid phase %q (must be 'deploy' or 'run')", phase)
+		}
+	}
+	return nil
+}
+
+// describeMount renders the short label used in Mutations entries. The
+// named form quotes the entry; the legacy form keeps the original
+// host:container layout so existing recipes diff cleanly.
+func (t StorageMountTask) describeMount() string {
+	if t.EntryName != "" {
+		return fmt.Sprintf("%s at %s", t.EntryName, t.ContainerDir)
+	}
+	return fmt.Sprintf("%s:%s", t.HostDir, t.ContainerDir)
+}
+
+// mountArgs renders the dokku storage:mount invocation. The named form
+// passes the entry name positionally and --container-dir; the legacy
+// form keeps the host:container colon syntax.
+func (t StorageMountTask) mountArgs() []string {
+	args := []string{"--quiet", "storage:mount"}
+	if t.EntryName != "" {
+		args = append(args, t.App, t.EntryName, "--container-dir", t.ContainerDir)
+	} else {
+		args = append(args, t.App, fmt.Sprintf("%s:%s", t.HostDir, t.ContainerDir))
+	}
+	return append(args, t.attachmentFlags()...)
+}
+
+// unmountArgs mirrors mountArgs for the storage:unmount path.
+func (t StorageMountTask) unmountArgs() []string {
+	args := []string{"--quiet", "storage:unmount"}
+	if t.EntryName != "" {
+		args = append(args, t.App, t.EntryName, "--container-dir", t.ContainerDir)
+	} else {
+		args = append(args, t.App, fmt.Sprintf("%s:%s", t.HostDir, t.ContainerDir))
+	}
+	return args
+}
+
+// attachmentFlags renders the optional --phase / --process-type /
+// --volume-subpath / --volume-readonly / --volume-chown flags. Empty
+// fields are omitted so the resulting command line stays minimal.
+func (t StorageMountTask) attachmentFlags() []string {
+	var flags []string
+	for _, phase := range t.Phases {
+		flags = append(flags, "--phase", phase)
+	}
+	if t.ProcessType != "" {
+		flags = append(flags, "--process-type", t.ProcessType)
+	}
+	if t.Subpath != "" {
+		flags = append(flags, "--volume-subpath", t.Subpath)
+	}
+	if t.Readonly {
+		flags = append(flags, "--volume-readonly")
+	}
+	if t.VolumeChown != "" {
+		flags = append(flags, "--volume-chown", t.VolumeChown)
+	}
+	return flags
+}
+
+// mountExists reports whether an attachment matching either the
+// named-entry form (entry_name + container_path) or the legacy form
+// (host_path + container_path) is present on the app. A transport-level
 // failure (`*subprocess.SSHError`) is propagated; a dokku-level non-
-// zero exit (e.g. app does not exist) is treated as "no mount."
-func mountExists(app, hostDir, containerDir string) (bool, error) {
+// zero exit (e.g. app does not exist) is treated as "no mount." The
+// richer attachment attributes (phases, subpath, readonly, etc.) are
+// not exposed by storage:list, so a change to those values does not
+// surface as drift.
+func mountExists(app, entryName, hostDir, containerDir string) (bool, error) {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
@@ -146,6 +283,7 @@ func mountExists(app, hostDir, containerDir string) (bool, error) {
 	}
 
 	var mounts []struct {
+		EntryName     string `json:"entry_name"`
 		HostPath      string `json:"host_path"`
 		ContainerPath string `json:"container_path"`
 	}
@@ -155,7 +293,13 @@ func mountExists(app, hostDir, containerDir string) (bool, error) {
 	}
 
 	for _, mount := range mounts {
-		if mount.HostPath == hostDir && mount.ContainerPath == containerDir {
+		if mount.ContainerPath != containerDir {
+			continue
+		}
+		if entryName != "" && mount.EntryName == entryName {
+			return true, nil
+		}
+		if hostDir != "" && mount.HostPath == hostDir {
 			return true, nil
 		}
 	}

--- a/tasks/storage_mount_task_integration_test.go
+++ b/tasks/storage_mount_task_integration_test.go
@@ -1,8 +1,9 @@
 package tasks
 
 import (
-	"github.com/dokku/docket/subprocess"
 	"testing"
+
+	"github.com/dokku/docket/subprocess"
 )
 
 func TestIntegrationStorageMount(t *testing.T) {
@@ -11,6 +12,7 @@ func TestIntegrationStorageMount(t *testing.T) {
 	appName := "docket-test-mount"
 	hostDir := "/var/lib/dokku/data/storage/docket-test-mount"
 	containerDir := "/app/storage"
+	entryName := "docket-test-mount-entry"
 
 	destroyApp(appName)
 	createApp(appName)
@@ -22,7 +24,7 @@ func TestIntegrationStorageMount(t *testing.T) {
 		Args:    []string{"-p", hostDir},
 	})
 
-	// mount storage
+	// legacy form: mount storage
 	mountTask := StorageMountTask{
 		App:          appName,
 		HostDir:      hostDir,
@@ -31,7 +33,7 @@ func TestIntegrationStorageMount(t *testing.T) {
 	}
 	result := mountTask.Execute()
 	if result.Error != nil {
-		t.Fatalf("failed to mount storage: %v", result.Error)
+		t.Fatalf("failed to mount storage (legacy): %v", result.Error)
 	}
 	if result.State != StatePresent {
 		t.Errorf("expected state 'present', got '%s'", result.State)
@@ -58,7 +60,7 @@ func TestIntegrationStorageMount(t *testing.T) {
 	}
 	result = unmountTask.Execute()
 	if result.Error != nil {
-		t.Fatalf("failed to unmount storage: %v", result.Error)
+		t.Fatalf("failed to unmount storage (legacy): %v", result.Error)
 	}
 	if result.State != StateAbsent {
 		t.Errorf("expected state 'absent', got '%s'", result.State)
@@ -74,5 +76,65 @@ func TestIntegrationStorageMount(t *testing.T) {
 	}
 	if result.Changed {
 		t.Error("expected changed=false for nonexistent mount")
+	}
+
+	// named-entry form: create an entry first, then mount it
+	entry := StorageEntryTask{
+		Name:  entryName,
+		Chown: "herokuish",
+		State: StatePresent,
+	}
+	if r := entry.Execute(); r.Error != nil {
+		t.Fatalf("failed to create entry: %v", r.Error)
+	}
+	defer func() {
+		destroy := StorageEntryTask{Name: entryName, State: StateAbsent}
+		destroy.Execute()
+	}()
+
+	namedMount := StorageMountTask{
+		App:          appName,
+		EntryName:    entryName,
+		ContainerDir: "/app/named",
+		Phases:       []string{"deploy", "run"},
+		State:        StatePresent,
+	}
+	result = namedMount.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to mount named entry: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for new named-entry mount")
+	}
+
+	// idempotent re-apply
+	result = namedMount.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent named-entry mount failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false for existing named-entry mount")
+	}
+
+	// unmount named entry
+	namedUnmount := StorageMountTask{
+		App:          appName,
+		EntryName:    entryName,
+		ContainerDir: "/app/named",
+		State:        StateAbsent,
+	}
+	result = namedUnmount.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unmount named entry: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for named-entry unmount")
+	}
+	result = namedUnmount.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent named-entry unmount failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false for nonexistent named-entry mount")
 	}
 }

--- a/tasks/storage_mount_task_test.go
+++ b/tasks/storage_mount_task_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -15,4 +16,112 @@ func TestStorageMountTaskInvalidState(t *testing.T) {
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
 	}
+}
+
+func TestStorageMountRequiresExactlyOneSource(t *testing.T) {
+	cases := []struct {
+		name string
+		task StorageMountTask
+		want string
+	}{
+		{
+			name: "neither set",
+			task: StorageMountTask{App: "test-app", ContainerDir: "/c", State: StatePresent},
+			want: "exactly one of 'entry_name' or 'host_dir' is required",
+		},
+		{
+			name: "both set",
+			task: StorageMountTask{App: "test-app", EntryName: "e", HostDir: "/h", ContainerDir: "/c", State: StatePresent},
+			want: "'entry_name' and 'host_dir' are mutually exclusive",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.task.Plan()
+			if result.Error == nil {
+				t.Fatalf("expected error %q, got nil", tc.want)
+			}
+			if !strings.Contains(result.Error.Error(), tc.want) {
+				t.Errorf("expected error to contain %q, got %q", tc.want, result.Error.Error())
+			}
+		})
+	}
+}
+
+func TestStorageMountRejectsInvalidPhase(t *testing.T) {
+	task := StorageMountTask{
+		App:          "test-app",
+		EntryName:    "data",
+		ContainerDir: "/app/storage",
+		Phases:       []string{"deploy", "boot"},
+		State:        StatePresent,
+	}
+	result := task.Plan()
+	if result.Error == nil {
+		t.Fatal("expected error for invalid phase")
+	}
+	if !strings.Contains(result.Error.Error(), `invalid phase "boot"`) {
+		t.Errorf("expected invalid phase error, got %q", result.Error.Error())
+	}
+}
+
+func TestStorageMountNamedEntryCommandShape(t *testing.T) {
+	task := StorageMountTask{
+		App:          "test-app",
+		EntryName:    "data",
+		ContainerDir: "/app/storage",
+		Phases:       []string{"deploy", "run"},
+		ProcessType:  "web",
+		Subpath:      "sub",
+		Readonly:     true,
+		VolumeChown:  "herokuish",
+	}
+	args := task.mountArgs()
+	want := []string{
+		"--quiet", "storage:mount", "test-app", "data",
+		"--container-dir", "/app/storage",
+		"--phase", "deploy", "--phase", "run",
+		"--process-type", "web",
+		"--volume-subpath", "sub",
+		"--volume-readonly",
+		"--volume-chown", "herokuish",
+	}
+	if !equalStrings(args, want) {
+		t.Errorf("mountArgs mismatch:\n  got: %v\n want: %v", args, want)
+	}
+	unmount := task.unmountArgs()
+	wantUnmount := []string{"--quiet", "storage:unmount", "test-app", "data", "--container-dir", "/app/storage"}
+	if !equalStrings(unmount, wantUnmount) {
+		t.Errorf("unmountArgs mismatch:\n  got: %v\n want: %v", unmount, wantUnmount)
+	}
+}
+
+func TestStorageMountLegacyCommandShape(t *testing.T) {
+	task := StorageMountTask{
+		App:          "test-app",
+		HostDir:      "/var/data",
+		ContainerDir: "/app/storage",
+	}
+	args := task.mountArgs()
+	want := []string{"--quiet", "storage:mount", "test-app", "/var/data:/app/storage"}
+	if !equalStrings(args, want) {
+		t.Errorf("legacy mountArgs mismatch:\n  got: %v\n want: %v", args, want)
+	}
+	unmount := task.unmountArgs()
+	wantUnmount := []string{"--quiet", "storage:unmount", "test-app", "/var/data:/app/storage"}
+	if !equalStrings(unmount, wantUnmount) {
+		t.Errorf("legacy unmountArgs mismatch:\n  got: %v\n want: %v", unmount, wantUnmount)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/tests/bats/list_resume.bats
+++ b/tests/bats/list_resume.bats
@@ -104,6 +104,36 @@ EOF
   assert_output --partial "[skipped] gated"
 }
 
+@test "--list-tasks marks deprecated task types" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure storage
+      dokku_storage_ensure:
+        app: docket-test-list-1
+        chown: herokuish
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  assert_output --partial "ensure storage"
+  assert_output --partial "(deprecated)"
+}
+
+@test "--list-tasks --json sets deprecated:true on deprecated tasks" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure storage
+      dokku_storage_ensure:
+        app: docket-test-list-1
+        chown: herokuish
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks --json
+  assert_success
+  assert_output --partial '"deprecated":true'
+  assert_output --partial '"deprecation":"'
+}
+
 @test "--list-tasks works on plan as well" {
   write_tasks_file <<EOF
 ---


### PR DESCRIPTION
`dokku_storage_mount` could only express the legacy `host_dir:container_dir` bind-mount form, so recipes could not faithfully round-trip the current Dokku storage model (named registry entries plus attachments with phases, process type, subpath, readonly, and volume chown). This adds a new `dokku_storage_entry` task that wraps `storage:create` and `storage:destroy --force` and extends `dokku_storage_mount` to attach named entries with the richer attachment attributes, while keeping the legacy form working for back-compat. Along the way, docket grows a general task-deprecation mechanism (an optional `Deprecation()` method surfaced in the generated docs, in `--list-tasks`, and as a runtime warning on apply and plan); `dokku_storage_ensure` uses it because dokku's underlying `storage:ensure-directory` has itself been deprecated in favour of `storage:create`. The minimum supported dokku version is bumped to 0.38.10 to pick up `storage:destroy --force`.

Closes #246.