### PR TITLE
feat: add dokku_scheduler_k3s_profile task

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -58,6 +58,7 @@ Reference for every task type docket can run inside a recipe. Each page lists th
 - [dokku_scheduler_k3s_autoscaling_auth](dokku_scheduler_k3s_autoscaling_auth.md) - Manages KEDA TriggerAuthentication metadata grouped under a single trigger for a dokku application or globally
 - [dokku_scheduler_k3s_chart](dokku_scheduler_k3s_chart.md) - Manages helm chart value overrides for a dokku scheduler-k3s bundled chart
 - [dokku_scheduler_k3s_labels](dokku_scheduler_k3s_labels.md) - Manages scheduler-k3s labels scoped to a (process_type, resource_type) pair for a dokku application or globally
+- [dokku_scheduler_k3s_profile](dokku_scheduler_k3s_profile.md) - Manages a global scheduler-k3s node profile used when joining nodes to a cluster
 - [dokku_scheduler_k3s_property](dokku_scheduler_k3s_property.md) - Manages the scheduler-k3s configuration for a given dokku application.
 - [dokku_scheduler_property](dokku_scheduler_property.md) - Manages the scheduler configuration for a given dokku application
 - [dokku_service_backup](dokku_service_backup.md) - Manages the S3 backup schedule, authentication, and encryption for a dokku service

--- a/docs/tasks/dokku_scheduler_k3s_profile.md
+++ b/docs/tasks/dokku_scheduler_k3s_profile.md
@@ -1,0 +1,63 @@
+# dokku_scheduler_k3s_profile
+
+## Synopsis
+
+Manages a global scheduler-k3s node profile used when joining nodes to a cluster
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `name` | string | yes |  |  | Name of the node profile. |
+| `role` | string | yes |  | server, worker | Role for nodes joined with this profile. |
+| `kubelet_args` | list | no |  |  | List of key=value kubelet arguments to forward to k3s. |
+| `taint_scheduling` | bool | no |  |  | Whether to taint the node so only workloads that tolerate the taint schedule on it. |
+| `allow_unknown_hosts` | bool | no |  |  | Whether to allow ssh connections to nodes whose host key is not yet trusted. |
+| `state` | string | no | present | present, absent | Desired state of the profile. |
+
+## Examples
+
+### Define a worker profile with kubelet args
+
+```yaml
+dokku_scheduler_k3s_profile:
+    name: edge-pool
+    role: worker
+    kubelet_args:
+        - max-pods=64
+        - eviction-hard=memory.available<5%
+```
+
+### Define a tainted server profile that accepts unknown hosts
+
+```yaml
+dokku_scheduler_k3s_profile:
+    name: control-plane
+    role: server
+    taint_scheduling: true
+    allow_unknown_hosts: true
+```
+
+### Remove a profile
+
+```yaml
+dokku_scheduler_k3s_profile:
+    name: edge-pool
+    role: worker
+    state: absent
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -491,7 +491,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 68
+	expected := 69
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}

--- a/tasks/scheduler_k3s_profile_task.go
+++ b/tasks/scheduler_k3s_profile_task.go
@@ -1,0 +1,326 @@
+package tasks
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// SchedulerK3sProfileTask manages a global scheduler-k3s node profile via the
+// dokku `scheduler-k3s:profiles:add` / `:profiles:remove` subcommands. Each
+// profile is stored on the dokku host as a single JSON blob
+// (`node-profile-<name>.json`); the task represents the complete desired state
+// of that blob because dokku's `profiles:add` is a full replace, not a patch.
+type SchedulerK3sProfileTask struct {
+	// Name is the profile name. It is the lookup key both for the on-disk
+	// global property and for `scheduler-k3s:profiles:list --format json`.
+	Name string `required:"true" yaml:"name" description:"Name of the node profile."`
+
+	// Role is the k3s role nodes joined with this profile take. Required and
+	// validated up front; dokku also rejects unknown values but failing in the
+	// task gives a clearer message.
+	Role string `required:"true" yaml:"role" options:"server,worker" description:"Role for nodes joined with this profile."`
+
+	// KubeletArgs is the list of `key=value` strings forwarded to k3s via
+	// `--kubelet-arg`. Drift detection compares this as a multiset; the
+	// emitted command preserves the user-declared order so the on-disk JSON
+	// tracks the YAML when an apply actually runs.
+	KubeletArgs []string `required:"false" yaml:"kubelet_args,omitempty" description:"List of key=value kubelet arguments to forward to k3s."`
+
+	// TaintScheduling toggles the `--taint-scheduling` flag on
+	// `scheduler-k3s:profiles:add`. Absent or false is "explicitly cleared".
+	TaintScheduling bool `required:"false" yaml:"taint_scheduling,omitempty" description:"Whether to taint the node so only workloads that tolerate the taint schedule on it."`
+
+	// AllowUnknownHosts toggles `--insecure-allow-unknown-hosts`. Absent or
+	// false is "explicitly cleared".
+	AllowUnknownHosts bool `required:"false" yaml:"allow_unknown_hosts,omitempty" description:"Whether to allow ssh connections to nodes whose host key is not yet trusted."`
+
+	// State is the desired state of the profile.
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the profile."`
+}
+
+// SchedulerK3sProfileTaskExample contains an example of a SchedulerK3sProfileTask
+type SchedulerK3sProfileTaskExample struct {
+	// Name is the task name holding the SchedulerK3sProfileTask description
+	Name string `yaml:"-"`
+
+	// SchedulerK3sProfileTask is the SchedulerK3sProfileTask configuration
+	SchedulerK3sProfileTask SchedulerK3sProfileTask `yaml:"dokku_scheduler_k3s_profile"`
+}
+
+// GetName returns the name of the example
+func (e SchedulerK3sProfileTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the scheduler-k3s profile task
+func (t SchedulerK3sProfileTask) Doc() string {
+	return "Manages a global scheduler-k3s node profile used when joining nodes to a cluster"
+}
+
+// Examples returns the examples for the scheduler-k3s profile task
+func (t SchedulerK3sProfileTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]SchedulerK3sProfileTaskExample{
+		{
+			Name: "Define a worker profile with kubelet args",
+			SchedulerK3sProfileTask: SchedulerK3sProfileTask{
+				Name: "edge-pool",
+				Role: "worker",
+				KubeletArgs: []string{
+					"max-pods=64",
+					"eviction-hard=memory.available<5%",
+				},
+			},
+		},
+		{
+			Name: "Define a tainted server profile that accepts unknown hosts",
+			SchedulerK3sProfileTask: SchedulerK3sProfileTask{
+				Name:              "control-plane",
+				Role:              "server",
+				TaintScheduling:   true,
+				AllowUnknownHosts: true,
+			},
+		},
+		{
+			Name: "Remove a profile",
+			SchedulerK3sProfileTask: SchedulerK3sProfileTask{
+				Name:  "edge-pool",
+				Role:  "worker",
+				State: StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute drives the profile to the configured state.
+func (t SchedulerK3sProfileTask) Execute() TaskOutputState {
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the SchedulerK3sProfileTask would produce.
+func (t SchedulerK3sProfileTask) Plan() PlanResult {
+	if err := validateSchedulerK3sProfile(t); err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return planSchedulerK3sProfileSet(t) },
+		StateAbsent:  func() PlanResult { return planSchedulerK3sProfileUnset(t) },
+	})
+}
+
+// validateSchedulerK3sProfile rejects malformed inputs before any subprocess
+// runs. Both states require name + role; absent state ignores the other
+// fields entirely but they are still rejected if obviously broken.
+func validateSchedulerK3sProfile(t SchedulerK3sProfileTask) error {
+	if t.Name == "" {
+		return errors.New("name is required")
+	}
+	if t.Role == "" {
+		return errors.New("role is required")
+	}
+	if t.Role != "server" && t.Role != "worker" {
+		return fmt.Errorf("role must be 'server' or 'worker', got %q", t.Role)
+	}
+	for i, arg := range t.KubeletArgs {
+		if arg == "" {
+			return fmt.Errorf("kubelet_args[%d] must not be empty", i)
+		}
+		if !strings.Contains(arg, "=") {
+			return fmt.Errorf("kubelet_args[%d] %q must be in key=value form", i, arg)
+		}
+	}
+	return nil
+}
+
+// planSchedulerK3sProfileSet probes for the named profile and, if its
+// captured state differs from the task's desired state, emits a single
+// `profiles:add` that carries the complete desired state. `--role` is always
+// present (dokku defaults a missing `--role` back to "worker" on each call);
+// boolean flags appear only when true; kubelet args are emitted in
+// user-declared order so the stored slice tracks the YAML for any apply that
+// actually runs.
+func planSchedulerK3sProfileSet(t SchedulerK3sProfileTask) PlanResult {
+	current, found, err := getSchedulerK3sProfile(t.Name)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+
+	status := PlanStatusCreate
+	if found {
+		if profileMatches(current, t) {
+			return PlanResult{InSync: true, Status: PlanStatusOK}
+		}
+		status = PlanStatusModify
+	}
+
+	inputs := []subprocess.ExecCommandInput{schedulerK3sProfileSetCommand(t)}
+	return PlanResult{
+		InSync:    false,
+		Status:    status,
+		Reason:    fmt.Sprintf("profile %s drift", t.Name),
+		Mutations: []string{formatProfileSetMutation(t, current, found)},
+		Commands:  resolveCommands(inputs),
+		apply: func() TaskOutputState {
+			return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+		},
+	}
+}
+
+// planSchedulerK3sProfileUnset probes for the named profile and removes it
+// only when present. dokku's `profiles:remove` silently succeeds when the
+// profile is missing, but skipping the call keeps Changed=false honest.
+func planSchedulerK3sProfileUnset(t SchedulerK3sProfileTask) PlanResult {
+	_, found, err := getSchedulerK3sProfile(t.Name)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	if !found {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+
+	inputs := []subprocess.ExecCommandInput{{
+		Command: "dokku",
+		Args:    []string{"--quiet", "scheduler-k3s:profiles:remove", t.Name},
+	}}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    fmt.Sprintf("profile %s present", t.Name),
+		Mutations: []string{"remove profile " + t.Name},
+		Commands:  resolveCommands(inputs),
+		apply: func() TaskOutputState {
+			return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+		},
+	}
+}
+
+// schedulerK3sProfileSetCommand builds the bulk
+// `dokku scheduler-k3s:profiles:add <name> --role <role> [...]` call.
+func schedulerK3sProfileSetCommand(t SchedulerK3sProfileTask) subprocess.ExecCommandInput {
+	args := []string{"--quiet", "scheduler-k3s:profiles:add", t.Name, "--role", t.Role}
+	if t.TaintScheduling {
+		args = append(args, "--taint-scheduling")
+	}
+	if t.AllowUnknownHosts {
+		args = append(args, "--insecure-allow-unknown-hosts")
+	}
+	for _, arg := range t.KubeletArgs {
+		args = append(args, "--kubelet-args", arg)
+	}
+	return subprocess.ExecCommandInput{Command: "dokku", Args: args}
+}
+
+// schedulerK3sProfileEntry mirrors the JSON shape dokku writes both to
+// `node-profile-<name>.json` and to `scheduler-k3s:profiles:list --format
+// json`. Boolean fields use plain bool because dokku omits the keys when
+// false, and the Go default is the value we want in that case.
+type schedulerK3sProfileEntry struct {
+	Name              string   `json:"name"`
+	Role              string   `json:"role"`
+	KubeletArgs       []string `json:"kubelet_args"`
+	TaintScheduling   bool     `json:"taint_scheduling"`
+	AllowUnknownHosts bool     `json:"allow_unknown_hosts"`
+}
+
+// getSchedulerK3sProfile fetches the live state of the named profile via
+// `scheduler-k3s:profiles:list --format json`. There is no `profiles:report`
+// subcommand, so the list call (returning every profile) is the only public
+// route to a single profile.
+func getSchedulerK3sProfile(name string) (schedulerK3sProfileEntry, bool, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args: []string{
+			"--quiet",
+			"scheduler-k3s:profiles:list",
+			"--format", "json",
+		},
+	})
+	if err != nil {
+		return schedulerK3sProfileEntry{}, false, err
+	}
+	return parseSchedulerK3sProfile(result.StdoutBytes(), name)
+}
+
+// parseSchedulerK3sProfile decodes the `:profiles:list --format json`
+// payload (a JSON array of profile objects) and returns the entry matching
+// name. Kept separate from getSchedulerK3sProfile so the parse path is unit
+// testable without a fake subprocess.
+func parseSchedulerK3sProfile(raw []byte, name string) (schedulerK3sProfileEntry, bool, error) {
+	if len(raw) == 0 {
+		return schedulerK3sProfileEntry{}, false, nil
+	}
+	var entries []schedulerK3sProfileEntry
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return schedulerK3sProfileEntry{}, false, fmt.Errorf("parse scheduler-k3s:profiles:list json: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.Name == name {
+			return entry, true, nil
+		}
+	}
+	return schedulerK3sProfileEntry{}, false, nil
+}
+
+// profileMatches reports whether the captured profile already satisfies the
+// task's desired state. KubeletArgs is compared as a multiset so reordering
+// alone does not trigger drift; everything else compares verbatim.
+func profileMatches(current schedulerK3sProfileEntry, desired SchedulerK3sProfileTask) bool {
+	if current.Role != desired.Role {
+		return false
+	}
+	if current.TaintScheduling != desired.TaintScheduling {
+		return false
+	}
+	if current.AllowUnknownHosts != desired.AllowUnknownHosts {
+		return false
+	}
+	return sameKubeletArgs(current.KubeletArgs, desired.KubeletArgs)
+}
+
+// sameKubeletArgs returns true when a and b are equal as multisets (same
+// elements with the same multiplicities, ignoring order). nil and empty are
+// treated identically.
+func sameKubeletArgs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if len(a) == 0 {
+		return true
+	}
+	aSorted := append([]string{}, a...)
+	bSorted := append([]string{}, b...)
+	sort.Strings(aSorted)
+	sort.Strings(bSorted)
+	for i := range aSorted {
+		if aSorted[i] != bSorted[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// formatProfileSetMutation summarises the create or modify intent for plan
+// output. For modifies it shows the desired role and the count of kubelet
+// args; for creates it just names the new profile.
+func formatProfileSetMutation(t SchedulerK3sProfileTask, current schedulerK3sProfileEntry, found bool) string {
+	if !found {
+		return fmt.Sprintf("create profile %s (role=%s, kubelet_args=%d)", t.Name, t.Role, len(t.KubeletArgs))
+	}
+	return fmt.Sprintf("update profile %s (role=%s was %s, kubelet_args=%d was %d, taint_scheduling=%t was %t, allow_unknown_hosts=%t was %t)",
+		t.Name,
+		t.Role, current.Role,
+		len(t.KubeletArgs), len(current.KubeletArgs),
+		t.TaintScheduling, current.TaintScheduling,
+		t.AllowUnknownHosts, current.AllowUnknownHosts,
+	)
+}
+
+// init registers the SchedulerK3sProfileTask with the task registry
+func init() {
+	RegisterTask(&SchedulerK3sProfileTask{})
+}

--- a/tasks/scheduler_k3s_profile_task_integration_test.go
+++ b/tasks/scheduler_k3s_profile_task_integration_test.go
@@ -1,0 +1,165 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationSchedulerK3sProfileAll(t *testing.T) {
+	skipUnlessSchedulerK3sT(t)
+
+	cases := []struct {
+		name string
+		task SchedulerK3sProfileTask
+	}{
+		{
+			name: "minimal-worker",
+			task: SchedulerK3sProfileTask{
+				Name: "docket-test-profile-minimal",
+				Role: "worker",
+			},
+		},
+		{
+			name: "full-server",
+			task: SchedulerK3sProfileTask{
+				Name:              "docket-test-profile-full",
+				Role:              "server",
+				KubeletArgs:       []string{"max-pods=64", "eviction-hard=memory.available<5%"},
+				TaintScheduling:   true,
+				AllowUnknownHosts: true,
+			},
+		},
+		{
+			name: "multiple-kubelet-args",
+			task: SchedulerK3sProfileTask{
+				Name:        "docket-test-profile-args",
+				Role:        "worker",
+				KubeletArgs: []string{"max-pods=100", "node-labels=tier=spot", "system-reserved=cpu=200m"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setTask := tc.task
+			setTask.State = StatePresent
+			unsetTask := tc.task
+			unsetTask.State = StateAbsent
+			defer unsetTask.Execute()
+			runPropertyIdempotencyTest(t, propertyIdempotencyCase{
+				label:     "scheduler-k3s profile " + tc.name,
+				setTask:   setTask,
+				unsetTask: unsetTask,
+			})
+		})
+	}
+}
+
+// TestIntegrationSchedulerK3sProfileFieldDrift locks in the per-field
+// idempotency story given dokku's full-replace semantics: changing one field
+// while re-declaring the others must converge in one apply and report
+// Changed=false on the immediate re-apply.
+func TestIntegrationSchedulerK3sProfileFieldDrift(t *testing.T) {
+	skipUnlessSchedulerK3sT(t)
+
+	profileName := "docket-test-profile-drift"
+
+	seed := SchedulerK3sProfileTask{
+		Name:              profileName,
+		Role:              "worker",
+		KubeletArgs:       []string{"max-pods=64", "eviction-hard=memory.available<5%"},
+		TaintScheduling:   true,
+		AllowUnknownHosts: true,
+		State:             StatePresent,
+	}
+	defer SchedulerK3sProfileTask{Name: profileName, Role: "worker", State: StateAbsent}.Execute()
+
+	if result := seed.Execute(); result.Error != nil {
+		t.Fatalf("seed failed: %v", result.Error)
+	}
+
+	steps := []struct {
+		name   string
+		mutate func(SchedulerK3sProfileTask) SchedulerK3sProfileTask
+		check  func(t *testing.T, entry schedulerK3sProfileEntry)
+	}{
+		{
+			name: "flip role",
+			mutate: func(s SchedulerK3sProfileTask) SchedulerK3sProfileTask {
+				s.Role = "server"
+				return s
+			},
+			check: func(t *testing.T, e schedulerK3sProfileEntry) {
+				if e.Role != "server" {
+					t.Errorf("role expected server, got %q", e.Role)
+				}
+				if len(e.KubeletArgs) != 2 {
+					t.Errorf("kubelet_args expected to survive role flip, got %v", e.KubeletArgs)
+				}
+				if !e.TaintScheduling || !e.AllowUnknownHosts {
+					t.Errorf("bool flags expected to survive role flip, got taint=%v allow=%v",
+						e.TaintScheduling, e.AllowUnknownHosts)
+				}
+			},
+		},
+		{
+			name: "drop one kubelet arg",
+			mutate: func(s SchedulerK3sProfileTask) SchedulerK3sProfileTask {
+				s.KubeletArgs = []string{"max-pods=64"}
+				return s
+			},
+			check: func(t *testing.T, e schedulerK3sProfileEntry) {
+				if len(e.KubeletArgs) != 1 || e.KubeletArgs[0] != "max-pods=64" {
+					t.Errorf("expected kubelet_args=[max-pods=64], got %v", e.KubeletArgs)
+				}
+			},
+		},
+		{
+			name: "flip taint_scheduling off",
+			mutate: func(s SchedulerK3sProfileTask) SchedulerK3sProfileTask {
+				s.TaintScheduling = false
+				return s
+			},
+			check: func(t *testing.T, e schedulerK3sProfileEntry) {
+				if e.TaintScheduling {
+					t.Errorf("expected taint_scheduling=false, got true")
+				}
+				if !e.AllowUnknownHosts {
+					t.Errorf("expected allow_unknown_hosts to survive, got false")
+				}
+			},
+		},
+	}
+
+	current := seed
+	for _, step := range steps {
+		t.Run(step.name, func(t *testing.T) {
+			next := step.mutate(current)
+			result := next.Execute()
+			if result.Error != nil {
+				t.Fatalf("apply failed: %v", result.Error)
+			}
+			if !result.Changed {
+				t.Errorf("expected Changed=true on drift apply, got false")
+			}
+
+			reapply := next.Execute()
+			if reapply.Error != nil {
+				t.Fatalf("re-apply failed: %v", reapply.Error)
+			}
+			if reapply.Changed {
+				t.Errorf("expected Changed=false on immediate re-apply, got true")
+			}
+
+			entry, found, err := getSchedulerK3sProfile(profileName)
+			if err != nil {
+				t.Fatalf("probe failed: %v", err)
+			}
+			if !found {
+				t.Fatal("profile missing after apply")
+			}
+			step.check(t, entry)
+
+			current = next
+		})
+	}
+}

--- a/tasks/scheduler_k3s_profile_task_test.go
+++ b/tasks/scheduler_k3s_profile_task_test.go
@@ -1,0 +1,288 @@
+package tasks
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSchedulerK3sProfileTaskMissingName(t *testing.T) {
+	task := SchedulerK3sProfileTask{Role: "worker", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when name is empty")
+	}
+	if !strings.Contains(result.Error.Error(), "name is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerK3sProfileTaskMissingRole(t *testing.T) {
+	task := SchedulerK3sProfileTask{Name: "edge-pool", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when role is empty")
+	}
+	if !strings.Contains(result.Error.Error(), "role is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerK3sProfileTaskInvalidRole(t *testing.T) {
+	task := SchedulerK3sProfileTask{Name: "edge-pool", Role: "controlplane", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when role is invalid")
+	}
+	if !strings.Contains(result.Error.Error(), "role must be 'server' or 'worker'") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerK3sProfileTaskInvalidKubeletArg(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "empty entry", args: []string{""}, want: "must not be empty"},
+		{name: "missing equals", args: []string{"max-pods"}, want: "key=value form"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			task := SchedulerK3sProfileTask{
+				Name:        "edge-pool",
+				Role:        "worker",
+				KubeletArgs: tc.args,
+				State:       StatePresent,
+			}
+			result := task.Execute()
+			if result.Error == nil {
+				t.Fatalf("expected error for kubelet_args=%v", tc.args)
+			}
+			if !strings.Contains(result.Error.Error(), tc.want) {
+				t.Errorf("unexpected error: %v", result.Error)
+			}
+		})
+	}
+}
+
+func TestSchedulerK3sProfileTaskInvalidState(t *testing.T) {
+	task := SchedulerK3sProfileTask{Name: "edge-pool", Role: "worker", State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when state is invalid")
+	}
+	if !strings.Contains(result.Error.Error(), "invalid state") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestSchedulerK3sProfileSetCommandRoleOnly(t *testing.T) {
+	task := SchedulerK3sProfileTask{Name: "edge-pool", Role: "worker"}
+	got := schedulerK3sProfileSetCommand(task)
+	want := []string{"--quiet", "scheduler-k3s:profiles:add", "edge-pool", "--role", "worker"}
+	if got.Command != "dokku" {
+		t.Errorf("expected command 'dokku', got %q", got.Command)
+	}
+	if !reflect.DeepEqual(got.Args, want) {
+		t.Errorf("args mismatch\n got: %v\nwant: %v", got.Args, want)
+	}
+}
+
+func TestSchedulerK3sProfileSetCommandAllFlags(t *testing.T) {
+	task := SchedulerK3sProfileTask{
+		Name:              "edge-pool",
+		Role:              "server",
+		KubeletArgs:       []string{"max-pods=64", "eviction-hard=memory.available<5%"},
+		TaintScheduling:   true,
+		AllowUnknownHosts: true,
+	}
+	got := schedulerK3sProfileSetCommand(task)
+	want := []string{
+		"--quiet", "scheduler-k3s:profiles:add", "edge-pool",
+		"--role", "server",
+		"--taint-scheduling",
+		"--insecure-allow-unknown-hosts",
+		"--kubelet-args", "max-pods=64",
+		"--kubelet-args", "eviction-hard=memory.available<5%",
+	}
+	if !reflect.DeepEqual(got.Args, want) {
+		t.Errorf("args mismatch\n got: %v\nwant: %v", got.Args, want)
+	}
+}
+
+// TestSchedulerK3sProfileSetCommandAlwaysHasRole guards the full-replace
+// invariant: omitting --role from `profiles:add` lets dokku default the
+// role back to "worker", which would silently flip an existing "server"
+// profile on every re-apply.
+func TestSchedulerK3sProfileSetCommandAlwaysHasRole(t *testing.T) {
+	task := SchedulerK3sProfileTask{Name: "edge-pool", Role: "server", TaintScheduling: true}
+	got := schedulerK3sProfileSetCommand(task)
+	roleIdx := -1
+	for i, a := range got.Args {
+		if a == "--role" {
+			roleIdx = i
+			break
+		}
+	}
+	if roleIdx == -1 || roleIdx+1 >= len(got.Args) {
+		t.Fatalf("expected --role <value> in args, got %v", got.Args)
+	}
+	if got.Args[roleIdx+1] != "server" {
+		t.Errorf("expected --role server, got --role %q", got.Args[roleIdx+1])
+	}
+}
+
+func TestSchedulerK3sProfileMatchesIgnoresKubeletArgOrder(t *testing.T) {
+	current := schedulerK3sProfileEntry{
+		Name:        "edge-pool",
+		Role:        "worker",
+		KubeletArgs: []string{"b=2", "a=1"},
+	}
+	desired := SchedulerK3sProfileTask{
+		Name:        "edge-pool",
+		Role:        "worker",
+		KubeletArgs: []string{"a=1", "b=2"},
+	}
+	if !profileMatches(current, desired) {
+		t.Error("expected reordered kubelet_args to match")
+	}
+}
+
+func TestSchedulerK3sProfileMatchesDetectsDrift(t *testing.T) {
+	current := schedulerK3sProfileEntry{
+		Name:        "edge-pool",
+		Role:        "worker",
+		KubeletArgs: []string{"a=1"},
+	}
+	cases := []struct {
+		name    string
+		desired SchedulerK3sProfileTask
+	}{
+		{
+			name: "extra kubelet arg",
+			desired: SchedulerK3sProfileTask{
+				Name: "edge-pool", Role: "worker",
+				KubeletArgs: []string{"a=1", "b=2"},
+			},
+		},
+		{
+			name: "different role",
+			desired: SchedulerK3sProfileTask{
+				Name: "edge-pool", Role: "server",
+				KubeletArgs: []string{"a=1"},
+			},
+		},
+		{
+			name: "taint_scheduling differs",
+			desired: SchedulerK3sProfileTask{
+				Name: "edge-pool", Role: "worker",
+				KubeletArgs:     []string{"a=1"},
+				TaintScheduling: true,
+			},
+		},
+		{
+			name: "allow_unknown_hosts differs",
+			desired: SchedulerK3sProfileTask{
+				Name: "edge-pool", Role: "worker",
+				KubeletArgs:       []string{"a=1"},
+				AllowUnknownHosts: true,
+			},
+		},
+		{
+			name: "different kubelet arg value with same length",
+			desired: SchedulerK3sProfileTask{
+				Name: "edge-pool", Role: "worker",
+				KubeletArgs: []string{"a=2"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if profileMatches(current, tc.desired) {
+				t.Errorf("expected drift, got match (desired=%+v)", tc.desired)
+			}
+		})
+	}
+}
+
+func TestParseSchedulerK3sProfileEmpty(t *testing.T) {
+	entry, found, err := parseSchedulerK3sProfile([]byte("[]"), "edge-pool")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found {
+		t.Errorf("expected found=false for empty list, got entry=%+v", entry)
+	}
+}
+
+func TestParseSchedulerK3sProfileNilInput(t *testing.T) {
+	entry, found, err := parseSchedulerK3sProfile(nil, "edge-pool")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found {
+		t.Errorf("expected found=false for nil input, got entry=%+v", entry)
+	}
+}
+
+func TestParseSchedulerK3sProfileSingleMatch(t *testing.T) {
+	raw := []byte(`[{"name":"edge-pool","role":"worker","kubelet_args":["max-pods=64"]}]`)
+	entry, found, err := parseSchedulerK3sProfile(raw, "edge-pool")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found=true")
+	}
+	if entry.Role != "worker" {
+		t.Errorf("role mismatch: got %q", entry.Role)
+	}
+	if !reflect.DeepEqual(entry.KubeletArgs, []string{"max-pods=64"}) {
+		t.Errorf("kubelet_args mismatch: got %v", entry.KubeletArgs)
+	}
+	if entry.TaintScheduling || entry.AllowUnknownHosts {
+		t.Errorf("expected booleans false when omitted from JSON, got taint=%v allow=%v",
+			entry.TaintScheduling, entry.AllowUnknownHosts)
+	}
+}
+
+func TestParseSchedulerK3sProfileMatchInMiddle(t *testing.T) {
+	raw := []byte(`[
+		{"name":"first","role":"worker"},
+		{"name":"edge-pool","role":"server","taint_scheduling":true,"allow_unknown_hosts":true},
+		{"name":"last","role":"worker","kubelet_args":["x=1"]}
+	]`)
+	entry, found, err := parseSchedulerK3sProfile(raw, "edge-pool")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found=true")
+	}
+	if entry.Role != "server" || !entry.TaintScheduling || !entry.AllowUnknownHosts {
+		t.Errorf("entry mismatch: %+v", entry)
+	}
+}
+
+func TestParseSchedulerK3sProfileNoMatch(t *testing.T) {
+	raw := []byte(`[{"name":"other","role":"worker"}]`)
+	_, found, err := parseSchedulerK3sProfile(raw, "edge-pool")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found {
+		t.Error("expected found=false")
+	}
+}
+
+func TestParseSchedulerK3sProfileMalformed(t *testing.T) {
+	_, _, err := parseSchedulerK3sProfile([]byte("not json"), "edge-pool")
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !strings.Contains(err.Error(), "parse scheduler-k3s:profiles:list json") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Wraps dokku's `scheduler-k3s:profiles:add` and `:profiles:remove` subcommands as a first-class task representing the complete desired state of a global node profile. Each profile carries a name, role, optional kubelet args, and two boolean flags (taint scheduling, allow unknown hosts).

dokku's `profiles:add` is a full replace rather than a patch, so the task always emits `--role` on every apply (omitting it lets dokku silently default the role back to `worker`), and the absence of `kubelet_args` or the boolean flags in YAML is treated as "explicitly cleared". Drift detection compares `kubelet_args` as a multiset so reordering alone is a no-op, while the emitted command preserves the user-declared order so the stored slice tracks the YAML for any apply that actually runs.

The probe reads `scheduler-k3s:profiles:list --format json` and filters by name, since dokku exposes no per-profile report subcommand. The parser is split out from the subprocess call so it can be exercised against captured JSON fixtures in the unit tests.

Closes #256.