### PR TITLE
feat: export dokku-created networks

### DIFF
--- a/docs/tasks/dokku_network.md
+++ b/docs/tasks/dokku_network.md
@@ -6,7 +6,7 @@ Creates or destroys a Docker network
 
 ## Export support
 
-Not supported - network:list cannot distinguish dokku-created networks from Docker built-ins and other apps' networks (docket#285, dokku/dokku#8797).
+Supported.
 
 ## Parameters
 

--- a/tasks/export.go
+++ b/tasks/export.go
@@ -34,6 +34,9 @@ var globalExportOrder = []string{
 	// plugins first: installing a third-party plugin is a prerequisite for the
 	// resources that follow.
 	"dokku_plugin",
+	// networks next: a foundational resource that app network attachments
+	// (dokku_network_property, emitted in the app plays) bind to.
+	"dokku_network",
 	"dokku_ssh_key",
 	"dokku_storage_entry",
 	"dokku_scheduler_k3s_profile",

--- a/tasks/network_task.go
+++ b/tasks/network_task.go
@@ -1,6 +1,10 @@
 package tasks
 
 import (
+	"encoding/json"
+	"errors"
+	"sort"
+
 	"github.com/dokku/docket/subprocess"
 )
 
@@ -34,7 +38,7 @@ func (t NetworkTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t NetworkTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportUnsupported, Caveat: "network:list cannot distinguish dokku-created networks from Docker built-ins and other apps' networks (docket#285, dokku/dokku#8797)"}
+	return ExportSupport{Status: ExportSupported}
 }
 
 // Examples returns a list of NetworkTaskExamples as yaml
@@ -111,6 +115,53 @@ func (t NetworkTask) Plan() PlanResult {
 			}
 		},
 	})
+}
+
+// networkListEntry is the subset of `dokku network:list --format json` the
+// exporter reads. dokku serializes its DockerNetwork struct with capitalized
+// keys, and DokkuManaged (added in dokku 0.39) is true only for networks
+// created by network:create, so it distinguishes them from Docker built-ins
+// (bridge/host/none) and networks created by other tooling (e.g. compose
+// *_default networks).
+type networkListEntry struct {
+	Name         string `json:"Name"`
+	DokkuManaged bool   `json:"DokkuManaged"`
+}
+
+// ExportGlobal reconstructs the server's dokku-created networks from
+// `network:list --format json`, emitting a dokku_network task for each network
+// reporting DokkuManaged. Networks docket did not create - Docker built-ins and
+// networks from other tooling - report DokkuManaged false and are skipped. A
+// dokku predating the DokkuManaged field reports it absent (decoding to false)
+// for every network, so nothing is exported rather than every network being
+// re-emitted.
+func (t NetworkTask) ExportGlobal() ([]interface{}, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "network:list", "--format", "json"},
+	})
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return nil, err
+		}
+		return nil, nil
+	}
+
+	var entries []networkListEntry
+	if err := json.Unmarshal(result.StdoutBytes(), &entries); err != nil {
+		return nil, nil
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+
+	var out []interface{}
+	for _, e := range entries {
+		if e.Name == "" || !e.DokkuManaged {
+			continue
+		}
+		out = append(out, NetworkTask{Name: e.Name})
+	}
+	return out, nil
 }
 
 // networkExists checks if a Docker network exists. Returns (false,

--- a/tasks/network_task_integration_test.go
+++ b/tasks/network_task_integration_test.go
@@ -103,3 +103,67 @@ func TestIntegrationNetworkCreateAndDestroy(t *testing.T) {
 		t.Errorf("expected state 'absent', got '%s'", result.State)
 	}
 }
+
+func TestIntegrationExportNetwork(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	// The DokkuManaged field the exporter keys on landed in dokku 0.39; a dokku
+	// predating it omits the field for every network, so the exporter has
+	// nothing to distinguish dokku-created networks. network:list --format json
+	// serializes DokkuManaged for every network (including the built-ins that
+	// always exist), so its presence in the raw output gates the test.
+	probe, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "network:list", "--format", "json"},
+	})
+	if err != nil {
+		t.Skipf("network:list --format json not available: %v", err)
+	}
+	if !strings.Contains(string(probe.StdoutBytes()), "DokkuManaged") {
+		t.Skip("network:list --format json does not expose DokkuManaged on this dokku")
+	}
+
+	networkName := "docket-test-export-network"
+	destroyNetwork(networkName)
+	defer destroyNetwork(networkName)
+
+	if r := (NetworkTask{Name: networkName, State: StatePresent}).Execute(); r.Error != nil {
+		t.Fatalf("failed to create network: %v", r.Error)
+	}
+
+	bodies, err := NetworkTask{}.ExportGlobal()
+	if err != nil {
+		t.Fatalf("ExportGlobal: %v", err)
+	}
+
+	var found *NetworkTask
+	for i := range bodies {
+		nt, ok := bodies[i].(NetworkTask)
+		if !ok {
+			t.Fatalf("ExportGlobal returned %T, want NetworkTask", bodies[i])
+		}
+		// The always-present bridge built-in is not dokku-created and must be
+		// filtered out.
+		if nt.Name == "bridge" {
+			t.Errorf("ExportGlobal emitted Docker built-in %q", nt.Name)
+		}
+		if nt.Name == networkName {
+			nt := nt
+			found = &nt
+		}
+	}
+	if found == nil {
+		t.Fatalf("ExportGlobal did not include %q; got %+v", networkName, bodies)
+	}
+
+	// The exported task round-trips: re-planning it against the same server is a
+	// no-op because the network already exists. The exporter omits state, which
+	// the recipe loader defaults to present; set it here since we plan the body
+	// directly without going through the loader.
+	found.State = StatePresent
+	if plan := found.Plan(); plan.Error != nil {
+		t.Fatalf("re-plan of exported task failed: %v", plan.Error)
+	} else if !plan.InSync {
+		t.Errorf("exported task should be in sync after export, got %+v", plan)
+	}
+}

--- a/tasks/network_task_test.go
+++ b/tasks/network_task_test.go
@@ -1,8 +1,10 @@
 package tasks
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/dokku/docket/subprocess"
 	_ "github.com/gliderlabs/sigil/builtin"
 )
 
@@ -47,5 +49,97 @@ func TestGetTasksNetworkTaskParsedCorrectly(t *testing.T) {
 	}
 	if netTask.State != StatePresent {
 		t.Errorf("expected default state 'present', got %q", netTask.State)
+	}
+}
+
+// networkListFixture is a network:list --format json payload mixing dokku-created
+// networks (DokkuManaged true) with Docker built-ins and a compose *_default
+// network (DokkuManaged false), deliberately unsorted to exercise the sort.
+const networkListFixture = `[
+	{"Name":"host","DokkuManaged":false},
+	{"Name":"web-net","DokkuManaged":true},
+	{"Name":"bridge","DokkuManaged":false},
+	{"Name":"app-net","DokkuManaged":true},
+	{"Name":"none","DokkuManaged":false},
+	{"Name":"myproject_default","DokkuManaged":false}
+]`
+
+func TestNetworkExportGlobalOnlyDokkuManaged(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet network:list --format json": networkListFixture,
+	}))()
+
+	bodies, err := NetworkTask{}.ExportGlobal()
+	if err != nil {
+		t.Fatalf("ExportGlobal: %v", err)
+	}
+
+	got := make([]string, len(bodies))
+	for i, b := range bodies {
+		nt, ok := b.(NetworkTask)
+		if !ok {
+			t.Fatalf("export body %d is %T, want NetworkTask", i, b)
+		}
+		if nt.State != "" {
+			t.Errorf("exported network %q sets state %q, want it omitted", nt.Name, nt.State)
+		}
+		got[i] = nt.Name
+	}
+
+	// Only the two dokku-created networks come back, sorted by name; the
+	// built-ins and the compose *_default network are dropped.
+	want := []string{"app-net", "web-net"}
+	if !equalStrings(got, want) {
+		t.Errorf("exported networks = %v, want %v", got, want)
+	}
+}
+
+func TestExportNetworksBecomeTasks(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet network:list --format json": networkListFixture,
+	}))()
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+
+	// A network name is not sensitive, so nothing is lifted into the vars map.
+	if res.HasVars() {
+		t.Errorf("expected no lifted vars, got %v", res.Vars)
+	}
+
+	recipe, err := res.MarshalRecipe("yaml")
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	out := string(recipe)
+
+	// The dokku-created networks land in the leading global play, keyed by
+	// dokku_network, with the state omitted (the loader defaults it to present).
+	for _, want := range []string{
+		"name: global",
+		"dokku_network:",
+		"name: app-net",
+		"name: web-net",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("recipe missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "state:") {
+		t.Errorf("exported network should omit state:\n%s", out)
+	}
+
+	// Docker built-ins and the compose *_default network are never emitted.
+	for _, unwanted := range []string{"name: bridge", "name: host", "name: none", "name: myproject_default"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("recipe should not contain %q:\n%s", unwanted, out)
+		}
+	}
+
+	// A network name is emitted inline, never lifted into a templated input.
+	if strings.Contains(out, "{{") {
+		t.Errorf("recipe should not template a network name:\n%s", out)
 	}
 }


### PR DESCRIPTION
`docket export` reconstructs a live Dokku server as a recipe, but the `dokku_network` task was left out because `network:list` returned every Docker network on the host - the built-ins (`bridge`, `host`, `none`), compose `*_default` networks, and dokku-created ones - with no signal for which were created by `dokku network:create`.

dokku/dokku#8797 resolved that upstream: `network:list --format json` now reports a `DokkuManaged` boolean that is true only for networks created via `network:create`. This wires `dokku_network` into export as a global resource, emitting a `dokku_network` task in the leading global play for each dokku-created network so a server's networks round-trip into a recipe. Docker built-ins and networks created by other tooling report `DokkuManaged` false and are skipped, and a dokku predating the field exports no networks rather than re-emitting every network on the host.

Closes #285.
