### PR TITLE
feat: reconstruct full storage_mount attachment state on export

### DIFF
--- a/docs/tasks/dokku_storage_mount.md
+++ b/docs/tasks/dokku_storage_mount.md
@@ -6,7 +6,7 @@ Attaches or detaches storage on a dokku application
 
 ## Export support
 
-Partial - storage:list does not expose phases, readonly, subpath, or process-type, so those attachment details are not reconstructed.
+Supported.
 
 ## Parameters
 

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -5,10 +5,16 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/dokku/docket/subprocess"
 )
+
+// storageDefaultProcessType is dokku's wildcard process type (DefaultProcessType
+// in the storage plugin). An attachment carrying it applies to every process, so
+// export omits process_type in that case to keep the recipe minimal.
+const storageDefaultProcessType = "_default_"
 
 // StorageMountTask manages a storage attachment for a dokku application.
 // It supports two forms:
@@ -22,11 +28,12 @@ import (
 //     plus the matching attachment flags.
 //
 // Exactly one of entry_name / host_dir must be set. Idempotency is keyed
-// on (source, container_path, volume_options) using `storage:list <app>
+// on (source, container_path, volume_options) using `storage:report <app>
 // --format json`; the other attachment attributes (phases, process_type,
 // subpath, readonly, volume_chown) are applied at mount time only and
 // are not drift-detected (mirroring the partial-probe pattern in
-// service_backup and storage_ensure).
+// service_backup and storage_ensure). Export reads the same report and
+// reconstructs every attribute in full.
 type StorageMountTask struct {
 	// App is the name of the app
 	App string `required:"true" yaml:"app" description:"Name of the app"`
@@ -89,7 +96,7 @@ func (t StorageMountTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t StorageMountTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportPartial, Caveat: "storage:list does not expose phases, readonly, subpath, or process-type, so those attachment details are not reconstructed"}
+	return ExportSupport{Status: ExportSupported}
 }
 
 // Examples returns the examples for the storage mount task
@@ -263,7 +270,7 @@ func (t StorageMountTask) describeMount() string {
 // the legacy host:container[:opts] colon form is used so dokku
 // auto-generates a `legacy-<id>` entry; later operations against that
 // attachment go through namedMountArgs/namedUnmountArgs via the entry
-// name discovered from storage:list.
+// name discovered from storage:report.
 func (t StorageMountTask) mountArgs() []string {
 	if t.EntryName != "" {
 		return t.namedMountArgs(t.EntryName)
@@ -275,7 +282,7 @@ func (t StorageMountTask) mountArgs() []string {
 // namedMountArgs renders storage:mount in the named-entry CLI form for
 // the given entry. Used both when the recipe specifies entry_name and
 // when docket is remediating drift on a legacy-CLI mount whose auto-
-// generated entry name was discovered from storage:list. Dokku 0.38.13's
+// generated entry name was discovered from storage:report. Dokku 0.38.13's
 // upsert semantic (dokku/dokku#8713) makes the call idempotent.
 func (t StorageMountTask) namedMountArgs(entryName string) []string {
 	args := []string{"--quiet", "storage:mount", t.App, entryName, "--container-dir", t.ContainerDir}
@@ -334,70 +341,84 @@ func (t StorageMountTask) attachmentFlags() []string {
 // generated as `legacy-<id>` for attachments created via the legacy CLI
 // form), and is the address docket uses for follow-up mount/unmount
 // commands. VolumeOptions enables option-drift detection on
-// state: present. The other mount-time attributes (phases, subpath,
-// readonly, volume_chown) are not exposed in a way docket compares today.
+// state: present. The other mount-time attributes (phases, process_type,
+// subpath, readonly, volume_chown) are read by the exporter but
+// intentionally not drift-detected here.
 type existingMount struct {
 	EntryName     string
 	VolumeOptions string
 }
 
-// ExportApp reads the app's storage attachments and returns a dokku_storage_mount
-// task per mount. Legacy bind-mounts (dokku wraps these under an auto-generated
+// ExportApp reads the app's storage attachments via storage:report and returns
+// a dokku_storage_mount task per attachment, reconstructing every mount-time
+// attribute (phases, process_type, subpath, readonly, volume_options,
+// volume_chown). Legacy bind-mounts (dokku wraps these under an auto-generated
 // "legacy-" entry name) use the host_dir form; named registry entries use the
-// entry_name form. Phase/readonly/subpath details are not exposed by
-// storage:list, so only the mount itself is reconstructed.
+// entry_name form. Phases and process_type that match dokku's defaults are
+// omitted so the exported recipe stays minimal.
 func (t StorageMountTask) ExportApp(app string) ([]interface{}, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    []string{"--quiet", "storage:list", app, "--format", "json"},
-	})
+	attachments, err := readStorageAttachments(app)
 	if err != nil {
-		var sshErr *subprocess.SSHError
-		if errors.As(err, &sshErr) {
-			return nil, err
-		}
-		return nil, nil
+		return nil, err
 	}
-
-	var mounts []struct {
-		EntryName     string `json:"entry_name"`
-		HostPath      string `json:"host_path"`
-		ContainerPath string `json:"container_path"`
-		VolumeOptions string `json:"volume_options"`
-	}
-	if err := json.Unmarshal(result.StdoutBytes(), &mounts); err != nil {
-		return nil, nil
-	}
-	sort.Slice(mounts, func(i, j int) bool { return mounts[i].ContainerPath < mounts[j].ContainerPath })
 
 	var out []interface{}
-	for _, m := range mounts {
-		task := StorageMountTask{App: app, ContainerDir: m.ContainerPath, VolumeOptions: m.VolumeOptions}
-		if m.EntryName == "" || strings.HasPrefix(m.EntryName, "legacy-") {
-			task.HostDir = m.HostPath
+	for _, a := range attachments {
+		task := StorageMountTask{
+			App:           app,
+			ContainerDir:  a.ContainerPath,
+			Subpath:       a.Subpath,
+			Readonly:      a.Readonly,
+			VolumeChown:   a.VolumeChown,
+			VolumeOptions: a.VolumeOptions,
+		}
+		if a.EntryName == "" || strings.HasPrefix(a.EntryName, "legacy-") {
+			task.HostDir = a.HostPath
 		} else {
-			task.EntryName = m.EntryName
+			task.EntryName = a.EntryName
+		}
+		if !isDefaultPhases(a.Phases) {
+			task.Phases = a.Phases
+		}
+		if a.ProcessType != "" && a.ProcessType != storageDefaultProcessType {
+			task.ProcessType = a.ProcessType
 		}
 		out = append(out, task)
 	}
 	return out, nil
 }
 
-// findMount returns the existing attachment matching either the named-entry
-// form (entry_name + container_path) or the legacy form (host_path +
-// container_path), or nil if none exists. A transport-level failure
-// (`*subprocess.SSHError`) is propagated; a dokku-level non-zero exit
-// (e.g. app does not exist) is treated as "no mount."
-func findMount(app, entryName, hostDir, containerDir string) (*existingMount, error) {
+// reportAttachment is one storage attachment reconstructed from
+// `storage:report <app> --format json`. Unlike the deploy-phase-filtered
+// storage:list view, it carries every mount-time attribute the dokku
+// Attachment model exposes.
+type reportAttachment struct {
+	EntryName     string
+	HostPath      string
+	ContainerPath string
+	Phases        []string
+	ProcessType   string
+	Subpath       string
+	VolumeOptions string
+	VolumeChown   string
+	Readonly      bool
+}
+
+// readStorageAttachments reads every storage attachment on an app via
+// `storage:report <app> --format json`. That report (unlike storage:list)
+// exposes all attachment attributes and is not filtered to the deploy phase.
+// dokku emits each attachment as a set of flat indexed keys
+// (attachment.<N>.<field>); this regroups them by index and returns the
+// attachments sorted by (container_path, process_type, entry_name) for stable
+// output.
+//
+// A transport-level failure (*subprocess.SSHError) is propagated; a dokku-level
+// non-zero exit (e.g. app does not exist) or a JSON parse failure is treated as
+// "no attachments."
+func readStorageAttachments(app string) ([]reportAttachment, error) {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
-		Args: []string{
-			"--quiet",
-			"storage:list",
-			app,
-			"--format",
-			"json",
-		},
+		Args:    []string{"--quiet", "storage:report", app, "--format", "json"},
 	})
 	if err != nil {
 		var sshErr *subprocess.SSHError
@@ -407,26 +428,105 @@ func findMount(app, entryName, hostDir, containerDir string) (*existingMount, er
 		return nil, nil
 	}
 
-	var mounts []struct {
-		EntryName     string `json:"entry_name"`
-		HostPath      string `json:"host_path"`
-		ContainerPath string `json:"container_path"`
-		VolumeOptions string `json:"volume_options"`
-	}
-
-	if err := json.Unmarshal(result.StdoutBytes(), &mounts); err != nil {
+	payload := map[string]string{}
+	if err := json.Unmarshal(result.StdoutBytes(), &payload); err != nil {
 		return nil, nil
 	}
 
-	for _, mount := range mounts {
-		if mount.ContainerPath != containerDir {
+	// Enumerate attachment indices via the always-present container-path key.
+	// Keys look like "attachment.1.container-path"; the legacy-prefixed
+	// duplicates ("storage-attachment.1.container-path") are skipped since they
+	// do not start with the bare "attachment." prefix.
+	var indices []int
+	for key := range payload {
+		rest := strings.TrimPrefix(key, "attachment.")
+		if rest == key {
 			continue
 		}
-		if entryName != "" && mount.EntryName == entryName {
-			return &existingMount{EntryName: mount.EntryName, VolumeOptions: mount.VolumeOptions}, nil
+		dot := strings.IndexByte(rest, '.')
+		if dot < 0 || rest[dot+1:] != "container-path" {
+			continue
 		}
-		if hostDir != "" && mount.HostPath == hostDir {
-			return &existingMount{EntryName: mount.EntryName, VolumeOptions: mount.VolumeOptions}, nil
+		n, err := strconv.Atoi(rest[:dot])
+		if err != nil {
+			continue
+		}
+		indices = append(indices, n)
+	}
+	sort.Ints(indices)
+
+	field := func(n int, name string) string {
+		return payload[fmt.Sprintf("attachment.%d.%s", n, name)]
+	}
+
+	attachments := make([]reportAttachment, 0, len(indices))
+	for _, n := range indices {
+		a := reportAttachment{
+			EntryName:     field(n, "entry-name"),
+			HostPath:      field(n, "host-path"),
+			ContainerPath: field(n, "container-path"),
+			ProcessType:   field(n, "process-type"),
+			Subpath:       field(n, "subpath"),
+			VolumeOptions: field(n, "volume-options"),
+			VolumeChown:   field(n, "volume-chown"),
+			Readonly:      field(n, "readonly") == "true",
+		}
+		if phases := field(n, "phases"); phases != "" {
+			a.Phases = strings.Split(phases, ",")
+		}
+		attachments = append(attachments, a)
+	}
+
+	sort.Slice(attachments, func(i, j int) bool {
+		a, b := attachments[i], attachments[j]
+		if a.ContainerPath != b.ContainerPath {
+			return a.ContainerPath < b.ContainerPath
+		}
+		if a.ProcessType != b.ProcessType {
+			return a.ProcessType < b.ProcessType
+		}
+		return a.EntryName < b.EntryName
+	})
+	return attachments, nil
+}
+
+// isDefaultPhases reports whether phases is exactly dokku's default set
+// {deploy, run} (in any order). Export omits the phases field in that case so
+// the recipe defers to the default, matching the "empty means both phases"
+// contract on StorageMountTask.Phases.
+func isDefaultPhases(phases []string) bool {
+	if len(phases) != 2 {
+		return false
+	}
+	seen := map[string]bool{}
+	for _, phase := range phases {
+		seen[phase] = true
+	}
+	return seen["deploy"] && seen["run"]
+}
+
+// findMount returns the existing attachment matching either the named-entry
+// form (entry_name + container_path) or the legacy form (host_path +
+// container_path), or nil if none exists. It reads storage:report (via
+// readStorageAttachments) so attachments on any phase are visible - storage:list
+// only reports the deploy phase, which would hide run-only mounts. A
+// transport-level failure (`*subprocess.SSHError`) is propagated; a dokku-level
+// non-zero exit (e.g. app does not exist) is treated as "no mount."
+func findMount(app, entryName, hostDir, containerDir string) (*existingMount, error) {
+	attachments, err := readStorageAttachments(app)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, a := range attachments {
+		if a.ContainerPath != containerDir {
+			continue
+		}
+		if entryName != "" && a.EntryName == entryName {
+			return &existingMount{EntryName: a.EntryName, VolumeOptions: a.VolumeOptions}, nil
+		}
+		if hostDir != "" && a.HostPath == hostDir {
+			return &existingMount{EntryName: a.EntryName, VolumeOptions: a.VolumeOptions}, nil
 		}
 	}
 	return nil, nil

--- a/tasks/storage_mount_task_integration_test.go
+++ b/tasks/storage_mount_task_integration_test.go
@@ -247,3 +247,75 @@ func TestIntegrationStorageMountVolumeOptions(t *testing.T) {
 		t.Fatalf("failed to unmount named entry with options: %v", r.Error)
 	}
 }
+
+// TestIntegrationStorageMountExportRoundTrip mounts a named entry with the full
+// set of mount-time attributes and verifies the exporter reconstructs every one
+// of them from storage:report, such that re-planning the exported body reports
+// no drift.
+func TestIntegrationStorageMountExportRoundTrip(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-mount-export"
+	entryName := "docket-test-mount-export-entry"
+	containerDir := "/app/exported"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	entry := StorageEntryTask{Name: entryName, Chown: "herokuish", State: StatePresent}
+	if r := entry.Execute(); r.Error != nil {
+		t.Fatalf("failed to create entry: %v", r.Error)
+	}
+	defer func() {
+		destroy := StorageEntryTask{Name: entryName, State: StateAbsent}
+		destroy.Execute()
+	}()
+
+	mount := StorageMountTask{
+		App:          appName,
+		EntryName:    entryName,
+		ContainerDir: containerDir,
+		ProcessType:  "web",
+		Subpath:      "nested",
+		Readonly:     true,
+		State:        StatePresent,
+	}
+	if r := mount.Execute(); r.Error != nil {
+		t.Fatalf("failed to mount named entry: %v", r.Error)
+	}
+
+	bodies, err := StorageMountTask{}.ExportApp(appName)
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 exported mount, got %d", len(bodies))
+	}
+	got := bodies[0].(StorageMountTask)
+	if got.EntryName != entryName {
+		t.Errorf("expected entry_name %q, got %q", entryName, got.EntryName)
+	}
+	if got.ContainerDir != containerDir {
+		t.Errorf("expected container_dir %q, got %q", containerDir, got.ContainerDir)
+	}
+	if got.ProcessType != "web" {
+		t.Errorf("expected process_type web, got %q", got.ProcessType)
+	}
+	if got.Subpath != "nested" {
+		t.Errorf("expected subpath nested, got %q", got.Subpath)
+	}
+	if !got.Readonly {
+		t.Error("expected readonly true, got false")
+	}
+	// phases default to {deploy, run}, so the exporter omits the field.
+	if len(got.Phases) != 0 {
+		t.Errorf("expected default phases to be omitted, got %v", got.Phases)
+	}
+
+	// The exporter omits state; set it so the body can be planned directly.
+	got.State = StatePresent
+	if plan := got.Plan(); !plan.InSync {
+		t.Errorf("exported mount should report no drift, got status %v reason %q", plan.Status, plan.Reason)
+	}
+}

--- a/tasks/storage_mount_task_test.go
+++ b/tasks/storage_mount_task_test.go
@@ -3,6 +3,8 @@ package tasks
 import (
 	"strings"
 	"testing"
+
+	"github.com/dokku/docket/subprocess"
 )
 
 func TestStorageMountTaskInvalidState(t *testing.T) {
@@ -126,7 +128,7 @@ func TestStorageMountLegacyFirstMountWithVolumeOptions(t *testing.T) {
 }
 
 func TestStorageMountNamedRemediationFromLegacy(t *testing.T) {
-	// Recipe uses host_dir; storage:list discovered the auto-named
+	// Recipe uses host_dir; storage:report discovered the auto-named
 	// entry. Drift remediation must upsert via the named-entry CLI.
 	task := StorageMountTask{
 		App:          "test-app",
@@ -173,6 +175,220 @@ func TestStorageMountNamedUnmount(t *testing.T) {
 	want := []string{"--quiet", "storage:unmount", "test-app", "legacy-abc123def4", "--container-dir", "/app/storage"}
 	if !equalStrings(args, want) {
 		t.Errorf("namedUnmountArgs mismatch:\n  got: %v\n want: %v", args, want)
+	}
+}
+
+// exportMounts runs ExportApp against a canned storage:report payload and
+// returns the reconstructed tasks, so the export reconstruction can be asserted
+// without a live server.
+func exportMounts(t *testing.T, app, report string) []StorageMountTask {
+	t.Helper()
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet storage:report " + app + " --format json": report,
+	}))()
+
+	bodies, err := StorageMountTask{}.ExportApp(app)
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+	out := make([]StorageMountTask, len(bodies))
+	for i, b := range bodies {
+		mt, ok := b.(StorageMountTask)
+		if !ok {
+			t.Fatalf("export body %d is %T, want StorageMountTask", i, b)
+		}
+		out[i] = mt
+	}
+	return out
+}
+
+func TestStorageMountExportNamedEntryFullFidelity(t *testing.T) {
+	report := `{
+		"attachment.1.entry-name": "data",
+		"attachment.1.host-path": "/var/lib/dokku/data/storage/data",
+		"attachment.1.container-path": "/app/storage",
+		"attachment.1.phases": "deploy,run",
+		"attachment.1.process-type": "web",
+		"attachment.1.subpath": "sub",
+		"attachment.1.readonly": "true",
+		"attachment.1.volume-options": "noexec,nosuid",
+		"attachment.1.volume-chown": "herokuish",
+		"deploy-mounts": "/var/lib/dokku/data/storage/data:/app/storage"
+	}`
+	tasks := exportMounts(t, "node-js-app", report)
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	got := tasks[0]
+	checks := []struct {
+		name      string
+		got, want string
+	}{
+		{"app", got.App, "node-js-app"},
+		{"entry_name", got.EntryName, "data"},
+		{"host_dir", got.HostDir, ""},
+		{"container_dir", got.ContainerDir, "/app/storage"},
+		{"process_type", got.ProcessType, "web"},
+		{"subpath", got.Subpath, "sub"},
+		{"volume_chown", got.VolumeChown, "herokuish"},
+		{"volume_options", got.VolumeOptions, "noexec,nosuid"},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s = %q, want %q", c.name, c.got, c.want)
+		}
+	}
+	if !got.Readonly {
+		t.Error("expected readonly true, got false")
+	}
+	// phases {deploy,run} is the dokku default, so it is omitted.
+	if len(got.Phases) != 0 {
+		t.Errorf("expected default phases to be omitted, got %v", got.Phases)
+	}
+}
+
+func TestStorageMountExportSinglePhaseAndDefaultProcessType(t *testing.T) {
+	report := `{
+		"attachment.1.entry-name": "logs",
+		"attachment.1.host-path": "/var/lib/dokku/data/storage/logs",
+		"attachment.1.container-path": "/app/logs",
+		"attachment.1.phases": "run",
+		"attachment.1.process-type": "_default_",
+		"attachment.1.readonly": "false"
+	}`
+	tasks := exportMounts(t, "node-js-app", report)
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	got := tasks[0]
+	if !equalStrings(got.Phases, []string{"run"}) {
+		t.Errorf("expected phases [run], got %v", got.Phases)
+	}
+	if got.ProcessType != "" {
+		t.Errorf("expected default process_type to be omitted, got %q", got.ProcessType)
+	}
+	if got.Readonly {
+		t.Errorf("expected readonly false, got true")
+	}
+	if got.EntryName != "logs" || got.HostDir != "" {
+		t.Errorf("expected named-entry form, got entry_name=%q host_dir=%q", got.EntryName, got.HostDir)
+	}
+}
+
+func TestStorageMountExportLegacyEntryUsesHostDir(t *testing.T) {
+	report := `{
+		"attachment.1.entry-name": "legacy-abc123def4",
+		"attachment.1.host-path": "/var/data",
+		"attachment.1.container-path": "/app/storage",
+		"attachment.1.phases": "deploy,run"
+	}`
+	tasks := exportMounts(t, "node-js-app", report)
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	got := tasks[0]
+	if got.HostDir != "/var/data" {
+		t.Errorf("expected host_dir /var/data, got %q", got.HostDir)
+	}
+	if got.EntryName != "" {
+		t.Errorf("legacy entry must not surface entry_name, got %q", got.EntryName)
+	}
+}
+
+func TestStorageMountExportSortsByContainerPath(t *testing.T) {
+	// Indices are intentionally out of container-path order to prove the
+	// exporter sorts deterministically rather than trusting report order.
+	report := `{
+		"attachment.1.entry-name": "data",
+		"attachment.1.host-path": "/h/data",
+		"attachment.1.container-path": "/app/z",
+		"attachment.1.phases": "deploy,run",
+		"attachment.2.entry-name": "cache",
+		"attachment.2.host-path": "/h/cache",
+		"attachment.2.container-path": "/app/a",
+		"attachment.2.phases": "deploy,run"
+	}`
+	tasks := exportMounts(t, "node-js-app", report)
+	if len(tasks) != 2 {
+		t.Fatalf("expected 2 tasks, got %d", len(tasks))
+	}
+	if tasks[0].ContainerDir != "/app/a" || tasks[1].ContainerDir != "/app/z" {
+		t.Errorf("expected container dirs sorted [/app/a /app/z], got [%s %s]",
+			tasks[0].ContainerDir, tasks[1].ContainerDir)
+	}
+}
+
+func TestStorageMountExportRecipeEmitsFields(t *testing.T) {
+	// End-to-end through ExportRecipe: the reconstructed fields must survive
+	// YAML marshaling in the user-facing recipe (bool readonly, single-phase
+	// list, process_type).
+	report := `{
+		"attachment.1.entry-name": "data",
+		"attachment.1.host-path": "/h/data",
+		"attachment.1.container-path": "/app/storage",
+		"attachment.1.phases": "deploy",
+		"attachment.1.process-type": "web",
+		"attachment.1.readonly": "true"
+	}`
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list": "node-js-app",
+		"--quiet storage:report node-js-app --format json": report,
+	}))()
+
+	res, err := ExportRecipe(ExportOptions{Apps: []string{"node-js-app"}})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	recipe, err := res.MarshalRecipe("yaml")
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	out := string(recipe)
+	for _, want := range []string{
+		"dokku_storage_mount",
+		"entry_name: data",
+		"container_dir: /app/storage",
+		"process_type: web",
+		"readonly: true",
+		"- deploy",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("recipe missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "- run") {
+		t.Errorf("deploy-only mount must not emit the run phase:\n%s", out)
+	}
+}
+
+func TestStorageMountPlanFindsRunOnlyMount(t *testing.T) {
+	// storage:list hides run-only mounts (it reports the deploy phase only);
+	// findMount now reads storage:report, so a run-only mount is discovered and
+	// the recipe reports InSync instead of a perpetual create.
+	report := `{
+		"attachment.1.entry-name": "data",
+		"attachment.1.host-path": "/h/data",
+		"attachment.1.container-path": "/app/x",
+		"attachment.1.phases": "run",
+		"attachment.1.readonly": "false"
+	}`
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet storage:report node-js-app --format json": report,
+	}))()
+
+	task := StorageMountTask{
+		App:          "node-js-app",
+		EntryName:    "data",
+		ContainerDir: "/app/x",
+		Phases:       []string{"run"},
+		State:        StatePresent,
+	}
+	plan := task.Plan()
+	if plan.Error != nil {
+		t.Fatalf("Plan returned error: %v", plan.Error)
+	}
+	if !plan.InSync {
+		t.Errorf("expected run-only mount to be InSync, got status %v reason %q", plan.Status, plan.Reason)
 	}
 }
 


### PR DESCRIPTION
The dokku_storage_mount exporter read `storage:list --format json`, which only exposes the entry/host and container paths and is filtered to the deploy phase, so `phases`, `process_type`, `subpath`, `readonly`, and `volume_chown` were dropped and run-only mounts were missed. It now reads `storage:report --format json`, which exposes every attachment attribute for all phases, and reconstructs each field in full while omitting values that match dokku's defaults. The drift-detection read is unified onto the same report so run-only mounts are visible and the exported recipe round-trips.

Closes #281