### PR TITLE
feat: add dokku_scheduler_k3s_labels task

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.13
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.14
           sudo dokku plugin:install-dependencies --core
       - name: install dokku redis plugin
         run: sudo dokku plugin:install https://github.com/dokku/dokku-redis.git redis
@@ -87,7 +87,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.13
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.14
           sudo dokku plugin:install-dependencies --core
       - name: install bats
         run: sudo apt-get install -qq -y bats bats-support bats-assert

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,7 @@ code into it:
 
 ## Prerequisites
 
-- **Dokku >= 0.38.13.**
+- **Dokku >= 0.38.14.**
 - **dokku-letsencrypt >= 0.25.0.**
 
 ## Installation

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -54,6 +54,7 @@ Reference for every task type docket can run inside a recipe. Each page lists th
 - [dokku_resource_limit](dokku_resource_limit.md) - Manages the resource limits for a given dokku application
 - [dokku_resource_reserve](dokku_resource_reserve.md) - Manages the resource reservations for a given dokku application
 - [dokku_scheduler_docker_local_property](dokku_scheduler_docker_local_property.md) - Manages the scheduler-docker-local configuration for a given dokku application
+- [dokku_scheduler_k3s_labels](dokku_scheduler_k3s_labels.md) - Manages scheduler-k3s labels scoped to a (process_type, resource_type) pair for a dokku application or globally
 - [dokku_scheduler_k3s_property](dokku_scheduler_k3s_property.md) - Manages the scheduler-k3s configuration for a given dokku application
 - [dokku_scheduler_property](dokku_scheduler_property.md) - Manages the scheduler configuration for a given dokku application
 - [dokku_service_backup](dokku_service_backup.md) - Manages the S3 backup schedule, authentication, and encryption for a dokku service

--- a/docs/tasks/dokku_scheduler_k3s_labels.md
+++ b/docs/tasks/dokku_scheduler_k3s_labels.md
@@ -1,0 +1,77 @@
+# dokku_scheduler_k3s_labels
+
+## Synopsis
+
+Manages scheduler-k3s labels scoped to a (process_type, resource_type) pair for a dokku application or globally
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the labels should be applied globally |
+| `process_type` | string | no |  |  | Process type to scope the labels to. Defaults to the global process type when empty. |
+| `resource_type` | string | yes |  |  | Kubernetes resource type to scope the labels to (e.g. deployment, ingress). |
+| `labels` | dict | no |  |  | Map of label key to value to apply at the scope. |
+| `state` | string | no | present | present, absent | Desired state of the labels |
+
+## Examples
+
+### Set deployment labels on an app's web process
+
+```yaml
+dokku_scheduler_k3s_labels:
+    app: node-js-app
+    process_type: web
+    resource_type: deployment
+    labels:
+        app.kubernetes.io/component: api
+        tier: edge
+```
+
+### Set ingress labels on an app at the global process scope
+
+```yaml
+dokku_scheduler_k3s_labels:
+    app: node-js-app
+    resource_type: ingress
+    labels:
+        team: platform
+```
+
+### Set a global deployment label across all apps
+
+```yaml
+dokku_scheduler_k3s_labels:
+    app: ""
+    global: true
+    resource_type: deployment
+    labels:
+        managed-by: docket
+```
+
+### Remove specific labels from an app's deployment
+
+```yaml
+dokku_scheduler_k3s_labels:
+    app: node-js-app
+    resource_type: deployment
+    labels:
+        tier: ""
+    state: absent
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/tasks/config_task.go
+++ b/tasks/config_task.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"sort"
+
 	"github.com/dokku/docket/subprocess"
 )
 
@@ -97,7 +99,8 @@ func (t ConfigTask) Plan() PlanResult {
 	})
 }
 
-// configKeysToSet returns keys whose desired value differs from the current value.
+// configKeysToSet returns keys whose desired value differs from the current
+// value. The slice is sorted so Plan output is stable across runs.
 func configKeysToSet(current, desired map[string]string) []string {
 	keys := []string{}
 	for k, v := range desired {
@@ -105,10 +108,12 @@ func configKeysToSet(current, desired map[string]string) []string {
 			keys = append(keys, k)
 		}
 	}
+	sort.Strings(keys)
 	return keys
 }
 
 // configKeysToUnset returns keys present in desired that exist in current.
+// The slice is sorted so Plan output is stable across runs.
 func configKeysToUnset(current, desired map[string]string) []string {
 	keys := []string{}
 	for k := range desired {
@@ -116,6 +121,7 @@ func configKeysToUnset(current, desired map[string]string) []string {
 			keys = append(keys, k)
 		}
 	}
+	sort.Strings(keys)
 	return keys
 }
 

--- a/tasks/integration_shard_test.go
+++ b/tasks/integration_shard_test.go
@@ -85,6 +85,7 @@ var integrationTestWeights = map[string]float64{
 	"TestIntegrationRunExecInputsCapturesFailureOutput":     0.2,
 	"TestIntegrationRunExecInputsPopulatesExitCodeAndStdout": 0.2,
 	"TestIntegrationSchedulerDockerLocalPropertyAll":        7.7,
+	"TestIntegrationSchedulerK3sLabelsAll":                  8.0,
 	"TestIntegrationSchedulerK3sPropertyAll":                21.3,
 	"TestIntegrationSchedulerPropertyAll":                   8.6,
 	"TestIntegrationServiceCreateAndDestroy":                2.9,

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -210,6 +210,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_resource_limit",
 		"dokku_resource_reserve",
 		"dokku_scheduler_docker_local_property",
+		"dokku_scheduler_k3s_labels",
 		"dokku_scheduler_k3s_property",
 		"dokku_scheduler_property",
 		"dokku_service_create",
@@ -488,7 +489,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 64
+	expected := 65
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}

--- a/tasks/scheduler_k3s_labels_task.go
+++ b/tasks/scheduler_k3s_labels_task.go
@@ -1,0 +1,330 @@
+package tasks
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// SchedulerK3sLabelsTask manages a group of scheduler-k3s labels scoped to a
+// (process_type, resource_type) pair on a dokku application or globally.
+type SchedulerK3sLabelsTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+
+	// Global is a flag indicating if the labels should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the labels should be applied globally"`
+
+	// ProcessType narrows the labels to a specific process type. When empty,
+	// dokku stores the labels under its default global process type.
+	ProcessType string `required:"false" yaml:"process_type,omitempty" description:"Process type to scope the labels to. Defaults to the global process type when empty."`
+
+	// ResourceType narrows the labels to a specific kubernetes resource type
+	// (e.g. deployment, ingress, service). Required, mirroring dokku's own
+	// scheduler-k3s:labels:set rejection of empty resource types.
+	ResourceType string `required:"true" yaml:"resource_type" description:"Kubernetes resource type to scope the labels to (e.g. deployment, ingress)."`
+
+	// Labels is the desired set of label key/value pairs to apply at the
+	// (process_type, resource_type) scope.
+	Labels map[string]string `required:"false" yaml:"labels,omitempty" description:"Map of label key to value to apply at the scope."`
+
+	// State is the desired state of the labels
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the labels"`
+}
+
+// SchedulerK3sLabelsTaskExample contains an example of a SchedulerK3sLabelsTask
+type SchedulerK3sLabelsTaskExample struct {
+	// Name is the task name holding the SchedulerK3sLabelsTask description
+	Name string `yaml:"-"`
+
+	// SchedulerK3sLabelsTask is the SchedulerK3sLabelsTask configuration
+	SchedulerK3sLabelsTask SchedulerK3sLabelsTask `yaml:"dokku_scheduler_k3s_labels"`
+}
+
+// GetName returns the name of the example
+func (e SchedulerK3sLabelsTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the scheduler-k3s labels task
+func (t SchedulerK3sLabelsTask) Doc() string {
+	return "Manages scheduler-k3s labels scoped to a (process_type, resource_type) pair for a dokku application or globally"
+}
+
+// Examples returns the examples for the scheduler-k3s labels task
+func (t SchedulerK3sLabelsTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]SchedulerK3sLabelsTaskExample{
+		{
+			Name: "Set deployment labels on an app's web process",
+			SchedulerK3sLabelsTask: SchedulerK3sLabelsTask{
+				App:          "node-js-app",
+				ProcessType:  "web",
+				ResourceType: "deployment",
+				Labels: map[string]string{
+					"app.kubernetes.io/component": "api",
+					"tier":                        "edge",
+				},
+			},
+		},
+		{
+			Name: "Set ingress labels on an app at the global process scope",
+			SchedulerK3sLabelsTask: SchedulerK3sLabelsTask{
+				App:          "node-js-app",
+				ResourceType: "ingress",
+				Labels: map[string]string{
+					"team": "platform",
+				},
+			},
+		},
+		{
+			Name: "Set a global deployment label across all apps",
+			SchedulerK3sLabelsTask: SchedulerK3sLabelsTask{
+				Global:       true,
+				ResourceType: "deployment",
+				Labels: map[string]string{
+					"managed-by": "docket",
+				},
+			},
+		},
+		{
+			Name: "Remove specific labels from an app's deployment",
+			SchedulerK3sLabelsTask: SchedulerK3sLabelsTask{
+				App:          "node-js-app",
+				ResourceType: "deployment",
+				Labels: map[string]string{
+					"tier": "",
+				},
+				State: StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute sets or clears the scheduler-k3s labels for the configured scope
+func (t SchedulerK3sLabelsTask) Execute() TaskOutputState {
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the SchedulerK3sLabelsTask would produce.
+func (t SchedulerK3sLabelsTask) Plan() PlanResult {
+	if err := t.validate(); err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return planSchedulerK3sLabelsSet(t) },
+		StateAbsent:  func() PlanResult { return planSchedulerK3sLabelsUnset(t) },
+	})
+}
+
+// validate checks the task fields prior to any subprocess call.
+func (t SchedulerK3sLabelsTask) validate() error {
+	if !t.Global && t.App == "" {
+		return errors.New("app is required when global is false")
+	}
+	if t.Global && t.App != "" {
+		return fmt.Errorf("'app' must not be set when 'global' is set to true")
+	}
+	if t.ResourceType == "" {
+		return errors.New("resource_type is required")
+	}
+	if len(t.Labels) == 0 {
+		state := t.State
+		if state == "" {
+			state = StatePresent
+		}
+		return fmt.Errorf("'labels' must not be empty for state '%s'", state)
+	}
+	for key := range t.Labels {
+		if key == "" {
+			return errors.New("label keys must not be empty")
+		}
+	}
+	return nil
+}
+
+// planSchedulerK3sLabelsSet probes current labels once, computes the diff, and
+// embeds an apply closure that runs `dokku scheduler-k3s:labels:set` once per
+// drifted key.
+func planSchedulerK3sLabelsSet(t SchedulerK3sLabelsTask) PlanResult {
+	current, err := getSchedulerK3sLabels(t)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+
+	driftedKeys := []string{}
+	for k, v := range t.Labels {
+		if cur, ok := current[k]; !ok || cur != v {
+			driftedKeys = append(driftedKeys, k)
+		}
+	}
+	if len(driftedKeys) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	sort.Strings(driftedKeys)
+
+	mutations := make([]string, 0, len(driftedKeys))
+	allNew := true
+	for _, k := range driftedKeys {
+		if _, ok := current[k]; ok {
+			mutations = append(mutations, fmt.Sprintf("set %s=%s (was %q)", k, t.Labels[k], current[k]))
+			allNew = false
+		} else {
+			mutations = append(mutations, fmt.Sprintf("set %s=%s (new)", k, t.Labels[k]))
+		}
+	}
+
+	status := PlanStatusModify
+	if allNew {
+		status = PlanStatusCreate
+	}
+
+	inputs := schedulerK3sLabelsSetInputs(t, driftedKeys)
+	return PlanResult{
+		InSync:    false,
+		Status:    status,
+		Reason:    fmt.Sprintf("%d label(s) to set", len(driftedKeys)),
+		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
+		apply: func() TaskOutputState {
+			return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+		},
+	}
+}
+
+// planSchedulerK3sLabelsUnset probes current labels once, computes the diff,
+// and embeds an apply closure that clears each listed key that exists.
+func planSchedulerK3sLabelsUnset(t SchedulerK3sLabelsTask) PlanResult {
+	current, err := getSchedulerK3sLabels(t)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+
+	toClear := []string{}
+	for k := range t.Labels {
+		if _, ok := current[k]; ok {
+			toClear = append(toClear, k)
+		}
+	}
+	if len(toClear) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	sort.Strings(toClear)
+
+	mutations := make([]string, 0, len(toClear))
+	for _, k := range toClear {
+		mutations = append(mutations, fmt.Sprintf("unset %s (was %q)", k, current[k]))
+	}
+
+	inputs := schedulerK3sLabelsClearInputs(t, toClear)
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    fmt.Sprintf("%d label(s) to unset", len(toClear)),
+		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
+		apply: func() TaskOutputState {
+			return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+		},
+	}
+}
+
+// schedulerK3sLabelsSetInputs returns one subprocess input per drifted key,
+// each invoking `dokku scheduler-k3s:labels:set` with the desired value.
+func schedulerK3sLabelsSetInputs(t SchedulerK3sLabelsTask, keys []string) []subprocess.ExecCommandInput {
+	inputs := make([]subprocess.ExecCommandInput, 0, len(keys))
+	for _, key := range keys {
+		inputs = append(inputs, schedulerK3sLabelsCommand(t, key, t.Labels[key]))
+	}
+	return inputs
+}
+
+// schedulerK3sLabelsClearInputs returns one subprocess input per key to clear.
+// Dokku interprets an empty value as a clear-this-label operation.
+func schedulerK3sLabelsClearInputs(t SchedulerK3sLabelsTask, keys []string) []subprocess.ExecCommandInput {
+	inputs := make([]subprocess.ExecCommandInput, 0, len(keys))
+	for _, key := range keys {
+		inputs = append(inputs, schedulerK3sLabelsCommand(t, key, ""))
+	}
+	return inputs
+}
+
+// schedulerK3sLabelsCommand builds one `dokku scheduler-k3s:labels:set` call.
+func schedulerK3sLabelsCommand(t SchedulerK3sLabelsTask, key, value string) subprocess.ExecCommandInput {
+	args := []string{"--quiet", "scheduler-k3s:labels:set"}
+	args = append(args, "--resource-type", t.ResourceType)
+	if t.ProcessType != "" {
+		args = append(args, "--process-type", t.ProcessType)
+	}
+	if t.Global {
+		args = append(args, "--global", key, value)
+	} else {
+		args = append(args, t.App, key, value)
+	}
+	return subprocess.ExecCommandInput{Command: "dokku", Args: args}
+}
+
+// getSchedulerK3sLabels reads the labels currently stored at the task's
+// (app|global, process_type, resource_type) scope. It calls
+// `dokku scheduler-k3s:labels:report ... --format json`, which returns a
+// flat map keyed by `<rendered_process_type>.<resource_type>.<label_key>`,
+// and strips the prefix to recover the original label keys.
+func getSchedulerK3sLabels(t SchedulerK3sLabelsTask) (map[string]string, error) {
+	args := []string{"--quiet", "scheduler-k3s:labels:report"}
+	if t.Global {
+		args = append(args, "--global")
+	} else {
+		args = append(args, t.App)
+	}
+	args = append(args, "--resource-type", t.ResourceType)
+
+	effectiveProcessType := t.ProcessType
+	if effectiveProcessType == "" {
+		effectiveProcessType = "--global"
+	}
+	args = append(args, "--process-type", effectiveProcessType)
+	args = append(args, "--format", "json")
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	payload := map[string]string{}
+	if err := json.Unmarshal(result.StdoutBytes(), &payload); err != nil {
+		return nil, fmt.Errorf("parse scheduler-k3s:labels:report json: %w", err)
+	}
+
+	prefix := renderedSchedulerK3sProcessType(t.ProcessType) + "." + t.ResourceType + "."
+	labels := map[string]string{}
+	for composedKey, value := range payload {
+		if !strings.HasPrefix(composedKey, prefix) {
+			continue
+		}
+		labels[strings.TrimPrefix(composedKey, prefix)] = value
+	}
+	return labels, nil
+}
+
+// renderedSchedulerK3sProcessType mirrors dokku's report-side rendering of the
+// in-storage process type: the global sentinel "--global" (used when the task
+// omits process_type) is rendered as "global"; explicit process types pass
+// through unchanged.
+func renderedSchedulerK3sProcessType(processType string) string {
+	if processType == "" || processType == "--global" {
+		return "global"
+	}
+	return processType
+}
+
+// init registers the SchedulerK3sLabelsTask with the task registry
+func init() {
+	RegisterTask(&SchedulerK3sLabelsTask{})
+}

--- a/tasks/scheduler_k3s_labels_task_integration_test.go
+++ b/tasks/scheduler_k3s_labels_task_integration_test.go
@@ -1,0 +1,94 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationSchedulerK3sLabelsAll(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-scheduler-k3s-labels"
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	cases := []struct {
+		name         string
+		global       bool
+		processType  string
+		resourceType string
+		labels       map[string]string
+	}{
+		{
+			name:         "per-app/default-process-type/deployment",
+			resourceType: "deployment",
+			labels: map[string]string{
+				"app.kubernetes.io/component": "api",
+				"tier":                        "edge",
+			},
+		},
+		{
+			name:         "per-app/explicit-process-type/deployment",
+			processType:  "web",
+			resourceType: "deployment",
+			labels: map[string]string{
+				"role": "frontend",
+			},
+		},
+		{
+			name:         "per-app/default-process-type/ingress",
+			resourceType: "ingress",
+			labels: map[string]string{
+				"team": "platform",
+			},
+		},
+		{
+			name:         "global/default-process-type/deployment",
+			global:       true,
+			resourceType: "deployment",
+			labels: map[string]string{
+				"managed-by": "docket",
+			},
+		},
+		{
+			name:         "global/explicit-process-type/deployment",
+			global:       true,
+			processType:  "worker",
+			resourceType: "deployment",
+			labels: map[string]string{
+				"queue": "default",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := appName
+			if tc.global {
+				app = ""
+			}
+			setTask := SchedulerK3sLabelsTask{
+				App:          app,
+				Global:       tc.global,
+				ProcessType:  tc.processType,
+				ResourceType: tc.resourceType,
+				Labels:       tc.labels,
+				State:        StatePresent,
+			}
+			unsetTask := SchedulerK3sLabelsTask{
+				App:          app,
+				Global:       tc.global,
+				ProcessType:  tc.processType,
+				ResourceType: tc.resourceType,
+				Labels:       tc.labels,
+				State:        StateAbsent,
+			}
+			defer unsetTask.Execute()
+			runPropertyIdempotencyTest(t, propertyIdempotencyCase{
+				label:     "scheduler-k3s labels " + tc.name,
+				setTask:   setTask,
+				unsetTask: unsetTask,
+			})
+		})
+	}
+}

--- a/tasks/scheduler_k3s_labels_task_test.go
+++ b/tasks/scheduler_k3s_labels_task_test.go
@@ -1,0 +1,112 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSchedulerK3sLabelsTaskInvalidState(t *testing.T) {
+	task := SchedulerK3sLabelsTask{
+		App:          "test-app",
+		ResourceType: "deployment",
+		Labels:       map[string]string{"tier": "edge"},
+		State:        "invalid",
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestSchedulerK3sLabelsTaskMissingApp(t *testing.T) {
+	task := SchedulerK3sLabelsTask{
+		ResourceType: "deployment",
+		Labels:       map[string]string{"tier": "edge"},
+		State:        StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "app is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerK3sLabelsTaskGlobalWithAppSet(t *testing.T) {
+	task := SchedulerK3sLabelsTask{
+		App:          "test-app",
+		Global:       true,
+		ResourceType: "deployment",
+		Labels:       map[string]string{"tier": "edge"},
+		State:        StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerK3sLabelsTaskMissingResourceType(t *testing.T) {
+	task := SchedulerK3sLabelsTask{
+		App:    "test-app",
+		Labels: map[string]string{"tier": "edge"},
+		State:  StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when resource_type is empty")
+	}
+	if !strings.Contains(result.Error.Error(), "resource_type is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerK3sLabelsTaskPresentWithoutLabels(t *testing.T) {
+	task := SchedulerK3sLabelsTask{
+		App:          "test-app",
+		ResourceType: "deployment",
+		State:        StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no labels")
+	}
+	if !strings.Contains(result.Error.Error(), "'labels' must not be empty") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerK3sLabelsTaskAbsentWithoutLabels(t *testing.T) {
+	task := SchedulerK3sLabelsTask{
+		App:          "test-app",
+		ResourceType: "deployment",
+		State:        StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has no labels")
+	}
+	if !strings.Contains(result.Error.Error(), "'labels' must not be empty") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerK3sLabelsTaskEmptyLabelKey(t *testing.T) {
+	task := SchedulerK3sLabelsTask{
+		App:          "test-app",
+		ResourceType: "deployment",
+		Labels:       map[string]string{"": "edge"},
+		State:        StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when a label key is empty")
+	}
+	if !strings.Contains(result.Error.Error(), "label keys must not be empty") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}


### PR DESCRIPTION
Wraps `dokku scheduler-k3s:labels:set` so a recipe can manage a map of labels scoped to a (process_type, resource_type) pair. Diffs against the `scheduler-k3s:labels:report --format json` payload so re-applies report `Changed=false` once the scope already matches. `state: absent` clears only the listed keys by setting each to the empty value. Also sorts the key slice in `dokku_config` so its plan output is stable across runs, matching the new task's behavior.

Closes #254.