### PR TITLE
feat: scope dokku_docker_options to a process type

### DIFF
--- a/docs/tasks/dokku_docker_options.md
+++ b/docs/tasks/dokku_docker_options.md
@@ -10,6 +10,7 @@ Manages docker-options for a given dokku application
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | yes |  |  | Name of the app |
 | `phase` | string | yes |  | build, deploy, run | Deployment phase the option applies to |
+| `process_type` | string | no |  |  | Process type the option is scoped to (deploy phase only). Empty applies to the default scope (every container). |
 | `option` | string | yes |  |  | Docker option string (e.g. '-v /var/run/docker.sock:/var/run/docker.sock') |
 | `state` | string | no | present | present, absent | Desired state of the docker option |
 
@@ -22,6 +23,16 @@ dokku_docker_options:
     app: node-js-app
     phase: deploy
     option: -v /var/run/docker.sock:/var/run/docker.sock
+```
+
+### Scope a deploy option to the web process type
+
+```yaml
+dokku_docker_options:
+    app: node-js-app
+    phase: deploy
+    process_type: web
+    option: --memory=512m
 ```
 
 ### Remove a docker option from the deploy phase

--- a/tasks/docker_options_task.go
+++ b/tasks/docker_options_task.go
@@ -1,12 +1,18 @@
 package tasks
 
 import (
+	"encoding/json"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/dokku/docket/subprocess"
 )
+
+// defaultDockerOptionsProcessType is the sentinel dokku uses for options that
+// apply to every container in an app. It is rejected as an explicit
+// --process value, so the task accepts an empty ProcessType to target the
+// default scope and rejects this literal.
+const defaultDockerOptionsProcessType = "_default_"
 
 // DockerOptionsTask manages docker-options for a given dokku application
 type DockerOptionsTask struct {
@@ -15,6 +21,11 @@ type DockerOptionsTask struct {
 
 	// Phase is the deployment phase the option applies to
 	Phase string `required:"true" yaml:"phase" options:"build,deploy,run" description:"Deployment phase the option applies to"`
+
+	// ProcessType scopes the option to a specific Procfile process type.
+	// Only valid for the deploy phase; empty applies to the default scope
+	// (every container in the app).
+	ProcessType string `required:"false" yaml:"process_type,omitempty" description:"Process type the option is scoped to (deploy phase only). Empty applies to the default scope (every container)."`
 
 	// Option is the docker option string (e.g. "-v /var/run/docker.sock:/var/run/docker.sock")
 	Option string `required:"true" yaml:"option" description:"Docker option string (e.g. '-v /var/run/docker.sock:/var/run/docker.sock')"`
@@ -54,6 +65,15 @@ func (t DockerOptionsTask) Examples() ([]Doc, error) {
 			},
 		},
 		{
+			Name: "Scope a deploy option to the web process type",
+			DockerOptionsTask: DockerOptionsTask{
+				App:         "node-js-app",
+				Phase:       "deploy",
+				ProcessType: "web",
+				Option:      "--memory=512m",
+			},
+		},
+		{
 			Name: "Remove a docker option from the deploy phase",
 			DockerOptionsTask: DockerOptionsTask{
 				App:    "node-js-app",
@@ -81,18 +101,19 @@ func (t DockerOptionsTask) Plan() PlanResult {
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
-			if optionPresent(current[t.Phase], t.Option) {
+			scope := dockerOptionsScope{Phase: t.Phase, ProcessType: t.ProcessType}
+			if optionPresent(current[scope], t.Option) {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			inputs := []subprocess.ExecCommandInput{{
 				Command: "dokku",
-				Args:    []string{"--quiet", "docker-options:add", t.App, t.Phase, t.Option},
+				Args:    dockerOptionsCommandArgs("docker-options:add", t),
 			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusCreate,
-				Reason:    fmt.Sprintf("missing on %s phase", t.Phase),
-				Mutations: []string{fmt.Sprintf("add %s option %q", t.Phase, t.Option)},
+				Reason:    fmt.Sprintf("missing on %s", describeDockerOptionsScope(scope)),
+				Mutations: []string{fmt.Sprintf("add %s option %q", describeDockerOptionsScope(scope), t.Option)},
 				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
 					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
@@ -107,18 +128,19 @@ func (t DockerOptionsTask) Plan() PlanResult {
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
-			if !optionPresent(current[t.Phase], t.Option) {
+			scope := dockerOptionsScope{Phase: t.Phase, ProcessType: t.ProcessType}
+			if !optionPresent(current[scope], t.Option) {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			inputs := []subprocess.ExecCommandInput{{
 				Command: "dokku",
-				Args:    []string{"--quiet", "docker-options:remove", t.App, t.Phase, t.Option},
+				Args:    dockerOptionsCommandArgs("docker-options:remove", t),
 			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusDestroy,
-				Reason:    fmt.Sprintf("present on %s phase", t.Phase),
-				Mutations: []string{fmt.Sprintf("remove %s option %q", t.Phase, t.Option)},
+				Reason:    fmt.Sprintf("present on %s", describeDockerOptionsScope(scope)),
+				Mutations: []string{fmt.Sprintf("remove %s option %q", describeDockerOptionsScope(scope), t.Option)},
 				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
 					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
@@ -129,6 +151,39 @@ func (t DockerOptionsTask) Plan() PlanResult {
 }
 
 var dockerOptionPhases = map[string]bool{"build": true, "deploy": true, "run": true}
+
+// dockerOptionsProcessScopedPhases mirrors dokku's processScopedPhases: only
+// the deploy phase accepts a --process value. Build runs once per app and run
+// is invoked outside the Procfile process-type context.
+var dockerOptionsProcessScopedPhases = map[string]bool{"deploy": true}
+
+// dockerOptionsScope identifies one (phase, process type) bucket in dokku's
+// docker-options storage. An empty ProcessType means the default scope.
+type dockerOptionsScope struct {
+	Phase       string
+	ProcessType string
+}
+
+// describeDockerOptionsScope renders the scope for use in Reason/Mutations
+// strings. Default scope shows just the phase; a process-scoped value names
+// the process so plan output makes the scope visible.
+func describeDockerOptionsScope(scope dockerOptionsScope) string {
+	if scope.ProcessType == "" {
+		return fmt.Sprintf("%s phase", scope.Phase)
+	}
+	return fmt.Sprintf("%s phase for %s process", scope.Phase, scope.ProcessType)
+}
+
+// dockerOptionsCommandArgs builds the dokku argument list for
+// docker-options:add / :remove. --process is placed before positionals
+// because the subcommand uses pflag with SetInterspersed(false).
+func dockerOptionsCommandArgs(subcommand string, t DockerOptionsTask) []string {
+	args := []string{"--quiet", subcommand}
+	if t.ProcessType != "" {
+		args = append(args, "--process", t.ProcessType)
+	}
+	return append(args, t.App, t.Phase, t.Option)
+}
 
 // validateDockerOptionsTask validates the docker options task parameters
 func validateDockerOptionsTask(t DockerOptionsTask) error {
@@ -141,30 +196,71 @@ func validateDockerOptionsTask(t DockerOptionsTask) error {
 	if strings.TrimSpace(t.Option) == "" {
 		return fmt.Errorf("'option' is required")
 	}
+	if t.ProcessType != "" {
+		if t.ProcessType == defaultDockerOptionsProcessType {
+			return fmt.Errorf("'process_type' must not be %q (reserved sentinel)", defaultDockerOptionsProcessType)
+		}
+		if !dockerOptionsProcessScopedPhases[t.Phase] {
+			return fmt.Errorf("'process_type' is only supported for the deploy phase, got %q", t.Phase)
+		}
+	}
 	return nil
 }
 
-var dockerOptionsReportRe = regexp.MustCompile(`^Docker options (build|deploy|run):\s*(.*)$`)
-
-// getDockerOptions returns the current docker options for each phase of an app
-func getDockerOptions(app string) (map[string]string, error) {
+// getDockerOptions reads the docker-options JSON report and indexes it by
+// (phase, process type). The JSON payload carries one entry per
+// `<phase>` and one per `<phase>.<process_type>` for any process-scoped
+// option, plus legacy `docker-options-*` duplicates emitted during the
+// 0.38.x deprecation window which we discard.
+func getDockerOptions(app string) (map[dockerOptionsScope]string, error) {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
-		Args:    []string{"--quiet", "docker-options:report", app},
+		Args:    []string{"--quiet", "docker-options:report", app, "--format", "json"},
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	options := map[string]string{"build": "", "deploy": "", "run": ""}
-	for _, line := range strings.Split(result.StdoutContents(), "\n") {
-		match := dockerOptionsReportRe.FindStringSubmatch(strings.TrimSpace(line))
-		if match == nil {
+	payload := map[string]string{}
+	if err := json.Unmarshal(result.StdoutBytes(), &payload); err != nil {
+		return nil, fmt.Errorf("parse docker-options:report json: %w", err)
+	}
+
+	return parseDockerOptionsPayload(payload), nil
+}
+
+// parseDockerOptionsPayload turns the report JSON map into scope-keyed
+// options. Legacy plugin-prefixed keys and any unknown keys are dropped so
+// that future report additions do not surface as drift.
+func parseDockerOptionsPayload(payload map[string]string) map[dockerOptionsScope]string {
+	out := map[dockerOptionsScope]string{}
+	for key, value := range payload {
+		if strings.HasPrefix(key, "docker-options-") {
 			continue
 		}
-		options[match[1]] = strings.TrimSpace(match[2])
+		phase, processType, ok := splitDockerOptionsKey(key)
+		if !ok {
+			continue
+		}
+		out[dockerOptionsScope{Phase: phase, ProcessType: processType}] = value
 	}
-	return options, nil
+	return out
+}
+
+// splitDockerOptionsKey parses a JSON key like "deploy" or "deploy.web" into
+// its phase and process-type components. Returns ok=false for keys whose head
+// is not a recognized phase.
+func splitDockerOptionsKey(key string) (phase, processType string, ok bool) {
+	if idx := strings.Index(key, "."); idx > 0 {
+		phase = key[:idx]
+		processType = key[idx+1:]
+	} else {
+		phase = key
+	}
+	if !dockerOptionPhases[phase] {
+		return "", "", false
+	}
+	return phase, processType, true
 }
 
 // optionPresent returns true if option appears as a contiguous token sequence in existing

--- a/tasks/docker_options_task_integration_test.go
+++ b/tasks/docker_options_task_integration_test.go
@@ -15,13 +15,14 @@ func TestIntegrationDockerOptions(t *testing.T) {
 
 	option := "-v /tmp/docket-test:/tmp/docket-test"
 	phase := "deploy"
+	scope := dockerOptionsScope{Phase: phase}
 
 	// initial state - option not present
 	current, err := getDockerOptions(appName)
 	if err != nil {
 		t.Fatalf("getDockerOptions failed: %v", err)
 	}
-	if optionPresent(current[phase], option) {
+	if optionPresent(current[scope], option) {
 		t.Fatalf("expected option not to be present initially")
 	}
 
@@ -41,8 +42,8 @@ func TestIntegrationDockerOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getDockerOptions failed: %v", err)
 	}
-	if !optionPresent(current[phase], option) {
-		t.Errorf("expected option to be present after add (got %q for phase %s)", current[phase], phase)
+	if !optionPresent(current[scope], option) {
+		t.Errorf("expected option to be present after add (got %q for scope %+v)", current[scope], scope)
 	}
 
 	// add same option - idempotent
@@ -70,8 +71,8 @@ func TestIntegrationDockerOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getDockerOptions failed: %v", err)
 	}
-	if optionPresent(current[phase], option) {
-		t.Errorf("expected option not to be present after remove (got %q for phase %s)", current[phase], phase)
+	if optionPresent(current[scope], option) {
+		t.Errorf("expected option not to be present after remove (got %q for scope %+v)", current[scope], scope)
 	}
 
 	// remove again - idempotent
@@ -81,5 +82,130 @@ func TestIntegrationDockerOptions(t *testing.T) {
 	}
 	if result.Changed {
 		t.Errorf("expected Changed=false on idempotent remove")
+	}
+}
+
+func TestIntegrationDockerOptionsProcessType(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-docker-options-proc"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	option := "--memory=512m"
+	phase := "deploy"
+	processType := "web"
+	procScope := dockerOptionsScope{Phase: phase, ProcessType: processType}
+	defaultScope := dockerOptionsScope{Phase: phase}
+
+	// initial state - option not present in either scope
+	current, err := getDockerOptions(appName)
+	if err != nil {
+		t.Fatalf("getDockerOptions failed: %v", err)
+	}
+	if optionPresent(current[procScope], option) {
+		t.Fatalf("expected option not to be present initially in %+v", procScope)
+	}
+
+	// add option scoped to the web process
+	addTask := DockerOptionsTask{
+		App:         appName,
+		Phase:       phase,
+		ProcessType: processType,
+		Option:      option,
+		State:       StatePresent,
+	}
+	result := addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to add scoped option: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first add")
+	}
+
+	current, err = getDockerOptions(appName)
+	if err != nil {
+		t.Fatalf("getDockerOptions failed: %v", err)
+	}
+	if !optionPresent(current[procScope], option) {
+		t.Errorf("expected option in %+v after add (got %q)", procScope, current[procScope])
+	}
+	// The default scope must not have the option - they are independent buckets.
+	if optionPresent(current[defaultScope], option) {
+		t.Errorf("expected option NOT in default scope after process-scoped add (got %q)", current[defaultScope])
+	}
+
+	// adding the same scoped option is idempotent
+	result = addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second scoped add: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent scoped add")
+	}
+
+	// adding the same option to the default scope is not a no-op because the
+	// scopes are independent
+	defaultAddTask := DockerOptionsTask{
+		App:    appName,
+		Phase:  phase,
+		Option: option,
+		State:  StatePresent,
+	}
+	result = defaultAddTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to add default-scope option: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true when adding the same option in the default scope")
+	}
+
+	current, err = getDockerOptions(appName)
+	if err != nil {
+		t.Fatalf("getDockerOptions failed: %v", err)
+	}
+	if !optionPresent(current[defaultScope], option) {
+		t.Errorf("expected option in default scope after add (got %q)", current[defaultScope])
+	}
+	if !optionPresent(current[procScope], option) {
+		t.Errorf("expected option still in %+v (got %q)", procScope, current[procScope])
+	}
+
+	// remove the scoped option; default scope must be unaffected
+	removeScopedTask := DockerOptionsTask{
+		App:         appName,
+		Phase:       phase,
+		ProcessType: processType,
+		Option:      option,
+		State:       StateAbsent,
+	}
+	result = removeScopedTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to remove scoped option: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first scoped remove")
+	}
+
+	current, err = getDockerOptions(appName)
+	if err != nil {
+		t.Fatalf("getDockerOptions failed: %v", err)
+	}
+	if optionPresent(current[procScope], option) {
+		t.Errorf("expected option NOT in %+v after remove (got %q)", procScope, current[procScope])
+	}
+	if !optionPresent(current[defaultScope], option) {
+		t.Errorf("expected option still in default scope after scoped remove (got %q)", current[defaultScope])
+	}
+
+	// idempotent scoped remove
+	result = removeScopedTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second scoped remove: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent scoped remove")
 	}
 }

--- a/tasks/docker_options_task_test.go
+++ b/tasks/docker_options_task_test.go
@@ -48,6 +48,128 @@ func TestDockerOptionsTaskMissingOption(t *testing.T) {
 	}
 }
 
+func TestDockerOptionsTaskProcessTypeRejectsDefaultSentinel(t *testing.T) {
+	task := DockerOptionsTask{
+		App:         "test-app",
+		Phase:       "deploy",
+		ProcessType: "_default_",
+		Option:      "-v /a:/a",
+		State:       StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with process_type='_default_' should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "reserved sentinel") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestDockerOptionsTaskProcessTypeRejectsNonDeployPhase(t *testing.T) {
+	for _, phase := range []string{"build", "run"} {
+		task := DockerOptionsTask{
+			App:         "test-app",
+			Phase:       phase,
+			ProcessType: "web",
+			Option:      "-v /a:/a",
+			State:       StatePresent,
+		}
+		result := task.Execute()
+		if result.Error == nil {
+			t.Fatalf("Execute with process_type set and phase=%q should return an error", phase)
+		}
+		if !strings.Contains(result.Error.Error(), "only supported for the deploy phase") {
+			t.Errorf("phase=%q: unexpected error: %v", phase, result.Error)
+		}
+	}
+}
+
+func TestDockerOptionsCommandArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		task DockerOptionsTask
+		want []string
+	}{
+		{
+			name: "default scope",
+			task: DockerOptionsTask{App: "app", Phase: "deploy", Option: "-v /a:/a"},
+			want: []string{"--quiet", "docker-options:add", "app", "deploy", "-v /a:/a"},
+		},
+		{
+			name: "with process type",
+			task: DockerOptionsTask{App: "app", Phase: "deploy", ProcessType: "web", Option: "--memory=512m"},
+			want: []string{"--quiet", "docker-options:add", "--process", "web", "app", "deploy", "--memory=512m"},
+		},
+	}
+	for _, tt := range tests {
+		got := dockerOptionsCommandArgs("docker-options:add", tt.task)
+		if len(got) != len(tt.want) {
+			t.Errorf("%s: got %v, want %v", tt.name, got, tt.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tt.want[i] {
+				t.Errorf("%s: arg %d got %q, want %q", tt.name, i, got[i], tt.want[i])
+			}
+		}
+	}
+}
+
+func TestParseDockerOptionsPayload(t *testing.T) {
+	payload := map[string]string{
+		"build":                       "",
+		"deploy":                      "-v /a:/a",
+		"run":                         "",
+		"deploy.web":                  "--memory=512m",
+		"deploy.worker":               "--cpus=1",
+		"docker-options-build":        "",
+		"docker-options-deploy":       "-v /a:/a",
+		"docker-options-deploy.web":   "--memory=512m",
+		"some-unrelated-key":          "ignored",
+	}
+	got := parseDockerOptionsPayload(payload)
+
+	want := map[dockerOptionsScope]string{
+		{Phase: "build"}:                            "",
+		{Phase: "deploy"}:                           "-v /a:/a",
+		{Phase: "run"}:                              "",
+		{Phase: "deploy", ProcessType: "web"}:       "--memory=512m",
+		{Phase: "deploy", ProcessType: "worker"}:    "--cpus=1",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d entries, want %d (got: %#v)", len(got), len(want), got)
+	}
+	for scope, expected := range want {
+		if got[scope] != expected {
+			t.Errorf("scope %+v: got %q, want %q", scope, got[scope], expected)
+		}
+	}
+}
+
+func TestSplitDockerOptionsKey(t *testing.T) {
+	tests := []struct {
+		key             string
+		wantPhase       string
+		wantProcessType string
+		wantOk          bool
+	}{
+		{"deploy", "deploy", "", true},
+		{"build", "build", "", true},
+		{"run", "run", "", true},
+		{"deploy.web", "deploy", "web", true},
+		{"deploy.web-worker", "deploy", "web-worker", true},
+		{"unknown", "", "", false},
+		{"deploy.web.extra", "deploy", "web.extra", true},
+	}
+	for _, tt := range tests {
+		phase, processType, ok := splitDockerOptionsKey(tt.key)
+		if ok != tt.wantOk || phase != tt.wantPhase || processType != tt.wantProcessType {
+			t.Errorf("splitDockerOptionsKey(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				tt.key, phase, processType, ok, tt.wantPhase, tt.wantProcessType, tt.wantOk)
+		}
+	}
+}
+
 func TestOptionPresent(t *testing.T) {
 	tests := []struct {
 		existing string
@@ -58,10 +180,10 @@ func TestOptionPresent(t *testing.T) {
 		{"-v /a:/a", "-v /a:/a", true},
 		{"-v /a:/a -p 80:80", "-p 80:80", true},
 		{"-v /a:/a -p 80:80", "-v /a:/a", true},
-		{"-v /a:/aa", "-v /a:/a", false},      // exact token match, not substring
-		{"-v /a:/a", "-v /a:/aa", false},      // exact token match
+		{"-v /a:/aa", "-v /a:/a", false}, // exact token match, not substring
+		{"-v /a:/a", "-v /a:/aa", false}, // exact token match
 		{"-p 80:80 -v /a:/a", "-v /a:/a", true},
-		{"-p 8080:80", "-p 80:80", false},     // distinct tokens
+		{"-p 8080:80", "-p 80:80", false}, // distinct tokens
 	}
 	for _, tt := range tests {
 		got := optionPresent(tt.existing, tt.option)
@@ -108,5 +230,39 @@ func TestGetTasksDockerOptionsTaskParsedCorrectly(t *testing.T) {
 	}
 	if doTask.State != StatePresent {
 		t.Errorf("State = %q, want %q", doTask.State, StatePresent)
+	}
+}
+
+func TestGetTasksDockerOptionsTaskParsesProcessType(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: add web option
+      dokku_docker_options:
+        app: test-app
+        phase: deploy
+        process_type: web
+        option: "--memory=512m"
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("add web option")
+	if task == nil {
+		t.Fatal("task 'add web option' not found")
+	}
+
+	doTask, ok := task.(*DockerOptionsTask)
+	if !ok {
+		t.Fatalf("task is not a DockerOptionsTask (type is %T)", task)
+	}
+	if doTask.ProcessType != "web" {
+		t.Errorf("ProcessType = %q, want %q", doTask.ProcessType, "web")
+	}
+	if doTask.Option != "--memory=512m" {
+		t.Errorf("Option = %q, want %q", doTask.Option, "--memory=512m")
 	}
 }

--- a/tasks/integration_shard_test.go
+++ b/tasks/integration_shard_test.go
@@ -42,6 +42,7 @@ var integrationTestWeights = map[string]float64{
 	"TestIntegrationConfigSetAndUnset":                      6.5,
 	"TestIntegrationCronPropertyAll":                        10.9,
 	"TestIntegrationDockerOptions":                          6.8,
+	"TestIntegrationDockerOptionsProcessType":               7.0,
 	"TestIntegrationDomainsAddAndRemove":                    19.2,
 	"TestIntegrationDomainsToggle":                          10.0,
 	"TestIntegrationExecuteIdempotent":                      5.9,


### PR DESCRIPTION
The `dokku_docker_options` task only set or cleared options against dokku's default scope (`_default_.<phase>`), so a recipe could not represent per-process docker options. Since dokku 0.38 the docker-options plugin stores options under `<process_type>.<phase>` and exposes a `--process` flag on `docker-options:add`/`docker-options:remove`, scoped to the deploy phase. Recipes (and anything that round-trips through docket's task format) now had a lossy hole.

This adds an optional `process_type` field to the task, switches the report probe to `docker-options:report --format json` so per-process options are read back via the dynamic `deploy.<process_type>` key, and routes the `--process` flag through `docker-options:add`/`:remove`. Validation rejects `_default_` (the reserved sentinel) and any non-deploy phase, mirroring dokku's own `ValidateProcessFlag`.

Closes #248.