### PR TITLE
feat: add volume_options to dokku_storage_mount

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.12
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.13
           sudo dokku plugin:install-dependencies --core
       - name: install dokku redis plugin
         run: sudo dokku plugin:install https://github.com/dokku/dokku-redis.git redis
@@ -87,7 +87,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.12
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.13
           sudo dokku plugin:install-dependencies --core
       - name: install bats
         run: sudo apt-get install -qq -y bats bats-support bats-assert

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,7 @@ code into it:
 
 ## Prerequisites
 
-- **Dokku >= 0.38.12.**
+- **Dokku >= 0.38.13.**
 - **dokku-letsencrypt >= 0.25.0.**
 
 ## Installation

--- a/docs/tasks/dokku_storage_mount.md
+++ b/docs/tasks/dokku_storage_mount.md
@@ -17,6 +17,7 @@ Attaches or detaches storage on a dokku application
 | `subpath` | string | no |  |  | Subpath within the entry to mount |
 | `readonly` | bool | no |  |  | Mount the attachment as read-only |
 | `volume_chown` | string | no |  |  | Chown option applied to the volume at mount time |
+| `volume_options` | string | no |  |  | Comma-separated mount options applied to the attachment (e.g. 'Z' for SELinux, 'noexec,nosuid', NFS opts) |
 | `state` | string | no | present | present, absent | Desired state of the storage |
 
 ## Examples
@@ -50,6 +51,26 @@ dokku_storage_mount:
     app: node-js-app
     host_dir: /var/lib/dokku/data/storage/node-js-app
     container_dir: /app/storage
+```
+
+### Mount a host directory with SELinux relabeling
+
+```yaml
+dokku_storage_mount:
+    app: node-js-app
+    host_dir: /var/lib/dokku/data/storage/node-js-app
+    container_dir: /app/storage
+    volume_options: Z
+```
+
+### Attach a named entry with mount options
+
+```yaml
+dokku_storage_mount:
+    app: node-js-app
+    entry_name: node-js-app-data
+    container_dir: /app/storage
+    volume_options: noexec,nosuid
 ```
 
 ### Unmount a named entry from an app

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -12,16 +12,17 @@ import (
 // It supports two forms:
 //
 //   - Legacy bind mount: set host_dir + container_dir to pass the colon
-//     form to `storage:mount <app> <host:container>`. Round-tripped with
-//     dokku versions that predate the named-entry registry.
+//     form to `storage:mount <app> <host:container[:opts]>`. Round-tripped
+//     with dokku versions that predate the named-entry registry.
 //   - Named-entry attachment: set entry_name + container_dir and (optionally)
-//     phases, process_type, subpath, readonly, volume_chown. Maps to
-//     `storage:mount <app> <entry_name> --container-dir <container_dir>`
+//     phases, process_type, subpath, readonly, volume_chown, volume_options.
+//     Maps to `storage:mount <app> <entry_name> --container-dir <container_dir>`
 //     plus the matching attachment flags.
 //
 // Exactly one of entry_name / host_dir must be set. Idempotency is keyed
-// on (source, container_path) using `storage:list <app> --format json`;
-// the richer attachment attributes are applied at mount time only and
+// on (source, container_path, volume_options) using `storage:list <app>
+// --format json`; the other attachment attributes (phases, process_type,
+// subpath, readonly, volume_chown) are applied at mount time only and
 // are not drift-detected (mirroring the partial-probe pattern in
 // service_backup and storage_ensure).
 type StorageMountTask struct {
@@ -54,6 +55,12 @@ type StorageMountTask struct {
 
 	// VolumeChown is the chown option applied to the volume at mount time
 	VolumeChown string `required:"false" yaml:"volume_chown,omitempty" description:"Chown option applied to the volume at mount time"`
+
+	// VolumeOptions is the comma-separated mount options applied to the
+	// attachment (e.g. "Z" for SELinux relabeling, "noexec,nosuid", NFS
+	// opts). On the legacy form it is appended as the third colon segment;
+	// on the named-entry form it is passed via --volume-options.
+	VolumeOptions string `required:"false" yaml:"volume_options,omitempty" description:"Comma-separated mount options applied to the attachment (e.g. 'Z' for SELinux, 'noexec,nosuid', NFS opts)"`
 
 	// State is the desired state of the storage
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the storage"`
@@ -109,6 +116,24 @@ func (t StorageMountTask) Examples() ([]Doc, error) {
 			},
 		},
 		{
+			Name: "Mount a host directory with SELinux relabeling",
+			StorageMountTask: StorageMountTask{
+				App:           "node-js-app",
+				HostDir:       "/var/lib/dokku/data/storage/node-js-app",
+				ContainerDir:  "/app/storage",
+				VolumeOptions: "Z",
+			},
+		},
+		{
+			Name: "Attach a named entry with mount options",
+			StorageMountTask: StorageMountTask{
+				App:           "node-js-app",
+				EntryName:     "node-js-app-data",
+				ContainerDir:  "/app/storage",
+				VolumeOptions: "noexec,nosuid",
+			},
+		},
+		{
 			Name: "Unmount a named entry from an app",
 			StorageMountTask: StorageMountTask{
 				App:          "node-js-app",
@@ -132,21 +157,25 @@ func (t StorageMountTask) Plan() PlanResult {
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			exists, err := mountExists(t.App, t.EntryName, t.HostDir, t.ContainerDir)
+			existing, err := findMount(t.App, t.EntryName, t.HostDir, t.ContainerDir)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
-			if exists {
+			if existing != nil && existing.VolumeOptions == t.VolumeOptions {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			inputs := []subprocess.ExecCommandInput{{
 				Command: "dokku",
 				Args:    t.mountArgs(),
 			}}
+			reason := "mount missing"
+			if existing != nil {
+				reason = fmt.Sprintf("volume_options drift (have %q, want %q)", existing.VolumeOptions, t.VolumeOptions)
+			}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusCreate,
-				Reason:    "mount missing",
+				Reason:    reason,
 				Mutations: []string{fmt.Sprintf("mount %s on %s", t.describeMount(), t.App)},
 				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
@@ -155,11 +184,11 @@ func (t StorageMountTask) Plan() PlanResult {
 			}
 		},
 		StateAbsent: func() PlanResult {
-			exists, err := mountExists(t.App, t.EntryName, t.HostDir, t.ContainerDir)
+			existing, err := findMount(t.App, t.EntryName, t.HostDir, t.ContainerDir)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
-			if !exists {
+			if existing == nil {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			inputs := []subprocess.ExecCommandInput{{
@@ -210,13 +239,13 @@ func (t StorageMountTask) describeMount() string {
 
 // mountArgs renders the dokku storage:mount invocation. The named form
 // passes the entry name positionally and --container-dir; the legacy
-// form keeps the host:container colon syntax.
+// form keeps the host:container[:opts] colon syntax.
 func (t StorageMountTask) mountArgs() []string {
 	args := []string{"--quiet", "storage:mount"}
 	if t.EntryName != "" {
 		args = append(args, t.App, t.EntryName, "--container-dir", t.ContainerDir)
 	} else {
-		args = append(args, t.App, fmt.Sprintf("%s:%s", t.HostDir, t.ContainerDir))
+		args = append(args, t.App, t.legacySpec())
 	}
 	return append(args, t.attachmentFlags()...)
 }
@@ -227,14 +256,27 @@ func (t StorageMountTask) unmountArgs() []string {
 	if t.EntryName != "" {
 		args = append(args, t.App, t.EntryName, "--container-dir", t.ContainerDir)
 	} else {
-		args = append(args, t.App, fmt.Sprintf("%s:%s", t.HostDir, t.ContainerDir))
+		args = append(args, t.App, t.legacySpec())
 	}
 	return args
 }
 
+// legacySpec renders the legacy host:container[:opts] colon syntax used
+// by the legacy form. volume_options is appended as the third segment so
+// dokku's parser stores it in Attachment.VolumeOptions verbatim.
+func (t StorageMountTask) legacySpec() string {
+	if t.VolumeOptions != "" {
+		return fmt.Sprintf("%s:%s:%s", t.HostDir, t.ContainerDir, t.VolumeOptions)
+	}
+	return fmt.Sprintf("%s:%s", t.HostDir, t.ContainerDir)
+}
+
 // attachmentFlags renders the optional --phase / --process-type /
-// --volume-subpath / --volume-readonly / --volume-chown flags. Empty
-// fields are omitted so the resulting command line stays minimal.
+// --volume-subpath / --volume-readonly / --volume-chown / --volume-options
+// flags. Empty fields are omitted so the resulting command line stays
+// minimal. --volume-options is only emitted for the named-entry form;
+// the legacy form already carries the value inside the host:container:opts
+// spec returned by legacySpec.
 func (t StorageMountTask) attachmentFlags() []string {
 	var flags []string
 	for _, phase := range t.Phases {
@@ -252,18 +294,29 @@ func (t StorageMountTask) attachmentFlags() []string {
 	if t.VolumeChown != "" {
 		flags = append(flags, "--volume-chown", t.VolumeChown)
 	}
+	if t.VolumeOptions != "" && t.EntryName != "" {
+		flags = append(flags, "--volume-options", t.VolumeOptions)
+	}
 	return flags
 }
 
-// mountExists reports whether an attachment matching either the
-// named-entry form (entry_name + container_path) or the legacy form
-// (host_path + container_path) is present on the app. A transport-level
-// failure (`*subprocess.SSHError`) is propagated; a dokku-level non-
-// zero exit (e.g. app does not exist) is treated as "no mount." The
-// richer attachment attributes (phases, subpath, readonly, etc.) are
-// not exposed by storage:list, so a change to those values does not
-// surface as drift.
-func mountExists(app, entryName, hostDir, containerDir string) (bool, error) {
+// existingMount captures the subset of an existing attachment that
+// docket compares against the desired state. volume_options is returned
+// alongside the source/container identity so the caller can detect
+// option drift on a state: present plan. The other mount-time attributes
+// (phases, subpath, readonly, volume_chown) are not exposed by
+// storage:list and so are not drift-detected (mirroring the partial-probe
+// pattern in service_backup and storage_ensure).
+type existingMount struct {
+	VolumeOptions string
+}
+
+// findMount returns the existing attachment matching either the named-entry
+// form (entry_name + container_path) or the legacy form (host_path +
+// container_path), or nil if none exists. A transport-level failure
+// (`*subprocess.SSHError`) is propagated; a dokku-level non-zero exit
+// (e.g. app does not exist) is treated as "no mount."
+func findMount(app, entryName, hostDir, containerDir string) (*existingMount, error) {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
@@ -277,19 +330,20 @@ func mountExists(app, entryName, hostDir, containerDir string) (bool, error) {
 	if err != nil {
 		var sshErr *subprocess.SSHError
 		if errors.As(err, &sshErr) {
-			return false, err
+			return nil, err
 		}
-		return false, nil
+		return nil, nil
 	}
 
 	var mounts []struct {
 		EntryName     string `json:"entry_name"`
 		HostPath      string `json:"host_path"`
 		ContainerPath string `json:"container_path"`
+		VolumeOptions string `json:"volume_options"`
 	}
 
 	if err := json.Unmarshal(result.StdoutBytes(), &mounts); err != nil {
-		return false, nil
+		return nil, nil
 	}
 
 	for _, mount := range mounts {
@@ -297,13 +351,13 @@ func mountExists(app, entryName, hostDir, containerDir string) (bool, error) {
 			continue
 		}
 		if entryName != "" && mount.EntryName == entryName {
-			return true, nil
+			return &existingMount{VolumeOptions: mount.VolumeOptions}, nil
 		}
 		if hostDir != "" && mount.HostPath == hostDir {
-			return true, nil
+			return &existingMount{VolumeOptions: mount.VolumeOptions}, nil
 		}
 	}
-	return false, nil
+	return nil, nil
 }
 
 // init registers the StorageMountTask with the task registry

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -164,14 +164,19 @@ func (t StorageMountTask) Plan() PlanResult {
 			if existing != nil && existing.VolumeOptions == t.VolumeOptions {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
-			inputs := []subprocess.ExecCommandInput{{
-				Command: "dokku",
-				Args:    t.mountArgs(),
-			}}
+			var args []string
 			reason := "mount missing"
-			if existing != nil {
+			if existing == nil {
+				args = t.mountArgs()
+			} else {
+				// Drift on an existing attachment: re-mount via the
+				// named-entry CLI form so dokku upserts in place. The
+				// legacy CLI form would error with "Mount path already
+				// exists." (dokku/dokku#8713 kept that contract).
+				args = t.namedMountArgs(existing.EntryName)
 				reason = fmt.Sprintf("volume_options drift (have %q, want %q)", existing.VolumeOptions, t.VolumeOptions)
 			}
+			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusCreate,
@@ -193,7 +198,7 @@ func (t StorageMountTask) Plan() PlanResult {
 			}
 			inputs := []subprocess.ExecCommandInput{{
 				Command: "dokku",
-				Args:    t.unmountArgs(),
+				Args:    t.namedUnmountArgs(existing.EntryName),
 			}}
 			return PlanResult{
 				InSync:    false,
@@ -237,33 +242,44 @@ func (t StorageMountTask) describeMount() string {
 	return fmt.Sprintf("%s:%s", t.HostDir, t.ContainerDir)
 }
 
-// mountArgs renders the dokku storage:mount invocation. The named form
-// passes the entry name positionally and --container-dir; the legacy
-// form keeps the host:container[:opts] colon syntax.
+// mountArgs renders the storage:mount invocation for the first-time
+// mount of a recipe. When entry_name is set, the named-entry CLI form
+// is used directly. When host_dir is set and no attachment yet exists,
+// the legacy host:container[:opts] colon form is used so dokku
+// auto-generates a `legacy-<id>` entry; later operations against that
+// attachment go through namedMountArgs/namedUnmountArgs via the entry
+// name discovered from storage:list.
 func (t StorageMountTask) mountArgs() []string {
-	args := []string{"--quiet", "storage:mount"}
 	if t.EntryName != "" {
-		args = append(args, t.App, t.EntryName, "--container-dir", t.ContainerDir)
-	} else {
-		args = append(args, t.App, t.legacySpec())
+		return t.namedMountArgs(t.EntryName)
 	}
+	args := []string{"--quiet", "storage:mount", t.App, t.legacySpec()}
 	return append(args, t.attachmentFlags()...)
 }
 
-// unmountArgs mirrors mountArgs for the storage:unmount path.
-func (t StorageMountTask) unmountArgs() []string {
-	args := []string{"--quiet", "storage:unmount"}
-	if t.EntryName != "" {
-		args = append(args, t.App, t.EntryName, "--container-dir", t.ContainerDir)
-	} else {
-		args = append(args, t.App, t.legacySpec())
+// namedMountArgs renders storage:mount in the named-entry CLI form for
+// the given entry. Used both when the recipe specifies entry_name and
+// when docket is remediating drift on a legacy-CLI mount whose auto-
+// generated entry name was discovered from storage:list. Dokku 0.38.13's
+// upsert semantic (dokku/dokku#8713) makes the call idempotent.
+func (t StorageMountTask) namedMountArgs(entryName string) []string {
+	args := []string{"--quiet", "storage:mount", t.App, entryName, "--container-dir", t.ContainerDir}
+	args = append(args, t.attachmentFlags()...)
+	if t.VolumeOptions != "" {
+		args = append(args, "--volume-options", t.VolumeOptions)
 	}
 	return args
 }
 
+// namedUnmountArgs mirrors namedMountArgs for the storage:unmount path.
+func (t StorageMountTask) namedUnmountArgs(entryName string) []string {
+	return []string{"--quiet", "storage:unmount", t.App, entryName, "--container-dir", t.ContainerDir}
+}
+
 // legacySpec renders the legacy host:container[:opts] colon syntax used
-// by the legacy form. volume_options is appended as the third segment so
-// dokku's parser stores it in Attachment.VolumeOptions verbatim.
+// for the first-time mount when the recipe specifies host_dir. volume_options
+// is appended as the third segment so dokku's parser stores it in
+// Attachment.VolumeOptions verbatim.
 func (t StorageMountTask) legacySpec() string {
 	if t.VolumeOptions != "" {
 		return fmt.Sprintf("%s:%s:%s", t.HostDir, t.ContainerDir, t.VolumeOptions)
@@ -272,11 +288,11 @@ func (t StorageMountTask) legacySpec() string {
 }
 
 // attachmentFlags renders the optional --phase / --process-type /
-// --volume-subpath / --volume-readonly / --volume-chown / --volume-options
-// flags. Empty fields are omitted so the resulting command line stays
-// minimal. --volume-options is only emitted for the named-entry form;
-// the legacy form already carries the value inside the host:container:opts
-// spec returned by legacySpec.
+// --volume-subpath / --volume-readonly / --volume-chown flags. Empty
+// fields are omitted so the resulting command line stays minimal.
+// --volume-options is NOT emitted here: namedMountArgs appends it
+// directly, and the legacy first-time-mount path carries it inside the
+// host:container:opts spec returned by legacySpec.
 func (t StorageMountTask) attachmentFlags() []string {
 	var flags []string
 	for _, phase := range t.Phases {
@@ -294,20 +310,19 @@ func (t StorageMountTask) attachmentFlags() []string {
 	if t.VolumeChown != "" {
 		flags = append(flags, "--volume-chown", t.VolumeChown)
 	}
-	if t.VolumeOptions != "" && t.EntryName != "" {
-		flags = append(flags, "--volume-options", t.VolumeOptions)
-	}
 	return flags
 }
 
 // existingMount captures the subset of an existing attachment that
-// docket compares against the desired state. volume_options is returned
-// alongside the source/container identity so the caller can detect
-// option drift on a state: present plan. The other mount-time attributes
-// (phases, subpath, readonly, volume_chown) are not exposed by
-// storage:list and so are not drift-detected (mirroring the partial-probe
-// pattern in service_backup and storage_ensure).
+// docket compares against the desired state. EntryName is the attachment's
+// dokku-side identifier (user-supplied for named-entry recipes; auto-
+// generated as `legacy-<id>` for attachments created via the legacy CLI
+// form), and is the address docket uses for follow-up mount/unmount
+// commands. VolumeOptions enables option-drift detection on
+// state: present. The other mount-time attributes (phases, subpath,
+// readonly, volume_chown) are not exposed in a way docket compares today.
 type existingMount struct {
+	EntryName     string
 	VolumeOptions string
 }
 
@@ -351,10 +366,10 @@ func findMount(app, entryName, hostDir, containerDir string) (*existingMount, er
 			continue
 		}
 		if entryName != "" && mount.EntryName == entryName {
-			return &existingMount{VolumeOptions: mount.VolumeOptions}, nil
+			return &existingMount{EntryName: mount.EntryName, VolumeOptions: mount.VolumeOptions}, nil
 		}
 		if hostDir != "" && mount.HostPath == hostDir {
-			return &existingMount{VolumeOptions: mount.VolumeOptions}, nil
+			return &existingMount{EntryName: mount.EntryName, VolumeOptions: mount.VolumeOptions}, nil
 		}
 	}
 	return nil, nil

--- a/tasks/storage_mount_task_integration_test.go
+++ b/tasks/storage_mount_task_integration_test.go
@@ -138,3 +138,112 @@ func TestIntegrationStorageMount(t *testing.T) {
 		t.Error("expected changed=false for nonexistent named-entry mount")
 	}
 }
+
+func TestIntegrationStorageMountVolumeOptions(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-mount-opts"
+	hostDir := "/var/lib/dokku/data/storage/docket-test-mount-opts"
+	containerDir := "/app/storage"
+	entryName := "docket-test-mount-opts-entry"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "mkdir",
+		Args:    []string{"-p", hostDir},
+	})
+
+	// legacy form with SELinux Z: mount then verify idempotency
+	withOpts := StorageMountTask{
+		App:           appName,
+		HostDir:       hostDir,
+		ContainerDir:  containerDir,
+		VolumeOptions: "Z",
+		State:         StatePresent,
+	}
+	result := withOpts.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to mount with volume_options=Z: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for new legacy mount with options")
+	}
+	result = withOpts.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent mount with volume_options failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false for unchanged legacy mount with options")
+	}
+
+	// dropping volume_options should surface as drift
+	withoutOpts := StorageMountTask{
+		App:          appName,
+		HostDir:      hostDir,
+		ContainerDir: containerDir,
+		State:        StatePresent,
+	}
+	result = withoutOpts.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to re-mount without volume_options: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true when volume_options is dropped")
+	}
+
+	// unmount (absent ignores volume_options - identity is source+container)
+	unmount := StorageMountTask{
+		App:          appName,
+		HostDir:      hostDir,
+		ContainerDir: containerDir,
+		State:        StateAbsent,
+	}
+	if r := unmount.Execute(); r.Error != nil {
+		t.Fatalf("failed to unmount legacy with options: %v", r.Error)
+	}
+
+	// named-entry form with multi-option round-trip
+	entry := StorageEntryTask{Name: entryName, Chown: "herokuish", State: StatePresent}
+	if r := entry.Execute(); r.Error != nil {
+		t.Fatalf("failed to create entry: %v", r.Error)
+	}
+	defer func() {
+		destroy := StorageEntryTask{Name: entryName, State: StateAbsent}
+		destroy.Execute()
+	}()
+
+	namedWithOpts := StorageMountTask{
+		App:           appName,
+		EntryName:     entryName,
+		ContainerDir:  "/app/named",
+		VolumeOptions: "noexec,nosuid",
+		State:         StatePresent,
+	}
+	result = namedWithOpts.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to mount named entry with options: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for new named-entry mount with options")
+	}
+	result = namedWithOpts.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent named-entry mount with options failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false for unchanged named-entry mount with options")
+	}
+
+	namedUnmount := StorageMountTask{
+		App:          appName,
+		EntryName:    entryName,
+		ContainerDir: "/app/named",
+		State:        StateAbsent,
+	}
+	if r := namedUnmount.Execute(); r.Error != nil {
+		t.Fatalf("failed to unmount named entry with options: %v", r.Error)
+	}
+}

--- a/tasks/storage_mount_task_test.go
+++ b/tasks/storage_mount_task_test.go
@@ -91,14 +91,9 @@ func TestStorageMountNamedEntryCommandShape(t *testing.T) {
 	if !equalStrings(args, want) {
 		t.Errorf("mountArgs mismatch:\n  got: %v\n want: %v", args, want)
 	}
-	unmount := task.unmountArgs()
-	wantUnmount := []string{"--quiet", "storage:unmount", "test-app", "data", "--container-dir", "/app/storage"}
-	if !equalStrings(unmount, wantUnmount) {
-		t.Errorf("unmountArgs mismatch:\n  got: %v\n want: %v", unmount, wantUnmount)
-	}
 }
 
-func TestStorageMountLegacyCommandShape(t *testing.T) {
+func TestStorageMountLegacyFirstMountCommandShape(t *testing.T) {
 	task := StorageMountTask{
 		App:          "test-app",
 		HostDir:      "/var/data",
@@ -107,16 +102,11 @@ func TestStorageMountLegacyCommandShape(t *testing.T) {
 	args := task.mountArgs()
 	want := []string{"--quiet", "storage:mount", "test-app", "/var/data:/app/storage"}
 	if !equalStrings(args, want) {
-		t.Errorf("legacy mountArgs mismatch:\n  got: %v\n want: %v", args, want)
-	}
-	unmount := task.unmountArgs()
-	wantUnmount := []string{"--quiet", "storage:unmount", "test-app", "/var/data:/app/storage"}
-	if !equalStrings(unmount, wantUnmount) {
-		t.Errorf("legacy unmountArgs mismatch:\n  got: %v\n want: %v", unmount, wantUnmount)
+		t.Errorf("legacy first-mount args mismatch:\n  got: %v\n want: %v", args, want)
 	}
 }
 
-func TestStorageMountLegacyVolumeOptions(t *testing.T) {
+func TestStorageMountLegacyFirstMountWithVolumeOptions(t *testing.T) {
 	task := StorageMountTask{
 		App:           "test-app",
 		HostDir:       "/var/data",
@@ -126,17 +116,63 @@ func TestStorageMountLegacyVolumeOptions(t *testing.T) {
 	args := task.mountArgs()
 	want := []string{"--quiet", "storage:mount", "test-app", "/var/data:/app/storage:Z"}
 	if !equalStrings(args, want) {
-		t.Errorf("legacy mountArgs with volume_options mismatch:\n  got: %v\n want: %v", args, want)
+		t.Errorf("legacy first-mount with volume_options mismatch:\n  got: %v\n want: %v", args, want)
 	}
 	for _, a := range args {
 		if a == "--volume-options" {
-			t.Errorf("legacy form must not emit --volume-options flag (carried in colon spec): %v", args)
+			t.Errorf("legacy first-mount must not emit --volume-options flag (carried in colon spec): %v", args)
 		}
 	}
-	unmount := task.unmountArgs()
-	wantUnmount := []string{"--quiet", "storage:unmount", "test-app", "/var/data:/app/storage:Z"}
-	if !equalStrings(unmount, wantUnmount) {
-		t.Errorf("legacy unmountArgs with volume_options mismatch:\n  got: %v\n want: %v", unmount, wantUnmount)
+}
+
+func TestStorageMountNamedRemediationFromLegacy(t *testing.T) {
+	// Recipe uses host_dir; storage:list discovered the auto-named
+	// entry. Drift remediation must upsert via the named-entry CLI.
+	task := StorageMountTask{
+		App:          "test-app",
+		HostDir:      "/var/data",
+		ContainerDir: "/app/storage",
+		// VolumeOptions intentionally empty: this represents the user
+		// dropping options and expecting dokku to clear them on re-mount.
+	}
+	args := task.namedMountArgs("legacy-abc123def4")
+	want := []string{
+		"--quiet", "storage:mount", "test-app", "legacy-abc123def4",
+		"--container-dir", "/app/storage",
+	}
+	if !equalStrings(args, want) {
+		t.Errorf("namedMountArgs (drift clear) mismatch:\n  got: %v\n want: %v", args, want)
+	}
+}
+
+func TestStorageMountNamedRemediationWithOptions(t *testing.T) {
+	task := StorageMountTask{
+		App:           "test-app",
+		HostDir:       "/var/data",
+		ContainerDir:  "/app/storage",
+		VolumeOptions: "noexec,nosuid",
+	}
+	args := task.namedMountArgs("legacy-abc123def4")
+	want := []string{
+		"--quiet", "storage:mount", "test-app", "legacy-abc123def4",
+		"--container-dir", "/app/storage",
+		"--volume-options", "noexec,nosuid",
+	}
+	if !equalStrings(args, want) {
+		t.Errorf("namedMountArgs (drift set) mismatch:\n  got: %v\n want: %v", args, want)
+	}
+}
+
+func TestStorageMountNamedUnmount(t *testing.T) {
+	task := StorageMountTask{
+		App:          "test-app",
+		HostDir:      "/var/data",
+		ContainerDir: "/app/storage",
+	}
+	args := task.namedUnmountArgs("legacy-abc123def4")
+	want := []string{"--quiet", "storage:unmount", "test-app", "legacy-abc123def4", "--container-dir", "/app/storage"}
+	if !equalStrings(args, want) {
+		t.Errorf("namedUnmountArgs mismatch:\n  got: %v\n want: %v", args, want)
 	}
 }
 

--- a/tasks/storage_mount_task_test.go
+++ b/tasks/storage_mount_task_test.go
@@ -67,14 +67,15 @@ func TestStorageMountRejectsInvalidPhase(t *testing.T) {
 
 func TestStorageMountNamedEntryCommandShape(t *testing.T) {
 	task := StorageMountTask{
-		App:          "test-app",
-		EntryName:    "data",
-		ContainerDir: "/app/storage",
-		Phases:       []string{"deploy", "run"},
-		ProcessType:  "web",
-		Subpath:      "sub",
-		Readonly:     true,
-		VolumeChown:  "herokuish",
+		App:           "test-app",
+		EntryName:     "data",
+		ContainerDir:  "/app/storage",
+		Phases:        []string{"deploy", "run"},
+		ProcessType:   "web",
+		Subpath:       "sub",
+		Readonly:      true,
+		VolumeChown:   "herokuish",
+		VolumeOptions: "noexec,nosuid",
 	}
 	args := task.mountArgs()
 	want := []string{
@@ -85,6 +86,7 @@ func TestStorageMountNamedEntryCommandShape(t *testing.T) {
 		"--volume-subpath", "sub",
 		"--volume-readonly",
 		"--volume-chown", "herokuish",
+		"--volume-options", "noexec,nosuid",
 	}
 	if !equalStrings(args, want) {
 		t.Errorf("mountArgs mismatch:\n  got: %v\n want: %v", args, want)
@@ -111,6 +113,30 @@ func TestStorageMountLegacyCommandShape(t *testing.T) {
 	wantUnmount := []string{"--quiet", "storage:unmount", "test-app", "/var/data:/app/storage"}
 	if !equalStrings(unmount, wantUnmount) {
 		t.Errorf("legacy unmountArgs mismatch:\n  got: %v\n want: %v", unmount, wantUnmount)
+	}
+}
+
+func TestStorageMountLegacyVolumeOptions(t *testing.T) {
+	task := StorageMountTask{
+		App:           "test-app",
+		HostDir:       "/var/data",
+		ContainerDir:  "/app/storage",
+		VolumeOptions: "Z",
+	}
+	args := task.mountArgs()
+	want := []string{"--quiet", "storage:mount", "test-app", "/var/data:/app/storage:Z"}
+	if !equalStrings(args, want) {
+		t.Errorf("legacy mountArgs with volume_options mismatch:\n  got: %v\n want: %v", args, want)
+	}
+	for _, a := range args {
+		if a == "--volume-options" {
+			t.Errorf("legacy form must not emit --volume-options flag (carried in colon spec): %v", args)
+		}
+	}
+	unmount := task.unmountArgs()
+	wantUnmount := []string{"--quiet", "storage:unmount", "test-app", "/var/data:/app/storage:Z"}
+	if !equalStrings(unmount, wantUnmount) {
+		t.Errorf("legacy unmountArgs with volume_options mismatch:\n  got: %v\n want: %v", unmount, wantUnmount)
 	}
 }
 


### PR DESCRIPTION
Dokku's storage `Attachment` struct preserves a `volume_options` string (the trailing comma-separated portion of a bind mount, e.g. `Z` for SELinux relabeling, `noexec`, NFS opts) and the legacy migration path goes out of its way to keep it intact. Docket's `dokku_storage_mount` had no corresponding field, so recipes - and anything built on docket like a backup/restore mechanism - silently dropped those options on every re-apply.

This adds an optional `volume_options` field on both supported forms. The legacy form appends the value as the third segment of the existing `host:container:opts` colon syntax, which dokku already parses into `Attachment.VolumeOptions`. The named-entry form passes the value via a new `--volume-options` flag on `storage:mount`. The drift probe (`storage:list --format json`) now reads back `volume_options` so a change to the field on `state: present` re-runs `storage:mount` to update the attachment in place. `state: absent` continues to identify a mount by source + container_dir only.

Depends on the dokku 0.38.13 release, which ships the fixes for dokku/dokku#8707, dokku/dokku#8708, dokku/dokku#8709, and dokku/dokku#8710. Minimum dokku is bumped accordingly.

Closes #252.