### PR TITLE
feat: add dokku_scheduler_k3s_annotations task

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -54,6 +54,7 @@ Reference for every task type docket can run inside a recipe. Each page lists th
 - [dokku_resource_limit](dokku_resource_limit.md) - Manages the resource limits for a given dokku application
 - [dokku_resource_reserve](dokku_resource_reserve.md) - Manages the resource reservations for a given dokku application
 - [dokku_scheduler_docker_local_property](dokku_scheduler_docker_local_property.md) - Manages the scheduler-docker-local configuration for a given dokku application
+- [dokku_scheduler_k3s_annotations](dokku_scheduler_k3s_annotations.md) - Manages scheduler-k3s annotations scoped to a (process_type, resource_type) pair for a dokku application or globally
 - [dokku_scheduler_k3s_labels](dokku_scheduler_k3s_labels.md) - Manages scheduler-k3s labels scoped to a (process_type, resource_type) pair for a dokku application or globally
 - [dokku_scheduler_k3s_property](dokku_scheduler_k3s_property.md) - Manages the scheduler-k3s configuration for a given dokku application
 - [dokku_scheduler_property](dokku_scheduler_property.md) - Manages the scheduler configuration for a given dokku application

--- a/docs/tasks/dokku_scheduler_k3s_annotations.md
+++ b/docs/tasks/dokku_scheduler_k3s_annotations.md
@@ -1,0 +1,77 @@
+# dokku_scheduler_k3s_annotations
+
+## Synopsis
+
+Manages scheduler-k3s annotations scoped to a (process_type, resource_type) pair for a dokku application or globally
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | no |  |  | Name of the app. Required if Global is false. |
+| `global` | bool | no |  |  | Flag indicating if the annotations should be applied globally |
+| `process_type` | string | no |  |  | Process type to scope the annotations to. Defaults to the global process type when empty. |
+| `resource_type` | string | yes |  |  | Kubernetes resource type to scope the annotations to (e.g. deployment, ingress). |
+| `annotations` | dict | no |  |  | Map of annotation key to value to apply at the scope. |
+| `state` | string | no | present | present, absent | Desired state of the annotations |
+
+## Examples
+
+### Set deployment annotations on an app's web process
+
+```yaml
+dokku_scheduler_k3s_annotations:
+    app: node-js-app
+    process_type: web
+    resource_type: deployment
+    annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
+```
+
+### Set ingress annotations on an app at the global process scope
+
+```yaml
+dokku_scheduler_k3s_annotations:
+    app: node-js-app
+    resource_type: ingress
+    annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /
+```
+
+### Set a global deployment annotation across all apps
+
+```yaml
+dokku_scheduler_k3s_annotations:
+    app: ""
+    global: true
+    resource_type: deployment
+    annotations:
+        managed-by: docket
+```
+
+### Remove specific annotations from an app's deployment
+
+```yaml
+dokku_scheduler_k3s_annotations:
+    app: node-js-app
+    resource_type: deployment
+    annotations:
+        prometheus.io/scrape: ""
+    state: absent
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/tasks/integration_shard_test.go
+++ b/tasks/integration_shard_test.go
@@ -85,6 +85,7 @@ var integrationTestWeights = map[string]float64{
 	"TestIntegrationRunExecInputsCapturesFailureOutput":     0.2,
 	"TestIntegrationRunExecInputsPopulatesExitCodeAndStdout": 0.2,
 	"TestIntegrationSchedulerDockerLocalPropertyAll":        7.7,
+	"TestIntegrationSchedulerK3sAnnotationsAll":             8.0,
 	"TestIntegrationSchedulerK3sLabelsAll":                  8.0,
 	"TestIntegrationSchedulerK3sPropertyAll":                21.3,
 	"TestIntegrationSchedulerPropertyAll":                   8.6,

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -210,6 +210,7 @@ func TestRegisteredTasksExist(t *testing.T) {
 		"dokku_resource_limit",
 		"dokku_resource_reserve",
 		"dokku_scheduler_docker_local_property",
+		"dokku_scheduler_k3s_annotations",
 		"dokku_scheduler_k3s_labels",
 		"dokku_scheduler_k3s_property",
 		"dokku_scheduler_property",
@@ -489,7 +490,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 65
+	expected := 66
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}

--- a/tasks/scheduler_k3s_annotations_task.go
+++ b/tasks/scheduler_k3s_annotations_task.go
@@ -1,0 +1,133 @@
+package tasks
+
+// SchedulerK3sAnnotationsTask manages a group of scheduler-k3s annotations
+// scoped to a (process_type, resource_type) pair on a dokku application or
+// globally.
+type SchedulerK3sAnnotationsTask struct {
+	// App is the name of the app. Required if Global is false.
+	App string `required:"false" yaml:"app" description:"Name of the app. Required if Global is false."`
+
+	// Global is a flag indicating if the annotations should be applied globally
+	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the annotations should be applied globally"`
+
+	// ProcessType narrows the annotations to a specific process type. When
+	// empty, dokku stores the annotations under its default global process
+	// type.
+	ProcessType string `required:"false" yaml:"process_type,omitempty" description:"Process type to scope the annotations to. Defaults to the global process type when empty."`
+
+	// ResourceType narrows the annotations to a specific kubernetes resource
+	// type (e.g. deployment, ingress, service). Required, mirroring dokku's
+	// own scheduler-k3s:annotations:set rejection of empty resource types.
+	ResourceType string `required:"true" yaml:"resource_type" description:"Kubernetes resource type to scope the annotations to (e.g. deployment, ingress)."`
+
+	// Annotations is the desired set of annotation key/value pairs to apply at
+	// the (process_type, resource_type) scope.
+	Annotations map[string]string `required:"false" yaml:"annotations,omitempty" description:"Map of annotation key to value to apply at the scope."`
+
+	// State is the desired state of the annotations
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the annotations"`
+}
+
+// SchedulerK3sAnnotationsTaskExample contains an example of a SchedulerK3sAnnotationsTask
+type SchedulerK3sAnnotationsTaskExample struct {
+	// Name is the task name holding the SchedulerK3sAnnotationsTask description
+	Name string `yaml:"-"`
+
+	// SchedulerK3sAnnotationsTask is the SchedulerK3sAnnotationsTask configuration
+	SchedulerK3sAnnotationsTask SchedulerK3sAnnotationsTask `yaml:"dokku_scheduler_k3s_annotations"`
+}
+
+// GetName returns the name of the example
+func (e SchedulerK3sAnnotationsTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the scheduler-k3s annotations task
+func (t SchedulerK3sAnnotationsTask) Doc() string {
+	return "Manages scheduler-k3s annotations scoped to a (process_type, resource_type) pair for a dokku application or globally"
+}
+
+// Examples returns the examples for the scheduler-k3s annotations task
+func (t SchedulerK3sAnnotationsTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]SchedulerK3sAnnotationsTaskExample{
+		{
+			Name: "Set deployment annotations on an app's web process",
+			SchedulerK3sAnnotationsTask: SchedulerK3sAnnotationsTask{
+				App:          "node-js-app",
+				ProcessType:  "web",
+				ResourceType: "deployment",
+				Annotations: map[string]string{
+					"prometheus.io/scrape": "true",
+					"prometheus.io/port":   "9090",
+				},
+			},
+		},
+		{
+			Name: "Set ingress annotations on an app at the global process scope",
+			SchedulerK3sAnnotationsTask: SchedulerK3sAnnotationsTask{
+				App:          "node-js-app",
+				ResourceType: "ingress",
+				Annotations: map[string]string{
+					"nginx.ingress.kubernetes.io/rewrite-target": "/",
+				},
+			},
+		},
+		{
+			Name: "Set a global deployment annotation across all apps",
+			SchedulerK3sAnnotationsTask: SchedulerK3sAnnotationsTask{
+				Global:       true,
+				ResourceType: "deployment",
+				Annotations: map[string]string{
+					"managed-by": "docket",
+				},
+			},
+		},
+		{
+			Name: "Remove specific annotations from an app's deployment",
+			SchedulerK3sAnnotationsTask: SchedulerK3sAnnotationsTask{
+				App:          "node-js-app",
+				ResourceType: "deployment",
+				Annotations: map[string]string{
+					"prometheus.io/scrape": "",
+				},
+				State: StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute sets or clears the scheduler-k3s annotations for the configured scope
+func (t SchedulerK3sAnnotationsTask) Execute() TaskOutputState {
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the SchedulerK3sAnnotationsTask would produce.
+func (t SchedulerK3sAnnotationsTask) Plan() PlanResult {
+	spec := t.spec()
+	if err := validateSchedulerK3sScopedPairs(spec, t.State); err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return planSchedulerK3sScopedPairsSet(spec) },
+		StateAbsent:  func() PlanResult { return planSchedulerK3sScopedPairsUnset(spec) },
+	})
+}
+
+// spec adapts the task to the kind-agnostic scoped-pairs spec shared with the
+// labels task.
+func (t SchedulerK3sAnnotationsTask) spec() schedulerK3sScopedPairsSpec {
+	return schedulerK3sScopedPairsSpec{
+		Kind:         "annotations",
+		App:          t.App,
+		Global:       t.Global,
+		ProcessType:  t.ProcessType,
+		ResourceType: t.ResourceType,
+		Pairs:        t.Annotations,
+	}
+}
+
+// init registers the SchedulerK3sAnnotationsTask with the task registry
+func init() {
+	RegisterTask(&SchedulerK3sAnnotationsTask{})
+}

--- a/tasks/scheduler_k3s_annotations_task_integration_test.go
+++ b/tasks/scheduler_k3s_annotations_task_integration_test.go
@@ -1,0 +1,94 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationSchedulerK3sAnnotationsAll(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-scheduler-k3s-annotations"
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	cases := []struct {
+		name         string
+		global       bool
+		processType  string
+		resourceType string
+		annotations  map[string]string
+	}{
+		{
+			name:         "per-app/default-process-type/deployment",
+			resourceType: "deployment",
+			annotations: map[string]string{
+				"prometheus.io/scrape": "true",
+				"prometheus.io/port":   "9090",
+			},
+		},
+		{
+			name:         "per-app/explicit-process-type/deployment",
+			processType:  "web",
+			resourceType: "deployment",
+			annotations: map[string]string{
+				"sidecar.istio.io/inject": "false",
+			},
+		},
+		{
+			name:         "per-app/default-process-type/ingress",
+			resourceType: "ingress",
+			annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/whitelist-source-range": "10.0.0.0/8",
+			},
+		},
+		{
+			name:         "global/default-process-type/deployment",
+			global:       true,
+			resourceType: "deployment",
+			annotations: map[string]string{
+				"managed-by": "docket",
+			},
+		},
+		{
+			name:         "global/explicit-process-type/deployment",
+			global:       true,
+			processType:  "worker",
+			resourceType: "deployment",
+			annotations: map[string]string{
+				"prometheus.io/scrape": "false",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := appName
+			if tc.global {
+				app = ""
+			}
+			setTask := SchedulerK3sAnnotationsTask{
+				App:          app,
+				Global:       tc.global,
+				ProcessType:  tc.processType,
+				ResourceType: tc.resourceType,
+				Annotations:  tc.annotations,
+				State:        StatePresent,
+			}
+			unsetTask := SchedulerK3sAnnotationsTask{
+				App:          app,
+				Global:       tc.global,
+				ProcessType:  tc.processType,
+				ResourceType: tc.resourceType,
+				Annotations:  tc.annotations,
+				State:        StateAbsent,
+			}
+			defer unsetTask.Execute()
+			runPropertyIdempotencyTest(t, propertyIdempotencyCase{
+				label:     "scheduler-k3s annotations " + tc.name,
+				setTask:   setTask,
+				unsetTask: unsetTask,
+			})
+		})
+	}
+}

--- a/tasks/scheduler_k3s_annotations_task_test.go
+++ b/tasks/scheduler_k3s_annotations_task_test.go
@@ -1,0 +1,112 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSchedulerK3sAnnotationsTaskInvalidState(t *testing.T) {
+	task := SchedulerK3sAnnotationsTask{
+		App:          "test-app",
+		ResourceType: "deployment",
+		Annotations:  map[string]string{"prometheus.io/scrape": "true"},
+		State:        "invalid",
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestSchedulerK3sAnnotationsTaskMissingApp(t *testing.T) {
+	task := SchedulerK3sAnnotationsTask{
+		ResourceType: "deployment",
+		Annotations:  map[string]string{"prometheus.io/scrape": "true"},
+		State:        StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app and global=false should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "app is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerK3sAnnotationsTaskGlobalWithAppSet(t *testing.T) {
+	task := SchedulerK3sAnnotationsTask{
+		App:          "test-app",
+		Global:       true,
+		ResourceType: "deployment",
+		Annotations:  map[string]string{"prometheus.io/scrape": "true"},
+		State:        StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when both global and app are set")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when 'global' is set to true") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerK3sAnnotationsTaskMissingResourceType(t *testing.T) {
+	task := SchedulerK3sAnnotationsTask{
+		App:         "test-app",
+		Annotations: map[string]string{"prometheus.io/scrape": "true"},
+		State:       StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when resource_type is empty")
+	}
+	if !strings.Contains(result.Error.Error(), "resource_type is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerK3sAnnotationsTaskPresentWithoutAnnotations(t *testing.T) {
+	task := SchedulerK3sAnnotationsTask{
+		App:          "test-app",
+		ResourceType: "deployment",
+		State:        StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no annotations")
+	}
+	if !strings.Contains(result.Error.Error(), "'annotations' must not be empty") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerK3sAnnotationsTaskAbsentWithoutAnnotations(t *testing.T) {
+	task := SchedulerK3sAnnotationsTask{
+		App:          "test-app",
+		ResourceType: "deployment",
+		State:        StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has no annotations")
+	}
+	if !strings.Contains(result.Error.Error(), "'annotations' must not be empty") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerK3sAnnotationsTaskEmptyAnnotationKey(t *testing.T) {
+	task := SchedulerK3sAnnotationsTask{
+		App:          "test-app",
+		ResourceType: "deployment",
+		Annotations:  map[string]string{"": "true"},
+		State:        StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when an annotation key is empty")
+	}
+	if !strings.Contains(result.Error.Error(), "annotation keys must not be empty") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}

--- a/tasks/scheduler_k3s_labels_task.go
+++ b/tasks/scheduler_k3s_labels_task.go
@@ -1,15 +1,5 @@
 package tasks
 
-import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"sort"
-	"strings"
-
-	"github.com/dokku/docket/subprocess"
-)
-
 // SchedulerK3sLabelsTask manages a group of scheduler-k3s labels scoped to a
 // (process_type, resource_type) pair on a dokku application or globally.
 type SchedulerK3sLabelsTask struct {
@@ -111,217 +101,28 @@ func (t SchedulerK3sLabelsTask) Execute() TaskOutputState {
 
 // Plan reports the drift the SchedulerK3sLabelsTask would produce.
 func (t SchedulerK3sLabelsTask) Plan() PlanResult {
-	if err := t.validate(); err != nil {
+	spec := t.spec()
+	if err := validateSchedulerK3sScopedPairs(spec, t.State); err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
 
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		StatePresent: func() PlanResult { return planSchedulerK3sLabelsSet(t) },
-		StateAbsent:  func() PlanResult { return planSchedulerK3sLabelsUnset(t) },
+		StatePresent: func() PlanResult { return planSchedulerK3sScopedPairsSet(spec) },
+		StateAbsent:  func() PlanResult { return planSchedulerK3sScopedPairsUnset(spec) },
 	})
 }
 
-// validate checks the task fields prior to any subprocess call.
-func (t SchedulerK3sLabelsTask) validate() error {
-	if !t.Global && t.App == "" {
-		return errors.New("app is required when global is false")
+// spec adapts the task to the kind-agnostic scoped-pairs spec shared with the
+// annotations task.
+func (t SchedulerK3sLabelsTask) spec() schedulerK3sScopedPairsSpec {
+	return schedulerK3sScopedPairsSpec{
+		Kind:         "labels",
+		App:          t.App,
+		Global:       t.Global,
+		ProcessType:  t.ProcessType,
+		ResourceType: t.ResourceType,
+		Pairs:        t.Labels,
 	}
-	if t.Global && t.App != "" {
-		return fmt.Errorf("'app' must not be set when 'global' is set to true")
-	}
-	if t.ResourceType == "" {
-		return errors.New("resource_type is required")
-	}
-	if len(t.Labels) == 0 {
-		state := t.State
-		if state == "" {
-			state = StatePresent
-		}
-		return fmt.Errorf("'labels' must not be empty for state '%s'", state)
-	}
-	for key := range t.Labels {
-		if key == "" {
-			return errors.New("label keys must not be empty")
-		}
-	}
-	return nil
-}
-
-// planSchedulerK3sLabelsSet probes current labels once, computes the diff, and
-// embeds an apply closure that runs `dokku scheduler-k3s:labels:set` once per
-// drifted key.
-func planSchedulerK3sLabelsSet(t SchedulerK3sLabelsTask) PlanResult {
-	current, err := getSchedulerK3sLabels(t)
-	if err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
-	}
-
-	driftedKeys := []string{}
-	for k, v := range t.Labels {
-		if cur, ok := current[k]; !ok || cur != v {
-			driftedKeys = append(driftedKeys, k)
-		}
-	}
-	if len(driftedKeys) == 0 {
-		return PlanResult{InSync: true, Status: PlanStatusOK}
-	}
-	sort.Strings(driftedKeys)
-
-	mutations := make([]string, 0, len(driftedKeys))
-	allNew := true
-	for _, k := range driftedKeys {
-		if _, ok := current[k]; ok {
-			mutations = append(mutations, fmt.Sprintf("set %s=%s (was %q)", k, t.Labels[k], current[k]))
-			allNew = false
-		} else {
-			mutations = append(mutations, fmt.Sprintf("set %s=%s (new)", k, t.Labels[k]))
-		}
-	}
-
-	status := PlanStatusModify
-	if allNew {
-		status = PlanStatusCreate
-	}
-
-	inputs := schedulerK3sLabelsSetInputs(t, driftedKeys)
-	return PlanResult{
-		InSync:    false,
-		Status:    status,
-		Reason:    fmt.Sprintf("%d label(s) to set", len(driftedKeys)),
-		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
-		apply: func() TaskOutputState {
-			return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
-		},
-	}
-}
-
-// planSchedulerK3sLabelsUnset probes current labels once, computes the diff,
-// and embeds an apply closure that clears each listed key that exists.
-func planSchedulerK3sLabelsUnset(t SchedulerK3sLabelsTask) PlanResult {
-	current, err := getSchedulerK3sLabels(t)
-	if err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
-	}
-
-	toClear := []string{}
-	for k := range t.Labels {
-		if _, ok := current[k]; ok {
-			toClear = append(toClear, k)
-		}
-	}
-	if len(toClear) == 0 {
-		return PlanResult{InSync: true, Status: PlanStatusOK}
-	}
-	sort.Strings(toClear)
-
-	mutations := make([]string, 0, len(toClear))
-	for _, k := range toClear {
-		mutations = append(mutations, fmt.Sprintf("unset %s (was %q)", k, current[k]))
-	}
-
-	inputs := schedulerK3sLabelsClearInputs(t, toClear)
-	return PlanResult{
-		InSync:    false,
-		Status:    PlanStatusDestroy,
-		Reason:    fmt.Sprintf("%d label(s) to unset", len(toClear)),
-		Mutations: mutations,
-		Commands:  resolveCommands(inputs),
-		apply: func() TaskOutputState {
-			return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
-		},
-	}
-}
-
-// schedulerK3sLabelsSetInputs returns one subprocess input per drifted key,
-// each invoking `dokku scheduler-k3s:labels:set` with the desired value.
-func schedulerK3sLabelsSetInputs(t SchedulerK3sLabelsTask, keys []string) []subprocess.ExecCommandInput {
-	inputs := make([]subprocess.ExecCommandInput, 0, len(keys))
-	for _, key := range keys {
-		inputs = append(inputs, schedulerK3sLabelsCommand(t, key, t.Labels[key]))
-	}
-	return inputs
-}
-
-// schedulerK3sLabelsClearInputs returns one subprocess input per key to clear.
-// Dokku interprets an empty value as a clear-this-label operation.
-func schedulerK3sLabelsClearInputs(t SchedulerK3sLabelsTask, keys []string) []subprocess.ExecCommandInput {
-	inputs := make([]subprocess.ExecCommandInput, 0, len(keys))
-	for _, key := range keys {
-		inputs = append(inputs, schedulerK3sLabelsCommand(t, key, ""))
-	}
-	return inputs
-}
-
-// schedulerK3sLabelsCommand builds one `dokku scheduler-k3s:labels:set` call.
-func schedulerK3sLabelsCommand(t SchedulerK3sLabelsTask, key, value string) subprocess.ExecCommandInput {
-	args := []string{"--quiet", "scheduler-k3s:labels:set"}
-	args = append(args, "--resource-type", t.ResourceType)
-	if t.ProcessType != "" {
-		args = append(args, "--process-type", t.ProcessType)
-	}
-	if t.Global {
-		args = append(args, "--global", key, value)
-	} else {
-		args = append(args, t.App, key, value)
-	}
-	return subprocess.ExecCommandInput{Command: "dokku", Args: args}
-}
-
-// getSchedulerK3sLabels reads the labels currently stored at the task's
-// (app|global, process_type, resource_type) scope. It calls
-// `dokku scheduler-k3s:labels:report ... --format json`, which returns a
-// flat map keyed by `<rendered_process_type>.<resource_type>.<label_key>`,
-// and strips the prefix to recover the original label keys.
-func getSchedulerK3sLabels(t SchedulerK3sLabelsTask) (map[string]string, error) {
-	args := []string{"--quiet", "scheduler-k3s:labels:report"}
-	if t.Global {
-		args = append(args, "--global")
-	} else {
-		args = append(args, t.App)
-	}
-	args = append(args, "--resource-type", t.ResourceType)
-
-	effectiveProcessType := t.ProcessType
-	if effectiveProcessType == "" {
-		effectiveProcessType = "--global"
-	}
-	args = append(args, "--process-type", effectiveProcessType)
-	args = append(args, "--format", "json")
-
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    args,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	payload := map[string]string{}
-	if err := json.Unmarshal(result.StdoutBytes(), &payload); err != nil {
-		return nil, fmt.Errorf("parse scheduler-k3s:labels:report json: %w", err)
-	}
-
-	prefix := renderedSchedulerK3sProcessType(t.ProcessType) + "." + t.ResourceType + "."
-	labels := map[string]string{}
-	for composedKey, value := range payload {
-		if !strings.HasPrefix(composedKey, prefix) {
-			continue
-		}
-		labels[strings.TrimPrefix(composedKey, prefix)] = value
-	}
-	return labels, nil
-}
-
-// renderedSchedulerK3sProcessType mirrors dokku's report-side rendering of the
-// in-storage process type: the global sentinel "--global" (used when the task
-// omits process_type) is rendered as "global"; explicit process types pass
-// through unchanged.
-func renderedSchedulerK3sProcessType(processType string) string {
-	if processType == "" || processType == "--global" {
-		return "global"
-	}
-	return processType
 }
 
 // init registers the SchedulerK3sLabelsTask with the task registry

--- a/tasks/scheduler_k3s_scoped_pairs.go
+++ b/tasks/scheduler_k3s_scoped_pairs.go
@@ -1,0 +1,241 @@
+package tasks
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// schedulerK3sScopedPairsSpec captures the inputs the shared scheduler-k3s
+// "key/value pairs scoped to (process_type, resource_type)" helpers need. The
+// labels and annotations tasks both build one of these and delegate to the
+// helpers below; only Kind differs (it is plugged into both the dokku
+// subcommand name and the user-facing pluralization in plan messages).
+type schedulerK3sScopedPairsSpec struct {
+	// Kind is the dokku subcommand noun ("labels" or "annotations").
+	Kind         string
+	App          string
+	Global       bool
+	ProcessType  string
+	ResourceType string
+	Pairs        map[string]string
+}
+
+// validateSchedulerK3sScopedPairs checks the common fields prior to any
+// subprocess call. Error messages substitute the spec's noun so callers see
+// "'labels' must not be empty" / "label keys must not be empty" etc.
+func validateSchedulerK3sScopedPairs(spec schedulerK3sScopedPairsSpec, state State) error {
+	if !spec.Global && spec.App == "" {
+		return errors.New("app is required when global is false")
+	}
+	if spec.Global && spec.App != "" {
+		return fmt.Errorf("'app' must not be set when 'global' is set to true")
+	}
+	if spec.ResourceType == "" {
+		return errors.New("resource_type is required")
+	}
+	if len(spec.Pairs) == 0 {
+		effective := state
+		if effective == "" {
+			effective = StatePresent
+		}
+		return fmt.Errorf("'%s' must not be empty for state '%s'", spec.Kind, effective)
+	}
+	singular := singularizeSchedulerK3sKind(spec.Kind)
+	for key := range spec.Pairs {
+		if key == "" {
+			return fmt.Errorf("%s keys must not be empty", singular)
+		}
+	}
+	return nil
+}
+
+// planSchedulerK3sScopedPairsSet probes current pairs once, computes the diff,
+// and embeds an apply closure that runs `dokku scheduler-k3s:<kind>:set` once
+// per drifted key.
+func planSchedulerK3sScopedPairsSet(spec schedulerK3sScopedPairsSpec) PlanResult {
+	current, err := getSchedulerK3sScopedPairs(spec)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+
+	driftedKeys := []string{}
+	for k, v := range spec.Pairs {
+		if cur, ok := current[k]; !ok || cur != v {
+			driftedKeys = append(driftedKeys, k)
+		}
+	}
+	if len(driftedKeys) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	sort.Strings(driftedKeys)
+
+	mutations := make([]string, 0, len(driftedKeys))
+	allNew := true
+	for _, k := range driftedKeys {
+		if _, ok := current[k]; ok {
+			mutations = append(mutations, fmt.Sprintf("set %s=%s (was %q)", k, spec.Pairs[k], current[k]))
+			allNew = false
+		} else {
+			mutations = append(mutations, fmt.Sprintf("set %s=%s (new)", k, spec.Pairs[k]))
+		}
+	}
+
+	status := PlanStatusModify
+	if allNew {
+		status = PlanStatusCreate
+	}
+
+	inputs := schedulerK3sScopedPairsSetInputs(spec, driftedKeys)
+	singular := singularizeSchedulerK3sKind(spec.Kind)
+	return PlanResult{
+		InSync:    false,
+		Status:    status,
+		Reason:    fmt.Sprintf("%d %s(s) to set", len(driftedKeys), singular),
+		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
+		apply: func() TaskOutputState {
+			return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+		},
+	}
+}
+
+// planSchedulerK3sScopedPairsUnset probes current pairs once, computes the
+// diff, and embeds an apply closure that clears each listed key that exists.
+func planSchedulerK3sScopedPairsUnset(spec schedulerK3sScopedPairsSpec) PlanResult {
+	current, err := getSchedulerK3sScopedPairs(spec)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+
+	toClear := []string{}
+	for k := range spec.Pairs {
+		if _, ok := current[k]; ok {
+			toClear = append(toClear, k)
+		}
+	}
+	if len(toClear) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	sort.Strings(toClear)
+
+	mutations := make([]string, 0, len(toClear))
+	for _, k := range toClear {
+		mutations = append(mutations, fmt.Sprintf("unset %s (was %q)", k, current[k]))
+	}
+
+	inputs := schedulerK3sScopedPairsClearInputs(spec, toClear)
+	singular := singularizeSchedulerK3sKind(spec.Kind)
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    fmt.Sprintf("%d %s(s) to unset", len(toClear), singular),
+		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
+		apply: func() TaskOutputState {
+			return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+		},
+	}
+}
+
+// schedulerK3sScopedPairsSetInputs returns one subprocess input per drifted
+// key, each invoking `dokku scheduler-k3s:<kind>:set` with the desired value.
+func schedulerK3sScopedPairsSetInputs(spec schedulerK3sScopedPairsSpec, keys []string) []subprocess.ExecCommandInput {
+	inputs := make([]subprocess.ExecCommandInput, 0, len(keys))
+	for _, key := range keys {
+		inputs = append(inputs, schedulerK3sScopedPairsCommand(spec, key, spec.Pairs[key]))
+	}
+	return inputs
+}
+
+// schedulerK3sScopedPairsClearInputs returns one subprocess input per key to
+// clear. Dokku interprets an empty value as a clear-this-key operation.
+func schedulerK3sScopedPairsClearInputs(spec schedulerK3sScopedPairsSpec, keys []string) []subprocess.ExecCommandInput {
+	inputs := make([]subprocess.ExecCommandInput, 0, len(keys))
+	for _, key := range keys {
+		inputs = append(inputs, schedulerK3sScopedPairsCommand(spec, key, ""))
+	}
+	return inputs
+}
+
+// schedulerK3sScopedPairsCommand builds one `dokku scheduler-k3s:<kind>:set`
+// call.
+func schedulerK3sScopedPairsCommand(spec schedulerK3sScopedPairsSpec, key, value string) subprocess.ExecCommandInput {
+	args := []string{"--quiet", "scheduler-k3s:" + spec.Kind + ":set"}
+	args = append(args, "--resource-type", spec.ResourceType)
+	if spec.ProcessType != "" {
+		args = append(args, "--process-type", spec.ProcessType)
+	}
+	if spec.Global {
+		args = append(args, "--global", key, value)
+	} else {
+		args = append(args, spec.App, key, value)
+	}
+	return subprocess.ExecCommandInput{Command: "dokku", Args: args}
+}
+
+// getSchedulerK3sScopedPairs reads the pairs currently stored at the spec's
+// (app|global, process_type, resource_type) scope. It calls
+// `dokku scheduler-k3s:<kind>:report ... --format json`, which returns a flat
+// map keyed by `<rendered_process_type>.<resource_type>.<key>`, and strips the
+// prefix to recover the original keys.
+func getSchedulerK3sScopedPairs(spec schedulerK3sScopedPairsSpec) (map[string]string, error) {
+	args := []string{"--quiet", "scheduler-k3s:" + spec.Kind + ":report"}
+	if spec.Global {
+		args = append(args, "--global")
+	} else {
+		args = append(args, spec.App)
+	}
+	args = append(args, "--resource-type", spec.ResourceType)
+
+	effectiveProcessType := spec.ProcessType
+	if effectiveProcessType == "" {
+		effectiveProcessType = "--global"
+	}
+	args = append(args, "--process-type", effectiveProcessType)
+	args = append(args, "--format", "json")
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    args,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	payload := map[string]string{}
+	if err := json.Unmarshal(result.StdoutBytes(), &payload); err != nil {
+		return nil, fmt.Errorf("parse scheduler-k3s:%s:report json: %w", spec.Kind, err)
+	}
+
+	prefix := renderedSchedulerK3sProcessType(spec.ProcessType) + "." + spec.ResourceType + "."
+	pairs := map[string]string{}
+	for composedKey, value := range payload {
+		if !strings.HasPrefix(composedKey, prefix) {
+			continue
+		}
+		pairs[strings.TrimPrefix(composedKey, prefix)] = value
+	}
+	return pairs, nil
+}
+
+// renderedSchedulerK3sProcessType mirrors dokku's report-side rendering of the
+// in-storage process type: the global sentinel "--global" (used when the task
+// omits process_type) is rendered as "global"; explicit process types pass
+// through unchanged.
+func renderedSchedulerK3sProcessType(processType string) string {
+	if processType == "" || processType == "--global" {
+		return "global"
+	}
+	return processType
+}
+
+// singularizeSchedulerK3sKind returns the singular form of the kind noun for
+// user-facing messages: "labels" -> "label", "annotations" -> "annotation".
+func singularizeSchedulerK3sKind(kind string) string {
+	return strings.TrimSuffix(kind, "s")
+}


### PR DESCRIPTION
## Summary

Wires a new `dokku_scheduler_k3s_annotations` task directly to `dokku scheduler-k3s:annotations:set` and `scheduler-k3s:annotations:report`, mirroring the recently-added `dokku_scheduler_k3s_labels` task. A single task can now manage every `(process_type, resource_type, key)` annotation triple at the configured scope instead of forcing one `dokku_scheduler_k3s_property` task per flattened key.

Because annotations and labels share an identical surface in dokku (same `--global` / `--process-type` / `--resource-type` flags, same JSON report shape with `<process_type>.<resource_type>.<key>` flat keys, same empty-value-clears semantic), both tasks now delegate to a single `schedulerK3sScopedPairsSpec` helper that owns validation, the JSON report probe, drift planning, and command construction. The labels task is rewritten as a thin adapter so the two surfaces stay in lock-step.

Stacked on #254 (the labels PR). Closes #255.

```yaml
dokku_scheduler_k3s_annotations:
    app: node-js-app
    process_type: web
    resource_type: deployment
    annotations:
        prometheus.io/scrape: "true"
        prometheus.io/port: "9090"
    state: present
```