### PR TITLE
feat: add dokku_scheduler_k3s_chart task

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.14
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.15
           sudo dokku plugin:install-dependencies --core
       - name: install dokku redis plugin
         run: sudo dokku plugin:install https://github.com/dokku/dokku-redis.git redis
@@ -87,7 +87,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.14
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.15
           sudo dokku plugin:install-dependencies --core
       - name: initialize k3s cluster
         run: sudo dokku scheduler-k3s:initialize --server-ip 127.0.0.1
@@ -114,7 +114,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.14
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.15
           sudo dokku plugin:install-dependencies --core
       - name: install bats
         run: sudo apt-get install -qq -y bats bats-support bats-assert

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,7 @@ code into it:
 
 ## Prerequisites
 
-- **Dokku >= 0.38.14.**
+- **Dokku >= 0.38.15.**
 - **dokku-letsencrypt >= 0.25.0.**
 
 ## Installation

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -56,8 +56,9 @@ Reference for every task type docket can run inside a recipe. Each page lists th
 - [dokku_scheduler_docker_local_property](dokku_scheduler_docker_local_property.md) - Manages the scheduler-docker-local configuration for a given dokku application
 - [dokku_scheduler_k3s_annotations](dokku_scheduler_k3s_annotations.md) - Manages scheduler-k3s annotations scoped to a (process_type, resource_type) pair for a dokku application or globally
 - [dokku_scheduler_k3s_autoscaling_auth](dokku_scheduler_k3s_autoscaling_auth.md) - Manages KEDA TriggerAuthentication metadata grouped under a single trigger for a dokku application or globally
+- [dokku_scheduler_k3s_chart](dokku_scheduler_k3s_chart.md) - Manages helm chart value overrides for a dokku scheduler-k3s bundled chart
 - [dokku_scheduler_k3s_labels](dokku_scheduler_k3s_labels.md) - Manages scheduler-k3s labels scoped to a (process_type, resource_type) pair for a dokku application or globally
-- [dokku_scheduler_k3s_property](dokku_scheduler_k3s_property.md) - Manages the scheduler-k3s configuration for a given dokku application
+- [dokku_scheduler_k3s_property](dokku_scheduler_k3s_property.md) - Manages the scheduler-k3s configuration for a given dokku application.
 - [dokku_scheduler_property](dokku_scheduler_property.md) - Manages the scheduler configuration for a given dokku application
 - [dokku_service_backup](dokku_service_backup.md) - Manages the S3 backup schedule, authentication, and encryption for a dokku service
 - [dokku_service_create](dokku_service_create.md) - Creates or destroys a dokku service

--- a/docs/tasks/dokku_scheduler_k3s_chart.md
+++ b/docs/tasks/dokku_scheduler_k3s_chart.md
@@ -1,0 +1,75 @@
+# dokku_scheduler_k3s_chart
+
+## Synopsis
+
+Manages helm chart value overrides for a dokku scheduler-k3s bundled chart
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `chart` | string | yes |  |  | Name of the helm chart whose values to set (validated by dokku against its bundled HelmCharts list). |
+| `values` | dict | yes |  |  | Helm-style values for the chart. Accepts a flat map of dotted property paths or a nested tree; both coalesce to the same key/value form before being applied. In nested form, literal dots in a key segment are escaped to \. so they reach Helm as a single annotation/label key. |
+| `state` | string | no | present | present, absent | Desired state of the chart values. |
+
+## Examples
+
+### Set chart values via a flat map of dotted paths
+
+```yaml
+dokku_scheduler_k3s_chart:
+    chart: ingress-nginx
+    values:
+        controller.replicaCount: "3"
+        controller.resources.limits.cpu: 200m
+```
+
+### Set chart values via a nested tree (Helm values.yaml style)
+
+```yaml
+dokku_scheduler_k3s_chart:
+    chart: ingress-nginx
+    values:
+        controller:
+            replicaCount: "3"
+            resources:
+                limits:
+                    cpu: 200m
+```
+
+### Mix nested and flat; nested dotted leaves are escaped for Helm
+
+```yaml
+dokku_scheduler_k3s_chart:
+    chart: traefik
+    values:
+        ports.web.redirectTo.port: websecure
+        service:
+            annotations:
+                service.beta.kubernetes.io/aws-load-balancer-type: nlb
+```
+
+### Clear specific chart values
+
+```yaml
+dokku_scheduler_k3s_chart:
+    chart: ingress-nginx
+    values:
+        controller.replicaCount: ""
+    state: absent
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/docs/tasks/dokku_scheduler_k3s_property.md
+++ b/docs/tasks/dokku_scheduler_k3s_property.md
@@ -2,7 +2,7 @@
 
 ## Synopsis
 
-Manages the scheduler-k3s configuration for a given dokku application
+Manages the scheduler-k3s configuration for a given dokku application. chart.* properties are managed by dokku_scheduler_k3s_chart and rejected here, since dokku's scheduler-k3s:set path is deprecated for chart values.
 
 ## Parameters
 

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -491,7 +491,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 67
+	expected := 68
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}
@@ -682,7 +682,7 @@ func TestTaskDocStrings(t *testing.T) {
 		{&ResourceLimitTask{}, "Manages the resource limits for a given dokku application"},
 		{&ResourceReserveTask{}, "Manages the resource reservations for a given dokku application"},
 		{&SchedulerDockerLocalPropertyTask{}, "Manages the scheduler-docker-local configuration for a given dokku application"},
-		{&SchedulerK3sPropertyTask{}, "Manages the scheduler-k3s configuration for a given dokku application"},
+		{&SchedulerK3sPropertyTask{}, "Manages the scheduler-k3s configuration for a given dokku application. chart.* properties are managed by dokku_scheduler_k3s_chart and rejected here, since dokku's scheduler-k3s:set path is deprecated for chart values."},
 		{&SchedulerPropertyTask{}, "Manages the scheduler configuration for a given dokku application"},
 		{&ServiceCreateTask{}, "Creates or destroys a dokku service"},
 		{&ServiceLinkTask{}, "Links or unlinks a dokku service to an app"},

--- a/tasks/pairs.go
+++ b/tasks/pairs.go
@@ -1,0 +1,84 @@
+package tasks
+
+import (
+	"fmt"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// pairsCurrentFunc returns the pairs currently stored at the task's scope.
+// A non-nil error short-circuits the plan with PlanStatusError.
+type pairsCurrentFunc func() (map[string]string, error)
+
+// pairsCommandFunc builds one dokku subprocess invocation that sets or
+// clears a single key. Pass an empty value to clear (dokku interprets a
+// missing value on the subcommands this helper drives as a delete).
+type pairsCommandFunc func(key, value string) subprocess.ExecCommandInput
+
+// planPairsSet probes current pairs, diffs against desired, and returns a
+// PlanResult whose apply runs one command per drifted key. kind is the
+// singular noun the helper substitutes into the user-facing reason
+// ("label", "annotation", "chart value").
+func planPairsSet(kind string, desired map[string]string, currentFn pairsCurrentFunc, commandFn pairsCommandFunc) PlanResult {
+	current, err := currentFn()
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+
+	drifted, allNew := driftedKeys(desired, current)
+	if len(drifted) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+
+	status := PlanStatusModify
+	if allNew {
+		status = PlanStatusCreate
+	}
+
+	inputs := make([]subprocess.ExecCommandInput, 0, len(drifted))
+	for _, key := range drifted {
+		inputs = append(inputs, commandFn(key, desired[key]))
+	}
+
+	return PlanResult{
+		InSync:    false,
+		Status:    status,
+		Reason:    fmt.Sprintf("%d %s(s) to set", len(drifted), kind),
+		Mutations: formatSetMutations(drifted, desired, current),
+		Commands:  resolveCommands(inputs),
+		apply: func() TaskOutputState {
+			return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+		},
+	}
+}
+
+// planPairsUnset probes current pairs and returns a PlanResult whose apply
+// clears each desired key that exists in current. Keys absent from the
+// server are skipped silently (no-op).
+func planPairsUnset(kind string, desired map[string]string, currentFn pairsCurrentFunc, commandFn pairsCommandFunc) PlanResult {
+	current, err := currentFn()
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+
+	toClear := intersectingKeys(desired, current)
+	if len(toClear) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+
+	inputs := make([]subprocess.ExecCommandInput, 0, len(toClear))
+	for _, key := range toClear {
+		inputs = append(inputs, commandFn(key, ""))
+	}
+
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    fmt.Sprintf("%d %s(s) to unset", len(toClear), kind),
+		Mutations: formatClearMutations(toClear, current),
+		Commands:  resolveCommands(inputs),
+		apply: func() TaskOutputState {
+			return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+		},
+	}
+}

--- a/tasks/pairs_test.go
+++ b/tasks/pairs_test.go
@@ -1,0 +1,103 @@
+package tasks
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+func chartCommandStub(key, value string) subprocess.ExecCommandInput {
+	return subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "scheduler-k3s:charts:set", "demo." + key, value},
+	}
+}
+
+func staticCurrent(pairs map[string]string) pairsCurrentFunc {
+	return func() (map[string]string, error) { return pairs, nil }
+}
+
+func TestPlanPairsSetInSync(t *testing.T) {
+	desired := map[string]string{"foo": "1", "bar": "2"}
+	current := map[string]string{"foo": "1", "bar": "2", "extra": "z"}
+	plan := planPairsSet("chart value", desired, staticCurrent(current), chartCommandStub)
+	if !plan.InSync {
+		t.Fatalf("expected InSync, got %#v", plan)
+	}
+	if plan.Status != PlanStatusOK {
+		t.Errorf("expected PlanStatusOK, got %v", plan.Status)
+	}
+}
+
+func TestPlanPairsSetAllNewYieldsCreate(t *testing.T) {
+	desired := map[string]string{"foo": "1", "bar": "2"}
+	plan := planPairsSet("chart value", desired, staticCurrent(map[string]string{}), chartCommandStub)
+	if plan.InSync {
+		t.Fatal("expected drift")
+	}
+	if plan.Status != PlanStatusCreate {
+		t.Errorf("expected PlanStatusCreate, got %v", plan.Status)
+	}
+	if !strings.Contains(plan.Reason, "2 chart value(s) to set") {
+		t.Errorf("unexpected reason: %q", plan.Reason)
+	}
+	if len(plan.Mutations) != 2 {
+		t.Errorf("expected 2 mutations, got %d", len(plan.Mutations))
+	}
+	if len(plan.Commands) != 2 {
+		t.Errorf("expected 2 commands, got %d", len(plan.Commands))
+	}
+}
+
+func TestPlanPairsSetPartialDriftYieldsModify(t *testing.T) {
+	desired := map[string]string{"foo": "1", "bar": "2"}
+	current := map[string]string{"foo": "old"}
+	plan := planPairsSet("chart value", desired, staticCurrent(current), chartCommandStub)
+	if plan.Status != PlanStatusModify {
+		t.Errorf("expected PlanStatusModify, got %v", plan.Status)
+	}
+	if len(plan.Mutations) != 2 {
+		t.Fatalf("expected 2 mutations, got %d", len(plan.Mutations))
+	}
+}
+
+func TestPlanPairsSetProbeError(t *testing.T) {
+	probeErr := errors.New("boom")
+	fn := func() (map[string]string, error) { return nil, probeErr }
+	plan := planPairsSet("chart value", map[string]string{"k": "v"}, fn, chartCommandStub)
+	if plan.Error != probeErr {
+		t.Fatalf("expected probe error to propagate, got %v", plan.Error)
+	}
+	if plan.Status != PlanStatusError {
+		t.Errorf("expected PlanStatusError, got %v", plan.Status)
+	}
+}
+
+func TestPlanPairsUnsetSkipsMissingKeys(t *testing.T) {
+	desired := map[string]string{"foo": "", "missing": ""}
+	current := map[string]string{"foo": "1", "other": "2"}
+	plan := planPairsUnset("chart value", desired, staticCurrent(current), chartCommandStub)
+	if plan.InSync {
+		t.Fatal("expected drift (one key still exists)")
+	}
+	if plan.Status != PlanStatusDestroy {
+		t.Errorf("expected PlanStatusDestroy, got %v", plan.Status)
+	}
+	if len(plan.Commands) != 1 {
+		t.Fatalf("expected exactly 1 clear command (the present key), got %d", len(plan.Commands))
+	}
+	if !strings.Contains(plan.Commands[0], "demo.foo") {
+		t.Errorf("expected command to target 'demo.foo', got %q", plan.Commands[0])
+	}
+}
+
+func TestPlanPairsUnsetInSyncWhenNothingMatches(t *testing.T) {
+	desired := map[string]string{"foo": ""}
+	current := map[string]string{"bar": "1"}
+	plan := planPairsUnset("chart value", desired, staticCurrent(current), chartCommandStub)
+	if !plan.InSync {
+		t.Fatalf("expected InSync when no desired keys exist on the server, got %#v", plan)
+	}
+}

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -145,15 +145,15 @@ func warnIfUnknownProperty(plugin, property string, err error) {
 // set. Examples:
 //   - dokku-letsencrypt `dns-provider-*` (arbitrary env var names)
 //   - dokku traefik `dns-provider-*` (same shape, per-provider env vars)
-//   - dokku scheduler-k3s `chart.*.*` (arbitrary helm chart values)
 //
 // Dynamic property names are validated by `:set`, not the report schema.
+// scheduler-k3s `chart.*.*` used to live here but moved to the dedicated
+// dokku_scheduler_k3s_chart task; SchedulerK3sPropertyTask.Plan rejects
+// chart.* before reaching this helper.
 func isDynamicProperty(plugin, property string) bool {
 	switch plugin {
 	case "letsencrypt", "traefik":
 		return strings.HasPrefix(property, "dns-provider-")
-	case "scheduler-k3s":
-		return strings.HasPrefix(property, "chart.")
 	}
 	return false
 }

--- a/tasks/properties_test.go
+++ b/tasks/properties_test.go
@@ -138,7 +138,10 @@ func TestIsDynamicProperty(t *testing.T) {
 		{"letsencrypt", "email", false},
 		{"traefik", "dns-provider-CLOUDFLARE_API_TOKEN", true},
 		{"traefik", "dns-provider", false},
-		{"scheduler-k3s", "chart.traefik.replicas", true},
+		// scheduler-k3s chart.* used to be dynamic; it is now handled
+		// by the dedicated dokku_scheduler_k3s_chart task and the
+		// property task rejects chart.* before reaching here.
+		{"scheduler-k3s", "chart.traefik.replicas", false},
 		{"scheduler-k3s", "namespace", false},
 		{"nginx", "dns-provider-X", false},
 	}

--- a/tasks/property_keys_test.go
+++ b/tasks/property_keys_test.go
@@ -390,9 +390,11 @@ func TestSchedulerK3sPropertyKeys(t *testing.T) {
 	})
 	checkUnsupportedProperty(t, "scheduler-k3s", schedulerK3sPropertyKeys)
 	checkScopeMismatch(t, "scheduler-k3s", schedulerK3sPropertyKeys, "", "token")
-	// chart.*.* are dynamic and should bypass map validation.
-	if err := validateProperty("scheduler-k3s", "chart.traefik.replicas", false, schedulerK3sPropertyKeys); err != nil {
-		t.Errorf("dynamic property should pass validation, got %v", err)
+	// chart.* properties used to be dynamic; they are now rejected by
+	// SchedulerK3sPropertyTask.Plan and routed to dokku_scheduler_k3s_chart,
+	// so validateProperty against the property-keys map should fail.
+	if err := validateProperty("scheduler-k3s", "chart.traefik.replicas", false, schedulerK3sPropertyKeys); err == nil {
+		t.Error("expected chart.* to be rejected by the property map (no longer dynamic)")
 	}
 }
 

--- a/tasks/scheduler_k3s_annotations_task_integration_test.go
+++ b/tasks/scheduler_k3s_annotations_task_integration_test.go
@@ -59,6 +59,13 @@ func TestIntegrationSchedulerK3sAnnotationsAll(t *testing.T) {
 				"prometheus.io/scrape": "false",
 			},
 		},
+		{
+			name:         "per-app/multi-line-annotation-value",
+			resourceType: "ingress",
+			annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/configuration-snippet": "if ($host = 'old.example.com') {\n  return 301 https://new.example.com$request_uri;\n}\n",
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/tasks/scheduler_k3s_chart_task.go
+++ b/tasks/scheduler_k3s_chart_task.go
@@ -1,0 +1,315 @@
+package tasks
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// SchedulerK3sChartTask manages helm chart value overrides for one of
+// dokku's bundled scheduler-k3s charts via the dokku
+// `scheduler-k3s:charts:set` / `:charts:report` subcommands. Chart values
+// are global by design in dokku, so the task carries no app/global toggle.
+type SchedulerK3sChartTask struct {
+	// Chart is the helm chart whose values to manage. Dokku validates the
+	// chart name against its known HelmCharts list at apply time.
+	Chart string `required:"true" yaml:"chart" description:"Name of the helm chart whose values to set (validated by dokku against its bundled HelmCharts list)."`
+
+	// Values is the desired set of helm value overrides. It accepts either
+	// a flat map of dotted Helm property paths (e.g. resources.limits.cpu)
+	// or a nested tree (resources: { limits: { cpu: 200m } }). Both shapes
+	// flatten to the same dotted form before being handed to dokku. See
+	// flattenChartValues for the exact coalescing rules, including the
+	// nested-segment escaping that lets dotted leaf keys survive Helm's
+	// strvals parser.
+	Values map[string]any `required:"true" yaml:"values,omitempty" description:"Helm-style values for the chart. Accepts a flat map of dotted property paths or a nested tree; both coalesce to the same key/value form before being applied. In nested form, literal dots in a key segment are escaped to \\. so they reach Helm as a single annotation/label key."`
+
+	// State is the desired state of the chart values.
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the chart values."`
+}
+
+// SchedulerK3sChartTaskExample contains an example of a SchedulerK3sChartTask
+type SchedulerK3sChartTaskExample struct {
+	// Name is the task name holding the SchedulerK3sChartTask description
+	Name string `yaml:"-"`
+
+	// SchedulerK3sChartTask is the SchedulerK3sChartTask configuration
+	SchedulerK3sChartTask SchedulerK3sChartTask `yaml:"dokku_scheduler_k3s_chart"`
+}
+
+// GetName returns the name of the example
+func (e SchedulerK3sChartTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the scheduler-k3s chart task
+func (t SchedulerK3sChartTask) Doc() string {
+	return "Manages helm chart value overrides for a dokku scheduler-k3s bundled chart"
+}
+
+// Examples returns the examples for the scheduler-k3s chart task
+func (t SchedulerK3sChartTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]SchedulerK3sChartTaskExample{
+		{
+			Name: "Set chart values via a flat map of dotted paths",
+			SchedulerK3sChartTask: SchedulerK3sChartTask{
+				Chart: "ingress-nginx",
+				Values: map[string]any{
+					"controller.replicaCount":      "3",
+					"controller.resources.limits.cpu": "200m",
+				},
+			},
+		},
+		{
+			Name: "Set chart values via a nested tree (Helm values.yaml style)",
+			SchedulerK3sChartTask: SchedulerK3sChartTask{
+				Chart: "ingress-nginx",
+				Values: map[string]any{
+					"controller": map[string]any{
+						"replicaCount": "3",
+						"resources": map[string]any{
+							"limits": map[string]any{
+								"cpu": "200m",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "Mix nested and flat; nested dotted leaves are escaped for Helm",
+			SchedulerK3sChartTask: SchedulerK3sChartTask{
+				Chart: "traefik",
+				Values: map[string]any{
+					"service": map[string]any{
+						"annotations": map[string]any{
+							"service.beta.kubernetes.io/aws-load-balancer-type": "nlb",
+						},
+					},
+					"ports.web.redirectTo.port": "websecure",
+				},
+			},
+		},
+		{
+			Name: "Clear specific chart values",
+			SchedulerK3sChartTask: SchedulerK3sChartTask{
+				Chart: "ingress-nginx",
+				Values: map[string]any{
+					"controller.replicaCount": "",
+				},
+				State: StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute sets or clears the configured chart values
+func (t SchedulerK3sChartTask) Execute() TaskOutputState {
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the SchedulerK3sChartTask would produce.
+func (t SchedulerK3sChartTask) Plan() PlanResult {
+	if t.Chart == "" {
+		return PlanResult{Status: PlanStatusError, Error: errors.New("chart is required")}
+	}
+	if len(t.Values) == 0 {
+		state := t.State
+		if state == "" {
+			state = StatePresent
+		}
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'values' must not be empty for state '%s'", state)}
+	}
+
+	desired, err := flattenChartValues(t.Values)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+
+	currentFn := func() (map[string]string, error) {
+		return getSchedulerK3sChartValues(t.Chart)
+	}
+	commandFn := func(key, value string) subprocess.ExecCommandInput {
+		return subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args: []string{
+				"--quiet",
+				"scheduler-k3s:charts:set",
+				t.Chart + "." + key,
+				value,
+			},
+		}
+	}
+
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return planPairsSet("chart value", desired, currentFn, commandFn) },
+		StateAbsent:  func() PlanResult { return planPairsUnset("chart value", desired, currentFn, commandFn) },
+	})
+}
+
+// getSchedulerK3sChartValues reads the helm value overrides currently
+// stored for the given chart. The dokku command returns a flat JSON map
+// keyed `<chart>.<override-key>`; this strips the `<chart>.` prefix to
+// return a map keyed by the override key alone (matching the form
+// callers hand back when setting).
+func getSchedulerK3sChartValues(chart string) (map[string]string, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args: []string{
+			"--quiet",
+			"scheduler-k3s:charts:report",
+			chart,
+			"--format", "json",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	payload := map[string]string{}
+	if err := json.Unmarshal(result.StdoutBytes(), &payload); err != nil {
+		return nil, fmt.Errorf("parse scheduler-k3s:charts:report json: %w", err)
+	}
+
+	prefix := chart + "."
+	values := map[string]string{}
+	for composedKey, value := range payload {
+		if !strings.HasPrefix(composedKey, prefix) {
+			continue
+		}
+		values[strings.TrimPrefix(composedKey, prefix)] = value
+	}
+	return values, nil
+}
+
+// flattenChartValues coalesces a Values map (mix of flat dotted keys and
+// nested maps) into the dotted property/value form dokku's
+// `scheduler-k3s:charts:set` accepts.
+//
+// Rules:
+//   - Scalar leaf (string, int, float, bool) -> rendered via "%v".
+//   - nil -> "".
+//   - Nested map[string]any (or legacy map[any]any from yaml.v2) -> recurse,
+//     joining segments with ".". Each nested segment has any literal "."
+//     escaped to "\." so dotted annotation/label keys survive Helm's
+//     strvals parser as a single key.
+//   - Top-level keys are passed through verbatim (no escaping). This
+//     preserves the dokku CLI convention of writing "resources.limits.cpu"
+//     as a single dotted Helm path.
+//   - When a top-level key contains "." and its value is a nested map,
+//     the top-level prefix is unescaped (Helm path separator) and the
+//     nested-segment escaping applies inside the value.
+//   - Lists/arrays are rejected (Helm `--set` supports indexed flattening
+//     but it is out of scope here).
+//   - Two source paths that flatten to the same key produce a typed error
+//     so the caller (and the user) can fix the recipe rather than relying
+//     on map-iteration order.
+func flattenChartValues(in map[string]any) (map[string]string, error) {
+	out := map[string]string{}
+	for key, value := range in {
+		if err := flattenInto(out, key, value); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// flattenInto writes one or more entries into out for the (path, value)
+// pair. Leaves call assignChartValue once; nested maps recurse with a
+// joined, escaped child path.
+func flattenInto(out map[string]string, path string, value any) error {
+	switch v := value.(type) {
+	case nil:
+		return assignChartValue(out, path, "")
+	case string:
+		return assignChartValue(out, path, v)
+	case bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		return assignChartValue(out, path, fmt.Sprintf("%v", v))
+	case map[string]any:
+		return flattenNestedMap(out, path, v)
+	case map[any]any:
+		converted, err := convertLegacyMap(path, v)
+		if err != nil {
+			return err
+		}
+		return flattenNestedMap(out, path, converted)
+	case []any:
+		return fmt.Errorf("chart value %q: lists are not supported (Helm --set indexed syntax can be added later if needed)", path)
+	default:
+		return fmt.Errorf("chart value %q: unsupported value type %T", path, value)
+	}
+}
+
+// flattenNestedMap walks a nested map, escaping each child segment and
+// recursing with the joined path. Keys are sorted so the output is
+// deterministic across map-iteration orders.
+func flattenNestedMap(out map[string]string, path string, nested map[string]any) error {
+	if len(nested) == 0 {
+		return fmt.Errorf("chart value %q: nested map must contain at least one entry", path)
+	}
+	keys := make([]string, 0, len(nested))
+	for k := range nested {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if k == "" {
+			return fmt.Errorf("chart value %q: nested map key must not be empty", path)
+		}
+		childPath := path + "." + escapeChartSegment(k)
+		if err := flattenInto(out, childPath, nested[k]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// convertLegacyMap upgrades a map[any]any (yaml.v2 default for nested
+// mappings) to map[string]any. Non-string keys produce a typed error
+// rather than silently coercing.
+func convertLegacyMap(path string, in map[any]any) (map[string]any, error) {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		ks, ok := k.(string)
+		if !ok {
+			return nil, fmt.Errorf("chart value %q: nested map keys must be strings, got %T", path, k)
+		}
+		out[ks] = v
+	}
+	return out, nil
+}
+
+// assignChartValue writes (key, value) to out, erroring if key is already
+// present with a different value (catches collisions between flat and
+// nested forms of the same path).
+func assignChartValue(out map[string]string, key, value string) error {
+	if key == "" {
+		return errors.New("chart value key must not be empty")
+	}
+	if existing, ok := out[key]; ok {
+		if existing == value {
+			return nil
+		}
+		return fmt.Errorf("duplicate chart value key %q (set via both nested and flat forms with different values: %q vs %q)", key, existing, value)
+	}
+	out[key] = value
+	return nil
+}
+
+// escapeChartSegment doubles every "." in a single nested-map key segment
+// to "\." so Helm's strvals parser keeps the segment as one key.
+func escapeChartSegment(segment string) string {
+	if !strings.Contains(segment, ".") {
+		return segment
+	}
+	return strings.ReplaceAll(segment, ".", `\.`)
+}
+
+// init registers the SchedulerK3sChartTask with the task registry
+func init() {
+	RegisterTask(&SchedulerK3sChartTask{})
+}

--- a/tasks/scheduler_k3s_chart_task_integration_test.go
+++ b/tasks/scheduler_k3s_chart_task_integration_test.go
@@ -40,6 +40,13 @@ func TestIntegrationSchedulerK3sChartAll(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "multi-line-value",
+			chart: "traefik",
+			values: map[string]any{
+				"controller.config": "line one\nline two\nline three\n",
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/tasks/scheduler_k3s_chart_task_integration_test.go
+++ b/tasks/scheduler_k3s_chart_task_integration_test.go
@@ -1,0 +1,65 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationSchedulerK3sChartAll(t *testing.T) {
+	skipUnlessSchedulerK3sT(t)
+
+	cases := []struct {
+		name   string
+		chart  string
+		values map[string]any
+	}{
+		{
+			name:  "flat-dotted-values",
+			chart: "ingress-nginx",
+			values: map[string]any{
+				"controller.replicaCount":         "1",
+				"controller.resources.limits.cpu": "100m",
+			},
+		},
+		{
+			name:  "nested-values",
+			chart: "ingress-nginx",
+			values: map[string]any{
+				"controller": map[string]any{
+					"replicaCount": "2",
+				},
+			},
+		},
+		{
+			name:  "nested-with-dotted-leaf-escapes",
+			chart: "traefik",
+			values: map[string]any{
+				"service": map[string]any{
+					"annotations": map[string]any{
+						"prometheus.io/scrape": "true",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setTask := SchedulerK3sChartTask{
+				Chart:  tc.chart,
+				Values: tc.values,
+				State:  StatePresent,
+			}
+			unsetTask := SchedulerK3sChartTask{
+				Chart:  tc.chart,
+				Values: tc.values,
+				State:  StateAbsent,
+			}
+			defer unsetTask.Execute()
+			runPropertyIdempotencyTest(t, propertyIdempotencyCase{
+				label:     "scheduler-k3s chart " + tc.name,
+				setTask:   setTask,
+				unsetTask: unsetTask,
+			})
+		})
+	}
+}

--- a/tasks/scheduler_k3s_chart_task_test.go
+++ b/tasks/scheduler_k3s_chart_task_test.go
@@ -1,0 +1,329 @@
+package tasks
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+func TestSchedulerK3sChartTaskInvalidState(t *testing.T) {
+	task := SchedulerK3sChartTask{
+		Chart:  "ingress-nginx",
+		Values: map[string]any{"replicaCount": "3"},
+		State:  "invalid",
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestSchedulerK3sChartTaskMissingChart(t *testing.T) {
+	task := SchedulerK3sChartTask{
+		Values: map[string]any{"replicaCount": "3"},
+		State:  StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when chart is empty")
+	}
+	if !strings.Contains(result.Error.Error(), "chart is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerK3sChartTaskPresentWithoutValues(t *testing.T) {
+	task := SchedulerK3sChartTask{
+		Chart: "ingress-nginx",
+		State: StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when present state has no values")
+	}
+	if !strings.Contains(result.Error.Error(), "'values' must not be empty") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerK3sChartTaskAbsentWithoutValues(t *testing.T) {
+	task := SchedulerK3sChartTask{
+		Chart: "ingress-nginx",
+		State: StateAbsent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when absent state has no values")
+	}
+	if !strings.Contains(result.Error.Error(), "'values' must not be empty") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerK3sChartTaskRejectsListValue(t *testing.T) {
+	task := SchedulerK3sChartTask{
+		Chart:  "ingress-nginx",
+		Values: map[string]any{"hosts": []any{"a", "b"}},
+		State:  StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when value is a list")
+	}
+	if !strings.Contains(result.Error.Error(), "lists are not supported") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestFlattenChartValuesScalarCoercion(t *testing.T) {
+	in := map[string]any{
+		"replicaCount":   3,
+		"resources.cpu":  "200m",
+		"installCRDs":    false,
+		"timeout":        30.5,
+		"explicitString": "hello",
+	}
+	out, err := flattenChartValues(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]string{
+		"replicaCount":   "3",
+		"resources.cpu":  "200m",
+		"installCRDs":    "false",
+		"timeout":        "30.5",
+		"explicitString": "hello",
+	}
+	if !reflect.DeepEqual(out, want) {
+		t.Errorf("flattenChartValues mismatch\n got: %v\nwant: %v", out, want)
+	}
+}
+
+func TestFlattenChartValuesNestedMap(t *testing.T) {
+	in := map[string]any{
+		"resources": map[string]any{
+			"limits": map[string]any{
+				"cpu":    "200m",
+				"memory": "256Mi",
+			},
+			"requests": map[string]any{
+				"cpu": "100m",
+			},
+		},
+	}
+	out, err := flattenChartValues(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]string{
+		"resources.limits.cpu":    "200m",
+		"resources.limits.memory": "256Mi",
+		"resources.requests.cpu":  "100m",
+	}
+	if !reflect.DeepEqual(out, want) {
+		t.Errorf("flatten mismatch\n got: %v\nwant: %v", out, want)
+	}
+}
+
+func TestFlattenChartValuesDottedLeafEscapes(t *testing.T) {
+	in := map[string]any{
+		"service": map[string]any{
+			"annotations": map[string]any{
+				"prometheus.io/scrape": "true",
+				"prometheus.io/port":   "9090",
+			},
+		},
+	}
+	out, err := flattenChartValues(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]string{
+		`service.annotations.prometheus\.io/scrape`: "true",
+		`service.annotations.prometheus\.io/port`:   "9090",
+	}
+	if !reflect.DeepEqual(out, want) {
+		t.Errorf("escape mismatch\n got: %v\nwant: %v", out, want)
+	}
+}
+
+func TestFlattenChartValuesTopLevelDottedPassthrough(t *testing.T) {
+	in := map[string]any{
+		"resources.limits.cpu":    "200m",
+		"resources.limits.memory": "256Mi",
+	}
+	out, err := flattenChartValues(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]string{
+		"resources.limits.cpu":    "200m",
+		"resources.limits.memory": "256Mi",
+	}
+	if !reflect.DeepEqual(out, want) {
+		t.Errorf("passthrough mismatch\n got: %v\nwant: %v", out, want)
+	}
+}
+
+func TestFlattenChartValuesMixedTopDotAndNestedEscape(t *testing.T) {
+	in := map[string]any{
+		"service.annotations": map[string]any{
+			"foo.bar": "baz",
+		},
+		"ports.web.redirectTo.port": "websecure",
+	}
+	out, err := flattenChartValues(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]string{
+		`service.annotations.foo\.bar`: "baz",
+		"ports.web.redirectTo.port":    "websecure",
+	}
+	if !reflect.DeepEqual(out, want) {
+		t.Errorf("mixed mismatch\n got: %v\nwant: %v", out, want)
+	}
+}
+
+func TestFlattenChartValuesDuplicateKeyConflict(t *testing.T) {
+	in := map[string]any{
+		"resources.limits.cpu": "200m",
+		"resources": map[string]any{
+			"limits": map[string]any{
+				"cpu": "500m",
+			},
+		},
+	}
+	_, err := flattenChartValues(in)
+	if err == nil {
+		t.Fatal("expected duplicate-key error")
+	}
+	if !strings.Contains(err.Error(), "duplicate chart value key") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestFlattenChartValuesIdenticalDuplicateAllowed(t *testing.T) {
+	// Two paths producing the same key with the same value is harmless;
+	// the helper should fold them rather than rejecting.
+	in := map[string]any{
+		"resources.limits.cpu": "200m",
+		"resources": map[string]any{
+			"limits": map[string]any{
+				"cpu": "200m",
+			},
+		},
+	}
+	out, err := flattenChartValues(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["resources.limits.cpu"] != "200m" {
+		t.Errorf("expected resources.limits.cpu=200m, got %v", out)
+	}
+}
+
+func TestFlattenChartValuesNilLeafBecomesEmptyString(t *testing.T) {
+	in := map[string]any{"replicaCount": nil}
+	out, err := flattenChartValues(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, ok := out["replicaCount"]; !ok || got != "" {
+		t.Errorf("expected replicaCount=\"\", got %v (ok=%v)", got, ok)
+	}
+}
+
+func TestFlattenChartValuesLegacyMapAnyAny(t *testing.T) {
+	// yaml.v2 unmarshals nested mappings into map[any]any; verify the
+	// converter handles it.
+	in := map[string]any{
+		"resources": map[any]any{
+			"limits": map[any]any{
+				"cpu": "200m",
+			},
+		},
+	}
+	out, err := flattenChartValues(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["resources.limits.cpu"] != "200m" {
+		t.Errorf("expected resources.limits.cpu=200m, got %v", out)
+	}
+}
+
+func TestFlattenChartValuesEmptyNestedMapRejected(t *testing.T) {
+	in := map[string]any{"resources": map[string]any{}}
+	_, err := flattenChartValues(in)
+	if err == nil {
+		t.Fatal("expected error for empty nested map")
+	}
+}
+
+func TestFlattenChartValuesEmptyNestedKeyRejected(t *testing.T) {
+	in := map[string]any{"resources": map[string]any{"": "x"}}
+	_, err := flattenChartValues(in)
+	if err == nil {
+		t.Fatal("expected error for empty nested map key")
+	}
+}
+
+func TestSchedulerK3sChartTaskCommandShapeSet(t *testing.T) {
+	// Use the plan helpers directly to verify the per-key command shape
+	// without standing up a fake dokku.
+	current := map[string]string{}
+	desired := map[string]string{"replicaCount": "3"}
+	chart := "ingress-nginx"
+	commandFn := schedulerK3sChartsCommandFor(t, chart)
+	plan := planPairsSet("chart value", desired,
+		func() (map[string]string, error) { return current, nil },
+		commandFn,
+	)
+	if len(plan.Commands) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(plan.Commands))
+	}
+	want := "dokku --quiet scheduler-k3s:charts:set ingress-nginx.replicaCount 3"
+	if plan.Commands[0] != want {
+		t.Errorf("command mismatch\n got: %q\nwant: %q", plan.Commands[0], want)
+	}
+}
+
+func TestSchedulerK3sChartTaskCommandShapeClear(t *testing.T) {
+	current := map[string]string{"replicaCount": "3"}
+	desired := map[string]string{"replicaCount": "ignored"}
+	chart := "ingress-nginx"
+	commandFn := schedulerK3sChartsCommandFor(t, chart)
+	plan := planPairsUnset("chart value", desired,
+		func() (map[string]string, error) { return current, nil },
+		commandFn,
+	)
+	if len(plan.Commands) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(plan.Commands))
+	}
+	// Empty trailing value indicates a clear. The masked command string
+	// should still carry the empty arg as a quoted empty token.
+	if !strings.Contains(plan.Commands[0], "scheduler-k3s:charts:set ingress-nginx.replicaCount") {
+		t.Errorf("unexpected command: %q", plan.Commands[0])
+	}
+}
+
+// schedulerK3sChartsCommandFor returns the per-key command builder a
+// real SchedulerK3sChartTask uses; mirrors the closure inside Plan() so
+// the command-shape tests assert against the exact production command.
+func schedulerK3sChartsCommandFor(t *testing.T, chart string) pairsCommandFunc {
+	t.Helper()
+	return func(key, value string) subprocess.ExecCommandInput {
+		return subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args: []string{
+				"--quiet",
+				"scheduler-k3s:charts:set",
+				chart + "." + key,
+				value,
+			},
+		}
+	}
+}

--- a/tasks/scheduler_k3s_property_task.go
+++ b/tasks/scheduler_k3s_property_task.go
@@ -1,5 +1,10 @@
 package tasks
 
+import (
+	"fmt"
+	"strings"
+)
+
 // SchedulerK3sPropertyTask manages the scheduler-k3s configuration for a given dokku application
 type SchedulerK3sPropertyTask struct {
 	// App is the name of the app. Required if Global is false.
@@ -34,7 +39,7 @@ func (e SchedulerK3sPropertyTaskExample) GetName() string {
 
 // Doc returns the docblock for the scheduler-k3s property task
 func (t SchedulerK3sPropertyTask) Doc() string {
-	return "Manages the scheduler-k3s configuration for a given dokku application"
+	return "Manages the scheduler-k3s configuration for a given dokku application. chart.* properties are managed by dokku_scheduler_k3s_chart and rejected here, since dokku's scheduler-k3s:set path is deprecated for chart values."
 }
 
 // Examples returns the examples for the scheduler-k3s property task
@@ -81,8 +86,10 @@ func (t SchedulerK3sPropertyTask) Execute() TaskOutputState {
 
 // schedulerK3sPropertyKeys maps scheduler-k3s property names to the JSON
 // keys emitted by `dokku scheduler-k3s:report --format json` on dokku
-// 0.38.8+. The `chart.*.*` family is dynamic and handled by
-// isDynamicProperty without a map entry.
+// 0.38.8+. The `chart.*.*` family is intentionally absent: chart value
+// overrides are managed by dokku_scheduler_k3s_chart through dokku's
+// dedicated scheduler-k3s:charts:set surface, and Plan() rejects any
+// chart.* property before reaching this map.
 var schedulerK3sPropertyKeys = map[string]PropertyKeys{
 	"deploy-timeout":         {PerApp: "deploy-timeout", Global: "global-deploy-timeout"},
 	"image-pull-secrets":     {PerApp: "image-pull-secrets", Global: "global-image-pull-secrets"},
@@ -102,6 +109,12 @@ var schedulerK3sPropertyKeys = map[string]PropertyKeys{
 
 // Plan reports the drift the SchedulerK3sPropertyTask would produce.
 func (t SchedulerK3sPropertyTask) Plan() PlanResult {
+	if strings.HasPrefix(t.Property, "chart.") {
+		return PlanResult{
+			Status: PlanStatusError,
+			Error:  fmt.Errorf("chart.* properties are managed by dokku_scheduler_k3s_chart; the scheduler-k3s:set path for chart values is deprecated in dokku"),
+		}
+	}
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "scheduler-k3s:set", schedulerK3sPropertyKeys)
 }
 

--- a/tasks/scheduler_k3s_property_task_test.go
+++ b/tasks/scheduler_k3s_property_task_test.go
@@ -69,3 +69,23 @@ func TestSchedulerK3sPropertyTaskAbsentWithValue(t *testing.T) {
 		t.Errorf("unexpected error: %v", result.Error)
 	}
 }
+
+func TestSchedulerK3sPropertyTaskRejectsChartProperty(t *testing.T) {
+	task := SchedulerK3sPropertyTask{
+		Global:   true,
+		Property: "chart.traefik.replicas",
+		Value:    "3",
+		State:    StatePresent,
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected chart.* property to be rejected")
+	}
+	msg := result.Error.Error()
+	if !strings.Contains(msg, "dokku_scheduler_k3s_chart") {
+		t.Errorf("error should point users at the replacement task, got: %v", result.Error)
+	}
+	if !strings.Contains(msg, "deprecated") {
+		t.Errorf("error should mention the dokku deprecation, got: %v", result.Error)
+	}
+}

--- a/tasks/scheduler_k3s_scoped_pairs.go
+++ b/tasks/scheduler_k3s_scoped_pairs.go
@@ -11,9 +11,9 @@ import (
 
 // schedulerK3sScopedPairsSpec captures the inputs the shared scheduler-k3s
 // "key/value pairs scoped to (process_type, resource_type)" helpers need. The
-// labels and annotations tasks both build one of these and delegate to the
-// helpers below; only Kind differs (it is plugged into both the dokku
-// subcommand name and the user-facing pluralization in plan messages).
+// labels and annotations tasks both build one of these; only Kind differs (it
+// is plugged into both the dokku subcommand name and the user-facing
+// pluralization in plan messages).
 type schedulerK3sScopedPairsSpec struct {
 	// Kind is the dokku subcommand noun ("labels" or "annotations").
 	Kind         string
@@ -50,88 +50,35 @@ func validateSchedulerK3sScopedPairs(spec schedulerK3sScopedPairsSpec, state Sta
 	return nil
 }
 
-// planSchedulerK3sScopedPairsSet probes current pairs once, computes the diff,
-// and embeds an apply closure that runs `dokku scheduler-k3s:<kind>:set` once
-// per drifted key.
+// planSchedulerK3sScopedPairsSet delegates to planPairsSet with a current-state
+// reader and a per-key command builder bound to the spec's scope.
 func planSchedulerK3sScopedPairsSet(spec schedulerK3sScopedPairsSpec) PlanResult {
-	current, err := getSchedulerK3sScopedPairs(spec)
-	if err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
-	}
-
-	drifted, allNew := driftedKeys(spec.Pairs, current)
-	if len(drifted) == 0 {
-		return PlanResult{InSync: true, Status: PlanStatusOK}
-	}
-
-	status := PlanStatusModify
-	if allNew {
-		status = PlanStatusCreate
-	}
-
-	inputs := schedulerK3sScopedPairsSetInputs(spec, drifted)
-	singular := singularizeSchedulerK3sKind(spec.Kind)
-	return PlanResult{
-		InSync:    false,
-		Status:    status,
-		Reason:    fmt.Sprintf("%d %s(s) to set", len(drifted), singular),
-		Mutations: formatSetMutations(drifted, spec.Pairs, current),
-		Commands:  resolveCommands(inputs),
-		apply: func() TaskOutputState {
-			return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+	return planPairsSet(
+		singularizeSchedulerK3sKind(spec.Kind),
+		spec.Pairs,
+		func() (map[string]string, error) { return getSchedulerK3sScopedPairs(spec) },
+		func(key, value string) subprocess.ExecCommandInput {
+			return schedulerK3sScopedPairsCommand(spec, key, value)
 		},
-	}
+	)
 }
 
-// planSchedulerK3sScopedPairsUnset probes current pairs once, computes the
-// diff, and embeds an apply closure that clears each listed key that exists.
+// planSchedulerK3sScopedPairsUnset delegates to planPairsUnset; the command
+// builder passes an empty value, which dokku's `:labels:set` / `:annotations:set`
+// interpret as "clear this key".
 func planSchedulerK3sScopedPairsUnset(spec schedulerK3sScopedPairsSpec) PlanResult {
-	current, err := getSchedulerK3sScopedPairs(spec)
-	if err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
-	}
-
-	toClear := intersectingKeys(spec.Pairs, current)
-	if len(toClear) == 0 {
-		return PlanResult{InSync: true, Status: PlanStatusOK}
-	}
-
-	inputs := schedulerK3sScopedPairsClearInputs(spec, toClear)
-	singular := singularizeSchedulerK3sKind(spec.Kind)
-	return PlanResult{
-		InSync:    false,
-		Status:    PlanStatusDestroy,
-		Reason:    fmt.Sprintf("%d %s(s) to unset", len(toClear), singular),
-		Mutations: formatClearMutations(toClear, current),
-		Commands:  resolveCommands(inputs),
-		apply: func() TaskOutputState {
-			return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+	return planPairsUnset(
+		singularizeSchedulerK3sKind(spec.Kind),
+		spec.Pairs,
+		func() (map[string]string, error) { return getSchedulerK3sScopedPairs(spec) },
+		func(key, value string) subprocess.ExecCommandInput {
+			return schedulerK3sScopedPairsCommand(spec, key, value)
 		},
-	}
-}
-
-// schedulerK3sScopedPairsSetInputs returns one subprocess input per drifted
-// key, each invoking `dokku scheduler-k3s:<kind>:set` with the desired value.
-func schedulerK3sScopedPairsSetInputs(spec schedulerK3sScopedPairsSpec, keys []string) []subprocess.ExecCommandInput {
-	inputs := make([]subprocess.ExecCommandInput, 0, len(keys))
-	for _, key := range keys {
-		inputs = append(inputs, schedulerK3sScopedPairsCommand(spec, key, spec.Pairs[key]))
-	}
-	return inputs
-}
-
-// schedulerK3sScopedPairsClearInputs returns one subprocess input per key to
-// clear. Dokku interprets an empty value as a clear-this-key operation.
-func schedulerK3sScopedPairsClearInputs(spec schedulerK3sScopedPairsSpec, keys []string) []subprocess.ExecCommandInput {
-	inputs := make([]subprocess.ExecCommandInput, 0, len(keys))
-	for _, key := range keys {
-		inputs = append(inputs, schedulerK3sScopedPairsCommand(spec, key, ""))
-	}
-	return inputs
+	)
 }
 
 // schedulerK3sScopedPairsCommand builds one `dokku scheduler-k3s:<kind>:set`
-// call.
+// call. An empty value is forwarded verbatim; dokku interprets it as a clear.
 func schedulerK3sScopedPairsCommand(spec schedulerK3sScopedPairsSpec, key, value string) subprocess.ExecCommandInput {
 	args := []string{"--quiet", "scheduler-k3s:" + spec.Kind + ":set"}
 	args = append(args, "--resource-type", spec.ResourceType)


### PR DESCRIPTION
## Summary

Wraps dokku's `scheduler-k3s:charts:set` and `:charts:report` subcommands as a first-class task. Values may be supplied as a flat map of dotted Helm paths or a nested tree; nested key segments have literal dots escaped to `\.` so dotted leaf keys reach Helm's `strvals` parser as a single annotation/label key.

Routes through a new generic `pairs.go` helper (probe / diff / per-key set or clear) that the existing labels and annotations tasks now share, so the three call sites stay in one place.

The `dokku_scheduler_k3s_property` task now rejects `chart.*` with an error pointing at the new task, since dokku's `scheduler-k3s:set` path for chart values is deprecated and only emits a warning on every apply.

Closes #259.