### PR TITLE
feat: accept inline PEM contents on dokku_certs

### DIFF
--- a/docs/remote-execution.md
+++ b/docs/remote-execution.md
@@ -56,6 +56,10 @@ that path is interpreted on the **remote** host, not your local machine. docket 
 local files in this release, so any referenced file must already exist on the server. Place it there
 before the run.
 
+Some tasks offer an inline alternative that sidesteps this constraint. `dokku_certs`, for
+instance, accepts `cert_content` and `key_content` strings; docket streams the PEM material to
+dokku as a tarball over stdin, so the bytes never have to live as files on the remote.
+
 ## See also
 
 - [Command reference](command-reference.md) - the commands you run over SSH

--- a/docs/tasks/dokku_certs.md
+++ b/docs/tasks/dokku_certs.md
@@ -2,7 +2,7 @@
 
 ## Synopsis
 
-Manages SSL certificates for a dokku app or globally. The `cert` and `key` fields are paths on the dokku server, so when running with `DOKKU_HOST` set the referenced files must already exist on the remote host - docket does not upload them.
+Manages SSL certificates for a dokku app or globally.
 
 ## Requirements
 
@@ -14,8 +14,10 @@ Manages SSL certificates for a dokku app or globally. The `cert` and `key` field
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app. Required if Global is false. |
 | `global` | bool | no |  |  | Flag indicating if the certificate should be applied globally via the dokku-global-cert plugin |
-| `cert` | string | no |  |  | Path on the dokku server to the SSL certificate file (sensitive) |
-| `key` | string | no |  |  | Path on the dokku server to the SSL certificate key file (sensitive) |
+| `cert` | string | no |  |  | Path on the dokku server to the SSL certificate file. Mutually exclusive with cert_content. (sensitive) |
+| `key` | string | no |  |  | Path on the dokku server to the SSL certificate key file. Mutually exclusive with key_content. (sensitive) |
+| `cert_content` | string | no |  |  | PEM-encoded certificate contents. Mutually exclusive with cert. (sensitive) |
+| `key_content` | string | no |  |  | PEM-encoded private key contents. Mutually exclusive with key. (sensitive) |
 | `state` | string | no | present | present, absent | Desired state of the SSL configuration |
 
 ## Examples
@@ -54,6 +56,37 @@ dokku_certs:
     app: ""
     global: true
     state: absent
+```
+
+### Add an SSL certificate to an app from inline PEM
+
+```yaml
+dokku_certs:
+    app: node-js-app
+    cert_content: |
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+    key_content: |
+        -----BEGIN PRIVATE KEY-----
+        ...
+        -----END PRIVATE KEY-----
+```
+
+### Add a global SSL certificate from inline PEM (requires the dokku-global-cert plugin)
+
+```yaml
+dokku_certs:
+    app: ""
+    global: true
+    cert_content: |
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+    key_content: |
+        -----BEGIN PRIVATE KEY-----
+        ...
+        -----END PRIVATE KEY-----
 ```
 
 ## Return Values

--- a/tasks/certs_task.go
+++ b/tasks/certs_task.go
@@ -1,6 +1,8 @@
 package tasks
 
 import (
+	"archive/tar"
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -17,10 +19,18 @@ type CertsTask struct {
 	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the certificate should be applied globally via the dokku-global-cert plugin"`
 
 	// Cert is the path on the dokku server to the SSL certificate file
-	Cert string `required:"false" sensitive:"true" yaml:"cert,omitempty" description:"Path on the dokku server to the SSL certificate file"`
+	Cert string `required:"false" sensitive:"true" yaml:"cert,omitempty" description:"Path on the dokku server to the SSL certificate file. Mutually exclusive with cert_content."`
 
 	// Key is the path on the dokku server to the SSL certificate key file
-	Key string `required:"false" sensitive:"true" yaml:"key,omitempty" description:"Path on the dokku server to the SSL certificate key file"`
+	Key string `required:"false" sensitive:"true" yaml:"key,omitempty" description:"Path on the dokku server to the SSL certificate key file. Mutually exclusive with key_content."`
+
+	// CertContent is the PEM-encoded certificate contents. Mutually
+	// exclusive with Cert.
+	CertContent string `required:"false" sensitive:"true" yaml:"cert_content,omitempty" description:"PEM-encoded certificate contents. Mutually exclusive with cert."`
+
+	// KeyContent is the PEM-encoded private key contents. Mutually
+	// exclusive with Key.
+	KeyContent string `required:"false" sensitive:"true" yaml:"key_content,omitempty" description:"PEM-encoded private key contents. Mutually exclusive with key."`
 
 	// State is the desired state of the SSL configuration
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the SSL configuration"`
@@ -42,10 +52,7 @@ func (e CertsTaskExample) GetName() string {
 
 // Doc returns the docblock for the certs task
 func (t CertsTask) Doc() string {
-	return "Manages SSL certificates for a dokku app or globally. The `cert` " +
-		"and `key` fields are paths on the dokku server, so when running with " +
-		"`DOKKU_HOST` set the referenced files must already exist on the " +
-		"remote host - docket does not upload them."
+	return "Manages SSL certificates for a dokku app or globally."
 }
 
 // Requirements lists the non-core dokku plugins this task depends on.
@@ -86,6 +93,22 @@ func (t CertsTask) Examples() ([]Doc, error) {
 				State:  StateAbsent,
 			},
 		},
+		{
+			Name: "Add an SSL certificate to an app from inline PEM",
+			CertsTask: CertsTask{
+				App:         "node-js-app",
+				CertContent: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n",
+				KeyContent:  "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
+			},
+		},
+		{
+			Name: "Add a global SSL certificate from inline PEM (requires the dokku-global-cert plugin)",
+			CertsTask: CertsTask{
+				Global:      true,
+				CertContent: "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n",
+				KeyContent:  "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
+			},
+		},
 	})
 }
 
@@ -101,8 +124,10 @@ func (t CertsTask) Plan() PlanResult {
 			if err := validateCertsTask(t); err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
-			if t.Cert == "" || t.Key == "" {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'cert' and 'key' are required when state is 'present'")}
+			hasPaths := t.Cert != "" && t.Key != ""
+			hasContent := t.CertContent != "" && t.KeyContent != ""
+			if !hasPaths && !hasContent {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'cert' (or 'cert_content') and 'key' (or 'key_content') are required when state is 'present'")}
 			}
 			enabled, err := certsEnabled(t)
 			if err != nil {
@@ -115,11 +140,26 @@ func (t CertsTask) Plan() PlanResult {
 			if t.Global {
 				target = "(global)"
 			}
-			args := []string{"--quiet", "certs:add", t.App, t.Cert, t.Key}
-			if t.Global {
-				args = []string{"--quiet", "global-cert:set", t.Cert, t.Key}
+			input := subprocess.ExecCommandInput{Command: "dokku"}
+			if hasContent {
+				tarBytes, err := buildCertTarball(t.CertContent, t.KeyContent)
+				if err != nil {
+					return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("build cert tarball: %w", err)}
+				}
+				input.Stdin = bytes.NewReader(tarBytes)
+				if t.Global {
+					input.Args = []string{"--quiet", "global-cert:set"}
+				} else {
+					input.Args = []string{"--quiet", "certs:add", t.App}
+				}
+			} else {
+				if t.Global {
+					input.Args = []string{"--quiet", "global-cert:set", t.Cert, t.Key}
+				} else {
+					input.Args = []string{"--quiet", "certs:add", t.App, t.Cert, t.Key}
+				}
 			}
-			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
+			inputs := []subprocess.ExecCommandInput{input}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusCreate,
@@ -173,7 +213,47 @@ func validateCertsTask(t CertsTask) error {
 	if !t.Global && t.App == "" {
 		return fmt.Errorf("'app' is required when 'global' is not set to true")
 	}
+	if t.Cert != "" && t.CertContent != "" {
+		return fmt.Errorf("'cert' and 'cert_content' are mutually exclusive")
+	}
+	if t.Key != "" && t.KeyContent != "" {
+		return fmt.Errorf("'key' and 'key_content' are mutually exclusive")
+	}
+	if (t.Cert != "" && t.KeyContent != "") || (t.CertContent != "" && t.Key != "") {
+		return fmt.Errorf("'cert'/'key' and 'cert_content'/'key_content' cannot be mixed; supply both from the same source")
+	}
 	return nil
+}
+
+// buildCertTarball produces an uncompressed tar archive containing
+// server.crt and server.key entries with the supplied PEM contents.
+// Both dokku's core certs:add and the dokku-global-cert plugin extract
+// such an archive from stdin and select the cert/key by file extension.
+func buildCertTarball(certPEM, keyPEM string) ([]byte, error) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	entries := []struct {
+		name, body string
+	}{
+		{"server.crt", certPEM},
+		{"server.key", keyPEM},
+	}
+	for _, e := range entries {
+		if err := tw.WriteHeader(&tar.Header{
+			Name: e.name,
+			Mode: 0o600,
+			Size: int64(len(e.body)),
+		}); err != nil {
+			return nil, err
+		}
+		if _, err := tw.Write([]byte(e.body)); err != nil {
+			return nil, err
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // certsEnabled checks if a certificate is currently configured for an app or globally

--- a/tasks/certs_task_integration_test.go
+++ b/tasks/certs_task_integration_test.go
@@ -150,6 +150,114 @@ func TestIntegrationCertsApp(t *testing.T) {
 	}
 }
 
+func TestIntegrationCertsAppInline(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-certs-inline"
+	certPath, keyPath := generateSelfSignedCert(t, appName+".example.com")
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("read cert: %v", err)
+	}
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	enabled, err := certsEnabled(CertsTask{App: appName})
+	if err != nil {
+		t.Fatalf("certsEnabled failed: %v", err)
+	}
+	if enabled {
+		t.Fatalf("expected newly-created app to have no cert")
+	}
+
+	addTask := CertsTask{App: appName, CertContent: string(certPEM), KeyContent: string(keyPEM), State: StatePresent}
+	result := addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to add cert inline: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first inline add")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+	enabled, err = certsEnabled(CertsTask{App: appName})
+	if err != nil {
+		t.Fatalf("certsEnabled failed: %v", err)
+	}
+	if !enabled {
+		t.Errorf("expected cert to be enabled after inline add")
+	}
+
+	result = addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second inline add: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent inline add")
+	}
+
+	removeTask := CertsTask{App: appName, State: StateAbsent}
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to remove inline cert: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first remove")
+	}
+}
+
+func TestIntegrationCertsGlobalInline(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "global-cert")
+
+	certPath, keyPath := generateSelfSignedCert(t, "global-inline.example.com")
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("read cert: %v", err)
+	}
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+
+	cleanup := func() {
+		(CertsTask{Global: true, State: StateAbsent}).Execute()
+	}
+	cleanup()
+	defer cleanup()
+
+	addTask := CertsTask{Global: true, CertContent: string(certPEM), KeyContent: string(keyPEM), State: StatePresent}
+	result := addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to add global cert inline: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first global inline add")
+	}
+	enabled, err := certsEnabled(CertsTask{Global: true})
+	if err != nil {
+		t.Fatalf("certsEnabled failed: %v", err)
+	}
+	if !enabled {
+		t.Errorf("expected global cert to be enabled after inline add")
+	}
+
+	result = addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second global inline add: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent global inline add")
+	}
+}
+
 func TestIntegrationCertsGlobal(t *testing.T) {
 	skipIfNoDokkuT(t)
 	skipIfPluginMissingT(t, "global-cert")

--- a/tasks/certs_task_test.go
+++ b/tasks/certs_task_test.go
@@ -1,6 +1,9 @@
 package tasks
 
 import (
+	"archive/tar"
+	"bytes"
+	"io"
 	"strings"
 	"testing"
 )
@@ -41,7 +44,7 @@ func TestCertsTaskPresentMissingCert(t *testing.T) {
 	if result.Error == nil {
 		t.Fatal("Execute without cert should return an error")
 	}
-	if !strings.Contains(result.Error.Error(), "'cert' and 'key' are required") {
+	if !strings.Contains(result.Error.Error(), "'cert' (or 'cert_content') and 'key' (or 'key_content') are required") {
 		t.Errorf("unexpected error: %v", result.Error)
 	}
 }
@@ -52,8 +55,128 @@ func TestCertsTaskPresentMissingKey(t *testing.T) {
 	if result.Error == nil {
 		t.Fatal("Execute without key should return an error")
 	}
-	if !strings.Contains(result.Error.Error(), "'cert' and 'key' are required") {
+	if !strings.Contains(result.Error.Error(), "'cert' (or 'cert_content') and 'key' (or 'key_content') are required") {
 		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestCertsTaskInlineMissingKeyContent(t *testing.T) {
+	task := CertsTask{App: "test-app", CertContent: "cert-pem", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with cert_content but no key should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'cert' (or 'cert_content') and 'key' (or 'key_content') are required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestCertsTaskInlineMixedSources(t *testing.T) {
+	task := CertsTask{App: "test-app", Cert: "/tmp/cert", KeyContent: "key-pem", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with cert + key_content should return a validation error")
+	}
+	if !strings.Contains(result.Error.Error(), "cannot be mixed") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestCertsTaskInlineBothCertForms(t *testing.T) {
+	task := CertsTask{App: "test-app", Cert: "/tmp/cert", CertContent: "cert-pem", Key: "/tmp/key", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with both cert and cert_content should return a validation error")
+	}
+	if !strings.Contains(result.Error.Error(), "'cert' and 'cert_content' are mutually exclusive") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestBuildCertTarball(t *testing.T) {
+	certPEM := "-----BEGIN CERTIFICATE-----\nfake-cert\n-----END CERTIFICATE-----\n"
+	keyPEM := "-----BEGIN PRIVATE KEY-----\nfake-key\n-----END PRIVATE KEY-----\n"
+
+	out, err := buildCertTarball(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("buildCertTarball failed: %v", err)
+	}
+
+	tr := tar.NewReader(bytes.NewReader(out))
+	got := map[string]string{}
+	modes := map[string]int64{}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar read failed: %v", err)
+		}
+		body, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatalf("tar entry body read failed: %v", err)
+		}
+		got[hdr.Name] = string(body)
+		modes[hdr.Name] = hdr.Mode
+	}
+	if got["server.crt"] != certPEM {
+		t.Errorf("server.crt body = %q, want %q", got["server.crt"], certPEM)
+	}
+	if got["server.key"] != keyPEM {
+		t.Errorf("server.key body = %q, want %q", got["server.key"], keyPEM)
+	}
+	if modes["server.crt"] != 0o600 {
+		t.Errorf("server.crt mode = %o, want 0600", modes["server.crt"])
+	}
+	if modes["server.key"] != 0o600 {
+		t.Errorf("server.key mode = %o, want 0600", modes["server.key"])
+	}
+}
+
+func TestGetTasksCertsTaskInlineParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: install cert
+      dokku_certs:
+        app: test-app
+        cert_content: |
+          -----BEGIN CERTIFICATE-----
+          fake
+          -----END CERTIFICATE-----
+        key_content: |
+          -----BEGIN PRIVATE KEY-----
+          fake
+          -----END PRIVATE KEY-----
+        state: present
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("install cert")
+	if task == nil {
+		t.Fatal("task 'install cert' not found")
+	}
+
+	certsTask, ok := task.(*CertsTask)
+	if !ok {
+		t.Fatalf("task is not a CertsTask (type is %T)", task)
+	}
+	if certsTask.App != "test-app" {
+		t.Errorf("App = %q, want %q", certsTask.App, "test-app")
+	}
+	if !strings.Contains(certsTask.CertContent, "BEGIN CERTIFICATE") {
+		t.Errorf("CertContent missing PEM marker: %q", certsTask.CertContent)
+	}
+	if !strings.Contains(certsTask.KeyContent, "BEGIN PRIVATE KEY") {
+		t.Errorf("KeyContent missing PEM marker: %q", certsTask.KeyContent)
+	}
+	if certsTask.Cert != "" || certsTask.Key != "" {
+		t.Errorf("expected path fields empty, got cert=%q key=%q", certsTask.Cert, certsTask.Key)
 	}
 }
 

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -650,7 +650,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&BuildpacksPropertyTask{}, "Manages the buildpacks configuration for a given dokku application"},
 		{&BuildpacksTask{}, "Manages the buildpacks for a given dokku application"},
 		{&CaddyPropertyTask{}, "Manages the caddy configuration for a given dokku application"},
-		{&CertsTask{}, "Manages SSL certificates for a dokku app or globally. The `cert` and `key` fields are paths on the dokku server, so when running with `DOKKU_HOST` set the referenced files must already exist on the remote host - docket does not upload them."},
+		{&CertsTask{}, "Manages SSL certificates for a dokku app or globally."},
 		{&ChecksPropertyTask{}, "Manages the checks configuration for a given dokku application"},
 		{&ChecksToggleTask{}, "Enables or disables the checks plugin for a given dokku application"},
 		{&ConfigTask{}, "Manages the configuration for a given dokku application"},


### PR DESCRIPTION
The new `cert_content` and `key_content` fields stream a `server.crt` and `server.key` tarball to `dokku certs:add` or `dokku global-cert:set` over stdin, so recipes can install certificates from secrets without staging files on the dokku host first. The path-based `cert` and `key` fields remain and are mutually exclusive with the inline form.