### PR TITLE
feat: add dokku_apps_property task

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.11
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.12
           sudo dokku plugin:install-dependencies --core
       - name: install dokku redis plugin
         run: sudo dokku plugin:install https://github.com/dokku/dokku-redis.git redis
@@ -87,7 +87,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.11
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.12
           sudo dokku plugin:install-dependencies --core
       - name: install bats
         run: sudo apt-get install -qq -y bats bats-support bats-assert

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,7 @@ code into it:
 
 ## Prerequisites
 
-- **Dokku >= 0.38.11.**
+- **Dokku >= 0.38.12.**
 - **dokku-letsencrypt >= 0.25.0.**
 
 ## Installation

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -8,6 +8,7 @@ Reference for every task type docket can run inside a recipe. Each page lists th
 - [dokku_app_clone](dokku_app_clone.md) - Clones an existing dokku app to a new app
 - [dokku_app_json_property](dokku_app_json_property.md) - Manages the app.json configuration for a given dokku application
 - [dokku_app_lock](dokku_app_lock.md) - Locks or unlocks a dokku application from deployment
+- [dokku_apps_property](dokku_apps_property.md) - Manages the apps plugin configuration for a given dokku application or globally
 - [dokku_builder_dockerfile_property](dokku_builder_dockerfile_property.md) - Manages the builder-dockerfile configuration for a given dokku application
 - [dokku_builder_herokuish_property](dokku_builder_herokuish_property.md) - Manages the builder-herokuish configuration for a given dokku application
 - [dokku_builder_lambda_property](dokku_builder_lambda_property.md) - Manages the builder-lambda configuration for a given dokku application

--- a/docs/tasks/dokku_apps_property.md
+++ b/docs/tasks/dokku_apps_property.md
@@ -1,0 +1,70 @@
+# dokku_apps_property
+
+## Synopsis
+
+Manages the apps plugin configuration for a given dokku application or globally
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the apps property should be applied globally |
+| `property` | string | yes |  |  | Name of the apps property to set |
+| `value` | string | no |  |  | Value to set for the apps property |
+| `state` | string | no | present | present, absent | Desired state of the apps configuration |
+
+## Examples
+
+### Disabling app auto-creation globally
+
+```yaml
+dokku_apps_property:
+    app: ""
+    global: true
+    property: disable-autocreation
+    value: "true"
+```
+
+### Overriding the deploy-source for an app
+
+```yaml
+dokku_apps_property:
+    app: node-js-app
+    property: deploy-source
+    value: git
+```
+
+### Overriding the deploy-source-metadata for an app
+
+```yaml
+dokku_apps_property:
+    app: node-js-app
+    property: deploy-source-metadata
+    value: https://example.com/repo
+```
+
+### Re-enabling app auto-creation globally
+
+```yaml
+dokku_apps_property:
+    app: ""
+    global: true
+    property: disable-autocreation
+    state: absent
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/tasks/apps_property_task.go
+++ b/tasks/apps_property_task.go
@@ -1,0 +1,105 @@
+package tasks
+
+// AppsPropertyTask manages the apps plugin configuration for a given dokku application or globally
+type AppsPropertyTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+
+	// Global is a flag indicating if the apps property should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the apps property should be applied globally"`
+
+	// Property is the name of the apps property to set
+	Property string `required:"true" yaml:"property" description:"Name of the apps property to set"`
+
+	// Value is the value to set for the apps property
+	Value string `required:"false" yaml:"value,omitempty" description:"Value to set for the apps property"`
+
+	// State is the desired state of the apps configuration
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the apps configuration"`
+}
+
+// AppsPropertyTaskExample contains an example of an AppsPropertyTask
+type AppsPropertyTaskExample struct {
+	// Name is the task name holding the AppsPropertyTask description
+	Name string `yaml:"-"`
+
+	// AppsPropertyTask is the AppsPropertyTask configuration
+	AppsPropertyTask AppsPropertyTask `yaml:"dokku_apps_property"`
+}
+
+// GetName returns the name of the example
+func (e AppsPropertyTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the apps property task
+func (t AppsPropertyTask) Doc() string {
+	return "Manages the apps plugin configuration for a given dokku application or globally"
+}
+
+// Examples returns the examples for the apps property task
+func (t AppsPropertyTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]AppsPropertyTaskExample{
+		{
+			Name: "Disabling app auto-creation globally",
+			AppsPropertyTask: AppsPropertyTask{
+				Global:   true,
+				Property: "disable-autocreation",
+				Value:    "true",
+			},
+		},
+		{
+			Name: "Overriding the deploy-source for an app",
+			AppsPropertyTask: AppsPropertyTask{
+				App:      "node-js-app",
+				Property: "deploy-source",
+				Value:    "git",
+			},
+		},
+		{
+			Name: "Overriding the deploy-source-metadata for an app",
+			AppsPropertyTask: AppsPropertyTask{
+				App:      "node-js-app",
+				Property: "deploy-source-metadata",
+				Value:    "https://example.com/repo",
+			},
+		},
+		{
+			Name: "Re-enabling app auto-creation globally",
+			AppsPropertyTask: AppsPropertyTask{
+				Global:   true,
+				Property: "disable-autocreation",
+				State:    StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute sets or unsets the apps property
+func (t AppsPropertyTask) Execute() TaskOutputState {
+	return ExecutePlan(t.Plan())
+}
+
+// appsPropertyKeys maps apps property names to the JSON keys emitted by
+// `dokku apps:report [<app>|--global] --format json` on dokku 0.38.12+.
+// deploy-source and deploy-source-metadata are per-app only; disable-autocreation
+// is global only - dokku 0.38.12 narrowed apps.GlobalProperties to drop the
+// vestigial deploy-source* global forms, and maybeCreateApp only consults the
+// global value of disable-autocreation. The bare key `global-disable-autocreation`
+// falls out of stripping the `--app-` prefix from dokku's
+// `--app-global-disable-autocreation` report flag.
+var appsPropertyKeys = map[string]PropertyKeys{
+	"deploy-source":          {PerApp: "deploy-source", Global: ""},
+	"deploy-source-metadata": {PerApp: "deploy-source-metadata", Global: ""},
+	"disable-autocreation":   {PerApp: "", Global: "global-disable-autocreation"},
+}
+
+// Plan reports the drift the AppsPropertyTask would produce.
+func (t AppsPropertyTask) Plan() PlanResult {
+	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "apps:set", appsPropertyKeys)
+}
+
+// init registers the AppsPropertyTask with the task registry
+func init() {
+	RegisterTask(&AppsPropertyTask{})
+}

--- a/tasks/apps_property_task_integration_test.go
+++ b/tasks/apps_property_task_integration_test.go
@@ -1,0 +1,47 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationAppsPropertyAll(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-apps-prop"
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	cases := []struct {
+		property string
+		value    string
+		perApp   bool
+		global   bool
+	}{
+		{"deploy-source", "git", true, false},
+		{"deploy-source-metadata", "https://example.com/repo", true, false},
+		{"disable-autocreation", "true", false, true},
+	}
+	for _, tc := range cases {
+		if tc.perApp {
+			t.Run(tc.property+"/per-app", func(t *testing.T) {
+				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
+					label:     "apps per-app " + tc.property,
+					setTask:   AppsPropertyTask{App: appName, Property: tc.property, Value: tc.value, State: StatePresent},
+					unsetTask: AppsPropertyTask{App: appName, Property: tc.property, State: StateAbsent},
+				})
+			})
+		}
+		if tc.global {
+			t.Run(tc.property+"/global", func(t *testing.T) {
+				unsetTask := AppsPropertyTask{Global: true, Property: tc.property, State: StateAbsent}
+				defer unsetTask.Execute()
+				runPropertyIdempotencyTest(t, propertyIdempotencyCase{
+					label:     "apps global " + tc.property,
+					setTask:   AppsPropertyTask{Global: true, Property: tc.property, Value: tc.value, State: StatePresent},
+					unsetTask: unsetTask,
+				})
+			})
+		}
+	}
+}

--- a/tasks/apps_property_task_test.go
+++ b/tasks/apps_property_task_test.go
@@ -1,0 +1,71 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAppsPropertyTaskInvalidState(t *testing.T) {
+	task := AppsPropertyTask{App: "test-app", Property: "deploy-source", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestAppsPropertyTaskMissingApp(t *testing.T) {
+	task := AppsPropertyTask{Property: "deploy-source", Value: "git", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+}
+
+func TestAppsPropertyTaskGlobalWithAppSet(t *testing.T) {
+	task := AppsPropertyTask{
+		App:      "test-app",
+		Global:   true,
+		Property: "disable-autocreation",
+		Value:    "true",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestAppsPropertyTaskPresentWithoutValue(t *testing.T) {
+	task := AppsPropertyTask{
+		App:      "test-app",
+		Property: "deploy-source",
+		Value:    "",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid without a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestAppsPropertyTaskAbsentWithValue(t *testing.T) {
+	task := AppsPropertyTask{
+		App:      "test-app",
+		Property: "deploy-source",
+		Value:    "git",
+		State:    StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has a value")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid with a value") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}

--- a/tasks/integration_shard_test.go
+++ b/tasks/integration_shard_test.go
@@ -22,6 +22,7 @@ var integrationTestWeights = map[string]float64{
 	"TestIntegrationAppCreateAndDestroy":                    6.0,
 	"TestIntegrationAppJsonPropertyAll":                     7.2,
 	"TestIntegrationAppLock":                                7.0,
+	"TestIntegrationAppsPropertyAll":                        8.0,
 	"TestIntegrationBuilderDockerfilePropertyAll":           7.5,
 	"TestIntegrationBuilderHerokuishPropertyAll":            7.5,
 	"TestIntegrationBuilderLambdaPropertyAll":               7.5,

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -488,7 +488,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 63
+	expected := 64
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}

--- a/tasks/property_keys_test.go
+++ b/tasks/property_keys_test.go
@@ -72,6 +72,17 @@ func TestAppJsonPropertyKeys(t *testing.T) {
 	checkUnsupportedProperty(t, "app-json", appJsonPropertyKeys)
 }
 
+func TestAppsPropertyKeys(t *testing.T) {
+	checkPropertyKeys(t, "apps", appsPropertyKeys, []propertyKeysCase{
+		{"deploy-source", "deploy-source", ""},
+		{"deploy-source-metadata", "deploy-source-metadata", ""},
+		{"disable-autocreation", "", "global-disable-autocreation"},
+	})
+	checkUnsupportedProperty(t, "apps", appsPropertyKeys)
+	// deploy-source* are per-app only; disable-autocreation is global only.
+	checkScopeMismatch(t, "apps", appsPropertyKeys, "deploy-source", "disable-autocreation")
+}
+
 func TestBuilderPropertyKeys(t *testing.T) {
 	checkPropertyKeys(t, "builder", builderPropertyKeys, []propertyKeysCase{
 		{"build-dir", "build-dir", "global-build-dir"},


### PR DESCRIPTION
Adds a `dokku_apps_property` task that mirrors the other `dokku_<plugin>_property` tasks for the apps plugin's own settable properties. It exposes `deploy-source` and `deploy-source-metadata` per-app and `disable-autocreation` globally, matching the post-dokku/dokku#8705 surface where the only globally meaningful apps property is `disable-autocreation` and the deploy-source values are owned by dokku's deploy flow per-app.

The minimum dokku version is bumped to 0.38.12 to consume the fix for dokku/dokku#8705, which narrowed `apps.GlobalProperties` to drop the vestigial global forms of `deploy-source` and `deploy-source-metadata` and added `disable-autocreation` to `apps:report` in both per-app and global scopes so the planner can probe drift.

Fixes dokku/docket#247.