### PR TITLE
feat: add dokku_http_auth_user task

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -35,6 +35,7 @@ Reference for every task type docket can run inside a recipe. Each page lists th
 - [dokku_git_sync](dokku_git_sync.md) - Syncs a git repository to a dokku application
 - [dokku_haproxy_property](dokku_haproxy_property.md) - Manages the haproxy configuration for a given dokku application
 - [dokku_http_auth](dokku_http_auth.md) - Manages HTTP authentication for a given dokku application
+- [dokku_http_auth_user](dokku_http_auth_user.md) - Manages the set of HTTP auth users for a dokku application
 - [dokku_letsencrypt](dokku_letsencrypt.md) - Enables or disables letsencrypt SSL certificates for a dokku application
 - [dokku_letsencrypt_property](dokku_letsencrypt_property.md) - Manages the letsencrypt configuration for a given dokku application
 - [dokku_logs_property](dokku_logs_property.md) - Manages the logs configuration for a given dokku application

--- a/docs/tasks/dokku_http_auth_user.md
+++ b/docs/tasks/dokku_http_auth_user.md
@@ -1,0 +1,80 @@
+# dokku_http_auth_user
+
+## Synopsis
+
+Manages the set of HTTP auth users for a dokku application
+
+## Requirements
+
+- dokku-http-auth plugin
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `users` | list | no |  |  | List of HTTP auth users to add or remove. Each item has: username, password. |
+| `update_password` | bool | no | false |  | Re-issue add-user for users that already exist so their password converges |
+| `state` | string | no | present | present, absent | Desired state of the HTTP auth users |
+
+## Examples
+
+### Add HTTP auth users to an app
+
+```yaml
+dokku_http_auth_user:
+    app: hello-world
+    users:
+        - username: admin
+          password: secret
+        - username: ops
+          password: hunter2
+    update_password: false
+```
+
+### Rotate an existing user's password
+
+```yaml
+dokku_http_auth_user:
+    app: hello-world
+    users:
+        - username: admin
+          password: new-secret
+    update_password: true
+```
+
+### Remove a user from an app
+
+```yaml
+dokku_http_auth_user:
+    app: hello-world
+    users:
+        - username: ops
+    update_password: false
+    state: absent
+```
+
+### Remove all HTTP auth users from an app
+
+```yaml
+dokku_http_auth_user:
+    app: hello-world
+    users: []
+    update_password: false
+    state: absent
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/tasks/http_auth_user_task.go
+++ b/tasks/http_auth_user_task.go
@@ -1,0 +1,270 @@
+package tasks
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// HttpAuthUserTask manages the set of HTTP auth users for a dokku application
+type HttpAuthUserTask struct {
+	// App is the name of the app
+	App string `required:"true" yaml:"app" description:"Name of the app"`
+
+	// Users is the list of HTTP auth users to add or remove
+	Users []HttpAuthUser `required:"false" yaml:"users" description:"List of HTTP auth users to add or remove"`
+
+	// UpdatePassword re-issues http-auth:add-user for users that already exist
+	// so their password converges. Passwords are not exposed in the report, so
+	// a rotation cannot be drift-detected; enable this to force convergence.
+	UpdatePassword bool `required:"false" yaml:"update_password" default:"false" description:"Re-issue add-user for users that already exist so their password converges"`
+
+	// State is the desired state of the HTTP auth users
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the HTTP auth users"`
+}
+
+// HttpAuthUser represents a single HTTP auth user
+type HttpAuthUser struct {
+	// Username is the HTTP auth username
+	Username string `required:"true" yaml:"username" description:"HTTP auth username"`
+
+	// Password is the HTTP auth password. The `sensitive:"true"` tag documents
+	// intent, but because the field lives in a slice-of-structs the reflection
+	// walker in sensitive.go cannot reach it - the task's SensitiveValues method
+	// is what actually masks these values.
+	Password string `required:"false" sensitive:"true" yaml:"password,omitempty" description:"HTTP auth password"`
+}
+
+// HttpAuthUserTaskExample contains an example of an HttpAuthUserTask
+type HttpAuthUserTaskExample struct {
+	// Name is the task name holding the HttpAuthUserTask description
+	Name string `yaml:"-"`
+
+	// DokkuHttpAuthUser is the HttpAuthUserTask configuration
+	DokkuHttpAuthUser HttpAuthUserTask `yaml:"dokku_http_auth_user"`
+}
+
+// GetName returns the name of the example
+func (e HttpAuthUserTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the HTTP auth user task
+func (t HttpAuthUserTask) Doc() string {
+	return "Manages the set of HTTP auth users for a dokku application"
+}
+
+// Requirements lists the non-core dokku plugins this task depends on.
+func (t HttpAuthUserTask) Requirements() []string {
+	return []string{"dokku-http-auth plugin"}
+}
+
+// SensitiveValues returns the per-user passwords so they are masked in
+// user-facing output. The tag-based walker in sensitive.go does not descend
+// into slices of structs, so the sensitive passwords are collected here.
+func (t HttpAuthUserTask) SensitiveValues() []string {
+	out := make([]string, 0, len(t.Users))
+	for _, u := range t.Users {
+		if u.Password != "" {
+			out = append(out, u.Password)
+		}
+	}
+	return out
+}
+
+// Examples returns a list of HttpAuthUserTaskExamples as yaml
+func (t HttpAuthUserTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]HttpAuthUserTaskExample{
+		{
+			Name: "Add HTTP auth users to an app",
+			DokkuHttpAuthUser: HttpAuthUserTask{
+				App: "hello-world",
+				Users: []HttpAuthUser{
+					{Username: "admin", Password: "secret"},
+					{Username: "ops", Password: "hunter2"},
+				},
+			},
+		},
+		{
+			Name: "Rotate an existing user's password",
+			DokkuHttpAuthUser: HttpAuthUserTask{
+				App:            "hello-world",
+				Users:          []HttpAuthUser{{Username: "admin", Password: "new-secret"}},
+				UpdatePassword: true,
+			},
+		},
+		{
+			Name: "Remove a user from an app",
+			DokkuHttpAuthUser: HttpAuthUserTask{
+				App:   "hello-world",
+				Users: []HttpAuthUser{{Username: "ops"}},
+				State: StateAbsent,
+			},
+		},
+		{
+			Name: "Remove all HTTP auth users from an app",
+			DokkuHttpAuthUser: HttpAuthUserTask{
+				App:   "hello-world",
+				State: StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute manages the app's HTTP auth users
+func (t HttpAuthUserTask) Execute() TaskOutputState {
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the HttpAuthUserTask would produce.
+func (t HttpAuthUserTask) Plan() PlanResult {
+	if t.App == "" {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+	}
+	for _, u := range t.Users {
+		if u.Username == "" {
+			return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'username' is required for each user")}
+		}
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if len(t.Users) == 0 {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'users' must not be empty for state 'present'")}
+			}
+			for _, u := range t.Users {
+				if u.Password == "" {
+					return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'password' is required for user %q when state is present", u.Username)}
+				}
+			}
+			current, err := getHttpAuthUsers(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			toApply := []HttpAuthUser{}
+			mutations := []string{}
+			for _, u := range t.Users {
+				switch {
+				case !current[u.Username]:
+					toApply = append(toApply, u)
+					mutations = append(mutations, "add "+u.Username)
+				case t.UpdatePassword:
+					toApply = append(toApply, u)
+					mutations = append(mutations, "update "+u.Username)
+				}
+			}
+			if len(toApply) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			status := PlanStatusModify
+			if len(current) == 0 {
+				status = PlanStatusCreate
+			}
+			inputs := make([]subprocess.ExecCommandInput, 0, len(toApply))
+			for _, u := range toApply {
+				inputs = append(inputs, subprocess.ExecCommandInput{
+					Command: "dokku",
+					Args:    []string{"--quiet", "http-auth:add-user", t.App, u.Username, u.Password},
+				})
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    status,
+				Reason:    fmt.Sprintf("%d user(s) to add or update", len(toApply)),
+				Mutations: mutations,
+				Commands:  resolveCommands(inputs),
+				apply: func() TaskOutputState {
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			current, err := getHttpAuthUsers(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			toRemove := []string{}
+			if len(t.Users) == 0 {
+				for u := range current {
+					toRemove = append(toRemove, u)
+				}
+				sort.Strings(toRemove)
+			} else {
+				for _, u := range t.Users {
+					if current[u.Username] {
+						toRemove = append(toRemove, u.Username)
+					}
+				}
+			}
+			if len(toRemove) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			mutations := make([]string, 0, len(toRemove))
+			inputs := make([]subprocess.ExecCommandInput, 0, len(toRemove))
+			for _, u := range toRemove {
+				mutations = append(mutations, "remove "+u)
+				inputs = append(inputs, subprocess.ExecCommandInput{
+					Command: "dokku",
+					Args:    []string{"--quiet", "http-auth:remove-user", t.App, u},
+				})
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    fmt.Sprintf("%d user(s) to remove", len(toRemove)),
+				Mutations: mutations,
+				Commands:  resolveCommands(inputs),
+				apply: func() TaskOutputState {
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				},
+			}
+		},
+	})
+}
+
+// getHttpAuthUsers reads the current set of HTTP auth users for an app from the
+// `users` key of `http-auth:report --format json`. The plugin strips the
+// `http-auth-` prefix from JSON report keys (so the key is `users`, not
+// `http-auth-users`) and emits the usernames as a single space-separated
+// string. A transport-level failure (`*subprocess.SSHError`) is propagated; a
+// dokku-level non-zero exit (e.g. app does not exist) is treated as "no users";
+// malformed JSON surfaces as an error.
+func getHttpAuthUsers(appName string) (map[string]bool, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args: []string{
+			"http-auth:report",
+			appName,
+			"--format",
+			"json",
+		},
+	})
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return nil, err
+		}
+		return map[string]bool{}, nil
+	}
+
+	var report struct {
+		Users string `json:"users"`
+	}
+	if err := json.Unmarshal(result.StdoutBytes(), &report); err != nil {
+		return nil, err
+	}
+
+	users := map[string]bool{}
+	for _, u := range strings.Fields(report.Users) {
+		users[u] = true
+	}
+	return users, nil
+}
+
+// init registers the HttpAuthUserTask with the task registry
+func init() {
+	RegisterTask(&HttpAuthUserTask{})
+}

--- a/tasks/http_auth_user_task_integration_test.go
+++ b/tasks/http_auth_user_task_integration_test.go
@@ -1,0 +1,131 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationHttpAuthUser(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "http-auth")
+
+	appName := "docket-test-http-auth-user"
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	currentUsers := func(t *testing.T, label string) map[string]bool {
+		t.Helper()
+		got, err := getHttpAuthUsers(appName)
+		if err != nil {
+			t.Fatalf("%s: getHttpAuthUsers failed: %v", label, err)
+		}
+		return got
+	}
+	assertHas := func(t *testing.T, label, username string, want bool) {
+		t.Helper()
+		if got := currentUsers(t, label)[username]; got != want {
+			t.Errorf("%s: user %q present=%v, want %v", label, username, got, want)
+		}
+	}
+
+	// enable http auth so the app has an initialized auth config
+	if result := (HttpAuthTask{App: appName, Username: "admin", Password: "secret", State: StatePresent}).Execute(); result.Error != nil {
+		t.Fatalf("failed to enable http auth: %v", result.Error)
+	}
+
+	// add two users
+	addTask := HttpAuthUserTask{
+		App: appName,
+		Users: []HttpAuthUser{
+			{Username: "alice", Password: "alice-pass"},
+			{Username: "bob", Password: "bob-pass"},
+		},
+	}
+	result := addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to add users: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected Changed=true on first add")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+	assertHas(t, "after add", "alice", true)
+	assertHas(t, "after add", "bob", true)
+
+	// adding the same users again is idempotent
+	result = addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second add: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected Changed=false on idempotent add")
+	}
+
+	// present for an existing user without update_password is in sync
+	noop := HttpAuthUserTask{App: appName, Users: []HttpAuthUser{{Username: "alice", Password: "ignored"}}}
+	result = noop.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed present no-op: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected Changed=false for present existing user without update_password")
+	}
+
+	// update_password re-issues add-user for an existing user
+	rotate := HttpAuthUserTask{App: appName, Users: []HttpAuthUser{{Username: "alice", Password: "new-pass"}}, UpdatePassword: true}
+	result = rotate.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to rotate password: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected Changed=true when update_password rotates an existing user")
+	}
+
+	// remove one user
+	removeTask := HttpAuthUserTask{App: appName, Users: []HttpAuthUser{{Username: "bob"}}, State: StateAbsent}
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to remove user: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected Changed=true on first remove")
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+	assertHas(t, "after remove bob", "bob", false)
+	assertHas(t, "after remove bob", "alice", true)
+
+	// removing the same user again is idempotent
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second remove: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected Changed=false on idempotent remove")
+	}
+
+	// clearing with empty users removes every remaining user
+	clearTask := HttpAuthUserTask{App: appName, State: StateAbsent}
+	result = clearTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to clear users: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected Changed=true on first clear")
+	}
+	if remaining := currentUsers(t, "after clear"); len(remaining) != 0 {
+		t.Errorf("expected no users after clear, got %v", remaining)
+	}
+
+	// clearing again is idempotent
+	result = clearTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second clear: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected Changed=false on idempotent clear")
+	}
+}

--- a/tasks/http_auth_user_task_integration_test.go
+++ b/tasks/http_auth_user_task_integration_test.go
@@ -40,6 +40,7 @@ func TestIntegrationHttpAuthUser(t *testing.T) {
 			{Username: "alice", Password: "alice-pass"},
 			{Username: "bob", Password: "bob-pass"},
 		},
+		State: StatePresent,
 	}
 	result := addTask.Execute()
 	if result.Error != nil {
@@ -64,7 +65,7 @@ func TestIntegrationHttpAuthUser(t *testing.T) {
 	}
 
 	// present for an existing user without update_password is in sync
-	noop := HttpAuthUserTask{App: appName, Users: []HttpAuthUser{{Username: "alice", Password: "ignored"}}}
+	noop := HttpAuthUserTask{App: appName, Users: []HttpAuthUser{{Username: "alice", Password: "ignored"}}, State: StatePresent}
 	result = noop.Execute()
 	if result.Error != nil {
 		t.Fatalf("failed present no-op: %v", result.Error)
@@ -74,7 +75,7 @@ func TestIntegrationHttpAuthUser(t *testing.T) {
 	}
 
 	// update_password re-issues add-user for an existing user
-	rotate := HttpAuthUserTask{App: appName, Users: []HttpAuthUser{{Username: "alice", Password: "new-pass"}}, UpdatePassword: true}
+	rotate := HttpAuthUserTask{App: appName, Users: []HttpAuthUser{{Username: "alice", Password: "new-pass"}}, UpdatePassword: true, State: StatePresent}
 	result = rotate.Execute()
 	if result.Error != nil {
 		t.Fatalf("failed to rotate password: %v", result.Error)

--- a/tasks/http_auth_user_task_test.go
+++ b/tasks/http_auth_user_task_test.go
@@ -1,0 +1,144 @@
+package tasks
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	_ "github.com/gliderlabs/sigil/builtin"
+)
+
+func TestHttpAuthUserTaskInvalidState(t *testing.T) {
+	task := HttpAuthUserTask{App: "test-app", Users: []HttpAuthUser{{Username: "admin", Password: "secret"}}, State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestHttpAuthUserTaskPresentMissingApp(t *testing.T) {
+	task := HttpAuthUserTask{Users: []HttpAuthUser{{Username: "admin", Password: "secret"}}, State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'app' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestHttpAuthUserTaskAbsentMissingApp(t *testing.T) {
+	task := HttpAuthUserTask{State: StateAbsent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'app' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestHttpAuthUserTaskPresentEmptyUsers(t *testing.T) {
+	task := HttpAuthUserTask{App: "test-app", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with empty users and state=present should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'users' must not be empty") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestHttpAuthUserTaskPresentWithoutPassword(t *testing.T) {
+	task := HttpAuthUserTask{App: "test-app", Users: []HttpAuthUser{{Username: "admin"}}, State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when a present user has no password")
+	}
+	if !strings.Contains(result.Error.Error(), "'password' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestHttpAuthUserTaskMissingUsername(t *testing.T) {
+	task := HttpAuthUserTask{App: "test-app", Users: []HttpAuthUser{{Password: "secret"}}, State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when a user has no username")
+	}
+	if !strings.Contains(result.Error.Error(), "'username' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestHttpAuthUserTaskSensitiveValues(t *testing.T) {
+	task := HttpAuthUserTask{
+		App: "test-app",
+		Users: []HttpAuthUser{
+			{Username: "admin", Password: "secret"},
+			{Username: "ops", Password: "hunter2"},
+			{Username: "guest"},
+		},
+	}
+	got := task.SensitiveValues()
+	sort.Strings(got)
+	want := []string{"hunter2", "secret"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("SensitiveValues() = %v, want %v", got, want)
+	}
+}
+
+func TestGetTasksHttpAuthUserTaskParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: add http auth users
+      dokku_http_auth_user:
+        app: test-app
+        update_password: true
+        users:
+          - username: admin
+            password: secret
+          - username: ops
+            password: hunter2
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("add http auth users")
+	if task == nil {
+		t.Fatal("task 'add http auth users' not found")
+	}
+
+	hauTask, ok := task.(*HttpAuthUserTask)
+	if !ok {
+		ht, ok2 := task.(HttpAuthUserTask)
+		if !ok2 {
+			t.Fatalf("task is not an HttpAuthUserTask (type is %T)", task)
+		}
+		hauTask = &ht
+	}
+
+	if hauTask.App != "test-app" {
+		t.Errorf("App = %q, want %q", hauTask.App, "test-app")
+	}
+	if !hauTask.UpdatePassword {
+		t.Error("UpdatePassword = false, want true")
+	}
+	if len(hauTask.Users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(hauTask.Users))
+	}
+	if hauTask.Users[0].Username != "admin" || hauTask.Users[0].Password != "secret" {
+		t.Errorf("Users[0] = %+v, want {admin secret}", hauTask.Users[0])
+	}
+	if hauTask.Users[1].Username != "ops" || hauTask.Users[1].Password != "hunter2" {
+		t.Errorf("Users[1] = %+v, want {ops hunter2}", hauTask.Users[1])
+	}
+	if hauTask.State != StatePresent {
+		t.Errorf("expected default state 'present', got %q", hauTask.State)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -491,7 +491,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 69
+	expected := 70
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}


### PR DESCRIPTION
Adds a `dokku_http_auth_user` task that manages the named set of HTTP auth users for an app through `http-auth:add-user` and `http-auth:remove-user`, complementing the enable/disable-only `dokku_http_auth` task. Each user carries its own password, and `update_password` forces a password re-issue for users that already exist since the stored hash is never exposed for drift detection.

Closes #269
