### PR TITLE
feat: export third-party plugins

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -47,10 +47,12 @@ plus a companion vars-file describing it:
 docket export --host deploy@old-server
 ```
 
-This enumerates the apps and reconstructs their declarative state. Sensitive values (config and
-other secrets) are lifted into `tasks.vars.yml`; the recipe references them through inputs, so the
-pair is applied together with `--vars-file`. If you already maintain a recipe as the source of
-truth for the old server, skip this and use it directly.
+This enumerates the apps and reconstructs their declarative state. It also reconstructs any
+git-installed third-party plugins into [`dokku_plugin`](tasks/dokku_plugin.md) tasks in a leading
+global play; core plugins and plugins installed from a tarball or local path are omitted. Sensitive
+values (config and other secrets) are lifted into `tasks.vars.yml`; the recipe references them
+through inputs, so the pair is applied together with `--vars-file`. If you already maintain a recipe
+as the source of truth for the old server, skip this and use it directly.
 
 Some state cannot be read back and is left out with a warning - notably write-only credentials
 (`dokku_git_auth`, `dokku_registry_auth`) and datastore service data, which you add by hand. Each

--- a/docs/tasks/dokku_plugin.md
+++ b/docs/tasks/dokku_plugin.md
@@ -6,7 +6,7 @@ Installs or uninstalls a third-party dokku plugin. Installation is a root-level 
 
 ## Export support
 
-Not supported - plugin:list does not expose the install source URL a third-party plugin needs to be reinstalled (docket#286, dokku/dokku#8798).
+Supported.
 
 ## Parameters
 

--- a/tasks/export.go
+++ b/tasks/export.go
@@ -31,6 +31,9 @@ type GlobalExporter interface {
 // emitted into the leading global play. Adding a global resource means
 // implementing GlobalExporter on its task and adding its type-key here.
 var globalExportOrder = []string{
+	// plugins first: installing a third-party plugin is a prerequisite for the
+	// resources that follow.
+	"dokku_plugin",
 	"dokku_ssh_key",
 	"dokku_storage_entry",
 	"dokku_scheduler_k3s_profile",

--- a/tasks/export_test.go
+++ b/tasks/export_test.go
@@ -40,6 +40,79 @@ func TestAppExportOrderIsValid(t *testing.T) {
 	}
 }
 
+func TestGlobalExportOrderIsValid(t *testing.T) {
+	for _, key := range globalExportOrder {
+		proto, ok := RegisteredTasks[key]
+		if !ok {
+			t.Errorf("globalExportOrder has unknown task key %q", key)
+			continue
+		}
+		if _, ok := proto.(GlobalExporter); !ok {
+			t.Errorf("task %q in globalExportOrder does not implement GlobalExporter", key)
+		}
+	}
+}
+
+func TestExportPluginsBecomeTasks(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet plugin:list --format json": `[
+			{"name":"00_dokku-standard","core":true,"source_url":"","committish":"","branch":""},
+			{"name":"redis","core":false,"source_url":"https://github.com/dokku/dokku-redis.git","committish":"c0ffee1234","branch":"master"},
+			{"name":"acl","core":false,"source_url":"https://github.com/dokku/dokku-acl.git","committish":"def4567890abcdef","branch":""},
+			{"name":"tarball-plugin","core":false,"source_url":"","committish":"","branch":""}
+		]`,
+	}))()
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+
+	// Plugin URLs are readable, so nothing is lifted into the vars map.
+	if res.HasVars() {
+		t.Errorf("expected no lifted vars, got %v", res.Vars)
+	}
+
+	recipe, err := res.MarshalRecipe("yaml")
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	out := string(recipe)
+
+	// The two git-installed third-party plugins are reconstructed, with the URL
+	// inline and the committish following the branch (redis) or the exact commit
+	// for a detached checkout (acl).
+	for _, want := range []string{
+		"name: global",
+		"dokku_plugin",
+		"name: redis",
+		"https://github.com/dokku/dokku-redis.git",
+		"committish: master",
+		"name: acl",
+		"https://github.com/dokku/dokku-acl.git",
+		"committish: def4567890abcdef",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("recipe missing %q:\n%s", want, out)
+		}
+	}
+
+	// Core plugins and non-git (tarball/local) installs are skipped.
+	for _, unwanted := range []string{"00_dokku-standard", "tarball-plugin"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("recipe should not contain %q:\n%s", unwanted, out)
+		}
+	}
+
+	// The URL is emitted inline, never lifted into a (sensitive) input.
+	if strings.Contains(out, "{{") {
+		t.Errorf("recipe should not template the plugin url:\n%s", out)
+	}
+	if strings.Contains(out, "sensitive: true") {
+		t.Errorf("plugin url should not be marked sensitive:\n%s", out)
+	}
+}
+
 func TestExportRecipeFileMode(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
 

--- a/tasks/plugin_task.go
+++ b/tasks/plugin_task.go
@@ -1,7 +1,10 @@
 package tasks
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/dokku/docket/subprocess"
@@ -52,7 +55,7 @@ func (t PluginTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t PluginTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportUnsupported, Caveat: "plugin:list does not expose the install source URL a third-party plugin needs to be reinstalled (docket#286, dokku/dokku#8798)"}
+	return ExportSupport{Status: ExportSupported}
 }
 
 // Examples returns the examples for the plugin task
@@ -154,6 +157,63 @@ func (t PluginTask) Plan() PlanResult {
 			}
 		},
 	})
+}
+
+// pluginListEntry is one record of `dokku plugin:list --format json`. Only the
+// fields the exporter needs are decoded; version, enabled, and description are
+// ignored.
+type pluginListEntry struct {
+	Name       string `json:"name"`
+	Core       bool   `json:"core"`
+	SourceURL  string `json:"source_url"`
+	Committish string `json:"committish"`
+	Branch     string `json:"branch"`
+}
+
+// ExportGlobal reconstructs the server's third-party plugins from
+// `plugin:list --format json`, which exposes each plugin's install source URL,
+// followed branch, and checked-out commit. Core plugins ship with dokku (and
+// plugin:uninstall rejects them), and plugins without a git source (a tarball or
+// local path) cannot be reinstalled declaratively, so both are skipped.
+func (t PluginTask) ExportGlobal() ([]interface{}, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "plugin:list", "--format", "json"},
+	})
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return nil, err
+		}
+		return nil, nil
+	}
+
+	var entries []pluginListEntry
+	if err := json.Unmarshal(result.StdoutBytes(), &entries); err != nil {
+		return nil, nil
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+
+	var out []interface{}
+	for _, e := range entries {
+		if e.Core || e.SourceURL == "" {
+			continue
+		}
+		// Prefer the followed branch so the export mirrors the install intent; a
+		// detached checkout (a pinned commit or tag) reports no branch, so fall
+		// back to the exact commit.
+		committish := e.Branch
+		if committish == "" {
+			committish = e.Committish
+		}
+		out = append(out, PluginTask{
+			Name:       e.Name,
+			URL:        e.SourceURL,
+			Committish: committish,
+			State:      StatePresent,
+		})
+	}
+	return out, nil
 }
 
 // pluginInstalled reports whether a plugin is installed by parsing

--- a/tasks/plugin_task_integration_test.go
+++ b/tasks/plugin_task_integration_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/dokku/docket/subprocess"
@@ -82,5 +83,86 @@ func TestIntegrationPlugin(t *testing.T) {
 	}
 	if result.Changed {
 		t.Errorf("expected Changed=false on idempotent uninstall")
+	}
+}
+
+func TestIntegrationExportPlugin(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	// A dokku predating plugin:list --format json ignores the flag and prints
+	// stdout text with a zero exit, so skip unless the output parses as a JSON
+	// array rather than guarding on a non-zero exit.
+	probe, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "plugin:list", "--format", "json"},
+	})
+	if err != nil {
+		t.Skipf("plugin:list --format json not available: %v", err)
+	}
+	var probed []pluginListEntry
+	if err := json.Unmarshal(probe.StdoutBytes(), &probed); err != nil {
+		t.Skipf("plugin:list --format json unsupported on this dokku: %v", err)
+	}
+
+	pluginName := "smoke-test-plugin"
+	pluginURL := "https://github.com/dokku/smoke-test-plugin.git"
+	pluginCommittish := "v0.9.0"
+
+	uninstallPlugin := func() {
+		subprocess.CallExecCommand(subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", "plugin:uninstall", pluginName},
+		})
+	}
+
+	uninstallPlugin()
+	defer uninstallPlugin()
+
+	installTask := PluginTask{Name: pluginName, URL: pluginURL, Committish: pluginCommittish, State: StatePresent}
+	if result := installTask.Execute(); result.Error != nil {
+		t.Fatalf("failed to install plugin: %v", result.Error)
+	}
+
+	bodies, err := PluginTask{}.ExportGlobal()
+	if err != nil {
+		t.Fatalf("ExportGlobal: %v", err)
+	}
+
+	var found *PluginTask
+	for _, b := range bodies {
+		task, ok := b.(PluginTask)
+		if !ok {
+			t.Fatalf("ExportGlobal returned %T, want PluginTask", b)
+		}
+		if task.Name == pluginName {
+			task := task
+			found = &task
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("ExportGlobal did not include %q; got %+v", pluginName, bodies)
+	}
+
+	if found.URL != pluginURL {
+		t.Errorf("exported url = %q, want %q", found.URL, pluginURL)
+	}
+	// The plugin was pinned to a tag (a detached checkout), so the export records
+	// the exact commit rather than a branch.
+	if found.Committish == "" {
+		t.Errorf("expected a non-empty committish for the pinned plugin")
+	}
+	if found.State != StatePresent {
+		t.Errorf("exported state = %q, want %q", found.State, StatePresent)
+	}
+
+	// The exported task round-trips: re-planning it against the same server is a
+	// no-op because the plugin is already installed.
+	plan := found.Plan()
+	if plan.Error != nil {
+		t.Fatalf("re-plan of exported task failed: %v", plan.Error)
+	}
+	if !plan.InSync {
+		t.Errorf("exported task should be in sync after export, got %+v", plan)
 	}
 }


### PR DESCRIPTION
`docket export` now reconstructs git-installed third-party plugins into `dokku_plugin` tasks in a leading global play, reading each plugin's install source from `dokku plugin:list --format json` (added upstream in dokku/dokku#8801). Core plugins and plugins installed from a tarball or local path are omitted, since they cannot be reinstalled declaratively.

Closes #286.
