### PR TITLE
feat: export the custom maintenance page

### DIFF
--- a/docs/tasks/dokku_maintenance_custom_page.md
+++ b/docs/tasks/dokku_maintenance_custom_page.md
@@ -10,7 +10,7 @@ Installs or removes a custom maintenance page for a dokku application.
 
 ## Export support
 
-Partial - maintenance:report exposes only a custom-page-sha256 checksum, not the HTML; a faithful export needs an upstream export command (dokku/dokku-maintenance#28), otherwise the content is supplied as a required input (docket#284).
+Partial - maintenance:report exposes only a custom-page-sha256 checksum, not the HTML, so the page content cannot be read back; export detects that a custom page is set and lifts it into a required content input the user supplies before apply. Multi-file tarball pages collapse to that single content input, so extra assets are not captured. A faithful export awaits an upstream export command (dokku/dokku-maintenance#28).
 
 ## Parameters
 

--- a/tasks/export.go
+++ b/tasks/export.go
@@ -57,6 +57,7 @@ var appExportOrder = []string{
 	"dokku_proxy_toggle",
 	"dokku_domains_toggle",
 	"dokku_maintenance",
+	"dokku_maintenance_custom_page",
 	"dokku_http_auth_user",
 	"dokku_http_auth_allowed_ip",
 	"dokku_http_auth_domain",
@@ -251,6 +252,8 @@ func (res *ExportResult) processBody(app string, body interface{}, opts ExportOp
 		return res.processConfig(app, b, opts)
 	case HttpAuthUserTask:
 		return res.processHttpAuthUser(app, b, opts)
+	case MaintenanceCustomPageTask:
+		return res.processMaintenanceCustomPage(app, b, opts)
 	default:
 		return res.processSensitiveScalars(app, body, opts)
 	}
@@ -338,6 +341,25 @@ func (res *ExportResult) processHttpAuthUser(app string, b HttpAuthUserTask, opt
 		})
 	}
 	b.Users = users
+	return b, inputs
+}
+
+// processMaintenanceCustomPage lifts the custom page HTML into a required input,
+// since maintenance:report exposes only a checksum, never the page content. The
+// recipe therefore always needs the HTML supplied in the vars-file before apply,
+// so the value is blanked unconditionally (like http-auth passwords). Unlike a
+// secret, the page is public HTML, so the input is not marked sensitive.
+func (res *ExportResult) processMaintenanceCustomPage(app string, b MaintenanceCustomPageTask, opts ExportOptions) (interface{}, []map[string]interface{}) {
+	if opts.Inline {
+		return b, nil
+	}
+	name := res.uniqueVarName(app, "maintenance_custom_page")
+	b.Content = "{{ ." + name + " }}"
+	res.Vars[name] = "" // page HTML is not readable; the user fills this in
+	inputs := []map[string]interface{}{{
+		"name":     name,
+		"required": true,
+	}}
 	return b, inputs
 }
 

--- a/tasks/export_test.go
+++ b/tasks/export_test.go
@@ -124,6 +124,74 @@ func TestExportHttpAuthUserPasswordsBecomeInputs(t *testing.T) {
 	}
 }
 
+func TestExportMaintenanceCustomPageBecomesInput(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list":                    "web",
+		"maintenance:report web --format json": `{"enabled":"false","custom-page-sha256":"7b645f273842a941c68302a4022ed03e219bd8db318ef32a92dddb148a72ef05"}`,
+	}))()
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+
+	// The HTML is not readable, so it is lifted to a required input with an
+	// empty placeholder in the vars map.
+	v, ok := res.Vars["web_maintenance_custom_page"]
+	if !ok || v != "" {
+		t.Errorf("expected empty placeholder for custom page, got %q (ok=%v)", v, ok)
+	}
+
+	recipe, _ := res.MarshalRecipe("yaml")
+	out := string(recipe)
+	for _, want := range []string{
+		"dokku_maintenance_custom_page",
+		"{{ .web_maintenance_custom_page }}",
+		"name: web_maintenance_custom_page",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("recipe missing %q:\n%s", want, out)
+		}
+	}
+	// The page is public HTML, not a secret: the input is not marked sensitive,
+	// and the checksum never leaks into the recipe body.
+	if strings.Contains(out, "sensitive: true") {
+		t.Errorf("custom page input should not be sensitive:\n%s", out)
+	}
+	if strings.Contains(out, "7b645f273842a941") {
+		t.Errorf("recipe leaked the custom-page checksum:\n%s", out)
+	}
+}
+
+func TestExportMaintenanceCustomPageAbsentEmitsNothing(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		report string
+	}{
+		{"set but empty", `{"enabled":"false","custom-page-sha256":""}`},
+		{"key absent (old plugin)", `{"enabled":"false"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+				"--quiet apps:list":                    "web",
+				"maintenance:report web --format json": tc.report,
+			}))()
+
+			res, err := ExportRecipe(ExportOptions{})
+			if err != nil {
+				t.Fatalf("ExportRecipe: %v", err)
+			}
+			if _, ok := res.Vars["web_maintenance_custom_page"]; ok {
+				t.Errorf("expected no lifted var when no custom page is set")
+			}
+			recipe, _ := res.MarshalRecipe("yaml")
+			if strings.Contains(string(recipe), "dokku_maintenance_custom_page") {
+				t.Errorf("expected no dokku_maintenance_custom_page task:\n%s", recipe)
+			}
+		})
+	}
+}
+
 func TestExportRecipeRedactBlanksVars(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
 

--- a/tasks/maintenance_custom_page_task.go
+++ b/tasks/maintenance_custom_page_task.go
@@ -57,7 +57,7 @@ func (t MaintenanceCustomPageTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t MaintenanceCustomPageTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportPartial, Caveat: "maintenance:report exposes only a custom-page-sha256 checksum, not the HTML; a faithful export needs an upstream export command (dokku/dokku-maintenance#28), otherwise the content is supplied as a required input (docket#284)"}
+	return ExportSupport{Status: ExportPartial, Caveat: "maintenance:report exposes only a custom-page-sha256 checksum, not the HTML, so the page content cannot be read back; export detects that a custom page is set and lifts it into a required content input the user supplies before apply. Multi-file tarball pages collapse to that single content input, so extra assets are not captured. A faithful export awaits an upstream export command (dokku/dokku-maintenance#28)"}
 }
 
 // Requirements lists the non-core dokku plugins this task depends on.
@@ -342,6 +342,29 @@ func maintenanceCustomPageState(app string) (checksum string, reported bool, err
 		return "", false, nil
 	}
 	return *report.CustomPageSHA256, true, nil
+}
+
+// ExportApp emits a dokku_maintenance_custom_page task when the app has a custom
+// page installed. maintenance:report exposes only the custom-page-sha256
+// checksum, never the HTML, so the content cannot be read back; the engine lifts
+// it into a required input the user supplies before applying (see
+// processMaintenanceCustomPage). A custom page is detected purely by a non-empty
+// checksum, so nothing is emitted when no page is set or when the plugin is too
+// old to report the checksum. A transport-level SSH failure propagates as a
+// warning; a dokku-level or parse failure is treated as "nothing to export".
+func (t MaintenanceCustomPageTask) ExportApp(app string) ([]interface{}, error) {
+	checksum, reported, err := maintenanceCustomPageState(app)
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return nil, err
+		}
+		return nil, nil
+	}
+	if !reported || checksum == "" {
+		return nil, nil
+	}
+	return []interface{}{MaintenanceCustomPageTask{App: app}}, nil
 }
 
 // init registers the MaintenanceCustomPageTask with the task registry

--- a/tasks/maintenance_custom_page_task_integration_test.go
+++ b/tasks/maintenance_custom_page_task_integration_test.go
@@ -185,3 +185,68 @@ func TestIntegrationMaintenanceCustomPage(t *testing.T) {
 		t.Errorf("expected Changed=false on idempotent remove")
 	}
 }
+
+func TestIntegrationExportMaintenanceCustomPageRoundTrip(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "maintenance")
+
+	appName := "docket-test-maintenance-custom-page-export"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// The export detects the page via the reported checksum. If the installed
+	// plugin does not report it, there is nothing to detect, so skip.
+	if _, reported, err := maintenanceCustomPageState(appName); err != nil {
+		t.Fatalf("maintenanceCustomPageState failed: %v", err)
+	} else if !reported {
+		t.Skip("skipping: installed dokku-maintenance does not report custom-page-sha256")
+	}
+
+	// An app with no custom page exports nothing.
+	if bodies, err := (MaintenanceCustomPageTask{}).ExportApp(appName); err != nil {
+		t.Fatalf("ExportApp with no custom page failed: %v", err)
+	} else if len(bodies) != 0 {
+		t.Fatalf("expected no export bodies for an app without a custom page, got %d", len(bodies))
+	}
+
+	content := "<html><body>exported down for maintenance</body></html>\n"
+	set := MaintenanceCustomPageTask{App: appName, Content: content, State: StatePresent}
+	if result := set.Execute(); result.Error != nil {
+		t.Fatalf("failed to set custom page: %v", result.Error)
+	}
+
+	// Export reconstructs the task from the reported checksum. The content is
+	// not readable, so the exported body carries an empty Content; the engine is
+	// what lifts it into a required input.
+	bodies, err := (MaintenanceCustomPageTask{}).ExportApp(appName)
+	if err != nil {
+		t.Fatalf("ExportApp failed: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected exactly one export body, got %d", len(bodies))
+	}
+	got, ok := bodies[0].(MaintenanceCustomPageTask)
+	if !ok {
+		t.Fatalf("export body is %T, want MaintenanceCustomPageTask", bodies[0])
+	}
+	if got.App != appName {
+		t.Errorf("exported App = %q, want %q", got.App, appName)
+	}
+	if got.Content != "" {
+		t.Errorf("exported Content = %q, want empty (content is not readable)", got.Content)
+	}
+
+	// export -> apply idempotency: once the user supplies the same HTML the
+	// input would carry, re-planning reports no drift.
+	got.Content = content
+	got.State = StatePresent
+	plan := got.Plan()
+	if plan.Error != nil {
+		t.Fatalf("Plan after export failed: %v", plan.Error)
+	}
+	if !plan.InSync {
+		t.Errorf("expected re-plan to be InSync after supplying the exported content, got status %v (reason: %s)", plan.Status, plan.Reason)
+	}
+}


### PR DESCRIPTION
The dokku-maintenance plugin exposes only a `custom-page-sha256` checksum and never the page HTML, so the content cannot be read back from the server. Export now detects that a custom page is set and emits `dokku_maintenance_custom_page` with its content lifted into the companion vars-file as a required input the user supplies before applying, mirroring how http-auth passwords are handled.

Because the page is public HTML rather than a secret, the lifted input is required but not marked sensitive. Multi-file tarball pages collapse to the single content input, so extra assets are not captured; a faithful export awaits an upstream export command in dokku/dokku-maintenance#28.

Closes #284.