### PR TITLE
feat: add dokku_http_auth_domain task

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -36,6 +36,7 @@ Reference for every task type docket can run inside a recipe. Each page lists th
 - [dokku_haproxy_property](dokku_haproxy_property.md) - Manages the haproxy configuration for a given dokku application
 - [dokku_http_auth](dokku_http_auth.md) - Manages HTTP authentication for a given dokku application
 - [dokku_http_auth_allowed_ip](dokku_http_auth_allowed_ip.md) - Manages the set of IP addresses allowed to bypass HTTP auth for a dokku application
+- [dokku_http_auth_domain](dokku_http_auth_domain.md) - Manages the set of domains HTTP auth is restricted to for a dokku application
 - [dokku_http_auth_user](dokku_http_auth_user.md) - Manages the set of HTTP auth users for a dokku application
 - [dokku_letsencrypt](dokku_letsencrypt.md) - Enables or disables letsencrypt SSL certificates for a dokku application
 - [dokku_letsencrypt_property](dokku_letsencrypt_property.md) - Manages the letsencrypt configuration for a given dokku application

--- a/docs/tasks/dokku_http_auth_domain.md
+++ b/docs/tasks/dokku_http_auth_domain.md
@@ -1,0 +1,73 @@
+# dokku_http_auth_domain
+
+## Synopsis
+
+Manages the set of domains HTTP auth is restricted to for a dokku application
+
+## Requirements
+
+- dokku-http-auth plugin
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `domains` | list | no |  |  | List of domains to restrict HTTP auth to |
+| `state` | string | no | present | present, absent, set, clear | Desired state of the HTTP auth domain entries |
+
+## Examples
+
+### Restrict HTTP auth to specific domains for an app
+
+```yaml
+dokku_http_auth_domain:
+    app: hello-world
+    domains:
+        - app.example.com
+        - www.example.com
+```
+
+### Stop restricting HTTP auth to a domain for an app
+
+```yaml
+dokku_http_auth_domain:
+    app: hello-world
+    domains:
+        - www.example.com
+    state: absent
+```
+
+### Replace the set of HTTP auth domains for an app
+
+```yaml
+dokku_http_auth_domain:
+    app: hello-world
+    domains:
+        - app.example.com
+    state: set
+```
+
+### Clear all HTTP auth domains from an app
+
+```yaml
+dokku_http_auth_domain:
+    app: hello-world
+    domains: []
+    state: clear
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/tasks/http_auth_domain_task.go
+++ b/tasks/http_auth_domain_task.go
@@ -1,0 +1,304 @@
+package tasks
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// HttpAuthDomainTask manages the set of domains HTTP auth is restricted to for a
+// dokku application
+type HttpAuthDomainTask struct {
+	// App is the name of the app
+	App string `required:"true" yaml:"app" description:"Name of the app"`
+
+	// Domains is the list of domains to restrict HTTP auth to
+	Domains []string `required:"false" yaml:"domains" description:"List of domains to restrict HTTP auth to"`
+
+	// State is the desired state of the HTTP auth domain entries
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent,set,clear" description:"Desired state of the HTTP auth domain entries"`
+}
+
+// HttpAuthDomainTaskExample contains an example of an HttpAuthDomainTask
+type HttpAuthDomainTaskExample struct {
+	// Name is the task name holding the HttpAuthDomainTask description
+	Name string `yaml:"-"`
+
+	// DokkuHttpAuthDomain is the HttpAuthDomainTask configuration
+	DokkuHttpAuthDomain HttpAuthDomainTask `yaml:"dokku_http_auth_domain"`
+}
+
+// GetName returns the name of the example
+func (e HttpAuthDomainTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the HTTP auth domain task
+func (t HttpAuthDomainTask) Doc() string {
+	return "Manages the set of domains HTTP auth is restricted to for a dokku application"
+}
+
+// Requirements lists the non-core dokku plugins this task depends on.
+func (t HttpAuthDomainTask) Requirements() []string {
+	return []string{"dokku-http-auth plugin"}
+}
+
+// Examples returns a list of HttpAuthDomainTaskExamples as yaml
+func (t HttpAuthDomainTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]HttpAuthDomainTaskExample{
+		{
+			Name: "Restrict HTTP auth to specific domains for an app",
+			DokkuHttpAuthDomain: HttpAuthDomainTask{
+				App:     "hello-world",
+				Domains: []string{"app.example.com", "www.example.com"},
+			},
+		},
+		{
+			Name: "Stop restricting HTTP auth to a domain for an app",
+			DokkuHttpAuthDomain: HttpAuthDomainTask{
+				App:     "hello-world",
+				Domains: []string{"www.example.com"},
+				State:   StateAbsent,
+			},
+		},
+		{
+			Name: "Replace the set of HTTP auth domains for an app",
+			DokkuHttpAuthDomain: HttpAuthDomainTask{
+				App:     "hello-world",
+				Domains: []string{"app.example.com"},
+				State:   StateSet,
+			},
+		},
+		{
+			Name: "Clear all HTTP auth domains from an app",
+			DokkuHttpAuthDomain: HttpAuthDomainTask{
+				App:   "hello-world",
+				State: StateClear,
+			},
+		},
+	})
+}
+
+// Execute manages the app's HTTP auth domains
+func (t HttpAuthDomainTask) Execute() TaskOutputState {
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the HttpAuthDomainTask would produce.
+func (t HttpAuthDomainTask) Plan() PlanResult {
+	if t.App == "" {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+	}
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return planHttpAuthDomainsPresent(t) },
+		StateAbsent:  func() PlanResult { return planHttpAuthDomainsAbsent(t) },
+		StateSet:     func() PlanResult { return planHttpAuthDomainsSet(t) },
+		StateClear:   func() PlanResult { return planHttpAuthDomainsClear(t) },
+	})
+}
+
+// planHttpAuthDomainsPresent reports drift for the present-state domain add.
+func planHttpAuthDomainsPresent(t HttpAuthDomainTask) PlanResult {
+	if len(t.Domains) == 0 {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'domains' must not be empty for state 'present'")}
+	}
+	current, err := getHttpAuthDomains(t.App)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	toAdd := []string{}
+	mutations := []string{}
+	for _, d := range t.Domains {
+		if !current[d] {
+			toAdd = append(toAdd, d)
+			mutations = append(mutations, "add "+d)
+		}
+	}
+	if len(toAdd) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	status := PlanStatusModify
+	if len(current) == 0 {
+		status = PlanStatusCreate
+	}
+	inputs := make([]subprocess.ExecCommandInput, 0, len(toAdd))
+	for _, d := range toAdd {
+		inputs = append(inputs, subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", "http-auth:add-domain", t.App, d},
+		})
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    status,
+		Reason:    fmt.Sprintf("%d domain(s) to add", len(toAdd)),
+		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
+		apply: func() TaskOutputState {
+			return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+		},
+	}
+}
+
+// planHttpAuthDomainsAbsent reports drift for the absent-state domain remove.
+func planHttpAuthDomainsAbsent(t HttpAuthDomainTask) PlanResult {
+	if len(t.Domains) == 0 {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'domains' must not be empty for state 'absent'")}
+	}
+	current, err := getHttpAuthDomains(t.App)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	toRemove := []string{}
+	mutations := []string{}
+	for _, d := range t.Domains {
+		if current[d] {
+			toRemove = append(toRemove, d)
+			mutations = append(mutations, "remove "+d)
+		}
+	}
+	if len(toRemove) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	inputs := make([]subprocess.ExecCommandInput, 0, len(toRemove))
+	for _, d := range toRemove {
+		inputs = append(inputs, subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", "http-auth:remove-domain", t.App, d},
+		})
+	}
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    fmt.Sprintf("%d domain(s) to remove", len(toRemove)),
+		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
+		apply: func() TaskOutputState {
+			return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+		},
+	}
+}
+
+// planHttpAuthDomainsSet reports drift for the set-state full replacement.
+func planHttpAuthDomainsSet(t HttpAuthDomainTask) PlanResult {
+	if len(t.Domains) == 0 {
+		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'domains' must not be empty for state 'set'")}
+	}
+	current, err := getHttpAuthDomains(t.App)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	desired := map[string]bool{}
+	for _, d := range t.Domains {
+		desired[d] = true
+	}
+	mutations := []string{}
+	for _, d := range t.Domains {
+		if !current[d] {
+			mutations = append(mutations, "add "+d)
+		}
+	}
+	toRemove := []string{}
+	for d := range current {
+		if !desired[d] {
+			toRemove = append(toRemove, d)
+		}
+	}
+	sort.Strings(toRemove)
+	for _, d := range toRemove {
+		mutations = append(mutations, "remove "+d)
+	}
+	if len(mutations) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	inputs := dokkuArgsInputs("http-auth:set-domains", t.App, t.Domains)
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusModify,
+		Reason:    fmt.Sprintf("%d domain change(s)", len(mutations)),
+		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
+		apply:     applyDokkuArgs("http-auth:set-domains", t.App, t.Domains, StateSet, StateAbsent),
+	}
+}
+
+// planHttpAuthDomainsClear reports drift for the clear-state operation.
+func planHttpAuthDomainsClear(t HttpAuthDomainTask) PlanResult {
+	current, err := getHttpAuthDomains(t.App)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	if len(current) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	domains := make([]string, 0, len(current))
+	for d := range current {
+		domains = append(domains, d)
+	}
+	sort.Strings(domains)
+	mutations := make([]string, 0, len(domains))
+	for _, d := range domains {
+		mutations = append(mutations, "remove "+d)
+	}
+	inputs := dokkuArgsInputs("http-auth:set-domains", t.App, nil)
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    fmt.Sprintf("clear %d domain(s)", len(current)),
+		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
+		apply:     applyDokkuArgs("http-auth:set-domains", t.App, nil, StateClear, StatePresent),
+	}
+}
+
+// getHttpAuthDomains reads the current set of domains HTTP auth is restricted to
+// for an app from the `domains` key of `http-auth:report --format json`. The
+// plugin strips the `http-auth-` prefix from JSON report keys (so the key is
+// `domains`, not `http-auth-domains`) and emits the domains as a single
+// space-separated string. `http-auth:add-domain`/`http-auth:set-domains`
+// lowercase each domain before storing it, so comparing already-lowercased
+// desired values against this stored form is fully drift-detectable; mixed-case
+// desired values may report perpetual drift. A transport-level failure
+// (`*subprocess.SSHError`) is propagated; a dokku-level non-zero exit (e.g. app
+// does not exist) is treated as "no domains"; malformed JSON surfaces as an
+// error.
+func getHttpAuthDomains(appName string) (map[string]bool, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args: []string{
+			"http-auth:report",
+			appName,
+			"--format",
+			"json",
+		},
+	})
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return nil, err
+		}
+		return map[string]bool{}, nil
+	}
+
+	var report struct {
+		Domains string `json:"domains"`
+	}
+	if err := json.Unmarshal(result.StdoutBytes(), &report); err != nil {
+		return nil, err
+	}
+
+	domains := map[string]bool{}
+	for _, d := range strings.Fields(report.Domains) {
+		domains[d] = true
+	}
+	return domains, nil
+}
+
+// init registers the HttpAuthDomainTask with the task registry
+func init() {
+	RegisterTask(&HttpAuthDomainTask{})
+}

--- a/tasks/http_auth_domain_task_integration_test.go
+++ b/tasks/http_auth_domain_task_integration_test.go
@@ -1,0 +1,146 @@
+package tasks
+
+import (
+	"testing"
+)
+
+func TestIntegrationHttpAuthDomain(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "http-auth")
+
+	appName := "docket-test-http-auth-domain"
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	currentDomains := func(t *testing.T, label string) map[string]bool {
+		t.Helper()
+		got, err := getHttpAuthDomains(appName)
+		if err != nil {
+			t.Fatalf("%s: getHttpAuthDomains failed: %v", label, err)
+		}
+		return got
+	}
+	assertHas := func(t *testing.T, label, domain string, want bool) {
+		t.Helper()
+		if got := currentDomains(t, label)[domain]; got != want {
+			t.Errorf("%s: auth domain %q present=%v, want %v", label, domain, got, want)
+		}
+	}
+
+	firstDomain := "auth-first.example.com"
+	secondDomain := "auth-second.example.com"
+
+	// initialize auth so the app has a valid htpasswd/nginx config; add-domain
+	// flips enabled=true but does not create an htpasswd file on its own
+	if result := (HttpAuthTask{App: appName, Username: "admin", Password: "secret", State: StatePresent}).Execute(); result.Error != nil {
+		t.Fatalf("failed to enable http auth: %v", result.Error)
+	}
+
+	// http-auth:add-domain / set-domains only accept domains already attached to
+	// the app as nginx vhosts, so attach them first
+	if result := (DomainsTask{App: appName, Domains: []string{firstDomain, secondDomain}, State: StatePresent}).Execute(); result.Error != nil {
+		t.Fatalf("failed to attach app domains: %v", result.Error)
+	}
+
+	// add two auth domains
+	addTask := HttpAuthDomainTask{
+		App:     appName,
+		Domains: []string{firstDomain, secondDomain},
+		State:   StatePresent,
+	}
+	result := addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to add auth domains: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected Changed=true on first add")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+	assertHas(t, "after add", firstDomain, true)
+	assertHas(t, "after add", secondDomain, true)
+
+	// adding the same auth domains again is idempotent
+	result = addTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second add: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected Changed=false on idempotent add")
+	}
+
+	// remove one auth domain
+	removeTask := HttpAuthDomainTask{App: appName, Domains: []string{secondDomain}, State: StateAbsent}
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to remove auth domain: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected Changed=true on first remove")
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+	assertHas(t, "after remove second", secondDomain, false)
+	assertHas(t, "after remove second", firstDomain, true)
+
+	// removing the same auth domain again is idempotent
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second remove: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected Changed=false on idempotent remove")
+	}
+
+	// set replaces the whole list; from {first} to {first, second} adds second
+	setTask := HttpAuthDomainTask{App: appName, Domains: []string{firstDomain, secondDomain}, State: StateSet}
+	result = setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set auth domains: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected Changed=true on first set")
+	}
+	if result.State != StateSet {
+		t.Errorf("expected state 'set', got '%s'", result.State)
+	}
+	assertHas(t, "after set", firstDomain, true)
+	assertHas(t, "after set", secondDomain, true)
+
+	// setting the same list again is idempotent
+	result = setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second set: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected Changed=false on idempotent set")
+	}
+
+	// clear removes every auth domain
+	clearTask := HttpAuthDomainTask{App: appName, State: StateClear}
+	result = clearTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to clear auth domains: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected Changed=true on first clear")
+	}
+	if result.State != StateClear {
+		t.Errorf("expected state 'clear', got '%s'", result.State)
+	}
+	if remaining := currentDomains(t, "after clear"); len(remaining) != 0 {
+		t.Errorf("expected no auth domains after clear, got %v", remaining)
+	}
+
+	// clearing again is idempotent
+	result = clearTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second clear: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected Changed=false on idempotent clear")
+	}
+}

--- a/tasks/http_auth_domain_task_test.go
+++ b/tasks/http_auth_domain_task_test.go
@@ -1,0 +1,121 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHttpAuthDomainTaskInvalidState(t *testing.T) {
+	task := HttpAuthDomainTask{App: "test-app", Domains: []string{"app.example.com"}, State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestHttpAuthDomainTaskPresentMissingApp(t *testing.T) {
+	task := HttpAuthDomainTask{Domains: []string{"app.example.com"}, State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'app' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestHttpAuthDomainTaskAbsentMissingApp(t *testing.T) {
+	task := HttpAuthDomainTask{Domains: []string{"app.example.com"}, State: StateAbsent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'app' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestHttpAuthDomainTaskClearMissingApp(t *testing.T) {
+	task := HttpAuthDomainTask{State: StateClear}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'app' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestHttpAuthDomainTaskPresentEmptyDomains(t *testing.T) {
+	task := HttpAuthDomainTask{App: "test-app", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with empty domains and state=present should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'domains' must not be empty") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestHttpAuthDomainTaskAbsentEmptyDomains(t *testing.T) {
+	task := HttpAuthDomainTask{App: "test-app", State: StateAbsent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with empty domains and state=absent should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'domains' must not be empty") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestHttpAuthDomainTaskSetEmptyDomains(t *testing.T) {
+	task := HttpAuthDomainTask{App: "test-app", State: StateSet}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with empty domains and state=set should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'domains' must not be empty") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestGetTasksHttpAuthDomainTaskParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: restrict auth domains
+      dokku_http_auth_domain:
+        app: test-app
+        domains:
+          - app.example.com
+          - www.example.com
+        state: set
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("restrict auth domains")
+	if task == nil {
+		t.Fatal("task 'restrict auth domains' not found")
+	}
+
+	domainTask, ok := task.(*HttpAuthDomainTask)
+	if !ok {
+		t.Fatalf("task is not an HttpAuthDomainTask (type is %T)", task)
+	}
+	if domainTask.App != "test-app" {
+		t.Errorf("App = %q, want %q", domainTask.App, "test-app")
+	}
+	if len(domainTask.Domains) != 2 {
+		t.Fatalf("expected 2 domains, got %d", len(domainTask.Domains))
+	}
+	if domainTask.Domains[0] != "app.example.com" || domainTask.Domains[1] != "www.example.com" {
+		t.Errorf("Domains = %v, want [app.example.com, www.example.com]", domainTask.Domains)
+	}
+	if domainTask.State != StateSet {
+		t.Errorf("State = %q, want %q", domainTask.State, StateSet)
+	}
+}

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -491,7 +491,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 71
+	expected := 72
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}


### PR DESCRIPTION
Adds a `dokku_http_auth_domain` task that manages the set of domains HTTP auth is restricted to for an app through `http-auth:add-domain`, `http-auth:remove-domain`, and `http-auth:set-domains`, complementing the `dokku_http_auth`, `dokku_http_auth_user`, and `dokku_http_auth_allowed_ip` tasks. Its `present`, `absent`, `set`, and `clear` states map onto add, remove, and full replacement, and it reads the domain list from `http-auth:report` so it is drift-detectable and idempotent by comparing the desired domains against that stored form.

Closes #271
