### PR TITLE
feat: add dokku_maintenance_custom_page task

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -42,6 +42,7 @@ Reference for every task type docket can run inside a recipe. Each page lists th
 - [dokku_letsencrypt_property](dokku_letsencrypt_property.md) - Manages the letsencrypt configuration for a given dokku application
 - [dokku_logs_property](dokku_logs_property.md) - Manages the logs configuration for a given dokku application
 - [dokku_maintenance](dokku_maintenance.md) - Enables or disables maintenance mode for a given dokku application
+- [dokku_maintenance_custom_page](dokku_maintenance_custom_page.md) - Installs or removes a custom maintenance page for a dokku application.
 - [dokku_network](dokku_network.md) - Creates or destroys a Docker network
 - [dokku_network_property](dokku_network_property.md) - Manages the network property for a given dokku application
 - [dokku_nginx_property](dokku_nginx_property.md) - Manages the nginx configuration for a given dokku application

--- a/docs/tasks/dokku_maintenance_custom_page.md
+++ b/docs/tasks/dokku_maintenance_custom_page.md
@@ -1,0 +1,60 @@
+# dokku_maintenance_custom_page
+
+## Synopsis
+
+Installs or removes a custom maintenance page for a dokku application.
+
+## Requirements
+
+- dokku-maintenance plugin
+
+## Parameters
+
+| Parameter | Type | Required | Default | Choices | Description |
+| --- | --- | --- | --- | --- | --- |
+| `app` | string | yes |  |  | Name of the app |
+| `content` | string | no |  |  | Inline HTML stored as maintenance.html on the app. Mutually exclusive with tarball; one is required when state is present. |
+| `tarball` | string | no |  |  | Path on the machine running docket to a tar archive containing at least maintenance.html. Mutually exclusive with content; one is required when state is present. |
+| `state` | string | no | present | present, absent | Desired state of the custom maintenance page |
+
+## Examples
+
+### Set a custom maintenance page from inline HTML
+
+```yaml
+dokku_maintenance_custom_page:
+    app: node-js-app
+    content: |
+        <html><body><h1>Down for maintenance</h1></body></html>
+```
+
+### Set a custom maintenance page from a tarball (supports extra assets)
+
+```yaml
+dokku_maintenance_custom_page:
+    app: node-js-app
+    tarball: /etc/dokku/maintenance/node-js-app.tar
+```
+
+### Remove the custom maintenance page, resetting to the default
+
+```yaml
+dokku_maintenance_custom_page:
+    app: node-js-app
+    state: absent
+```
+
+## Return Values
+
+Available after the task runs when captured with `register:`, referenced as `result.<Key>` (or `registered.<name>.<Key>`).
+
+| Key | Returned | Type | Description |
+| --- | --- | --- | --- |
+| `Changed` | always | bool | Whether the task changed server state. |
+| `State` | always | string | Resulting state of the resource. |
+| `DesiredState` | always | string | The state the task targeted. |
+| `Message` | always | string | Human-readable result message (may be empty). |
+| `Commands` | when a subprocess ran | list | Resolved dokku command lines executed. |
+| `Stdout` | when a subprocess ran | string | Captured stdout of the final command. |
+| `Stderr` | when a subprocess ran | string | Captured stderr of the final command. |
+| `ExitCode` | when a subprocess ran | int | Exit code of the final command. |

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -491,7 +491,7 @@ func TestAllTasksExamplesReturnNoError(t *testing.T) {
 }
 
 func TestRegisteredTaskCount(t *testing.T) {
-	expected := 72
+	expected := 73
 	if got := len(RegisteredTasks); got != expected {
 		t.Errorf("expected %d registered tasks, got %d", expected, got)
 	}

--- a/tasks/maintenance_custom_page_task.go
+++ b/tasks/maintenance_custom_page_task.go
@@ -1,0 +1,342 @@
+package tasks
+
+import (
+	"archive/tar"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// MaintenanceCustomPageTask installs (or removes) a custom maintenance page for
+// a dokku app via the dokku-maintenance plugin. The page is delivered as a tar
+// archive streamed to `dokku maintenance:custom-page <app>` on stdin, either
+// built from inline HTML (Content) or read from a tarball on disk (Tarball).
+type MaintenanceCustomPageTask struct {
+	// App is the name of the app
+	App string `required:"true" yaml:"app" description:"Name of the app"`
+
+	// Content is inline HTML stored as maintenance.html. Mutually exclusive
+	// with Tarball.
+	Content string `required:"false" yaml:"content,omitempty" description:"Inline HTML stored as maintenance.html on the app. Mutually exclusive with tarball; one is required when state is present."`
+
+	// Tarball is the path on the machine running docket to a tar archive
+	// containing at least maintenance.html. Mutually exclusive with Content.
+	Tarball string `required:"false" yaml:"tarball,omitempty" description:"Path on the machine running docket to a tar archive containing at least maintenance.html. Mutually exclusive with content; one is required when state is present."`
+
+	// State is the desired state of the custom maintenance page
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the custom maintenance page"`
+}
+
+// MaintenanceCustomPageTaskExample contains an example of a MaintenanceCustomPageTask
+type MaintenanceCustomPageTaskExample struct {
+	// Name is the task name holding the MaintenanceCustomPageTask description
+	Name string `yaml:"-"`
+
+	// MaintenanceCustomPageTask is the MaintenanceCustomPageTask configuration
+	MaintenanceCustomPageTask MaintenanceCustomPageTask `yaml:"dokku_maintenance_custom_page"`
+}
+
+// GetName returns the name of the example
+func (e MaintenanceCustomPageTaskExample) GetName() string {
+	return e.Name
+}
+
+// Doc returns the docblock for the maintenance custom page task
+func (t MaintenanceCustomPageTask) Doc() string {
+	return "Installs or removes a custom maintenance page for a dokku application."
+}
+
+// Requirements lists the non-core dokku plugins this task depends on.
+func (t MaintenanceCustomPageTask) Requirements() []string {
+	return []string{"dokku-maintenance plugin"}
+}
+
+// Examples returns the examples for the maintenance custom page task
+func (t MaintenanceCustomPageTask) Examples() ([]Doc, error) {
+	return MarshalExamples([]MaintenanceCustomPageTaskExample{
+		{
+			Name: "Set a custom maintenance page from inline HTML",
+			MaintenanceCustomPageTask: MaintenanceCustomPageTask{
+				App:     "node-js-app",
+				Content: "<html><body><h1>Down for maintenance</h1></body></html>\n",
+			},
+		},
+		{
+			Name: "Set a custom maintenance page from a tarball (supports extra assets)",
+			MaintenanceCustomPageTask: MaintenanceCustomPageTask{
+				App:     "node-js-app",
+				Tarball: "/etc/dokku/maintenance/node-js-app.tar",
+			},
+		},
+		{
+			Name: "Remove the custom maintenance page, resetting to the default",
+			MaintenanceCustomPageTask: MaintenanceCustomPageTask{
+				App:   "node-js-app",
+				State: StateAbsent,
+			},
+		},
+	})
+}
+
+// Execute installs or removes the custom maintenance page
+func (t MaintenanceCustomPageTask) Execute() TaskOutputState {
+	return ExecutePlan(t.Plan())
+}
+
+// Plan reports the drift the MaintenanceCustomPageTask would produce.
+func (t MaintenanceCustomPageTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			if err := validateMaintenanceCustomPageTask(t); err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if t.Content == "" && t.Tarball == "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("one of 'content' or 'tarball' is required when state is 'present'")}
+			}
+
+			tarBytes, err := maintenanceCustomPageTarball(t)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			desired, err := maintenanceTarballChecksum(tarBytes)
+			if err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+
+			current, reported, err := maintenanceCustomPageState(t.App)
+			if err != nil {
+				var sshErr *subprocess.SSHError
+				if errors.As(err, &sshErr) {
+					return PlanResult{Status: PlanStatusError, Error: err}
+				}
+			}
+			if err == nil && reported && current == desired {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+
+			input := subprocess.ExecCommandInput{
+				Command: "dokku",
+				Args:    []string{"--quiet", "maintenance:custom-page", t.App},
+				Stdin:   bytes.NewReader(tarBytes),
+			}
+			inputs := []subprocess.ExecCommandInput{input}
+
+			status := PlanStatusModify
+			reason := fmt.Sprintf("custom page drift for %s", t.App)
+			switch {
+			case err != nil:
+				reason = fmt.Sprintf("custom page for %s not readable from server (probe failed: %v)", t.App, err)
+			case !reported:
+				status = PlanStatusCreate
+				reason = fmt.Sprintf("custom page checksum not reported for %s", t.App)
+			case current == "":
+				status = PlanStatusCreate
+				reason = fmt.Sprintf("custom page not set for %s", t.App)
+			}
+
+			return PlanResult{
+				InSync:    false,
+				Status:    status,
+				Reason:    reason,
+				Mutations: []string{fmt.Sprintf("set custom maintenance page for %s", t.App)},
+				Commands:  resolveCommands(inputs),
+				apply: func() TaskOutputState {
+					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+				},
+			}
+		},
+		StateAbsent: func() PlanResult {
+			if err := validateMaintenanceCustomPageTask(t); err != nil {
+				return PlanResult{Status: PlanStatusError, Error: err}
+			}
+			if t.Content != "" || t.Tarball != "" {
+				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'content' and 'tarball' must not be set when state is 'absent'")}
+			}
+
+			current, reported, err := maintenanceCustomPageState(t.App)
+			if err != nil {
+				var sshErr *subprocess.SSHError
+				if errors.As(err, &sshErr) {
+					return PlanResult{Status: PlanStatusError, Error: err}
+				}
+			}
+			if err == nil && reported && current == "" {
+				return PlanResult{InSync: true, Status: PlanStatusOK}
+			}
+
+			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: []string{"--quiet", "maintenance:custom-page-remove", t.App}}}
+
+			reason := fmt.Sprintf("custom page present for %s", t.App)
+			if err != nil {
+				reason = fmt.Sprintf("custom page for %s not readable from server (probe failed: %v)", t.App, err)
+			} else if !reported {
+				reason = fmt.Sprintf("custom page checksum not reported for %s", t.App)
+			}
+
+			return PlanResult{
+				InSync:    false,
+				Status:    PlanStatusDestroy,
+				Reason:    reason,
+				Mutations: []string{fmt.Sprintf("remove custom maintenance page for %s", t.App)},
+				Commands:  resolveCommands(inputs),
+				apply: func() TaskOutputState {
+					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
+				},
+			}
+		},
+	})
+}
+
+// validateMaintenanceCustomPageTask validates the task parameters shared by
+// both states.
+func validateMaintenanceCustomPageTask(t MaintenanceCustomPageTask) error {
+	if t.App == "" {
+		return fmt.Errorf("'app' is required")
+	}
+	if t.Content != "" && t.Tarball != "" {
+		return fmt.Errorf("'content' and 'tarball' are mutually exclusive")
+	}
+	return nil
+}
+
+// maintenanceCustomPageTarball resolves the tar bytes that will be streamed to
+// the plugin: an in-memory archive built from inline Content, or the raw bytes
+// of the on-disk Tarball.
+func maintenanceCustomPageTarball(t MaintenanceCustomPageTask) ([]byte, error) {
+	if t.Content != "" {
+		tarBytes, err := buildMaintenancePageTarball(t.Content)
+		if err != nil {
+			return nil, fmt.Errorf("build maintenance page tarball: %w", err)
+		}
+		return tarBytes, nil
+	}
+	tarBytes, err := os.ReadFile(t.Tarball)
+	if err != nil {
+		return nil, fmt.Errorf("read tarball %q: %w", t.Tarball, err)
+	}
+	return tarBytes, nil
+}
+
+// buildMaintenancePageTarball produces an uncompressed tar archive containing a
+// single maintenance.html entry with the supplied HTML. The plugin extracts
+// this archive from stdin and serves maintenance.html as the custom page.
+func buildMaintenancePageTarball(content string) ([]byte, error) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "maintenance.html",
+		Mode: 0o644,
+		Size: int64(len(content)),
+	}); err != nil {
+		return nil, err
+	}
+	if _, err := tw.Write([]byte(content)); err != nil {
+		return nil, err
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// maintenanceTarballChecksum reproduces the dokku-maintenance plugin's canonical
+// digest (fn-maintenance-custom-page-checksum) over the files a tar archive
+// would extract to. For each regular-file entry it emits a
+// "<sha256hex(contents)>  <relpath>\n" line (two spaces), sorts the lines by
+// relpath in byte order, concatenates them, and returns the sha256 hex of the
+// result. Because the digest is over the extracted content (not the raw tar
+// bytes, which embed mtimes and ordering) it is reproducible client-side, which
+// is what lets Plan() skip a redundant upload. The archive must contain a
+// root-level maintenance.html, matching the plugin's own requirement.
+//
+// Only regular files are hashed, matching the plugin's `find -type f`. Note the
+// plugin moves the extracted tree with `mv $TEMP_DIR/*`, whose glob omits
+// root-level dotfiles; such a file would make this digest differ from the
+// server's and force a re-upload every run (safe, just non-idempotent for that
+// rare case). That quirk is intentionally not replicated here.
+func maintenanceTarballChecksum(tarBytes []byte) (string, error) {
+	type entry struct {
+		name string
+		sum  string
+	}
+	var entries []entry
+	hasIndex := false
+
+	tr := tar.NewReader(bytes.NewReader(tarBytes))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("read tarball: %w", err)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		name := strings.TrimPrefix(hdr.Name, "./")
+		h := sha256.New()
+		if _, err := io.Copy(h, tr); err != nil {
+			return "", fmt.Errorf("read tarball entry %q: %w", name, err)
+		}
+		if name == "maintenance.html" {
+			hasIndex = true
+		}
+		entries = append(entries, entry{name: name, sum: hex.EncodeToString(h.Sum(nil))})
+	}
+
+	if !hasIndex {
+		return "", fmt.Errorf("tarball must contain a root-level maintenance.html")
+	}
+
+	sort.Slice(entries, func(i, j int) bool { return entries[i].name < entries[j].name })
+	var stream bytes.Buffer
+	for _, e := range entries {
+		fmt.Fprintf(&stream, "%s  %s\n", e.sum, e.name)
+	}
+	final := sha256.Sum256(stream.Bytes())
+	return hex.EncodeToString(final[:]), nil
+}
+
+// maintenanceCustomPageState reads the current custom page checksum from
+// `dokku maintenance:report <app> --format json`. The plugin strips the
+// `maintenance-` prefix from JSON report keys, so the checksum lands under
+// `custom-page-sha256` (empty string when no custom page is set). The key is
+// decoded into a *string so a missing key (a plugin too old to report it) is
+// distinguishable from a reported-but-empty value: reported is false only when
+// the key is absent. A transport-level SSH failure is returned as an error so
+// Plan() can short-circuit; a dokku-level failure is also returned so callers
+// can fall back to applying unconditionally.
+func maintenanceCustomPageState(app string) (checksum string, reported bool, err error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"maintenance:report", app, "--format", "json"},
+	})
+	if err != nil {
+		return "", false, err
+	}
+	var report struct {
+		CustomPageSHA256 *string `json:"custom-page-sha256"`
+	}
+	if err := json.Unmarshal(result.StdoutBytes(), &report); err != nil {
+		return "", false, err
+	}
+	if report.CustomPageSHA256 == nil {
+		return "", false, nil
+	}
+	return *report.CustomPageSHA256, true, nil
+}
+
+// init registers the MaintenanceCustomPageTask with the task registry
+func init() {
+	RegisterTask(&MaintenanceCustomPageTask{})
+}

--- a/tasks/maintenance_custom_page_task_integration_test.go
+++ b/tasks/maintenance_custom_page_task_integration_test.go
@@ -1,0 +1,187 @@
+package tasks
+
+import (
+	"archive/tar"
+	"bytes"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// writeTempTarball writes a tar archive built from name->body pairs to a temp
+// file and returns its path. docket reads the file locally and streams it to
+// the plugin over stdin, so the file only needs to be readable by the test
+// process.
+func writeTempTarball(t *testing.T, entries map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "maintenance.tar")
+
+	names := make([]string, 0, len(entries))
+	for name := range entries {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, name := range names {
+		body := entries[name]
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(body))}); err != nil {
+			t.Fatalf("write header %q: %v", name, err)
+		}
+		if _, err := tw.Write([]byte(body)); err != nil {
+			t.Fatalf("write body %q: %v", name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("write tarball: %v", err)
+	}
+	return path
+}
+
+func TestIntegrationMaintenanceCustomPage(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "maintenance")
+
+	appName := "docket-test-maintenance-custom-page"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// A freshly-created app has no custom page. If the installed plugin does
+	// not report the checksum, idempotency cannot be verified, so skip.
+	checksum, reported, err := maintenanceCustomPageState(appName)
+	if err != nil {
+		t.Fatalf("maintenanceCustomPageState failed: %v", err)
+	}
+	if !reported {
+		t.Skip("skipping: installed dokku-maintenance does not report custom-page-sha256")
+	}
+	if checksum != "" {
+		t.Fatalf("expected newly-created app to have no custom page, got checksum %q", checksum)
+	}
+
+	// --- inline content source ---
+	content := "<html><body>inline down for maintenance</body></html>\n"
+	setInline := MaintenanceCustomPageTask{App: appName, Content: content, State: StatePresent}
+	result := setInline.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set inline custom page: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first inline set")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+
+	// cross-check: the live report checksum must equal the locally-computed one
+	inlineTar, err := buildMaintenancePageTarball(content)
+	if err != nil {
+		t.Fatalf("buildMaintenancePageTarball failed: %v", err)
+	}
+	wantInline, err := maintenanceTarballChecksum(inlineTar)
+	if err != nil {
+		t.Fatalf("maintenanceTarballChecksum failed: %v", err)
+	}
+	gotInline, _, err := maintenanceCustomPageState(appName)
+	if err != nil {
+		t.Fatalf("maintenanceCustomPageState failed: %v", err)
+	}
+	if gotInline != wantInline {
+		t.Errorf("report checksum %q != locally-computed %q", gotInline, wantInline)
+	}
+
+	// reapply identical content - idempotent
+	result = setInline.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second inline set: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent inline set")
+	}
+
+	// change the content - should update
+	setInlineV2 := MaintenanceCustomPageTask{App: appName, Content: content + "<!-- v2 -->\n", State: StatePresent}
+	result = setInlineV2.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to update inline custom page: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true when content changes")
+	}
+
+	// --- tarball source (multi-file) ---
+	tarPath := writeTempTarball(t, map[string]string{
+		"maintenance.html": "<html><body>tarball down</body></html>\n",
+		"assets/style.css": "body { color: #333; }\n",
+	})
+	setTarball := MaintenanceCustomPageTask{App: appName, Tarball: tarPath, State: StatePresent}
+	result = setTarball.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set tarball custom page: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true when switching to tarball page")
+	}
+
+	rawTar, err := os.ReadFile(tarPath)
+	if err != nil {
+		t.Fatalf("read tarball: %v", err)
+	}
+	wantTarball, err := maintenanceTarballChecksum(rawTar)
+	if err != nil {
+		t.Fatalf("maintenanceTarballChecksum failed: %v", err)
+	}
+	gotTarball, _, err := maintenanceCustomPageState(appName)
+	if err != nil {
+		t.Fatalf("maintenanceCustomPageState failed: %v", err)
+	}
+	if gotTarball != wantTarball {
+		t.Errorf("report checksum %q != locally-computed %q", gotTarball, wantTarball)
+	}
+
+	// reapply identical tarball - idempotent
+	result = setTarball.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second tarball set: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent tarball set")
+	}
+
+	// --- remove ---
+	removeTask := MaintenanceCustomPageTask{App: appName, State: StateAbsent}
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to remove custom page: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Errorf("expected Changed=true on first remove")
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got '%s'", result.State)
+	}
+	gotAfter, _, err := maintenanceCustomPageState(appName)
+	if err != nil {
+		t.Fatalf("maintenanceCustomPageState failed: %v", err)
+	}
+	if gotAfter != "" {
+		t.Errorf("expected no custom page after remove, got checksum %q", gotAfter)
+	}
+
+	// remove again - idempotent
+	result = removeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed second remove: %v", result.Error)
+	}
+	if result.Changed {
+		t.Errorf("expected Changed=false on idempotent remove")
+	}
+}

--- a/tasks/maintenance_custom_page_task_test.go
+++ b/tasks/maintenance_custom_page_task_test.go
@@ -1,0 +1,281 @@
+package tasks
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// tarFromEntries builds an uncompressed tar archive from name->body pairs for
+// use in the checksum tests.
+func tarFromEntries(t *testing.T, entries map[string]string) []byte {
+	t.Helper()
+	names := make([]string, 0, len(entries))
+	for name := range entries {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, name := range names {
+		body := entries[name]
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(body))}); err != nil {
+			t.Fatalf("write header %q: %v", name, err)
+		}
+		if _, err := tw.Write([]byte(body)); err != nil {
+			t.Fatalf("write body %q: %v", name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// The known-answer digests below were computed independently with the
+// dokku-maintenance plugin's own shell algorithm
+// (fn-maintenance-custom-page-checksum) so they verify the Go reproduction
+// against ground truth, not against itself.
+const (
+	maintenanceTestPage           = "<html><body>down for maintenance</body></html>\n"
+	maintenanceTestCSS            = "body { color: red; }\n"
+	maintenanceSingleFileChecksum = "7b645f273842a941c68302a4022ed03e219bd8db318ef32a92dddb148a72ef05"
+	maintenanceMultiFileChecksum  = "7c9ca1d8a574bc5d575137b8f8289f4687285ee531d60ae0582017760a4e5627"
+)
+
+func TestMaintenanceCustomPageTaskInvalidState(t *testing.T) {
+	task := MaintenanceCustomPageTask{App: "test-app", Content: maintenanceTestPage, State: "invalid"}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestMaintenanceCustomPageTaskMissingApp(t *testing.T) {
+	task := MaintenanceCustomPageTask{Content: maintenanceTestPage, State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without app should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "'app' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestMaintenanceCustomPageTaskPresentMissingSource(t *testing.T) {
+	task := MaintenanceCustomPageTask{App: "test-app", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute without content or tarball should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "one of 'content' or 'tarball' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestMaintenanceCustomPageTaskPresentBothSources(t *testing.T) {
+	task := MaintenanceCustomPageTask{App: "test-app", Content: maintenanceTestPage, Tarball: "/tmp/page.tar", State: StatePresent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute with both content and tarball should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "mutually exclusive") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestMaintenanceCustomPageTaskAbsentWithContent(t *testing.T) {
+	task := MaintenanceCustomPageTask{App: "test-app", Content: maintenanceTestPage, State: StateAbsent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute absent with content should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when state is 'absent'") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestMaintenanceCustomPageTaskAbsentWithTarball(t *testing.T) {
+	task := MaintenanceCustomPageTask{App: "test-app", Tarball: "/tmp/page.tar", State: StateAbsent}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("Execute absent with tarball should return an error")
+	}
+	if !strings.Contains(result.Error.Error(), "must not be set when state is 'absent'") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestBuildMaintenancePageTarball(t *testing.T) {
+	out, err := buildMaintenancePageTarball(maintenanceTestPage)
+	if err != nil {
+		t.Fatalf("buildMaintenancePageTarball failed: %v", err)
+	}
+
+	tr := tar.NewReader(bytes.NewReader(out))
+	got := map[string]string{}
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar read failed: %v", err)
+		}
+		body, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatalf("tar entry body read failed: %v", err)
+		}
+		got[hdr.Name] = string(body)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one tar entry, got %d", len(got))
+	}
+	if got["maintenance.html"] != maintenanceTestPage {
+		t.Errorf("maintenance.html body = %q, want %q", got["maintenance.html"], maintenanceTestPage)
+	}
+}
+
+func TestMaintenanceTarballChecksumSingleFile(t *testing.T) {
+	tarBytes, err := buildMaintenancePageTarball(maintenanceTestPage)
+	if err != nil {
+		t.Fatalf("buildMaintenancePageTarball failed: %v", err)
+	}
+	sum, err := maintenanceTarballChecksum(tarBytes)
+	if err != nil {
+		t.Fatalf("maintenanceTarballChecksum failed: %v", err)
+	}
+	if sum != maintenanceSingleFileChecksum {
+		t.Errorf("checksum = %q, want %q", sum, maintenanceSingleFileChecksum)
+	}
+}
+
+func TestMaintenanceTarballChecksumMultiFile(t *testing.T) {
+	tarBytes := tarFromEntries(t, map[string]string{
+		"maintenance.html": maintenanceTestPage,
+		"assets/style.css": maintenanceTestCSS,
+	})
+	sum, err := maintenanceTarballChecksum(tarBytes)
+	if err != nil {
+		t.Fatalf("maintenanceTarballChecksum failed: %v", err)
+	}
+	if sum != maintenanceMultiFileChecksum {
+		t.Errorf("checksum = %q, want %q", sum, maintenanceMultiFileChecksum)
+	}
+}
+
+func TestMaintenanceTarballChecksumDeterministicAndSensitive(t *testing.T) {
+	a := tarFromEntries(t, map[string]string{"maintenance.html": maintenanceTestPage})
+	b := tarFromEntries(t, map[string]string{"maintenance.html": maintenanceTestPage + "<!-- changed -->"})
+
+	sumA1, err := maintenanceTarballChecksum(a)
+	if err != nil {
+		t.Fatalf("checksum a: %v", err)
+	}
+	sumA2, err := maintenanceTarballChecksum(a)
+	if err != nil {
+		t.Fatalf("checksum a again: %v", err)
+	}
+	if sumA1 != sumA2 {
+		t.Errorf("checksum not deterministic: %q != %q", sumA1, sumA2)
+	}
+	if len(sumA1) != 64 {
+		t.Errorf("checksum length = %d, want 64", len(sumA1))
+	}
+	sumB, err := maintenanceTarballChecksum(b)
+	if err != nil {
+		t.Fatalf("checksum b: %v", err)
+	}
+	if sumA1 == sumB {
+		t.Error("checksum should change when content changes")
+	}
+}
+
+func TestMaintenanceTarballChecksumMissingIndex(t *testing.T) {
+	tarBytes := tarFromEntries(t, map[string]string{"index.html": maintenanceTestPage})
+	if _, err := maintenanceTarballChecksum(tarBytes); err == nil {
+		t.Fatal("expected error when maintenance.html is absent")
+	} else if !strings.Contains(err.Error(), "maintenance.html") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestMaintenanceTarballChecksumMalformed(t *testing.T) {
+	if _, err := maintenanceTarballChecksum([]byte("not a tar archive at all")); err == nil {
+		t.Fatal("expected error for malformed tar bytes")
+	}
+}
+
+func TestGetTasksMaintenanceCustomPageInlineParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: set page
+      dokku_maintenance_custom_page:
+        app: test-app
+        content: |
+          <html><body>down</body></html>
+        state: present
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("set page")
+	if task == nil {
+		t.Fatal("task 'set page' not found")
+	}
+	pageTask, ok := task.(*MaintenanceCustomPageTask)
+	if !ok {
+		t.Fatalf("task is not a MaintenanceCustomPageTask (type is %T)", task)
+	}
+	if pageTask.App != "test-app" {
+		t.Errorf("App = %q, want %q", pageTask.App, "test-app")
+	}
+	if !strings.Contains(pageTask.Content, "down") {
+		t.Errorf("Content missing expected HTML: %q", pageTask.Content)
+	}
+	if pageTask.Tarball != "" {
+		t.Errorf("expected Tarball empty, got %q", pageTask.Tarball)
+	}
+	if pageTask.State != StatePresent {
+		t.Errorf("State = %q, want %q", pageTask.State, StatePresent)
+	}
+}
+
+func TestGetTasksMaintenanceCustomPageTarballParsedCorrectly(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: set page
+      dokku_maintenance_custom_page:
+        app: test-app
+        tarball: /etc/dokku/maintenance/test-app.tar
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("set page")
+	if task == nil {
+		t.Fatal("task 'set page' not found")
+	}
+	pageTask, ok := task.(*MaintenanceCustomPageTask)
+	if !ok {
+		t.Fatalf("task is not a MaintenanceCustomPageTask (type is %T)", task)
+	}
+	if pageTask.Tarball != "/etc/dokku/maintenance/test-app.tar" {
+		t.Errorf("Tarball = %q, want %q", pageTask.Tarball, "/etc/dokku/maintenance/test-app.tar")
+	}
+	if pageTask.Content != "" {
+		t.Errorf("expected Content empty, got %q", pageTask.Content)
+	}
+}


### PR DESCRIPTION
The `dokku_maintenance` task can toggle maintenance mode but cannot install a custom maintenance page. This adds a `dokku_maintenance_custom_page` task that sets or removes an app's custom page via the dokku-maintenance plugin, sourcing the page from either inline HTML or a tarball on disk. The task is idempotent: it reproduces the page checksum the plugin now exposes in `maintenance:report` and skips the upload when the stored page already matches.

Closes #272.
