### PR TITLE
feat: add dokku_http_auth_allowed_ip task

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -35,6 +35,7 @@ Reference for every task type docket can run inside a recipe. Each page lists th
 - [dokku_git_sync](dokku_git_sync.md) - Syncs a git repository to a dokku application
 - [dokku_haproxy_property](dokku_haproxy_property.md) - Manages the haproxy configuration for a given dokku application
 - [dokku_http_auth](dokku_http_auth.md) - Manages HTTP authentication for a given dokku application
+- [dokku_http_auth_allowed_ip](dokku_http_auth_allowed_ip.md) - Manages the set of IP addresses allowed to bypass HTTP auth for a dokku application
 - [dokku_http_auth_user](dokku_http_auth_user.md) - Manages the set of HTTP auth users for a dokku application
 - [dokku_letsencrypt](dokku_letsencrypt.md) - Enables or disables letsencrypt SSL certificates for a dokku application
 - [dokku_letsencrypt_property](dokku_letsencrypt_property.md) - Manages the letsencrypt configuration for a given dokku application

--- a/docs/tasks/dokku_http_auth_allowed_ip.md
+++ b/docs/tasks/dokku_http_auth_allowed_ip.md
@@ -1,0 +1,63 @@
+# dokku_http_auth_allowed_ip
+
+## Synopsis
+
+Manages the set of IP addresses allowed to bypass HTTP auth for a dokku application
+
+## Requirements
+
+- dokku-http-auth plugin
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `allowed_ips` | list | no |  |  | List of IP addresses to allow or remove |
+| `state` | string | no | present | present, absent | Desired state of the allowed IP entries |
+
+## Examples
+
+### Allow IP addresses to bypass HTTP auth for an app
+
+```yaml
+dokku_http_auth_allowed_ip:
+    app: hello-world
+    allowed_ips:
+        - 192.0.2.1
+        - 198.51.100.0/24
+```
+
+### Remove an allowed IP address from an app
+
+```yaml
+dokku_http_auth_allowed_ip:
+    app: hello-world
+    allowed_ips:
+        - 192.0.2.1
+    state: absent
+```
+
+### Remove all allowed IP addresses from an app
+
+```yaml
+dokku_http_auth_allowed_ip:
+    app: hello-world
+    allowed_ips: []
+    state: absent
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/tasks/http_auth_allowed_ip_task.go
+++ b/tasks/http_auth_allowed_ip_task.go
@@ -1,0 +1,218 @@
+package tasks
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// HttpAuthAllowedIpTask manages the set of IP addresses allowed to bypass HTTP
+// auth for a dokku application
+type HttpAuthAllowedIpTask struct {
+	// App is the name of the app
+	App string `required:"true" yaml:"app" description:"Name of the app"`
+
+	// AllowedIps is the list of IP addresses to allow or remove
+	AllowedIps []string `required:"false" yaml:"allowed_ips" description:"List of IP addresses to allow or remove"`
+
+	// State is the desired state of the allowed IP entries
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the allowed IP entries"`
+}
+
+// HttpAuthAllowedIpTaskExample contains an example of an HttpAuthAllowedIpTask
+type HttpAuthAllowedIpTaskExample struct {
+	// Name is the task name holding the HttpAuthAllowedIpTask description
+	Name string `yaml:"-"`
+
+	// DokkuHttpAuthAllowedIp is the HttpAuthAllowedIpTask configuration
+	DokkuHttpAuthAllowedIp HttpAuthAllowedIpTask `yaml:"dokku_http_auth_allowed_ip"`
+}
+
+// GetName returns the name of the example
+func (e HttpAuthAllowedIpTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the HTTP auth allowed ip task
+func (t HttpAuthAllowedIpTask) Doc() string {
+	return "Manages the set of IP addresses allowed to bypass HTTP auth for a dokku application"
+}
+
+// Requirements lists the non-core dokku plugins this task depends on.
+func (t HttpAuthAllowedIpTask) Requirements() []string {
+	return []string{"dokku-http-auth plugin"}
+}
+
+// Examples returns a list of HttpAuthAllowedIpTaskExamples as yaml
+func (t HttpAuthAllowedIpTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]HttpAuthAllowedIpTaskExample{
+		{
+			Name: "Allow IP addresses to bypass HTTP auth for an app",
+			DokkuHttpAuthAllowedIp: HttpAuthAllowedIpTask{
+				App:        "hello-world",
+				AllowedIps: []string{"192.0.2.1", "198.51.100.0/24"},
+			},
+		},
+		{
+			Name: "Remove an allowed IP address from an app",
+			DokkuHttpAuthAllowedIp: HttpAuthAllowedIpTask{
+				App:        "hello-world",
+				AllowedIps: []string{"192.0.2.1"},
+				State:      StateAbsent,
+			},
+		},
+		{
+			Name: "Remove all allowed IP addresses from an app",
+			DokkuHttpAuthAllowedIp: HttpAuthAllowedIpTask{
+				App:   "hello-world",
+				State: StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute manages the app's HTTP auth allowed IPs
+func (t HttpAuthAllowedIpTask) Execute() TaskOutputState {
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the HttpAuthAllowedIpTask would produce.
+func (t HttpAuthAllowedIpTask) Plan() PlanResult {
+	if t.App == "" {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if len(t.AllowedIps) == 0 {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'allowed_ips' must not be empty for state 'present'")}
+			}
+			current, err := getHttpAuthAllowedIps(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			toAdd := []string{}
+			mutations := []string{}
+			for _, ip := range t.AllowedIps {
+				if !current[ip] {
+					toAdd = append(toAdd, ip)
+					mutations = append(mutations, "add "+ip)
+				}
+			}
+			if len(toAdd) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			status := PlanStatusModify
+			if len(current) == 0 {
+				status = PlanStatusCreate
+			}
+			inputs := make([]subprocess.ExecCommandInput, 0, len(toAdd))
+			for _, ip := range toAdd {
+				inputs = append(inputs, subprocess.ExecCommandInput{
+					Command: "dokku",
+					Args:    []string{"--quiet", "http-auth:add-allowed-ip", t.App, ip},
+				})
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    status,
+				Reason:    fmt.Sprintf("%d allowed ip(s) to add", len(toAdd)),
+				Mutations: mutations,
+				Commands:  resolveCommands(inputs),
+				apply: func() TaskOutputState {
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			current, err := getHttpAuthAllowedIps(t.App)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			toRemove := []string{}
+			if len(t.AllowedIps) == 0 {
+				for ip := range current {
+					toRemove = append(toRemove, ip)
+				}
+				sort.Strings(toRemove)
+			} else {
+				for _, ip := range t.AllowedIps {
+					if current[ip] {
+						toRemove = append(toRemove, ip)
+					}
+				}
+			}
+			if len(toRemove) == 0 {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+			mutations := make([]string, 0, len(toRemove))
+			inputs := make([]subprocess.ExecCommandInput, 0, len(toRemove))
+			for _, ip := range toRemove {
+				mutations = append(mutations, "remove "+ip)
+				inputs = append(inputs, subprocess.ExecCommandInput{
+					Command: "dokku",
+					Args:    []string{"--quiet", "http-auth:remove-allowed-ip", t.App, ip},
+				})
+			}
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    fmt.Sprintf("%d allowed ip(s) to remove", len(toRemove)),
+				Mutations: mutations,
+				Commands:  resolveCommands(inputs),
+				apply: func() TaskOutputState {
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				},
+			}
+		},
+	})
+}
+
+// getHttpAuthAllowedIps reads the current set of allowed IPs for an app from the
+// `allowed-ips` key of `http-auth:report --format json`. The plugin strips the
+// `http-auth-` prefix from JSON report keys (so the key is `allowed-ips`, not
+// `http-auth-allowed-ips`) and emits the addresses as a single space-separated
+// string. Addresses are stored verbatim by `http-auth:add-allowed-ip` (no
+// normalization), so comparing the desired values against this stored form is
+// fully drift-detectable. A transport-level failure (`*subprocess.SSHError`) is
+// propagated; a dokku-level non-zero exit (e.g. app does not exist) is treated
+// as "no allowed ips"; malformed JSON surfaces as an error.
+func getHttpAuthAllowedIps(appName string) (map[string]bool, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args: []string{
+			"http-auth:report",
+			appName,
+			"--format",
+			"json",
+		},
+	})
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return nil, err
+		}
+		return map[string]bool{}, nil
+	}
+
+	var report struct {
+		AllowedIps string `json:"allowed-ips"`
+	}
+	if err := json.Unmarshal(result.StdoutBytes(), &report); err != nil {
+		return nil, err
+	}
+
+	ips := map[string]bool{}
+	for _, ip := range strings.Fields(report.AllowedIps) {
+		ips[ip] = true
+	}
+	return ips, nil
+}
+
+// init registers the HttpAuthAllowedIpTask with the task registry
+func init() {
+	RegisterTask(&HttpAuthAllowedIpTask{})
+}

--- a/tasks/http_auth_allowed_ip_task_integration_test.go
+++ b/tasks/http_auth_allowed_ip_task_integration_test.go
@@ -1,0 +1,113 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationHttpAuthAllowedIp(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "http-auth")
+
+	appName := "docket-test-http-auth-allowed-ip"
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	currentIps := func(t *testing.T, label string) map[string]bool {
+		t.Helper()
+		got, err := getHttpAuthAllowedIps(appName)
+		if err != nil {
+			t.Fatalf("%s: getHttpAuthAllowedIps failed: %v", label, err)
+		}
+		return got
+	}
+	assertHas := func(t *testing.T, label, ip string, want bool) {
+		t.Helper()
+		if got := currentIps(t, label)[ip]; got != want {
+			t.Errorf("%s: allowed ip %q present=%v, want %v", label, ip, got, want)
+		}
+	}
+
+	// initialize auth so the app has a valid htpasswd/nginx config; add-allowed-ip
+	// flips enabled=true but does not create an htpasswd file on its own
+	if result := (HttpAuthTask{App: appName, Username: "admin", Password: "secret", State: StatePresent}).Execute(); result.Error != nil {
+		t.Fatalf("failed to enable http auth: %v", result.Error)
+	}
+
+	firstIp := "192.0.2.1"
+	secondIp := "198.51.100.2"
+
+	// add two allowed ips
+	addTask := HttpAuthAllowedIpTask{
+		App:        appName,
+		AllowedIps: []string{firstIp, secondIp},
+		State:      StatePresent,
+	}
+	result := addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to add allowed ips: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected Changed=true on first add")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+	assertHas(t, "after add", firstIp, true)
+	assertHas(t, "after add", secondIp, true)
+
+	// adding the same allowed ips again is idempotent
+	result = addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second add: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected Changed=false on idempotent add")
+	}
+
+	// remove one allowed ip
+	removeTask := HttpAuthAllowedIpTask{App: appName, AllowedIps: []string{secondIp}, State: StateAbsent}
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to remove allowed ip: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected Changed=true on first remove")
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+	assertHas(t, "after remove second", secondIp, false)
+	assertHas(t, "after remove second", firstIp, true)
+
+	// removing the same allowed ip again is idempotent
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second remove: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected Changed=false on idempotent remove")
+	}
+
+	// clearing with empty allowed_ips removes every remaining allowed ip
+	clearTask := HttpAuthAllowedIpTask{App: appName, State: StateAbsent}
+	result = clearTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to clear allowed ips: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected Changed=true on first clear")
+	}
+	if remaining := currentIps(t, "after clear"); len(remaining) != 0 {
+		t.Errorf("expected no allowed ips after clear, got %v", remaining)
+	}
+
+	// clearing again is idempotent
+	result = clearTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second clear: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected Changed=false on idempotent clear")
+	}
+}

--- a/tasks/http_auth_allowed_ip_task_test.go
+++ b/tasks/http_auth_allowed_ip_task_test.go
@@ -1,0 +1,88 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHttpAuthAllowedIpTaskInvalidState(t *testing.T) {
+	task := HttpAuthAllowedIpTask{App: "test-app", AllowedIps: []string{"192.0.2.1"}, State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestHttpAuthAllowedIpTaskPresentMissingApp(t *testing.T) {
+	task := HttpAuthAllowedIpTask{AllowedIps: []string{"192.0.2.1"}, State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'app' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestHttpAuthAllowedIpTaskAbsentMissingApp(t *testing.T) {
+	task := HttpAuthAllowedIpTask{State: StateAbsent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'app' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestHttpAuthAllowedIpTaskPresentEmptyAllowedIps(t *testing.T) {
+	task := HttpAuthAllowedIpTask{App: "test-app", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with empty allowed_ips and state=present should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'allowed_ips' must not be empty") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestGetTasksHttpAuthAllowedIpTaskParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: allow ips
+      dokku_http_auth_allowed_ip:
+        app: test-app
+        allowed_ips:
+          - 192.0.2.1
+          - 198.51.100.0/24
+        state: present
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("allow ips")
+	if task == nil {
+		t.Fatal("task 'allow ips' not found")
+	}
+
+	allowedIpTask, ok := task.(*HttpAuthAllowedIpTask)
+	if !ok {
+		t.Fatalf("task is not an HttpAuthAllowedIpTask (type is %T)", task)
+	}
+	if allowedIpTask.App != "test-app" {
+		t.Errorf("App = %q, want %q", allowedIpTask.App, "test-app")
+	}
+	if len(allowedIpTask.AllowedIps) != 2 {
+		t.Fatalf("expected 2 allowed ips, got %d", len(allowedIpTask.AllowedIps))
+	}
+	if allowedIpTask.AllowedIps[0] != "192.0.2.1" || allowedIpTask.AllowedIps[1] != "198.51.100.0/24" {
+		t.Errorf("AllowedIps = %v, want [192.0.2.1, 198.51.100.0/24]", allowedIpTask.AllowedIps)
+	}
+	if allowedIpTask.State != StatePresent {
+		t.Errorf("State = %q, want %q", allowedIpTask.State, StatePresent)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -491,7 +491,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 70
+	expected := 71
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}


### PR DESCRIPTION
Adds a `dokku_http_auth_allowed_ip` task that manages the set of IP addresses allowed to bypass HTTP auth for an app through `http-auth:add-allowed-ip` and `http-auth:remove-allowed-ip`, complementing the `dokku_http_auth` and `dokku_http_auth_user` tasks. The plugin stores each address verbatim and exposes the set through `http-auth:report`, so the task is fully drift-detectable and idempotent by comparing the desired addresses against that stored form.

Closes #270
