### PR TITLE
feat: enforce conditional field requirements during validate

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -53,8 +53,11 @@ deploy.
 
 The checks cover: the file parses; the recipe shape is a list of plays; each task entry has the
 right envelope keys plus exactly one task-type key; the task type is registered (with a "did you
-mean" for typos); required fields decode; sigil templates render against the input defaults; expr
-predicates parse; and `.item` / `.index` are only used inside a `loop:`.
+mean" for typos); required fields decode; a task's conditional/semantic input rules hold (for
+example a list that must be non-empty when `state: present`, or mutually-exclusive fields) - the same
+checks `plan` and `apply` run, surfaced offline as `invalid_task_input`; sigil templates render
+against the input defaults; expr predicates parse; and `.item` / `.index` are only used inside a
+`loop:`.
 
 ```bash
 docket validate --tasks path/to/tasks.yml

--- a/docs/writing-tasks.md
+++ b/docs/writing-tasks.md
@@ -89,6 +89,40 @@ A few conventions to follow:
   `apply` and `plan` emit a one-time `warning` line above each deprecated task's result line.
   Keep the message short and name the replacement, e.g.
   `"use dokku_storage_entry instead; storage:ensure-directory has been deprecated"`.
+- When a task has conditional or semantic input rules that a `required:"true"` tag cannot express -
+  a list that must be non-empty only when `state: present`, mutually-exclusive fields, an enum, a
+  per-item requirement on a slice field - put them in the optional `Validate() error` method (the
+  `InputValidator` interface) and call it as the first line of `Plan()`. See below.
+
+## Validating inputs
+
+`required:"true"` field tags are enforced offline by `docket validate` (it reports
+`missing_required_field`), but they can only express "this scalar field must be present". Anything
+conditional - non-empty-when-present, mutually-exclusive fields, enums, per-item checks on a slice -
+has to live in code. Put it in `Validate() error` rather than inline in `Plan()`:
+
+```go
+// Validate checks inputs without contacting the server.
+func (t LollipopTask) Validate() error {
+  if t.State == StatePresent && len(t.Flavors) == 0 {
+    return fmt.Errorf("'flavors' must not be empty for state 'present'")
+  }
+  return nil
+}
+
+func (t LollipopTask) Plan() PlanResult {
+  if err := t.Validate(); err != nil {
+    return planErr(err)
+  }
+  // ... probe and DispatchPlan
+}
+```
+
+`Plan()` calls `Validate()` before it probes, so `plan` and `apply` still report the error. Because
+`Validate()` is a pure function of the struct - it must never call a probing or mutating dokku
+command - `docket validate` calls the same method offline and surfaces any error as
+`invalid_task_input`, catching the mistake before a server is ever contacted. Keep the error strings
+identical to what `Plan()` used to return so `plan`, `apply`, and `validate` all read the same.
 
 ## Toggle and property tasks
 

--- a/tasks/acl_app_task.go
+++ b/tasks/acl_app_task.go
@@ -81,16 +81,25 @@ func (t AclAppTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the AclAppTask's inputs without contacting the server, so
+// `docket validate` and Plan() surface the same errors.
+func (t AclAppTask) Validate() error {
+	if t.App == "" {
+		return fmt.Errorf("'app' is required")
+	}
+	if t.State == StatePresent && len(t.Users) == 0 {
+		return fmt.Errorf("'users' must not be empty for state 'present'")
+	}
+	return nil
+}
+
 // Plan reports the drift the AclAppTask would produce.
 func (t AclAppTask) Plan() PlanResult {
-	if t.App == "" {
-		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if len(t.Users) == 0 {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'users' must not be empty for state 'present'")}
-			}
 			current, err := getAclAppUsers(t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}

--- a/tasks/acl_service_task.go
+++ b/tasks/acl_service_task.go
@@ -87,16 +87,24 @@ func (t AclServiceTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the AclServiceTask's inputs without contacting the server.
+func (t AclServiceTask) Validate() error {
+	if err := validateAclServiceTask(t); err != nil {
+		return err
+	}
+	if t.State == StatePresent && len(t.Users) == 0 {
+		return fmt.Errorf("'users' must not be empty for state 'present'")
+	}
+	return nil
+}
+
 // Plan reports the drift the AclServiceTask would produce.
 func (t AclServiceTask) Plan() PlanResult {
-	if err := validateAclServiceTask(t); err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if len(t.Users) == 0 {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'users' must not be empty for state 'present'")}
-			}
 			current, err := getAclServiceUsers(t.Type, t.Service)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}

--- a/tasks/app_clone_task.go
+++ b/tasks/app_clone_task.go
@@ -71,16 +71,26 @@ func (t AppCloneTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the AppCloneTask's inputs without contacting the server.
+func (t AppCloneTask) Validate() error {
+	if t.State == StatePresent {
+		if t.App == "" {
+			return fmt.Errorf("'app' is required")
+		}
+		if t.SourceApp == "" {
+			return fmt.Errorf("'source_app' is required")
+		}
+	}
+	return nil
+}
+
 // Plan reports the drift the AppCloneTask would produce.
 func (t AppCloneTask) Plan() PlanResult {
+	if err := t.Validate(); err != nil {
+		return planErr(err)
+	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if t.App == "" {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
-			}
-			if t.SourceApp == "" {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'source_app' is required")}
-			}
 			exists, err := appExists(t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}

--- a/tasks/app_json_property_task.go
+++ b/tasks/app_json_property_task.go
@@ -82,6 +82,11 @@ var appJsonPropertyKeys = map[string]PropertyKeys{
 	"appjson-path": {PerApp: "appjson-path", Global: "global-appjson-path"},
 }
 
+// Validate checks the AppJsonPropertyTask's inputs without contacting the server.
+func (t AppJsonPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "app-json:set", appJsonPropertyKeys)
+}
+
 // Plan reports the drift the AppJsonPropertyTask would produce.
 func (t AppJsonPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "app-json:set", appJsonPropertyKeys)

--- a/tasks/apps_property_task.go
+++ b/tasks/apps_property_task.go
@@ -99,6 +99,11 @@ var appsPropertyKeys = map[string]PropertyKeys{
 	"disable-autocreation":   {PerApp: "", Global: "global-disable-autocreation"},
 }
 
+// Validate checks the AppsPropertyTask's inputs without contacting the server.
+func (t AppsPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "apps:set", appsPropertyKeys)
+}
+
 // Plan reports the drift the AppsPropertyTask would produce.
 func (t AppsPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "apps:set", appsPropertyKeys)

--- a/tasks/builder_dockerfile_property_task.go
+++ b/tasks/builder_dockerfile_property_task.go
@@ -83,6 +83,11 @@ var builderDockerfilePropertyKeys = map[string]PropertyKeys{
 	"dockerfile-path": {PerApp: "dockerfile-path", Global: "global-dockerfile-path"},
 }
 
+// Validate checks the BuilderDockerfilePropertyTask's inputs without contacting the server.
+func (t BuilderDockerfilePropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "builder-dockerfile:set", builderDockerfilePropertyKeys)
+}
+
 // Plan reports the drift the BuilderDockerfilePropertyTask would produce.
 func (t BuilderDockerfilePropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-dockerfile:set", builderDockerfilePropertyKeys)

--- a/tasks/builder_herokuish_property_task.go
+++ b/tasks/builder_herokuish_property_task.go
@@ -83,6 +83,11 @@ var builderHerokuishPropertyKeys = map[string]PropertyKeys{
 	"allowed": {PerApp: "allowed", Global: "global-allowed"},
 }
 
+// Validate checks the BuilderHerokuishPropertyTask's inputs without contacting the server.
+func (t BuilderHerokuishPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "builder-herokuish:set", builderHerokuishPropertyKeys)
+}
+
 // Plan reports the drift the BuilderHerokuishPropertyTask would produce.
 func (t BuilderHerokuishPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-herokuish:set", builderHerokuishPropertyKeys)

--- a/tasks/builder_lambda_property_task.go
+++ b/tasks/builder_lambda_property_task.go
@@ -83,6 +83,11 @@ var builderLambdaPropertyKeys = map[string]PropertyKeys{
 	"lambdayml-path": {PerApp: "lambdayml-path", Global: "global-lambdayml-path"},
 }
 
+// Validate checks the BuilderLambdaPropertyTask's inputs without contacting the server.
+func (t BuilderLambdaPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "builder-lambda:set", builderLambdaPropertyKeys)
+}
+
 // Plan reports the drift the BuilderLambdaPropertyTask would produce.
 func (t BuilderLambdaPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-lambda:set", builderLambdaPropertyKeys)

--- a/tasks/builder_nixpacks_property_task.go
+++ b/tasks/builder_nixpacks_property_task.go
@@ -83,6 +83,11 @@ var builderNixpacksPropertyKeys = map[string]PropertyKeys{
 	"nixpackstoml-path": {PerApp: "nixpackstoml-path", Global: "global-nixpackstoml-path"},
 }
 
+// Validate checks the BuilderNixpacksPropertyTask's inputs without contacting the server.
+func (t BuilderNixpacksPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "builder-nixpacks:set", builderNixpacksPropertyKeys)
+}
+
 // Plan reports the drift the BuilderNixpacksPropertyTask would produce.
 func (t BuilderNixpacksPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-nixpacks:set", builderNixpacksPropertyKeys)

--- a/tasks/builder_pack_property_task.go
+++ b/tasks/builder_pack_property_task.go
@@ -82,6 +82,11 @@ var builderPackPropertyKeys = map[string]PropertyKeys{
 	"projecttoml-path": {PerApp: "projecttoml-path", Global: "global-projecttoml-path"},
 }
 
+// Validate checks the BuilderPackPropertyTask's inputs without contacting the server.
+func (t BuilderPackPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "builder-pack:set", builderPackPropertyKeys)
+}
+
 // Plan reports the drift the BuilderPackPropertyTask would produce.
 func (t BuilderPackPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-pack:set", builderPackPropertyKeys)

--- a/tasks/builder_property_task.go
+++ b/tasks/builder_property_task.go
@@ -92,6 +92,11 @@ var builderPropertyKeys = map[string]PropertyKeys{
 	"skip-cleanup": {PerApp: "skip-cleanup", Global: "global-skip-cleanup"},
 }
 
+// Validate checks the BuilderPropertyTask's inputs without contacting the server.
+func (t BuilderPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "builder:set", builderPropertyKeys)
+}
+
 // Plan reports the drift the BuilderPropertyTask would produce.
 func (t BuilderPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder:set", builderPropertyKeys)

--- a/tasks/builder_railpack_property_task.go
+++ b/tasks/builder_railpack_property_task.go
@@ -83,6 +83,11 @@ var builderRailpackPropertyKeys = map[string]PropertyKeys{
 	"railpackjson-path": {PerApp: "railpackjson-path", Global: "global-railpackjson-path"},
 }
 
+// Validate checks the BuilderRailpackPropertyTask's inputs without contacting the server.
+func (t BuilderRailpackPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "builder-railpack:set", builderRailpackPropertyKeys)
+}
+
 // Plan reports the drift the BuilderRailpackPropertyTask would produce.
 func (t BuilderRailpackPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builder-railpack:set", builderRailpackPropertyKeys)

--- a/tasks/buildpacks_property_task.go
+++ b/tasks/buildpacks_property_task.go
@@ -84,6 +84,11 @@ var buildpacksPropertyKeys = map[string]PropertyKeys{
 	"stack": {PerApp: "stack", Global: "global-stack"},
 }
 
+// Validate checks the BuildpacksPropertyTask's inputs without contacting the server.
+func (t BuildpacksPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "buildpacks:set-property", buildpacksPropertyKeys)
+}
+
 // Plan reports the drift the BuildpacksPropertyTask would produce.
 func (t BuildpacksPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "buildpacks:set-property", buildpacksPropertyKeys)

--- a/tasks/buildpacks_task.go
+++ b/tasks/buildpacks_task.go
@@ -83,8 +83,22 @@ func (t BuildpacksTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the BuildpacksTask's inputs without contacting the server.
+func (t BuildpacksTask) Validate() error {
+	if t.App == "" {
+		return fmt.Errorf("'app' is required")
+	}
+	if t.State == StatePresent && len(t.Buildpacks) == 0 {
+		return fmt.Errorf("'buildpacks' must not be empty for state 'present'")
+	}
+	return nil
+}
+
 // Plan reports the drift the BuildpacksTask would produce.
 func (t BuildpacksTask) Plan() PlanResult {
+	if err := t.Validate(); err != nil {
+		return planErr(err)
+	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult { return planBuildpacksAdd(t) },
 		StateAbsent:  func() PlanResult { return planBuildpacksRemove(t) },
@@ -92,12 +106,6 @@ func (t BuildpacksTask) Plan() PlanResult {
 }
 
 func planBuildpacksAdd(t BuildpacksTask) PlanResult {
-	if t.App == "" {
-		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
-	}
-	if len(t.Buildpacks) == 0 {
-		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'buildpacks' must not be empty for state 'present'")}
-	}
 	current, err := getBuildpacks(t.App)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
@@ -137,9 +145,6 @@ func planBuildpacksAdd(t BuildpacksTask) PlanResult {
 }
 
 func planBuildpacksRemove(t BuildpacksTask) PlanResult {
-	if t.App == "" {
-		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
-	}
 	current, err := getBuildpacks(t.App)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}

--- a/tasks/builds_property_task.go
+++ b/tasks/builds_property_task.go
@@ -82,6 +82,11 @@ var buildsPropertyKeys = map[string]PropertyKeys{
 	"retention": {PerApp: "retention", Global: "global-retention"},
 }
 
+// Validate checks the BuildsPropertyTask's inputs without contacting the server.
+func (t BuildsPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "builds:set", buildsPropertyKeys)
+}
+
 // Plan reports the drift the BuildsPropertyTask would produce.
 func (t BuildsPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "builds:set", buildsPropertyKeys)

--- a/tasks/caddy_property_task.go
+++ b/tasks/caddy_property_task.go
@@ -88,6 +88,11 @@ var caddyPropertyKeys = map[string]PropertyKeys{
 	"tls-internal":       {PerApp: "tls-internal", Global: "global-tls-internal"},
 }
 
+// Validate checks the CaddyPropertyTask's inputs without contacting the server.
+func (t CaddyPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "caddy:set", caddyPropertyKeys)
+}
+
 // Plan reports the drift the CaddyPropertyTask would produce.
 func (t CaddyPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "caddy:set", caddyPropertyKeys)

--- a/tasks/certs_task.go
+++ b/tasks/certs_task.go
@@ -123,18 +123,29 @@ func (t CertsTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the CertsTask's inputs without contacting the server.
+func (t CertsTask) Validate() error {
+	if err := validateCertsTask(t); err != nil {
+		return err
+	}
+	if t.State == StatePresent {
+		hasPaths := t.Cert != "" && t.Key != ""
+		hasContent := t.CertContent != "" && t.KeyContent != ""
+		if !hasPaths && !hasContent {
+			return fmt.Errorf("'cert' (or 'cert_content') and 'key' (or 'key_content') are required when state is 'present'")
+		}
+	}
+	return nil
+}
+
 // Plan reports the drift the CertsTask would produce.
 func (t CertsTask) Plan() PlanResult {
+	if err := t.Validate(); err != nil {
+		return planErr(err)
+	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if err := validateCertsTask(t); err != nil {
-				return PlanResult{Status: PlanStatusError, Error: err}
-			}
-			hasPaths := t.Cert != "" && t.Key != ""
 			hasContent := t.CertContent != "" && t.KeyContent != ""
-			if !hasPaths && !hasContent {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'cert' (or 'cert_content') and 'key' (or 'key_content') are required when state is 'present'")}
-			}
 			enabled, err := certsEnabled(t)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
@@ -178,9 +189,6 @@ func (t CertsTask) Plan() PlanResult {
 			}
 		},
 		StateAbsent: func() PlanResult {
-			if err := validateCertsTask(t); err != nil {
-				return PlanResult{Status: PlanStatusError, Error: err}
-			}
 			enabled, err := certsEnabled(t)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}

--- a/tasks/checks_property_task.go
+++ b/tasks/checks_property_task.go
@@ -82,6 +82,11 @@ var checksPropertyKeys = map[string]PropertyKeys{
 	"wait-to-retire": {PerApp: "wait-to-retire", Global: "global-wait-to-retire"},
 }
 
+// Validate checks the ChecksPropertyTask's inputs without contacting the server.
+func (t ChecksPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "checks:set", checksPropertyKeys)
+}
+
 // Plan reports the drift the ChecksPropertyTask would produce.
 func (t ChecksPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "checks:set", checksPropertyKeys)

--- a/tasks/checks_toggle_task.go
+++ b/tasks/checks_toggle_task.go
@@ -115,6 +115,11 @@ func (t ChecksToggleTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the ChecksToggleTask's inputs without contacting the server.
+func (t ChecksToggleTask) Validate() error {
+	return validateToggleInput(t.App, t.Global, false)
+}
+
 // Plan reports the drift the ChecksToggleTask would produce.
 func (t ChecksToggleTask) Plan() PlanResult {
 	return planToggle(t.State, t.App, t.Global, false, "checks:enable", "checks:disable", checksEnabled)

--- a/tasks/cron_property_task.go
+++ b/tasks/cron_property_task.go
@@ -85,6 +85,11 @@ var cronPropertyKeys = map[string]PropertyKeys{
 	"mailto":      {PerApp: "", Global: "global-mailto"},
 }
 
+// Validate checks the CronPropertyTask's inputs without contacting the server.
+func (t CronPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "cron:set", cronPropertyKeys)
+}
+
 // Plan reports the drift the CronPropertyTask would produce.
 func (t CronPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "cron:set", cronPropertyKeys)

--- a/tasks/docker_options_task.go
+++ b/tasks/docker_options_task.go
@@ -136,13 +136,21 @@ func (t DockerOptionsTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the DockerOptionsTask's inputs without contacting the server.
+func (t DockerOptionsTask) Validate() error {
+	if err := validateDockerOptionsTask(t); err != nil {
+		return err
+	}
+	return nil
+}
+
 // Plan reports the drift the DockerOptionsTask would produce.
 func (t DockerOptionsTask) Plan() PlanResult {
+	if err := t.Validate(); err != nil {
+		return planErr(err)
+	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if err := validateDockerOptionsTask(t); err != nil {
-				return PlanResult{Status: PlanStatusError, Error: err}
-			}
 			current, err := getDockerOptions(t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
@@ -167,9 +175,6 @@ func (t DockerOptionsTask) Plan() PlanResult {
 			}
 		},
 		StateAbsent: func() PlanResult {
-			if err := validateDockerOptionsTask(t); err != nil {
-				return PlanResult{Status: PlanStatusError, Error: err}
-			}
 			current, err := getDockerOptions(t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}

--- a/tasks/domains_task.go
+++ b/tasks/domains_task.go
@@ -87,8 +87,19 @@ func (t DomainsTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the DomainsTask's inputs without contacting the server.
+func (t DomainsTask) Validate() error {
+	if err := validateDomainsTask(t, t.State != StateClear); err != nil {
+		return err
+	}
+	return nil
+}
+
 // Plan reports the drift the DomainsTask would produce.
 func (t DomainsTask) Plan() PlanResult {
+	if err := t.Validate(); err != nil {
+		return planErr(err)
+	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult { return planDomainsPresent(t) },
 		StateAbsent:  func() PlanResult { return planDomainsAbsent(t) },
@@ -99,9 +110,6 @@ func (t DomainsTask) Plan() PlanResult {
 
 // planDomainsPresent reports drift for the present-state domain add.
 func planDomainsPresent(t DomainsTask) PlanResult {
-	if err := validateDomainsTask(t, true); err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
-	}
 	currentDomains, err := getDomains(t.App, t.Global)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
@@ -140,9 +148,6 @@ func planDomainsPresent(t DomainsTask) PlanResult {
 
 // planDomainsAbsent reports drift for the absent-state domain remove.
 func planDomainsAbsent(t DomainsTask) PlanResult {
-	if err := validateDomainsTask(t, true); err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
-	}
 	currentDomains, err := getDomains(t.App, t.Global)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
@@ -177,9 +182,6 @@ func planDomainsAbsent(t DomainsTask) PlanResult {
 
 // planDomainsSet reports drift for the set-state full replacement.
 func planDomainsSet(t DomainsTask) PlanResult {
-	if err := validateDomainsTask(t, true); err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
-	}
 	currentDomains, err := getDomains(t.App, t.Global)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
@@ -221,9 +223,6 @@ func planDomainsSet(t DomainsTask) PlanResult {
 
 // planDomainsClear reports drift for the clear-state operation.
 func planDomainsClear(t DomainsTask) PlanResult {
-	if err := validateDomainsTask(t, false); err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
-	}
 	currentDomains, err := getDomains(t.App, t.Global)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}

--- a/tasks/domains_toggle_task.go
+++ b/tasks/domains_toggle_task.go
@@ -99,6 +99,11 @@ func (t DomainsToggleTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the DomainsToggleTask's inputs without contacting the server.
+func (t DomainsToggleTask) Validate() error {
+	return validateToggleInput(t.App, t.Global, false)
+}
+
 // Plan reports the drift the DomainsToggleTask would produce.
 func (t DomainsToggleTask) Plan() PlanResult {
 	return planToggle(t.State, t.App, t.Global, false, "domains:enable", "domains:disable", domainsEnabled)

--- a/tasks/git_auth_task.go
+++ b/tasks/git_auth_task.go
@@ -77,17 +77,25 @@ func (t GitAuthTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the GitAuthTask's inputs without contacting the server.
+func (t GitAuthTask) Validate() error {
+	if t.Host == "" {
+		return fmt.Errorf("'host' is required")
+	}
+	if t.State == StatePresent && (t.Username == "" || t.Password == "") {
+		return fmt.Errorf("'username' and 'password' are required when state is 'present'")
+	}
+	return nil
+}
+
 // Plan reports the drift the GitAuthTask would produce. dokku has no public
 // way to query netrc state, so the plan reports drift unconditionally.
 func (t GitAuthTask) Plan() PlanResult {
-	if t.Host == "" {
-		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'host' is required")}
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if t.Username == "" || t.Password == "" {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'username' and 'password' are required when state is 'present'")}
-			}
 			inputs := []subprocess.ExecCommandInput{{
 				Command: "dokku",
 				Args:    []string{"--quiet", "git:auth", t.Host, t.Username, t.Password},

--- a/tasks/git_from_archive_task.go
+++ b/tasks/git_from_archive_task.go
@@ -83,25 +83,37 @@ func (t GitFromArchiveTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the GitFromArchiveTask's inputs without contacting the server.
+func (t GitFromArchiveTask) Validate() error {
+	if t.App == "" {
+		return fmt.Errorf("'app' is required")
+	}
+	if t.ArchiveURL == "" {
+		return fmt.Errorf("'archive_url' is required")
+	}
+	archiveType := t.ArchiveType
+	if archiveType == "" {
+		archiveType = "tar"
+	}
+	if !validGitFromArchiveTypes[archiveType] {
+		return fmt.Errorf("'archive_type' must be one of tar, tar.gz, zip")
+	}
+	if (t.GitUsername == "") != (t.GitEmail == "") {
+		return fmt.Errorf("'git_username' and 'git_email' must be set together")
+	}
+	return nil
+}
+
 // Plan reports the drift the GitFromArchiveTask would produce.
 func (t GitFromArchiveTask) Plan() PlanResult {
+	if err := t.Validate(); err != nil {
+		return planErr(err)
+	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StateDeployed: func() PlanResult {
-			if t.App == "" {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
-			}
-			if t.ArchiveURL == "" {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'archive_url' is required")}
-			}
 			archiveType := t.ArchiveType
 			if archiveType == "" {
 				archiveType = "tar"
-			}
-			if !validGitFromArchiveTypes[archiveType] {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'archive_type' must be one of tar, tar.gz, zip")}
-			}
-			if (t.GitUsername == "") != (t.GitEmail == "") {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'git_username' and 'git_email' must be set together")}
 			}
 			match, err := checkAppSourceArchive(t.App, archiveType, t.ArchiveURL)
 			if err != nil {

--- a/tasks/git_property_task.go
+++ b/tasks/git_property_task.go
@@ -97,6 +97,11 @@ var gitPropertyKeys = map[string]PropertyKeys{
 	"source-image":      {PerApp: "source-image", Global: ""},
 }
 
+// Validate checks the GitPropertyTask's inputs without contacting the server.
+func (t GitPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "git:set", gitPropertyKeys)
+}
+
 // Plan reports the drift the GitPropertyTask would produce.
 func (t GitPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "git:set", gitPropertyKeys)

--- a/tasks/haproxy_property_task.go
+++ b/tasks/haproxy_property_task.go
@@ -87,6 +87,11 @@ var haproxyPropertyKeys = map[string]PropertyKeys{
 	"refresh-conf":       {PerApp: "", Global: "global-refresh-conf"},
 }
 
+// Validate checks the HaproxyPropertyTask's inputs without contacting the server.
+func (t HaproxyPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "haproxy:set", haproxyPropertyKeys)
+}
+
 // Plan reports the drift the HaproxyPropertyTask would produce.
 func (t HaproxyPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "haproxy:set", haproxyPropertyKeys)

--- a/tasks/http_auth_allowed_ip_task.go
+++ b/tasks/http_auth_allowed_ip_task.go
@@ -85,16 +85,24 @@ func (t HttpAuthAllowedIpTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the HttpAuthAllowedIpTask's inputs without contacting the server.
+func (t HttpAuthAllowedIpTask) Validate() error {
+	if t.App == "" {
+		return fmt.Errorf("'app' is required")
+	}
+	if t.State == StatePresent && len(t.AllowedIps) == 0 {
+		return fmt.Errorf("'allowed_ips' must not be empty for state 'present'")
+	}
+	return nil
+}
+
 // Plan reports the drift the HttpAuthAllowedIpTask would produce.
 func (t HttpAuthAllowedIpTask) Plan() PlanResult {
-	if t.App == "" {
-		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if len(t.AllowedIps) == 0 {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'allowed_ips' must not be empty for state 'present'")}
-			}
 			current, err := getHttpAuthAllowedIps(t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}

--- a/tasks/http_auth_domain_task.go
+++ b/tasks/http_auth_domain_task.go
@@ -93,10 +93,27 @@ func (t HttpAuthDomainTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the HttpAuthDomainTask's inputs without contacting the server.
+func (t HttpAuthDomainTask) Validate() error {
+	if t.App == "" {
+		return fmt.Errorf("'app' is required")
+	}
+	if t.State == StatePresent && len(t.Domains) == 0 {
+		return fmt.Errorf("'domains' must not be empty for state 'present'")
+	}
+	if t.State == StateAbsent && len(t.Domains) == 0 {
+		return fmt.Errorf("'domains' must not be empty for state 'absent'")
+	}
+	if t.State == StateSet && len(t.Domains) == 0 {
+		return fmt.Errorf("'domains' must not be empty for state 'set'")
+	}
+	return nil
+}
+
 // Plan reports the drift the HttpAuthDomainTask would produce.
 func (t HttpAuthDomainTask) Plan() PlanResult {
-	if t.App == "" {
-		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult { return planHttpAuthDomainsPresent(t) },
@@ -108,9 +125,6 @@ func (t HttpAuthDomainTask) Plan() PlanResult {
 
 // planHttpAuthDomainsPresent reports drift for the present-state domain add.
 func planHttpAuthDomainsPresent(t HttpAuthDomainTask) PlanResult {
-	if len(t.Domains) == 0 {
-		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'domains' must not be empty for state 'present'")}
-	}
 	current, err := getHttpAuthDomains(t.App)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
@@ -151,9 +165,6 @@ func planHttpAuthDomainsPresent(t HttpAuthDomainTask) PlanResult {
 
 // planHttpAuthDomainsAbsent reports drift for the absent-state domain remove.
 func planHttpAuthDomainsAbsent(t HttpAuthDomainTask) PlanResult {
-	if len(t.Domains) == 0 {
-		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'domains' must not be empty for state 'absent'")}
-	}
 	current, err := getHttpAuthDomains(t.App)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
@@ -190,9 +201,6 @@ func planHttpAuthDomainsAbsent(t HttpAuthDomainTask) PlanResult {
 
 // planHttpAuthDomainsSet reports drift for the set-state full replacement.
 func planHttpAuthDomainsSet(t HttpAuthDomainTask) PlanResult {
-	if len(t.Domains) == 0 {
-		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'domains' must not be empty for state 'set'")}
-	}
 	current, err := getHttpAuthDomains(t.App)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}

--- a/tasks/http_auth_task.go
+++ b/tasks/http_auth_task.go
@@ -78,13 +78,21 @@ func (t HttpAuthTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// Plan reports the drift the HttpAuthTask would produce.
-func (t HttpAuthTask) Plan() PlanResult {
+// Validate checks the HttpAuthTask's inputs without contacting the server.
+func (t HttpAuthTask) Validate() error {
 	if t.State == StatePresent && t.Username == "" {
-		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("username is required when state is present")}
+		return fmt.Errorf("username is required when state is present")
 	}
 	if t.State == StatePresent && t.Password == "" {
-		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("password is required when state is present")}
+		return fmt.Errorf("password is required when state is present")
+	}
+	return nil
+}
+
+// Plan reports the drift the HttpAuthTask would produce.
+func (t HttpAuthTask) Plan() PlanResult {
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {

--- a/tasks/http_auth_user_task.go
+++ b/tasks/http_auth_user_task.go
@@ -125,26 +125,36 @@ func (t HttpAuthUserTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// Plan reports the drift the HttpAuthUserTask would produce.
-func (t HttpAuthUserTask) Plan() PlanResult {
+// Validate checks the HttpAuthUserTask's inputs without contacting the server.
+func (t HttpAuthUserTask) Validate() error {
 	if t.App == "" {
-		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+		return fmt.Errorf("'app' is required")
 	}
 	for _, u := range t.Users {
 		if u.Username == "" {
-			return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'username' is required for each user")}
+			return fmt.Errorf("'username' is required for each user")
 		}
+	}
+	if t.State == StatePresent {
+		if len(t.Users) == 0 {
+			return fmt.Errorf("'users' must not be empty for state 'present'")
+		}
+		for _, u := range t.Users {
+			if u.Password == "" {
+				return fmt.Errorf("'password' is required for user %q when state is present", u.Username)
+			}
+		}
+	}
+	return nil
+}
+
+// Plan reports the drift the HttpAuthUserTask would produce.
+func (t HttpAuthUserTask) Plan() PlanResult {
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if len(t.Users) == 0 {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'users' must not be empty for state 'present'")}
-			}
-			for _, u := range t.Users {
-				if u.Password == "" {
-					return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'password' is required for user %q when state is present", u.Username)}
-				}
-			}
 			current, err := getHttpAuthUsers(t.App)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}

--- a/tasks/letsencrypt_property_task.go
+++ b/tasks/letsencrypt_property_task.go
@@ -104,6 +104,11 @@ var letsencryptPropertyKeys = map[string]PropertyKeys{
 	"server":              {PerApp: "server", Global: "global-server"},
 }
 
+// Validate checks the LetsencryptPropertyTask's inputs without contacting the server.
+func (t LetsencryptPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "letsencrypt:set", letsencryptPropertyKeys)
+}
+
 // Plan reports the drift the LetsencryptPropertyTask would produce.
 func (t LetsencryptPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "letsencrypt:set", letsencryptPropertyKeys)

--- a/tasks/letsencrypt_task.go
+++ b/tasks/letsencrypt_task.go
@@ -69,10 +69,18 @@ func (t LetsencryptTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the LetsencryptTask's inputs without contacting the server.
+func (t LetsencryptTask) Validate() error {
+	if t.App == "" {
+		return fmt.Errorf("'app' is required")
+	}
+	return nil
+}
+
 // Plan reports the drift the LetsencryptTask would produce.
 func (t LetsencryptTask) Plan() PlanResult {
-	if t.App == "" {
-		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'app' is required")}
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {

--- a/tasks/logs_property_task.go
+++ b/tasks/logs_property_task.go
@@ -87,6 +87,11 @@ var logsPropertyKeys = map[string]PropertyKeys{
 	"vector-sink":     {PerApp: "vector-sink", Global: "global-vector-sink"},
 }
 
+// Validate checks the LogsPropertyTask's inputs without contacting the server.
+func (t LogsPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "logs:set", logsPropertyKeys)
+}
+
 // Plan reports the drift the LogsPropertyTask would produce.
 func (t LogsPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "logs:set", logsPropertyKeys)

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -256,6 +256,14 @@ type PlanResult struct {
 	apply func() TaskOutputState
 }
 
+// planErr wraps an input-validation error in a PlanResult. Tasks return it
+// from Plan() when their Validate() (or another pure input check) fails, so
+// the error surfaces uniformly as a PlanStatusError without contacting the
+// server.
+func planErr(err error) PlanResult {
+	return PlanResult{Status: PlanStatusError, Error: err}
+}
+
 // Task represents a task
 type Task interface {
 	// Doc returns the docblock for the task
@@ -272,6 +280,20 @@ type Task interface {
 	// ExecutePlan(t.Plan()) so probing happens once and the per-state
 	// mutation logic lives only in Plan().
 	Execute() TaskOutputState
+}
+
+// InputValidator is an optional interface a task implements to expose
+// input-only validation: checks that are a pure function of the task's
+// fields and require no server probing (empty-list-when-present, per-item
+// required fields, enum values, mutually-exclusive fields, and so on).
+//
+// A task's Plan() calls Validate() before it probes, so plan and apply
+// surface these errors. `docket validate` calls the same Validate() offline
+// (see validateTaskBody) so the identical conditional/semantic errors are
+// caught without contacting a server. Implementations must never call a
+// mutating or probing dokku command; that is what keeps validate offline.
+type InputValidator interface {
+	Validate() error
 }
 
 // Global registry for Tasks.

--- a/tasks/maintenance_custom_page_task.go
+++ b/tasks/maintenance_custom_page_task.go
@@ -97,17 +97,27 @@ func (t MaintenanceCustomPageTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the MaintenanceCustomPageTask's inputs without contacting the server.
+func (t MaintenanceCustomPageTask) Validate() error {
+	if err := validateMaintenanceCustomPageTask(t); err != nil {
+		return err
+	}
+	if t.State == StatePresent && t.Content == "" && t.Tarball == "" {
+		return fmt.Errorf("one of 'content' or 'tarball' is required when state is 'present'")
+	}
+	if t.State == StateAbsent && (t.Content != "" || t.Tarball != "") {
+		return fmt.Errorf("'content' and 'tarball' must not be set when state is 'absent'")
+	}
+	return nil
+}
+
 // Plan reports the drift the MaintenanceCustomPageTask would produce.
 func (t MaintenanceCustomPageTask) Plan() PlanResult {
+	if err := t.Validate(); err != nil {
+		return planErr(err)
+	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if err := validateMaintenanceCustomPageTask(t); err != nil {
-				return PlanResult{Status: PlanStatusError, Error: err}
-			}
-			if t.Content == "" && t.Tarball == "" {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("one of 'content' or 'tarball' is required when state is 'present'")}
-			}
-
 			tarBytes, err := maintenanceCustomPageTarball(t)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
@@ -160,13 +170,6 @@ func (t MaintenanceCustomPageTask) Plan() PlanResult {
 			}
 		},
 		StateAbsent: func() PlanResult {
-			if err := validateMaintenanceCustomPageTask(t); err != nil {
-				return PlanResult{Status: PlanStatusError, Error: err}
-			}
-			if t.Content != "" || t.Tarball != "" {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'content' and 'tarball' must not be set when state is 'absent'")}
-			}
-
 			current, reported, err := maintenanceCustomPageState(t.App)
 			if err != nil {
 				var sshErr *subprocess.SSHError

--- a/tasks/maintenance_task.go
+++ b/tasks/maintenance_task.go
@@ -102,6 +102,11 @@ func (t MaintenanceTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the MaintenanceTask's inputs without contacting the server.
+func (t MaintenanceTask) Validate() error {
+	return validateToggleInput(t.App, false, false)
+}
+
 // Plan reports the drift the MaintenanceTask would produce.
 func (t MaintenanceTask) Plan() PlanResult {
 	return planToggle(t.State, t.App, false, false, "maintenance:enable", "maintenance:disable", maintenanceEnabled)

--- a/tasks/network_property_task.go
+++ b/tasks/network_property_task.go
@@ -96,6 +96,11 @@ var networkPropertyKeys = map[string]PropertyKeys{
 	"tld":                 {PerApp: "tld", Global: "global-tld"},
 }
 
+// Validate checks the NetworkPropertyTask's inputs without contacting the server.
+func (t NetworkPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "network:set", networkPropertyKeys)
+}
+
 // Plan reports the drift the NetworkPropertyTask would produce.
 func (t NetworkPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "network:set", networkPropertyKeys)

--- a/tasks/nginx_property_task.go
+++ b/tasks/nginx_property_task.go
@@ -128,6 +128,11 @@ func (t NginxPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// Validate checks the NginxPropertyTask's inputs without contacting the server.
+func (t NginxPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "nginx:set", nginxPropertyKeys)
+}
+
 // Plan reports the drift the NginxPropertyTask would produce.
 func (t NginxPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "nginx:set", nginxPropertyKeys)

--- a/tasks/openresty_property_task.go
+++ b/tasks/openresty_property_task.go
@@ -124,6 +124,11 @@ var openrestyPropertyKeys = map[string]PropertyKeys{
 	"x-forwarded-ssl":                         {PerApp: "x-forwarded-ssl", Global: "global-x-forwarded-ssl"},
 }
 
+// Validate checks the OpenrestyPropertyTask's inputs without contacting the server.
+func (t OpenrestyPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "openresty:set", openrestyPropertyKeys)
+}
+
 // Plan reports the drift the OpenrestyPropertyTask would produce.
 func (t OpenrestyPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "openresty:set", openrestyPropertyKeys)

--- a/tasks/plugin_task.go
+++ b/tasks/plugin_task.go
@@ -88,16 +88,24 @@ func (t PluginTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the PluginTask's inputs without contacting the server.
+func (t PluginTask) Validate() error {
+	if t.Name == "" {
+		return fmt.Errorf("'name' is required")
+	}
+	if t.State == StatePresent && t.URL == "" {
+		return fmt.Errorf("'url' is required when state is 'present'")
+	}
+	return nil
+}
+
 // Plan reports the drift the PluginTask would produce.
 func (t PluginTask) Plan() PlanResult {
-	if t.Name == "" {
-		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'name' is required")}
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if t.URL == "" {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'url' is required when state is 'present'")}
-			}
 			installed, err := pluginInstalled(t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -102,10 +102,18 @@ func (t PortsTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the PortsTask's inputs without contacting the server.
+func (t PortsTask) Validate() error {
+	if len(t.PortMappings) == 0 {
+		return errors.New("no port mappings provided")
+	}
+	return nil
+}
+
 // Plan reports the drift the PortsTask would produce.
 func (t PortsTask) Plan() PlanResult {
-	if len(t.PortMappings) == 0 {
-		return PlanResult{Status: PlanStatusError, Error: errors.New("no port mappings provided")}
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -217,18 +217,33 @@ func isDynamicProperty(plugin, property string) bool {
 // emitted via warnIfUnknownProperty for typos and unsupported plugin
 // versions; other probe failures are recorded in PlanResult.Reason and
 // the apply still runs, matching pre-probe behavior.
-func planProperty(state State, app string, global bool, property, value, subcommand string, keys map[string]PropertyKeys) PlanResult {
+// validatePropertyInput checks a property task's inputs without probing the
+// server: app/global scoping, that the property is supported for the target
+// scope, and that a value is supplied only in the state that allows it. Both
+// planProperty and each property task's Validate() call it so plan and
+// validate report the same errors.
+func validatePropertyInput(state State, app string, global bool, property, value, subcommand string, keys map[string]PropertyKeys) error {
 	if !global && app == "" {
-		return PlanResult{
-			Status: PlanStatusError,
-			Error:  errors.New("app is required when global is false"),
-		}
+		return errors.New("app is required when global is false")
 	}
 	if global && app != "" {
-		return PlanResult{
-			Status: PlanStatusError,
-			Error:  fmt.Errorf("'app' must not be set when 'global' is set to true"),
-		}
+		return fmt.Errorf("'app' must not be set when 'global' is set to true")
+	}
+	if err := validateProperty(pluginFromSubcommand(subcommand), property, global, keys); err != nil {
+		return err
+	}
+	if state == StatePresent && value == "" {
+		return fmt.Errorf("setting a state of 'present' is invalid without a value for 'value'")
+	}
+	if state == StateAbsent && value != "" {
+		return fmt.Errorf("setting a state of 'absent' is invalid with a value for 'value'")
+	}
+	return nil
+}
+
+func planProperty(state State, app string, global bool, property, value, subcommand string, keys map[string]PropertyKeys) PlanResult {
+	if err := validatePropertyInput(state, app, global, property, value, subcommand, keys); err != nil {
+		return planErr(err)
 	}
 
 	plugin := pluginFromSubcommand(subcommand)
@@ -237,19 +252,8 @@ func planProperty(state State, app string, global bool, property, value, subcomm
 		target = "--global"
 	}
 
-	if err := validateProperty(plugin, property, global, keys); err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
-	}
-
 	return DispatchPlan(state, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if value == "" {
-				return PlanResult{
-					Status: PlanStatusError,
-					Error:  fmt.Errorf("setting a state of 'present' is invalid without a value for 'value'"),
-				}
-			}
-
 			// Dynamic property families have no probe key; treat as drift
 			// and run the mutation unconditionally.
 			if _, mapped := keys[property]; !mapped && isDynamicProperty(plugin, property) {
@@ -293,13 +297,6 @@ func planProperty(state State, app string, global bool, property, value, subcomm
 			}
 		},
 		StateAbsent: func() PlanResult {
-			if value != "" {
-				return PlanResult{
-					Status: PlanStatusError,
-					Error:  fmt.Errorf("setting a state of 'absent' is invalid with a value for 'value'"),
-				}
-			}
-
 			if _, mapped := keys[property]; !mapped && isDynamicProperty(plugin, property) {
 				return runUnprobedUnset(subcommand, target, property)
 			}

--- a/tasks/proxy_property_task.go
+++ b/tasks/proxy_property_task.go
@@ -93,6 +93,11 @@ var proxyPropertyKeys = map[string]PropertyKeys{
 	"proxy-ssl-port": {PerApp: "proxy-ssl-port", Global: "global-proxy-ssl-port"},
 }
 
+// Validate checks the ProxyPropertyTask's inputs without contacting the server.
+func (t ProxyPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "proxy:set", proxyPropertyKeys)
+}
+
 // Plan reports the drift the ProxyPropertyTask would produce.
 func (t ProxyPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "proxy:set", proxyPropertyKeys)

--- a/tasks/proxy_toggle_task.go
+++ b/tasks/proxy_toggle_task.go
@@ -98,6 +98,11 @@ func (t ProxyToggleTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the ProxyToggleTask's inputs without contacting the server.
+func (t ProxyToggleTask) Validate() error {
+	return validateToggleInput(t.App, t.Global, false)
+}
+
 // Plan reports the drift the ProxyToggleTask would produce.
 func (t ProxyToggleTask) Plan() PlanResult {
 	return planToggle(t.State, t.App, t.Global, false, "proxy:enable", "proxy:disable", proxyEnabled)

--- a/tasks/ps_property_task.go
+++ b/tasks/ps_property_task.go
@@ -89,6 +89,11 @@ var psPropertyKeys = map[string]PropertyKeys{
 	"stop-timeout-seconds": {PerApp: "stop-timeout-seconds", Global: "global-stop-timeout-seconds"},
 }
 
+// Validate checks the PsPropertyTask's inputs without contacting the server.
+func (t PsPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "ps:set", psPropertyKeys)
+}
+
 // Plan reports the drift the PsPropertyTask would produce.
 func (t PsPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "ps:set", psPropertyKeys)

--- a/tasks/ps_scale_task.go
+++ b/tasks/ps_scale_task.go
@@ -78,10 +78,18 @@ func (t PsScaleTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the PsScaleTask's inputs without contacting the server.
+func (t PsScaleTask) Validate() error {
+	if t.State == StatePresent && len(t.Scale) == 0 {
+		return fmt.Errorf("scale must be specified when state is present")
+	}
+	return nil
+}
+
 // Plan reports the drift the PsScaleTask would produce.
 func (t PsScaleTask) Plan() PlanResult {
-	if t.State == StatePresent && len(t.Scale) == 0 {
-		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("scale must be specified when state is present")}
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {

--- a/tasks/registry_auth_task.go
+++ b/tasks/registry_auth_task.go
@@ -98,12 +98,23 @@ func (t RegistryAuthTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the RegistryAuthTask's inputs without contacting the server.
+func (t RegistryAuthTask) Validate() error {
+	if err := validateRegistryAuthTask(t); err != nil {
+		return err
+	}
+	if t.State == StatePresent && (t.Username == "" || t.Password == "") {
+		return fmt.Errorf("'username' and 'password' are required when state is 'present'")
+	}
+	return nil
+}
+
 // Plan reports the drift the RegistryAuthTask would produce. dokku registry
 // plugins do not expose a probe for current login state, so the plan
 // reports drift unconditionally.
 func (t RegistryAuthTask) Plan() PlanResult {
-	if err := validateRegistryAuthTask(t); err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
 	target := t.App
 	if t.Global {
@@ -111,9 +122,6 @@ func (t RegistryAuthTask) Plan() PlanResult {
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if t.Username == "" || t.Password == "" {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'username' and 'password' are required when state is 'present'")}
-			}
 			args := []string{"--quiet", "registry:login", "--password-stdin"}
 			if t.Global {
 				args = append(args, "--global")

--- a/tasks/registry_property_task.go
+++ b/tasks/registry_property_task.go
@@ -95,6 +95,11 @@ var registryPropertyKeys = map[string]PropertyKeys{
 	"server":              {PerApp: "server", Global: "global-server"},
 }
 
+// Validate checks the RegistryPropertyTask's inputs without contacting the server.
+func (t RegistryPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "registry:set", registryPropertyKeys)
+}
+
 // Plan reports the drift the RegistryPropertyTask would produce.
 func (t RegistryPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "registry:set", registryPropertyKeys)

--- a/tasks/resource_limit_task.go
+++ b/tasks/resource_limit_task.go
@@ -87,6 +87,11 @@ func (t ResourceLimitTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// Validate checks the ResourceLimitTask's inputs without contacting the server.
+func (t ResourceLimitTask) Validate() error {
+	return validateResourceInput(t.State, t.Resources)
+}
+
 // Plan reports the drift the ResourceLimitTask would produce.
 func (t ResourceLimitTask) Plan() PlanResult {
 	return planResource(t.State, t.App, t.ProcessType, t.Resources, t.ClearBefore, "resource:limit")

--- a/tasks/resource_reserve_task.go
+++ b/tasks/resource_reserve_task.go
@@ -87,6 +87,11 @@ func (t ResourceReserveTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// Validate checks the ResourceReserveTask's inputs without contacting the server.
+func (t ResourceReserveTask) Validate() error {
+	return validateResourceInput(t.State, t.Resources)
+}
+
 // Plan reports the drift the ResourceReserveTask would produce.
 func (t ResourceReserveTask) Plan() PlanResult {
 	return planResource(t.State, t.App, t.ProcessType, t.Resources, t.ClearBefore, "resource:reserve")

--- a/tasks/resources.go
+++ b/tasks/resources.go
@@ -123,12 +123,20 @@ func exportResourceTasks(app, kind string, factory func(app, processType string,
 
 // planResource is the shared Plan() implementation for resource tasks. The
 // probe runs once; the apply closure consumes the diff.
-func planResource(state State, app, processType string, resources map[string]string, clearBefore bool, subcommand string) PlanResult {
+// validateResourceInput checks a resource task's inputs without probing the
+// server. planResource and each resource task's Validate() call it so plan and
+// validate report the same error. The unknown-resource-key check stays in
+// planSetResource because it needs the live resource report.
+func validateResourceInput(state State, resources map[string]string) error {
 	if state == StatePresent && len(resources) == 0 {
-		return PlanResult{
-			Status: PlanStatusError,
-			Error:  errors.New("resources are required when state is present"),
-		}
+		return errors.New("resources are required when state is present")
+	}
+	return nil
+}
+
+func planResource(state State, app, processType string, resources map[string]string, clearBefore bool, subcommand string) PlanResult {
+	if err := validateResourceInput(state, resources); err != nil {
+		return planErr(err)
 	}
 
 	rctx := ResourceContext{

--- a/tasks/scheduler_docker_local_property_task.go
+++ b/tasks/scheduler_docker_local_property_task.go
@@ -82,6 +82,11 @@ var schedulerDockerLocalPropertyKeys = map[string]PropertyKeys{
 	"parallel-schedule-count": {PerApp: "parallel-schedule-count", Global: ""},
 }
 
+// Validate checks the SchedulerDockerLocalPropertyTask's inputs without contacting the server.
+func (t SchedulerDockerLocalPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, false, t.Property, t.Value, "scheduler-docker-local:set", schedulerDockerLocalPropertyKeys)
+}
+
 // Plan reports the drift the SchedulerDockerLocalPropertyTask would produce.
 func (t SchedulerDockerLocalPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, false, t.Property, t.Value, "scheduler-docker-local:set", schedulerDockerLocalPropertyKeys)

--- a/tasks/scheduler_k3s_annotations_task.go
+++ b/tasks/scheduler_k3s_annotations_task.go
@@ -106,13 +106,17 @@ func (t SchedulerK3sAnnotationsTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the SchedulerK3sAnnotationsTask's inputs without contacting the server.
+func (t SchedulerK3sAnnotationsTask) Validate() error {
+	return validateSchedulerK3sScopedPairs(t.spec(), t.State)
+}
+
 // Plan reports the drift the SchedulerK3sAnnotationsTask would produce.
 func (t SchedulerK3sAnnotationsTask) Plan() PlanResult {
-	spec := t.spec()
-	if err := validateSchedulerK3sScopedPairs(spec, t.State); err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
-
+	spec := t.spec()
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult { return planSchedulerK3sScopedPairsSet(spec) },
 		StateAbsent:  func() PlanResult { return planSchedulerK3sScopedPairsUnset(spec) },

--- a/tasks/scheduler_k3s_autoscaling_auth_task.go
+++ b/tasks/scheduler_k3s_autoscaling_auth_task.go
@@ -92,13 +92,17 @@ func (t SchedulerK3sAutoscalingAuthTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the SchedulerK3sAutoscalingAuthTask's inputs without contacting the server.
+func (t SchedulerK3sAutoscalingAuthTask) Validate() error {
+	return validateSchedulerK3sAutoscalingAuth(t.spec())
+}
+
 // Plan reports the drift the SchedulerK3sAutoscalingAuthTask would produce.
 func (t SchedulerK3sAutoscalingAuthTask) Plan() PlanResult {
-	spec := t.spec()
-	if err := validateSchedulerK3sAutoscalingAuth(spec); err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
-
+	spec := t.spec()
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult { return planSchedulerK3sAutoscalingAuthSet(spec) },
 		StateAbsent:  func() PlanResult { return planSchedulerK3sAutoscalingAuthUnset(spec) },

--- a/tasks/scheduler_k3s_chart_task.go
+++ b/tasks/scheduler_k3s_chart_task.go
@@ -117,23 +117,34 @@ func (t SchedulerK3sChartTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// Plan reports the drift the SchedulerK3sChartTask would produce.
-func (t SchedulerK3sChartTask) Plan() PlanResult {
+// Validate checks the SchedulerK3sChartTask's inputs without contacting the server.
+func (t SchedulerK3sChartTask) Validate() error {
 	if t.Chart == "" {
-		return PlanResult{Status: PlanStatusError, Error: errors.New("chart is required")}
+		return errors.New("chart is required")
 	}
 	if len(t.Values) == 0 {
 		state := t.State
 		if state == "" {
 			state = StatePresent
 		}
-		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'values' must not be empty for state '%s'", state)}
+		return fmt.Errorf("'values' must not be empty for state '%s'", state)
+	}
+	if _, err := flattenChartValues(t.Values); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Plan reports the drift the SchedulerK3sChartTask would produce.
+func (t SchedulerK3sChartTask) Plan() PlanResult {
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
 
-	desired, err := flattenChartValues(t.Values)
-	if err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
-	}
+	// Validate() already flattened the values (and returned any error), so
+	// the flattened map is reused here for the apply; the error is
+	// guaranteed nil.
+	desired, _ := flattenChartValues(t.Values)
 
 	currentFn := func() (map[string]string, error) {
 		return getSchedulerK3sChartValues(t.Chart)

--- a/tasks/scheduler_k3s_labels_task.go
+++ b/tasks/scheduler_k3s_labels_task.go
@@ -104,13 +104,17 @@ func (t SchedulerK3sLabelsTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the SchedulerK3sLabelsTask's inputs without contacting the server.
+func (t SchedulerK3sLabelsTask) Validate() error {
+	return validateSchedulerK3sScopedPairs(t.spec(), t.State)
+}
+
 // Plan reports the drift the SchedulerK3sLabelsTask would produce.
 func (t SchedulerK3sLabelsTask) Plan() PlanResult {
-	spec := t.spec()
-	if err := validateSchedulerK3sScopedPairs(spec, t.State); err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
-
+	spec := t.spec()
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult { return planSchedulerK3sScopedPairsSet(spec) },
 		StateAbsent:  func() PlanResult { return planSchedulerK3sScopedPairsUnset(spec) },

--- a/tasks/scheduler_k3s_profile_task.go
+++ b/tasks/scheduler_k3s_profile_task.go
@@ -106,10 +106,18 @@ func (t SchedulerK3sProfileTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the SchedulerK3sProfileTask's inputs without contacting the server.
+func (t SchedulerK3sProfileTask) Validate() error {
+	if err := validateSchedulerK3sProfile(t); err != nil {
+		return err
+	}
+	return nil
+}
+
 // Plan reports the drift the SchedulerK3sProfileTask would produce.
 func (t SchedulerK3sProfileTask) Plan() PlanResult {
-	if err := validateSchedulerK3sProfile(t); err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
 
 	return DispatchPlan(t.State, map[State]func() PlanResult{

--- a/tasks/scheduler_k3s_property_task.go
+++ b/tasks/scheduler_k3s_property_task.go
@@ -112,6 +112,11 @@ var schedulerK3sPropertyKeys = map[string]PropertyKeys{
 	"token":                  {PerApp: "", Global: "global-token"},
 }
 
+// Validate checks the SchedulerK3sPropertyTask's inputs without contacting the server.
+func (t SchedulerK3sPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "scheduler-k3s:set", schedulerK3sPropertyKeys)
+}
+
 // Plan reports the drift the SchedulerK3sPropertyTask would produce.
 func (t SchedulerK3sPropertyTask) Plan() PlanResult {
 	if strings.HasPrefix(t.Property, "chart.") {

--- a/tasks/scheduler_property_task.go
+++ b/tasks/scheduler_property_task.go
@@ -83,6 +83,11 @@ var schedulerPropertyKeys = map[string]PropertyKeys{
 	"shell":    {PerApp: "shell", Global: "global-shell"},
 }
 
+// Validate checks the SchedulerPropertyTask's inputs without contacting the server.
+func (t SchedulerPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "scheduler:set", schedulerPropertyKeys)
+}
+
 // Plan reports the drift the SchedulerPropertyTask would produce.
 func (t SchedulerPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "scheduler:set", schedulerPropertyKeys)

--- a/tasks/service_backup_task.go
+++ b/tasks/service_backup_task.go
@@ -131,22 +131,32 @@ func (t ServiceBackupTask) hasAuth() bool {
 	return t.AwsAccessKeyID != "" || t.AwsSecretAccessKey != ""
 }
 
+// Validate checks the ServiceBackupTask's inputs without contacting the server.
+func (t ServiceBackupTask) Validate() error {
+	if t.State == StatePresent {
+		if t.Schedule != "" && t.Bucket == "" {
+			return fmt.Errorf("'bucket' is required when 'schedule' is set")
+		}
+		if t.Bucket != "" && t.Schedule == "" {
+			return fmt.Errorf("'schedule' is required when 'bucket' is set")
+		}
+		if t.hasAuth() && (t.AwsAccessKeyID == "" || t.AwsSecretAccessKey == "") {
+			return fmt.Errorf("'aws_access_key_id' and 'aws_secret_access_key' are both required to configure backup auth")
+		}
+		if t.Schedule == "" && !t.hasAuth() && t.EncryptionPassphrase == "" {
+			return fmt.Errorf("at least one of 'schedule', aws credentials, or 'encryption_passphrase' is required when state is 'present'")
+		}
+	}
+	return nil
+}
+
 // Plan reports the drift the ServiceBackupTask would produce.
 func (t ServiceBackupTask) Plan() PlanResult {
+	if err := t.Validate(); err != nil {
+		return planErr(err)
+	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if t.Schedule != "" && t.Bucket == "" {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'bucket' is required when 'schedule' is set")}
-			}
-			if t.Bucket != "" && t.Schedule == "" {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'schedule' is required when 'bucket' is set")}
-			}
-			if t.hasAuth() && (t.AwsAccessKeyID == "" || t.AwsSecretAccessKey == "") {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'aws_access_key_id' and 'aws_secret_access_key' are both required to configure backup auth")}
-			}
-			if t.Schedule == "" && !t.hasAuth() && t.EncryptionPassphrase == "" {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("at least one of 'schedule', aws credentials, or 'encryption_passphrase' is required when state is 'present'")}
-			}
 			exists, err := serviceExists(t.Service, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}

--- a/tasks/service_expose_task.go
+++ b/tasks/service_expose_task.go
@@ -87,13 +87,21 @@ func (t ServiceExposeTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the ServiceExposeTask's inputs without contacting the server.
+func (t ServiceExposeTask) Validate() error {
+	if t.State == StatePresent && len(t.Ports) == 0 {
+		return fmt.Errorf("'ports' is required when state is 'present'")
+	}
+	return nil
+}
+
 // Plan reports the drift the ServiceExposeTask would produce.
 func (t ServiceExposeTask) Plan() PlanResult {
+	if err := t.Validate(); err != nil {
+		return planErr(err)
+	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if len(t.Ports) == 0 {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'ports' is required when state is 'present'")}
-			}
 			exists, err := serviceExists(t.Service, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}

--- a/tasks/service_property_task.go
+++ b/tasks/service_property_task.go
@@ -91,18 +91,29 @@ func (t ServicePropertyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the ServicePropertyTask's inputs without contacting the server.
+func (t ServicePropertyTask) Validate() error {
+	if t.Property == "" {
+		return fmt.Errorf("'property' is required")
+	}
+	if t.State == StatePresent && t.Value == "" {
+		return fmt.Errorf("'value' is required when state is 'present'")
+	}
+	if t.State == StateAbsent && t.Value != "" {
+		return fmt.Errorf("'value' must not be set when state is 'absent'")
+	}
+	return nil
+}
+
 // Plan reports the drift the ServicePropertyTask would produce. dokku has no
 // reliable way to read back a service set key, so the plan reports drift
 // unconditionally once the service is confirmed to exist.
 func (t ServicePropertyTask) Plan() PlanResult {
-	if t.Property == "" {
-		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'property' is required")}
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if t.Value == "" {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'value' is required when state is 'present'")}
-			}
 			exists, err := serviceExists(t.Service, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
@@ -126,9 +137,6 @@ func (t ServicePropertyTask) Plan() PlanResult {
 			}
 		},
 		StateAbsent: func() PlanResult {
-			if t.Value != "" {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'value' must not be set when state is 'absent'")}
-			}
 			exists, err := serviceExists(t.Service, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}

--- a/tasks/ssh_key_task.go
+++ b/tasks/ssh_key_task.go
@@ -73,20 +73,30 @@ func (t SshKeyTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the SshKeyTask's inputs without contacting the server.
+func (t SshKeyTask) Validate() error {
+	if t.Name == "" {
+		return fmt.Errorf("'name' is required")
+	}
+	if t.State == StatePresent {
+		if t.Key == "" {
+			return fmt.Errorf("'key' is required when state is 'present'")
+		}
+		if _, _, _, _, err := ssh.ParseAuthorizedKey([]byte(t.Key)); err != nil {
+			return fmt.Errorf("invalid public key: %v", err)
+		}
+	}
+	return nil
+}
+
 // Plan reports the drift the SshKeyTask would produce.
 func (t SshKeyTask) Plan() PlanResult {
-	if t.Name == "" {
-		return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'name' is required")}
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if t.Key == "" {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("'key' is required when state is 'present'")}
-			}
-			pub, _, _, _, err := ssh.ParseAuthorizedKey([]byte(t.Key))
-			if err != nil {
-				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("invalid public key: %v", err)}
-			}
+			pub, _, _, _, _ := ssh.ParseAuthorizedKey([]byte(t.Key))
 			keys, err := sshKeysList()
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}

--- a/tasks/storage_ensure_task.go
+++ b/tasks/storage_ensure_task.go
@@ -74,18 +74,31 @@ func (t StorageEnsureTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the StorageEnsureTask's inputs without contacting the server.
+func (t StorageEnsureTask) Validate() error {
+	if t.State == StatePresent {
+		chownValues := map[string]bool{
+			"heroku": true, "herokuish": true, "paketo": true, "root": true, "false": true,
+		}
+		if !chownValues[t.Chown] {
+			return errors.New("invalid chown value specified")
+		}
+	}
+	if t.State == StateAbsent {
+		return errors.New("the absent state is not supported for storage:ensure")
+	}
+	return nil
+}
+
 // Plan reports the drift the StorageEnsureTask would produce. dokku does
 // not expose a probe for storage:ensure-directory, so the plan reports
 // drift unconditionally.
 func (t StorageEnsureTask) Plan() PlanResult {
-	chownValues := map[string]bool{
-		"heroku": true, "herokuish": true, "paketo": true, "root": true, "false": true,
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			if !chownValues[t.Chown] {
-				return PlanResult{Status: PlanStatusError, Error: errors.New("invalid chown value specified")}
-			}
 			inputs := []subprocess.ExecCommandInput{{
 				Command: "dokku",
 				Args:    []string{"--quiet", "storage:ensure-directory", "--chown", t.Chown, t.App},
@@ -100,9 +113,6 @@ func (t StorageEnsureTask) Plan() PlanResult {
 					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
 				},
 			}
-		},
-		StateAbsent: func() PlanResult {
-			return PlanResult{Status: PlanStatusError, Error: errors.New("the absent state is not supported for storage:ensure")}
 		},
 	})
 }

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -157,10 +157,18 @@ func (t StorageMountTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the StorageMountTask's inputs without contacting the server.
+func (t StorageMountTask) Validate() error {
+	if err := t.validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
 // Plan reports the drift the StorageMountTask would produce.
 func (t StorageMountTask) Plan() PlanResult {
-	if err := t.validate(); err != nil {
-		return PlanResult{Status: PlanStatusError, Error: err}
+	if err := t.Validate(); err != nil {
+		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {

--- a/tasks/toggle.go
+++ b/tasks/toggle.go
@@ -27,12 +27,19 @@ type ToggleProbe func(ctx ToggleContext) (enabled bool, err error)
 // probe reports whether the underlying plugin is currently in the
 // "enabled" position; when probe is nil or fails, planToggle reports drift
 // and the apply closure runs the underlying enable/disable command.
-func planToggle(state State, app string, global bool, allowGlobal bool, enableCmd, disableCmd string, probe ToggleProbe) PlanResult {
+// validateToggleInput checks a toggle task's inputs without probing the
+// server. planToggle and each toggle task's Validate() call it so plan and
+// validate report the same error.
+func validateToggleInput(app string, global, allowGlobal bool) error {
 	if allowGlobal && global && app != "" {
-		return PlanResult{
-			Status: PlanStatusError,
-			Error:  fmt.Errorf("'app' must not be set when 'global' is set to true"),
-		}
+		return fmt.Errorf("'app' must not be set when 'global' is set to true")
+	}
+	return nil
+}
+
+func planToggle(state State, app string, global bool, allowGlobal bool, enableCmd, disableCmd string, probe ToggleProbe) PlanResult {
+	if err := validateToggleInput(app, global, allowGlobal); err != nil {
+		return planErr(err)
 	}
 
 	target := app

--- a/tasks/traefik_property_task.go
+++ b/tasks/traefik_property_task.go
@@ -98,6 +98,11 @@ var traefikPropertyKeys = map[string]PropertyKeys{
 	"log-level":               {PerApp: "", Global: "global-log-level"},
 }
 
+// Validate checks the TraefikPropertyTask's inputs without contacting the server.
+func (t TraefikPropertyTask) Validate() error {
+	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "traefik:set", traefikPropertyKeys)
+}
+
 // Plan reports the drift the TraefikPropertyTask would produce.
 func (t TraefikPropertyTask) Plan() PlanResult {
 	return planProperty(t.State, t.App, t.Global, t.Property, t.Value, "traefik:set", traefikPropertyKeys)

--- a/tasks/validate.go
+++ b/tasks/validate.go
@@ -650,6 +650,27 @@ func validateTaskBody(registered Task, typeName string, body *yaml.Node, playLab
 		})
 	}
 
+	// Enforce the task's conditional/semantic input rules offline, but only
+	// when the body is fully concrete. Skip if a required field is missing
+	// (that primary problem is already reported and the conditional checks
+	// depend on it) or if a required-no-default input rendered to the
+	// validatePlaceholder sentinel, whose real value is unknown offline and
+	// could otherwise trip a "must not be set" check into a false positive.
+	if len(problems) == 0 && !strings.Contains(string(marshaled), validatePlaceholder) {
+		if validator, ok := v.Interface().(InputValidator); ok {
+			if err := validator.Validate(); err != nil {
+				problems = append(problems, Problem{
+					Code:    "invalid_task_input",
+					Play:    playLabel,
+					Task:    taskLabel,
+					Line:    body.Line,
+					Column:  body.Column,
+					Message: err.Error(),
+				})
+			}
+		}
+	}
+
 	return problems
 }
 

--- a/tasks/validate_integration_test.go
+++ b/tasks/validate_integration_test.go
@@ -77,3 +77,29 @@ func TestIntegrationValidateRunsOffline(t *testing.T) {
 		t.Fatalf("expected no problems with empty PATH, got: %+v", problems)
 	}
 }
+
+// TestIntegrationValidateInputValidationRunsOffline confirms the conditional
+// input validation (InputValidator.Validate) also stays offline: with PATH
+// cleared, a recipe that trips a task's Validate() must still surface the
+// invalid_task_input problem without ever shelling out to `dokku`.
+func TestIntegrationValidateInputValidationRunsOffline(t *testing.T) {
+	skipIfNotInShardT(t)
+	original := os.Getenv("PATH")
+	if err := os.Setenv("PATH", ""); err != nil {
+		t.Fatalf("os.Setenv: %v", err)
+	}
+	defer os.Setenv("PATH", original)
+
+	data := []byte(`---
+- tasks:
+    - dokku_acl_app:
+        app: docket-validate-offline
+        users: []
+        state: present
+`)
+
+	problems := Validate(data, ValidateOptions{})
+	if p := findProblem(problems, "invalid_task_input"); p == nil {
+		t.Fatalf("expected invalid_task_input with empty PATH, got: %+v", problems)
+	}
+}

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -338,6 +338,50 @@ func TestValidateInvalidTaskInputSkippedWithPlaceholder(t *testing.T) {
 	}
 }
 
+func TestValidateInvalidTaskInputNestedItem(t *testing.T) {
+	// http_auth_user validates each user in the list; a present user without
+	// a password is a conditional error the offline validator now catches.
+	data := []byte(`---
+- tasks:
+    - dokku_http_auth_user:
+        app: my-app
+        state: present
+        users:
+            - username: alice
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "invalid_task_input")
+	if p == nil {
+		t.Fatalf("expected invalid_task_input problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, "'password' is required") {
+		t.Errorf("expected message to mention required password, got: %q", p.Message)
+	}
+}
+
+func TestValidateInvalidTaskInputForbiddenWhenAbsent(t *testing.T) {
+	// service_property forbids a value when clearing (state absent); this is
+	// the "must not be set" shape, which the placeholder guard protects from
+	// false positives but concrete recipes still enforce.
+	data := []byte(`---
+- tasks:
+    - dokku_service_property:
+        service: postgres
+        name: my-db
+        property: some-property
+        value: nope
+        state: absent
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "invalid_task_input")
+	if p == nil {
+		t.Fatalf("expected invalid_task_input problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, "must not be set") {
+		t.Errorf("expected message to mention value must not be set, got: %q", p.Message)
+	}
+}
+
 func TestValidateNearestTaskName(t *testing.T) {
 	tests := []struct {
 		input  string

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -255,6 +255,89 @@ func TestValidateMultipleProblemsCollected(t *testing.T) {
 	}
 }
 
+func TestValidateInvalidTaskInput(t *testing.T) {
+	// acl_app requires a non-empty users list when state is present. That
+	// conditional rule lives in AclAppTask.Validate(), which the offline
+	// validator now enforces.
+	data := []byte(`---
+- tasks:
+    - dokku_acl_app:
+        app: my-app
+        users: []
+        state: present
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "invalid_task_input")
+	if p == nil {
+		t.Fatalf("expected invalid_task_input problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, "'users' must not be empty") {
+		t.Errorf("expected message to mention empty users, got: %q", p.Message)
+	}
+	if p.Line == 0 {
+		t.Errorf("expected non-zero line, got: %d", p.Line)
+	}
+}
+
+func TestValidateInvalidTaskInputSatisfied(t *testing.T) {
+	// A present acl_app with users, and an absent acl_app with no users
+	// (clear the whole ACL), are both valid inputs.
+	data := []byte(`---
+- tasks:
+    - dokku_acl_app:
+        app: my-app
+        users:
+            - alice
+        state: present
+    - dokku_acl_app:
+        app: my-app
+        state: absent
+`)
+	problems := Validate(data, ValidateOptions{})
+	if n := countProblems(problems, "invalid_task_input"); n != 0 {
+		t.Errorf("expected no invalid_task_input, got %d: %+v", n, problems)
+	}
+}
+
+func TestValidateInvalidTaskInputSkippedWhenRequiredMissing(t *testing.T) {
+	// When a required field is missing, only missing_required_field is
+	// reported; the conditional Validate() check (which depends on that
+	// field) is skipped so the two do not double-report.
+	data := []byte(`---
+- tasks:
+    - dokku_acl_app:
+        users: []
+        state: present
+`)
+	problems := Validate(data, ValidateOptions{})
+	if p := findProblem(problems, "missing_required_field"); p == nil {
+		t.Fatalf("expected missing_required_field problem, got: %+v", problems)
+	}
+	if n := countProblems(problems, "invalid_task_input"); n != 0 {
+		t.Errorf("expected no invalid_task_input when a required field is missing, got %d: %+v", n, problems)
+	}
+}
+
+func TestValidateInvalidTaskInputSkippedWithPlaceholder(t *testing.T) {
+	// A required-no-default input renders to the validate placeholder, whose
+	// real value is unknown offline. The conditional check is skipped for the
+	// whole task so it can never false-positive on a parameterized recipe.
+	data := []byte(`---
+- inputs:
+    - name: app
+      required: true
+  tasks:
+    - dokku_acl_app:
+        app: {{ .app }}
+        users: []
+        state: present
+`)
+	problems := Validate(data, ValidateOptions{})
+	if n := countProblems(problems, "invalid_task_input"); n != 0 {
+		t.Errorf("expected no invalid_task_input with placeholder input, got %d: %+v", n, problems)
+	}
+}
+
 func TestValidateNearestTaskName(t *testing.T) {
 	tests := []struct {
 		input  string

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -382,6 +382,28 @@ func TestValidateInvalidTaskInputForbiddenWhenAbsent(t *testing.T) {
 	}
 }
 
+func TestValidateInvalidTaskInputMutuallyExclusive(t *testing.T) {
+	// certs routes its validateCertsTask helper through Validate(); supplying
+	// both a cert path and cert_content is a mutually-exclusive input error.
+	data := []byte(`---
+- tasks:
+    - dokku_certs:
+        app: my-app
+        cert: /etc/ssl/server.crt
+        cert_content: "-----BEGIN CERTIFICATE-----"
+        key: /etc/ssl/server.key
+        state: present
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "invalid_task_input")
+	if p == nil {
+		t.Fatalf("expected invalid_task_input problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, "mutually exclusive") {
+		t.Errorf("expected message to mention mutual exclusion, got: %q", p.Message)
+	}
+}
+
 func TestValidateNearestTaskName(t *testing.T) {
 	tests := []struct {
 		input  string

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -404,6 +404,29 @@ func TestValidateInvalidTaskInputMutuallyExclusive(t *testing.T) {
 	}
 }
 
+func TestValidateInvalidTaskInputPropertyScope(t *testing.T) {
+	// Property tasks route their input validation through validatePropertyInput
+	// via the shared planProperty helper; setting both global and app is a
+	// scoping error the offline validator now catches.
+	data := []byte(`---
+- tasks:
+    - dokku_nginx_property:
+        app: my-app
+        global: true
+        property: client-max-body-size
+        value: 10m
+        state: present
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "invalid_task_input")
+	if p == nil {
+		t.Fatalf("expected invalid_task_input problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, "must not be set when 'global'") {
+		t.Errorf("expected message to mention global/app conflict, got: %q", p.Message)
+	}
+}
+
 func TestValidateNearestTaskName(t *testing.T) {
 	tests := []struct {
 		input  string

--- a/tests/bats/validate.bats
+++ b/tests/bats/validate.bats
@@ -43,6 +43,34 @@ EOF
   assert_output --partial 'missing required field "app"'
 }
 
+@test "docket validate exits 1 on a conditional input error" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_acl_app:
+        app: docket-test-validate
+        users: []
+        state: present
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "'users' must not be empty"
+}
+
+@test "docket validate --json emits invalid_task_input" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_acl_app:
+        app: docket-test-validate
+        users: []
+        state: present
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE" --json
+  assert_failure
+  assert_output --partial '"code":"invalid_task_input"'
+}
+
 @test "docket validate exits 1 on broken sigil template" {
   write_tasks_file <<EOF
 ---


### PR DESCRIPTION
`docket validate` enforced `required:"true"` struct-tag fields offline but not the conditional and semantic input requirements each task encodes inside its `Plan()` method, so recipe-authoring mistakes such as an empty `allowed_ips` or `users` list when `state: present`, a missing `password`, or setting a property both globally and per-app only surfaced at plan or apply time after contacting a server. This teaches `docket validate` to run each task's conditional and semantic input checks offline as well, reporting any failure as a new `invalid_task_input` problem so those mistakes are caught before a server is contacted. The same checks continue to run during plan and apply, so all three report identical errors, and validation stays offline because the checks never contact the server.

Closes #276.
