### PR TITLE
feat: export scheduler-k3s annotations, labels, auth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.15
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.22
           sudo dokku plugin:install-dependencies --core
       - name: install dokku redis plugin
         run: sudo dokku plugin:install https://github.com/dokku/dokku-redis.git redis
@@ -87,7 +87,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.15
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.22
           sudo dokku plugin:install-dependencies --core
       - name: initialize k3s cluster
         run: sudo dokku scheduler-k3s:initialize --server-ip 127.0.0.1
@@ -114,7 +114,7 @@ jobs:
           curl -fsSL https://packagecloud.io/dokku/dokku/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/dokku-archive-keyring.gpg
           echo "deb [signed-by=/etc/apt/keyrings/dokku-archive-keyring.gpg] https://packagecloud.io/dokku/dokku/ubuntu/ $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/dokku.list
           sudo apt-get update -qq
-          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.15
+          sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.22
           sudo dokku plugin:install-dependencies --core
       - name: install bats
         run: sudo apt-get install -qq -y bats bats-support bats-assert

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,7 @@ code into it:
 
 ## Prerequisites
 
-- **Dokku >= 0.38.15.**
+- **Dokku >= 0.38.22.**
 - **dokku-letsencrypt >= 0.25.0.**
 
 ## Installation

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -31,7 +31,7 @@ once DNS points at it.
 
 ## Before you start
 
-Provision the new server first. docket needs [Dokku >= 0.38.15 and dokku-letsencrypt >=
+Provision the new server first. docket needs [Dokku >= 0.38.22 and dokku-letsencrypt >=
 0.25.0](getting-started.md#prerequisites), plus any datastore plugins your services rely on
 (dokku-postgres, dokku-redis, dokku-mysql, and so on) already installed. The
 [`dokku_plugin`](tasks/dokku_plugin.md) task can install third-party plugins as part of the

--- a/docs/tasks/dokku_scheduler_k3s_annotations.md
+++ b/docs/tasks/dokku_scheduler_k3s_annotations.md
@@ -6,7 +6,7 @@ Manages scheduler-k3s annotations scoped to a (process_type, resource_type) pair
 
 ## Export support
 
-Not supported - scheduler-k3s exposes no report for annotations, so the current state cannot be read back (docket#287, dokku/dokku#8800).
+Supported.
 
 ## Parameters
 

--- a/docs/tasks/dokku_scheduler_k3s_autoscaling_auth.md
+++ b/docs/tasks/dokku_scheduler_k3s_autoscaling_auth.md
@@ -6,7 +6,7 @@ Manages KEDA TriggerAuthentication metadata grouped under a single trigger for a
 
 ## Export support
 
-Not supported - scheduler-k3s exposes no report for KEDA trigger authentication, so the current state cannot be read back (docket#287, dokku/dokku#8800).
+Partial - trigger authentication metadata values are secrets, so they are written to the companion vars-file.
 
 ## Parameters
 

--- a/docs/tasks/dokku_scheduler_k3s_labels.md
+++ b/docs/tasks/dokku_scheduler_k3s_labels.md
@@ -6,7 +6,7 @@ Manages scheduler-k3s labels scoped to a (process_type, resource_type) pair for 
 
 ## Export support
 
-Not supported - scheduler-k3s exposes no report for labels, so the current state cannot be read back (docket#287, dokku/dokku#8800).
+Supported.
 
 ## Parameters
 

--- a/tasks/docker_options_task.go
+++ b/tasks/docker_options_task.go
@@ -262,7 +262,10 @@ func validateDockerOptionsTask(t DockerOptionsTask) error {
 // (phase, process type). The JSON payload carries one entry per
 // `<phase>` and one per `<phase>.<process_type>` for any process-scoped
 // option, plus legacy `docker-options-*` duplicates emitted during the
-// 0.38.x deprecation window which we discard.
+// 0.38.x deprecation window which we discard. dokku 0.38.22+ additionally
+// emits parallel `<key>-list` companions whose values are JSON arrays
+// (dokku/dokku#8799); the payload is decoded loosely so those array values do
+// not break parsing.
 func getDockerOptions(app string) (map[dockerOptionsScope]string, error) {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
@@ -272,7 +275,7 @@ func getDockerOptions(app string) (map[dockerOptionsScope]string, error) {
 		return nil, err
 	}
 
-	payload := map[string]string{}
+	payload := map[string]interface{}{}
 	if err := json.Unmarshal(result.StdoutBytes(), &payload); err != nil {
 		return nil, fmt.Errorf("parse docker-options:report json: %w", err)
 	}
@@ -282,18 +285,25 @@ func getDockerOptions(app string) (map[dockerOptionsScope]string, error) {
 
 // parseDockerOptionsPayload turns the report JSON map into scope-keyed
 // options. Legacy plugin-prefixed keys and any unknown keys are dropped so
-// that future report additions do not surface as drift.
-func parseDockerOptionsPayload(payload map[string]string) map[dockerOptionsScope]string {
+// that future report additions do not surface as drift. Only string-valued
+// shorthand keys are consumed; the `<key>-list` structured-list companions
+// added in dokku 0.38.22 (dokku/dokku#8799) carry array values and are skipped
+// here, leaving the space-joined string keys as the source of truth.
+func parseDockerOptionsPayload(payload map[string]interface{}) map[dockerOptionsScope]string {
 	out := map[dockerOptionsScope]string{}
 	for key, value := range payload {
 		if strings.HasPrefix(key, "docker-options-") {
+			continue
+		}
+		str, ok := value.(string)
+		if !ok {
 			continue
 		}
 		phase, processType, ok := splitDockerOptionsKey(key)
 		if !ok {
 			continue
 		}
-		out[dockerOptionsScope{Phase: phase, ProcessType: processType}] = value
+		out[dockerOptionsScope{Phase: phase, ProcessType: processType}] = str
 	}
 	return out
 }

--- a/tasks/docker_options_task_test.go
+++ b/tasks/docker_options_task_test.go
@@ -116,25 +116,31 @@ func TestDockerOptionsCommandArgs(t *testing.T) {
 }
 
 func TestParseDockerOptionsPayload(t *testing.T) {
-	payload := map[string]string{
-		"build":                       "",
-		"deploy":                      "-v /a:/a",
-		"run":                         "",
-		"deploy.web":                  "--memory=512m",
-		"deploy.worker":               "--cpus=1",
-		"docker-options-build":        "",
-		"docker-options-deploy":       "-v /a:/a",
-		"docker-options-deploy.web":   "--memory=512m",
-		"some-unrelated-key":          "ignored",
+	payload := map[string]interface{}{
+		"build":                     "",
+		"deploy":                    "-v /a:/a",
+		"run":                       "",
+		"deploy.web":                "--memory=512m",
+		"deploy.worker":             "--cpus=1",
+		"docker-options-build":      "",
+		"docker-options-deploy":     "-v /a:/a",
+		"docker-options-deploy.web": "--memory=512m",
+		"some-unrelated-key":        "ignored",
+		// dokku 0.38.22+ structured-list companions (dokku/dokku#8799): array
+		// values that must be skipped in favor of the string keys above.
+		"build-list":      []interface{}{},
+		"deploy-list":     []interface{}{"-v /a:/a"},
+		"run-list":        []interface{}{},
+		"deploy.web-list": []interface{}{"--memory=512m"},
 	}
 	got := parseDockerOptionsPayload(payload)
 
 	want := map[dockerOptionsScope]string{
-		{Phase: "build"}:                            "",
-		{Phase: "deploy"}:                           "-v /a:/a",
-		{Phase: "run"}:                              "",
-		{Phase: "deploy", ProcessType: "web"}:       "--memory=512m",
-		{Phase: "deploy", ProcessType: "worker"}:    "--cpus=1",
+		{Phase: "build"}:                         "",
+		{Phase: "deploy"}:                        "-v /a:/a",
+		{Phase: "run"}:                           "",
+		{Phase: "deploy", ProcessType: "web"}:    "--memory=512m",
+		{Phase: "deploy", ProcessType: "worker"}: "--cpus=1",
 	}
 	if len(got) != len(want) {
 		t.Fatalf("got %d entries, want %d (got: %#v)", len(got), len(want), got)

--- a/tasks/export.go
+++ b/tasks/export.go
@@ -41,6 +41,12 @@ var globalExportOrder = []string{
 	"dokku_storage_entry",
 	"dokku_scheduler_k3s_profile",
 	"dokku_scheduler_k3s_chart",
+	// scheduler-k3s annotations/labels/trigger-auth can be set globally as well
+	// as per-app; the global scope is emitted here and the per-app scope in
+	// appExportOrder.
+	"dokku_scheduler_k3s_annotations",
+	"dokku_scheduler_k3s_labels",
+	"dokku_scheduler_k3s_autoscaling_auth",
 }
 
 // appExportOrder is the fixed order in which app-scoped task types are emitted
@@ -98,6 +104,11 @@ var appExportOrder = []string{
 	"dokku_scheduler_property",
 	"dokku_scheduler_docker_local_property",
 	"dokku_scheduler_k3s_property",
+	// scheduler-k3s annotations/labels/trigger-auth also emit a global-scope
+	// task in globalExportOrder; here they emit the per-app scope.
+	"dokku_scheduler_k3s_annotations",
+	"dokku_scheduler_k3s_labels",
+	"dokku_scheduler_k3s_autoscaling_auth",
 	"dokku_traefik_property",
 	// deploy source last: only one of these emits per app
 	"dokku_git_sync",
@@ -260,6 +271,8 @@ func (res *ExportResult) processBody(app string, body interface{}, opts ExportOp
 		return res.processHttpAuthUser(app, b, opts)
 	case MaintenanceCustomPageTask:
 		return res.processMaintenanceCustomPage(app, b, opts)
+	case SchedulerK3sAutoscalingAuthTask:
+		return res.processSchedulerK3sAutoscalingAuth(app, b, opts)
 	default:
 		return res.processSensitiveScalars(app, body, opts)
 	}
@@ -410,6 +423,52 @@ func (res *ExportResult) processConfig(app string, b ConfigTask, opts ExportOpti
 	}
 
 	b.Config = newConfig
+	return b, inputs
+}
+
+// processSchedulerK3sAutoscalingAuth lifts each KEDA trigger authentication
+// metadata value into the vars map (file mode) or blanks it (inline + redact),
+// since trigger-auth metadata are credentials. This mirrors processConfig; the
+// values are keyed by trigger and metadata key so they stay unique across
+// triggers and scopes.
+func (res *ExportResult) processSchedulerK3sAutoscalingAuth(app string, b SchedulerK3sAutoscalingAuthTask, opts ExportOptions) (interface{}, []map[string]interface{}) {
+	if len(b.Metadata) == 0 {
+		return b, nil
+	}
+
+	keys := make([]string, 0, len(b.Metadata))
+	for k := range b.Metadata {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	newMetadata := make(map[string]string, len(b.Metadata))
+	var inputs []map[string]interface{}
+
+	for _, k := range keys {
+		value := b.Metadata[k]
+		if opts.Inline {
+			if opts.Redact {
+				value = ""
+			}
+			newMetadata[k] = value
+			continue
+		}
+		name := res.uniqueVarName(app, b.Trigger+"_"+k)
+		newMetadata[k] = "{{ ." + name + " }}"
+		if opts.Redact {
+			res.Vars[name] = ""
+		} else {
+			res.Vars[name] = value
+		}
+		inputs = append(inputs, map[string]interface{}{
+			"name":      name,
+			"required":  true,
+			"sensitive": true,
+		})
+	}
+
+	b.Metadata = newMetadata
 	return b, inputs
 }
 

--- a/tasks/export_integration_test.go
+++ b/tasks/export_integration_test.go
@@ -199,6 +199,165 @@ func TestIntegrationExportSchedulerK3sChart(t *testing.T) {
 	}
 }
 
+// TestIntegrationExportSchedulerK3sAnnotations verifies the annotations
+// exporter reconstructs an app's annotations such that re-planning the exported
+// body reports no drift. Gated like the other scheduler-k3s task tests.
+func TestIntegrationExportSchedulerK3sAnnotations(t *testing.T) {
+	skipUnlessSchedulerK3sT(t)
+
+	app := "docket-test-export-k3s-annotations"
+	destroyApp(app)
+	createApp(app)
+	defer destroyApp(app)
+
+	cleanup := SchedulerK3sAnnotationsTask{
+		App:          app,
+		ResourceType: "deployment",
+		Annotations:  map[string]string{"prometheus.io/scrape": "", "prometheus.io/port": ""},
+		State:        StateAbsent,
+	}
+	defer cleanup.Execute()
+
+	set := SchedulerK3sAnnotationsTask{
+		App:          app,
+		ResourceType: "deployment",
+		Annotations:  map[string]string{"prometheus.io/scrape": "true", "prometheus.io/port": "9090"},
+		State:        StatePresent,
+	}
+	if r := set.Execute(); r.Error != nil {
+		t.Fatalf("set annotations: %v", r.Error)
+	}
+
+	bodies, err := SchedulerK3sAnnotationsTask{}.ExportApp(app)
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+	var found *SchedulerK3sAnnotationsTask
+	for i := range bodies {
+		if a, ok := bodies[i].(SchedulerK3sAnnotationsTask); ok && a.ProcessType == "" && a.ResourceType == "deployment" {
+			found = &a
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("exported annotations do not include the deployment scope: %+v", bodies)
+	}
+	if found.Annotations["prometheus.io/scrape"] != "true" || found.Annotations["prometheus.io/port"] != "9090" {
+		t.Errorf("exported annotations mismatch: %+v", found.Annotations)
+	}
+	found.State = StatePresent
+	if plan := found.Plan(); !plan.InSync {
+		t.Errorf("exported annotations should report no drift, got status %v reason %q", plan.Status, plan.Reason)
+	}
+}
+
+// TestIntegrationExportSchedulerK3sLabels verifies the labels exporter
+// reconstructs an app's labels such that re-planning the exported body reports
+// no drift. Gated like the other scheduler-k3s task tests.
+func TestIntegrationExportSchedulerK3sLabels(t *testing.T) {
+	skipUnlessSchedulerK3sT(t)
+
+	app := "docket-test-export-k3s-labels"
+	destroyApp(app)
+	createApp(app)
+	defer destroyApp(app)
+
+	cleanup := SchedulerK3sLabelsTask{
+		App:          app,
+		ProcessType:  "web",
+		ResourceType: "deployment",
+		Labels:       map[string]string{"tier": "", "app.kubernetes.io/component": ""},
+		State:        StateAbsent,
+	}
+	defer cleanup.Execute()
+
+	set := SchedulerK3sLabelsTask{
+		App:          app,
+		ProcessType:  "web",
+		ResourceType: "deployment",
+		Labels:       map[string]string{"tier": "edge", "app.kubernetes.io/component": "api"},
+		State:        StatePresent,
+	}
+	if r := set.Execute(); r.Error != nil {
+		t.Fatalf("set labels: %v", r.Error)
+	}
+
+	bodies, err := SchedulerK3sLabelsTask{}.ExportApp(app)
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+	var found *SchedulerK3sLabelsTask
+	for i := range bodies {
+		if l, ok := bodies[i].(SchedulerK3sLabelsTask); ok && l.ProcessType == "web" && l.ResourceType == "deployment" {
+			found = &l
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("exported labels do not include the web/deployment scope: %+v", bodies)
+	}
+	if found.Labels["tier"] != "edge" || found.Labels["app.kubernetes.io/component"] != "api" {
+		t.Errorf("exported labels mismatch: %+v", found.Labels)
+	}
+	found.State = StatePresent
+	if plan := found.Plan(); !plan.InSync {
+		t.Errorf("exported labels should report no drift, got status %v reason %q", plan.Status, plan.Reason)
+	}
+}
+
+// TestIntegrationExportSchedulerK3sAutoscalingAuth verifies the trigger-auth
+// exporter reads the real metadata values back (the dokku#8806 JSON contract)
+// so re-planning the exported body reports no drift. Gated like the other
+// scheduler-k3s task tests.
+func TestIntegrationExportSchedulerK3sAutoscalingAuth(t *testing.T) {
+	skipUnlessSchedulerK3sT(t)
+
+	app := "docket-test-export-k3s-autoscaling-auth"
+	destroyApp(app)
+	createApp(app)
+	defer destroyApp(app)
+
+	cleanup := SchedulerK3sAutoscalingAuthTask{
+		App:      app,
+		Trigger:  "aws-secret-manager",
+		Metadata: map[string]string{"awsRegion": "", "secretName": ""},
+		State:    StateAbsent,
+	}
+	defer cleanup.Execute()
+
+	set := SchedulerK3sAutoscalingAuthTask{
+		App:      app,
+		Trigger:  "aws-secret-manager",
+		Metadata: map[string]string{"awsRegion": "us-east-1", "secretName": "my-secret"},
+		State:    StatePresent,
+	}
+	if r := set.Execute(); r.Error != nil {
+		t.Fatalf("set autoscaling-auth: %v", r.Error)
+	}
+
+	bodies, err := SchedulerK3sAutoscalingAuthTask{}.ExportApp(app)
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+	var found *SchedulerK3sAutoscalingAuthTask
+	for i := range bodies {
+		if a, ok := bodies[i].(SchedulerK3sAutoscalingAuthTask); ok && a.Trigger == "aws-secret-manager" {
+			found = &a
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("exported trigger auth does not include aws-secret-manager: %+v", bodies)
+	}
+	if found.Metadata["awsRegion"] != "us-east-1" || found.Metadata["secretName"] != "my-secret" {
+		t.Errorf("exported metadata mismatch: %+v", found.Metadata)
+	}
+	found.State = StatePresent
+	if plan := found.Plan(); !plan.InSync {
+		t.Errorf("exported trigger auth should report no drift, got status %v reason %q", plan.Status, plan.Reason)
+	}
+}
+
 // TestIntegrationExportLetsencrypt verifies the letsencrypt exporter reads the
 // active state. Gated on the letsencrypt plugin (not a dokku core plugin).
 // Enabling letsencrypt triggers a real ACME issuance, so this only asserts the

--- a/tasks/export_integration_test.go
+++ b/tasks/export_integration_test.go
@@ -199,10 +199,12 @@ func TestIntegrationExportSchedulerK3sChart(t *testing.T) {
 	}
 }
 
-// TestIntegrationExportSchedulerK3sAnnotations verifies the annotations
+// TestIntegrationSchedulerK3sAnnotationsExport verifies the annotations
 // exporter reconstructs an app's annotations such that re-planning the exported
-// body reports no drift. Gated like the other scheduler-k3s task tests.
-func TestIntegrationExportSchedulerK3sAnnotations(t *testing.T) {
+// body reports no drift. Named with the TestIntegrationSchedulerK3s prefix so
+// the scheduler-k3s-test CI job's -run filter picks it up, and gated like the
+// other scheduler-k3s task tests.
+func TestIntegrationSchedulerK3sAnnotationsExport(t *testing.T) {
 	skipUnlessSchedulerK3sT(t)
 
 	app := "docket-test-export-k3s-annotations"
@@ -251,10 +253,12 @@ func TestIntegrationExportSchedulerK3sAnnotations(t *testing.T) {
 	}
 }
 
-// TestIntegrationExportSchedulerK3sLabels verifies the labels exporter
+// TestIntegrationSchedulerK3sLabelsExport verifies the labels exporter
 // reconstructs an app's labels such that re-planning the exported body reports
-// no drift. Gated like the other scheduler-k3s task tests.
-func TestIntegrationExportSchedulerK3sLabels(t *testing.T) {
+// no drift. Named with the TestIntegrationSchedulerK3s prefix so the
+// scheduler-k3s-test CI job's -run filter picks it up, and gated like the other
+// scheduler-k3s task tests.
+func TestIntegrationSchedulerK3sLabelsExport(t *testing.T) {
 	skipUnlessSchedulerK3sT(t)
 
 	app := "docket-test-export-k3s-labels"
@@ -305,11 +309,12 @@ func TestIntegrationExportSchedulerK3sLabels(t *testing.T) {
 	}
 }
 
-// TestIntegrationExportSchedulerK3sAutoscalingAuth verifies the trigger-auth
+// TestIntegrationSchedulerK3sAutoscalingAuthExport verifies the trigger-auth
 // exporter reads the real metadata values back (the dokku#8806 JSON contract)
-// so re-planning the exported body reports no drift. Gated like the other
-// scheduler-k3s task tests.
-func TestIntegrationExportSchedulerK3sAutoscalingAuth(t *testing.T) {
+// so re-planning the exported body reports no drift. Named with the
+// TestIntegrationSchedulerK3s prefix so the scheduler-k3s-test CI job's -run
+// filter picks it up, and gated like the other scheduler-k3s task tests.
+func TestIntegrationSchedulerK3sAutoscalingAuthExport(t *testing.T) {
 	skipUnlessSchedulerK3sT(t)
 
 	app := "docket-test-export-k3s-autoscaling-auth"

--- a/tasks/scheduler_k3s_annotations_task.go
+++ b/tasks/scheduler_k3s_annotations_task.go
@@ -49,7 +49,7 @@ func (t SchedulerK3sAnnotationsTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t SchedulerK3sAnnotationsTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportUnsupported, Caveat: "scheduler-k3s exposes no report for annotations, so the current state cannot be read back (docket#287, dokku/dokku#8800)"}
+	return ExportSupport{Status: ExportSupported}
 }
 
 // Examples returns the examples for the scheduler-k3s annotations task
@@ -134,6 +134,32 @@ func (t SchedulerK3sAnnotationsTask) spec() schedulerK3sScopedPairsSpec {
 		ResourceType: t.ResourceType,
 		Pairs:        t.Annotations,
 	}
+}
+
+// ExportApp reconstructs the app's annotations, one task per
+// (process_type, resource_type) scope, from scheduler-k3s:annotations:report.
+func (t SchedulerK3sAnnotationsTask) ExportApp(app string) ([]interface{}, error) {
+	return exportSchedulerK3sScopedPairs("annotations", app, false, func(processType, resourceType string, pairs map[string]string) interface{} {
+		return SchedulerK3sAnnotationsTask{
+			App:          app,
+			ProcessType:  processType,
+			ResourceType: resourceType,
+			Annotations:  pairs,
+		}
+	})
+}
+
+// ExportGlobal reconstructs the global-scope annotations, one task per
+// (process_type, resource_type) scope, from scheduler-k3s:annotations:report.
+func (t SchedulerK3sAnnotationsTask) ExportGlobal() ([]interface{}, error) {
+	return exportSchedulerK3sScopedPairs("annotations", "", true, func(processType, resourceType string, pairs map[string]string) interface{} {
+		return SchedulerK3sAnnotationsTask{
+			Global:       true,
+			ProcessType:  processType,
+			ResourceType: resourceType,
+			Annotations:  pairs,
+		}
+	})
 }
 
 // init registers the SchedulerK3sAnnotationsTask with the task registry

--- a/tasks/scheduler_k3s_autoscaling_auth.go
+++ b/tasks/scheduler_k3s_autoscaling_auth.go
@@ -171,10 +171,11 @@ func schedulerK3sAutoscalingAuthClearCommand(spec schedulerK3sAutoscalingAuthSpe
 
 // getSchedulerK3sAutoscalingAuth reads the metadata currently stored for the
 // spec's trigger. It calls
-// `dokku scheduler-k3s:autoscaling-auth:report <app|--global> --format json
-// --include-metadata`, which returns a flat map where the entry for the
-// trigger itself is the sentinel value "configured" and metadata entries are
-// keyed `<trigger>-<key>`. We strip the prefix and skip the sentinel.
+// `dokku scheduler-k3s:autoscaling-auth:report <app|--global> --format json`,
+// which returns a flat map keyed `<trigger>.<metadata_key>` carrying the real
+// metadata values (dokku only masks stdout and single-flag output, never the
+// JSON payload). We keep the entries under our trigger and strip the
+// `<trigger>.` prefix to recover the original metadata keys.
 func getSchedulerK3sAutoscalingAuth(spec schedulerK3sAutoscalingAuthSpec) (map[string]string, error) {
 	args := []string{"--quiet", "scheduler-k3s:autoscaling-auth:report"}
 	if spec.Global {
@@ -182,7 +183,7 @@ func getSchedulerK3sAutoscalingAuth(spec schedulerK3sAutoscalingAuthSpec) (map[s
 	} else {
 		args = append(args, spec.App)
 	}
-	args = append(args, "--include-metadata", "--format", "json")
+	args = append(args, "--format", "json")
 
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
@@ -192,21 +193,85 @@ func getSchedulerK3sAutoscalingAuth(spec schedulerK3sAutoscalingAuthSpec) (map[s
 		return nil, err
 	}
 
+	return parseSchedulerK3sAutoscalingAuthReport(result.StdoutBytes(), spec.Trigger)
+}
+
+// parseSchedulerK3sAutoscalingAuthReport decodes the flat
+// `scheduler-k3s:autoscaling-auth:report --format json` payload and returns the
+// metadata for a single trigger keyed by the original metadata key. The
+// composed keys are `<trigger>.<metadata_key>`; the trigger is dokku's first
+// segment and never contains a dot, but a metadata key may, so we strip the
+// `<trigger>.` prefix rather than splitting. Kept separate from the subprocess
+// call so the parse path is unit-testable without a fake executor.
+func parseSchedulerK3sAutoscalingAuthReport(raw []byte, trigger string) (map[string]string, error) {
 	payload := map[string]string{}
-	if err := json.Unmarshal(result.StdoutBytes(), &payload); err != nil {
+	if err := json.Unmarshal(raw, &payload); err != nil {
 		return nil, fmt.Errorf("parse scheduler-k3s:autoscaling-auth:report json: %w", err)
 	}
 
-	prefix := spec.Trigger + "-"
+	prefix := trigger + "."
 	metadata := map[string]string{}
 	for composedKey, value := range payload {
-		if composedKey == spec.Trigger {
-			continue
-		}
 		if !strings.HasPrefix(composedKey, prefix) {
 			continue
 		}
 		metadata[strings.TrimPrefix(composedKey, prefix)] = value
 	}
 	return metadata, nil
+}
+
+// exportSchedulerK3sAutoscalingAuth reconstructs the trigger-auth task bodies
+// for one scope (a single app, or the global scope when global is true) from
+// `scheduler-k3s:autoscaling-auth:report --format json`. The flat payload is
+// grouped by trigger and build turns each (trigger, metadata) group into a task
+// body. Non-SSH errors and unparseable output are swallowed (return nil) so a
+// host without scheduler-k3s state does not fail the whole export, mirroring
+// the profile and chart exporters.
+func exportSchedulerK3sAutoscalingAuth(app string, global bool, build func(trigger string, metadata map[string]string) interface{}) ([]interface{}, error) {
+	target := app
+	if global {
+		target = "--global"
+	}
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "scheduler-k3s:autoscaling-auth:report", target, "--format", "json"},
+	})
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return nil, err
+		}
+		return nil, nil
+	}
+
+	payload := map[string]string{}
+	if err := json.Unmarshal(result.StdoutBytes(), &payload); err != nil {
+		return nil, nil
+	}
+
+	byTrigger := map[string]map[string]string{}
+	for composed, value := range payload {
+		parts := strings.SplitN(composed, ".", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			continue
+		}
+		trigger, key := parts[0], parts[1]
+		if byTrigger[trigger] == nil {
+			byTrigger[trigger] = map[string]string{}
+		}
+		byTrigger[trigger][key] = value
+	}
+
+	triggers := make([]string, 0, len(byTrigger))
+	for trigger := range byTrigger {
+		triggers = append(triggers, trigger)
+	}
+	sort.Strings(triggers)
+
+	var out []interface{}
+	for _, trigger := range triggers {
+		out = append(out, build(trigger, byTrigger[trigger]))
+	}
+	return out, nil
 }

--- a/tasks/scheduler_k3s_autoscaling_auth_task.go
+++ b/tasks/scheduler_k3s_autoscaling_auth_task.go
@@ -45,7 +45,7 @@ func (t SchedulerK3sAutoscalingAuthTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t SchedulerK3sAutoscalingAuthTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportUnsupported, Caveat: "scheduler-k3s exposes no report for KEDA trigger authentication, so the current state cannot be read back (docket#287, dokku/dokku#8800)"}
+	return ExportSupport{Status: ExportPartial, Caveat: "trigger authentication metadata values are secrets, so they are written to the companion vars-file"}
 }
 
 // Examples returns the examples for the scheduler-k3s autoscaling-auth task
@@ -117,6 +117,31 @@ func (t SchedulerK3sAutoscalingAuthTask) spec() schedulerK3sAutoscalingAuthSpec 
 		Trigger:  t.Trigger,
 		Metadata: t.Metadata,
 	}
+}
+
+// ExportApp reconstructs the app's trigger authentication metadata, one task
+// per trigger, from scheduler-k3s:autoscaling-auth:report. The metadata values
+// are secrets; the export engine lifts them into the companion vars-file.
+func (t SchedulerK3sAutoscalingAuthTask) ExportApp(app string) ([]interface{}, error) {
+	return exportSchedulerK3sAutoscalingAuth(app, false, func(trigger string, metadata map[string]string) interface{} {
+		return SchedulerK3sAutoscalingAuthTask{
+			App:      app,
+			Trigger:  trigger,
+			Metadata: metadata,
+		}
+	})
+}
+
+// ExportGlobal reconstructs the global-scope trigger authentication metadata,
+// one task per trigger, from scheduler-k3s:autoscaling-auth:report.
+func (t SchedulerK3sAutoscalingAuthTask) ExportGlobal() ([]interface{}, error) {
+	return exportSchedulerK3sAutoscalingAuth("", true, func(trigger string, metadata map[string]string) interface{} {
+		return SchedulerK3sAutoscalingAuthTask{
+			Global:   true,
+			Trigger:  trigger,
+			Metadata: metadata,
+		}
+	})
 }
 
 // init registers the SchedulerK3sAutoscalingAuthTask with the task registry

--- a/tasks/scheduler_k3s_export_test.go
+++ b/tasks/scheduler_k3s_export_test.go
@@ -1,0 +1,280 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+func TestParseSchedulerK3sAutoscalingAuthReport(t *testing.T) {
+	t.Run("dot format grouped by trigger", func(t *testing.T) {
+		raw := []byte(`{"datadog.apiKey":"secret-1","datadog.appKey":"secret-2"}`)
+		md, err := parseSchedulerK3sAutoscalingAuthReport(raw, "datadog")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if md["apiKey"] != "secret-1" || md["appKey"] != "secret-2" {
+			t.Errorf("metadata mismatch: %+v", md)
+		}
+		if len(md) != 2 {
+			t.Errorf("expected 2 keys, got %d: %+v", len(md), md)
+		}
+	})
+
+	t.Run("only the requested trigger is returned", func(t *testing.T) {
+		raw := []byte(`{"datadog.apiKey":"a","aws-secret-manager.awsRegion":"us-east-1"}`)
+		md, err := parseSchedulerK3sAutoscalingAuthReport(raw, "datadog")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(md) != 1 || md["apiKey"] != "a" {
+			t.Errorf("expected only the datadog apiKey, got %+v", md)
+		}
+	})
+
+	t.Run("metadata key may contain dots", func(t *testing.T) {
+		raw := []byte(`{"datadog.some.dotted.key":"v"}`)
+		md, err := parseSchedulerK3sAutoscalingAuthReport(raw, "datadog")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if md["some.dotted.key"] != "v" {
+			t.Errorf("expected dotted key preserved, got %+v", md)
+		}
+	})
+
+	t.Run("empty payload yields empty metadata", func(t *testing.T) {
+		md, err := parseSchedulerK3sAutoscalingAuthReport([]byte(`{}`), "datadog")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(md) != 0 {
+			t.Errorf("expected no metadata, got %+v", md)
+		}
+	})
+
+	t.Run("malformed payload errors", func(t *testing.T) {
+		_, err := parseSchedulerK3sAutoscalingAuthReport([]byte("not json"), "datadog")
+		if err == nil {
+			t.Fatal("expected parse error")
+		}
+		if !strings.Contains(err.Error(), "parse scheduler-k3s:autoscaling-auth:report json") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}
+
+func annotationScope(bodies []interface{}, processType, resourceType string) *SchedulerK3sAnnotationsTask {
+	for i := range bodies {
+		if a, ok := bodies[i].(SchedulerK3sAnnotationsTask); ok && a.ProcessType == processType && a.ResourceType == resourceType {
+			return &a
+		}
+	}
+	return nil
+}
+
+func TestSchedulerK3sAnnotationsExportApp(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet scheduler-k3s:annotations:report myapp --format json": `{
+			"global.deployment.prometheus.io/scrape":"true",
+			"global.deployment.prometheus.io/port":"9090",
+			"web.ingress.nginx.ingress.kubernetes.io/rewrite-target":"/"
+		}`,
+	}))()
+
+	bodies, err := SchedulerK3sAnnotationsTask{}.ExportApp("myapp")
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("expected 2 scope bodies, got %d: %+v", len(bodies), bodies)
+	}
+
+	// Deterministic order: sorted by resourceType then processType, so the
+	// deployment scope precedes the ingress scope.
+	first, ok := bodies[0].(SchedulerK3sAnnotationsTask)
+	if !ok || first.ResourceType != "deployment" {
+		t.Fatalf("expected deployment scope first, got %+v", bodies[0])
+	}
+
+	// global process scope maps back to an empty ProcessType, and dotted/slashed
+	// annotation keys survive the split.
+	dep := annotationScope(bodies, "", "deployment")
+	if dep == nil {
+		t.Fatalf("missing global/deployment scope: %+v", bodies)
+	}
+	if dep.App != "myapp" || dep.Global {
+		t.Errorf("expected app scope, got App=%q Global=%v", dep.App, dep.Global)
+	}
+	if dep.Annotations["prometheus.io/scrape"] != "true" || dep.Annotations["prometheus.io/port"] != "9090" {
+		t.Errorf("deployment annotations mismatch: %+v", dep.Annotations)
+	}
+
+	ing := annotationScope(bodies, "web", "ingress")
+	if ing == nil {
+		t.Fatalf("missing web/ingress scope: %+v", bodies)
+	}
+	if ing.Annotations["nginx.ingress.kubernetes.io/rewrite-target"] != "/" {
+		t.Errorf("ingress annotations mismatch: %+v", ing.Annotations)
+	}
+}
+
+func TestSchedulerK3sAnnotationsExportGlobal(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet scheduler-k3s:annotations:report --global --format json": `{"global.deployment.managed-by":"docket"}`,
+	}))()
+
+	bodies, err := SchedulerK3sAnnotationsTask{}.ExportGlobal()
+	if err != nil {
+		t.Fatalf("ExportGlobal: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 body, got %d: %+v", len(bodies), bodies)
+	}
+	got := bodies[0].(SchedulerK3sAnnotationsTask)
+	if !got.Global || got.App != "" || got.ProcessType != "" || got.ResourceType != "deployment" {
+		t.Errorf("unexpected global body: %+v", got)
+	}
+	if got.Annotations["managed-by"] != "docket" {
+		t.Errorf("annotations mismatch: %+v", got.Annotations)
+	}
+}
+
+func TestSchedulerK3sLabelsExportApp(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet scheduler-k3s:labels:report myapp --format json": `{"web.deployment.tier":"edge","web.deployment.app.kubernetes.io/component":"api"}`,
+	}))()
+
+	bodies, err := SchedulerK3sLabelsTask{}.ExportApp("myapp")
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 scope body, got %d: %+v", len(bodies), bodies)
+	}
+	got := bodies[0].(SchedulerK3sLabelsTask)
+	if got.App != "myapp" || got.ProcessType != "web" || got.ResourceType != "deployment" {
+		t.Errorf("unexpected labels body: %+v", got)
+	}
+	if got.Labels["tier"] != "edge" || got.Labels["app.kubernetes.io/component"] != "api" {
+		t.Errorf("labels mismatch: %+v", got.Labels)
+	}
+}
+
+func TestSchedulerK3sAutoscalingAuthExportApp(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet scheduler-k3s:autoscaling-auth:report myapp --format json": `{
+			"datadog.apiKey":"secret-1",
+			"aws-secret-manager.awsRegion":"us-east-1",
+			"aws-secret-manager.secretName":"my-secret"
+		}`,
+	}))()
+
+	bodies, err := SchedulerK3sAutoscalingAuthTask{}.ExportApp("myapp")
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("expected 2 trigger bodies, got %d: %+v", len(bodies), bodies)
+	}
+
+	// Triggers are emitted in sorted order.
+	first := bodies[0].(SchedulerK3sAutoscalingAuthTask)
+	if first.Trigger != "aws-secret-manager" {
+		t.Errorf("expected aws-secret-manager first, got %q", first.Trigger)
+	}
+	if first.App != "myapp" || first.Global {
+		t.Errorf("expected app scope, got App=%q Global=%v", first.App, first.Global)
+	}
+	if first.Metadata["awsRegion"] != "us-east-1" || first.Metadata["secretName"] != "my-secret" {
+		t.Errorf("aws metadata mismatch: %+v", first.Metadata)
+	}
+
+	second := bodies[1].(SchedulerK3sAutoscalingAuthTask)
+	if second.Trigger != "datadog" || second.Metadata["apiKey"] != "secret-1" {
+		t.Errorf("datadog body mismatch: %+v", second)
+	}
+}
+
+func TestSchedulerK3sAutoscalingAuthExportGlobal(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet scheduler-k3s:autoscaling-auth:report --global --format json": `{"datadog.apiKey":"global-secret"}`,
+	}))()
+
+	bodies, err := SchedulerK3sAutoscalingAuthTask{}.ExportGlobal()
+	if err != nil {
+		t.Fatalf("ExportGlobal: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 body, got %d: %+v", len(bodies), bodies)
+	}
+	got := bodies[0].(SchedulerK3sAutoscalingAuthTask)
+	if !got.Global || got.App != "" || got.Trigger != "datadog" {
+		t.Errorf("unexpected global body: %+v", got)
+	}
+	if got.Metadata["apiKey"] != "global-secret" {
+		t.Errorf("metadata mismatch: %+v", got.Metadata)
+	}
+}
+
+func TestSchedulerK3sScopedPairsExportEmpty(t *testing.T) {
+	// An app with no annotations returns "{}"; the exporter yields no bodies.
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet scheduler-k3s:annotations:report myapp --format json": `{}`,
+	}))()
+
+	bodies, err := SchedulerK3sAnnotationsTask{}.ExportApp("myapp")
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+	if len(bodies) != 0 {
+		t.Errorf("expected no bodies, got %+v", bodies)
+	}
+}
+
+// TestExportSchedulerK3sScopedAndAuthRecipe drives the full engine: annotations
+// and labels are emitted inline, while trigger-auth metadata (a secret) is
+// lifted into the vars map and never leaks into the recipe body.
+func TestExportSchedulerK3sScopedAndAuthRecipe(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list": "web",
+		"--quiet scheduler-k3s:annotations:report web --format json":      `{"global.deployment.prometheus.io/scrape":"true"}`,
+		"--quiet scheduler-k3s:labels:report web --format json":           `{"web.deployment.tier":"edge"}`,
+		"--quiet scheduler-k3s:autoscaling-auth:report web --format json": `{"datadog.apiKey":"s3cr3t-key"}`,
+	}))()
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+
+	// The trigger-auth secret is lifted into the vars map, keyed by trigger.
+	if got := res.Vars["web_datadog_apiKey"]; got != "s3cr3t-key" {
+		t.Errorf("vars[web_datadog_apiKey] = %q, want s3cr3t-key", got)
+	}
+
+	recipe, err := res.MarshalRecipe("yaml")
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	out := string(recipe)
+
+	if strings.Contains(out, "s3cr3t-key") {
+		t.Errorf("recipe leaked the trigger-auth secret:\n%s", out)
+	}
+	for _, want := range []string{
+		"dokku_scheduler_k3s_annotations",
+		"prometheus.io/scrape",
+		"dokku_scheduler_k3s_labels",
+		"tier: edge",
+		"dokku_scheduler_k3s_autoscaling_auth",
+		"trigger: datadog",
+		"{{ .web_datadog_apiKey }}",
+		"name: web_datadog_apiKey",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("recipe missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/tasks/scheduler_k3s_labels_task.go
+++ b/tasks/scheduler_k3s_labels_task.go
@@ -47,7 +47,7 @@ func (t SchedulerK3sLabelsTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t SchedulerK3sLabelsTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportUnsupported, Caveat: "scheduler-k3s exposes no report for labels, so the current state cannot be read back (docket#287, dokku/dokku#8800)"}
+	return ExportSupport{Status: ExportSupported}
 }
 
 // Examples returns the examples for the scheduler-k3s labels task
@@ -132,6 +132,32 @@ func (t SchedulerK3sLabelsTask) spec() schedulerK3sScopedPairsSpec {
 		ResourceType: t.ResourceType,
 		Pairs:        t.Labels,
 	}
+}
+
+// ExportApp reconstructs the app's labels, one task per
+// (process_type, resource_type) scope, from scheduler-k3s:labels:report.
+func (t SchedulerK3sLabelsTask) ExportApp(app string) ([]interface{}, error) {
+	return exportSchedulerK3sScopedPairs("labels", app, false, func(processType, resourceType string, pairs map[string]string) interface{} {
+		return SchedulerK3sLabelsTask{
+			App:          app,
+			ProcessType:  processType,
+			ResourceType: resourceType,
+			Labels:       pairs,
+		}
+	})
+}
+
+// ExportGlobal reconstructs the global-scope labels, one task per
+// (process_type, resource_type) scope, from scheduler-k3s:labels:report.
+func (t SchedulerK3sLabelsTask) ExportGlobal() ([]interface{}, error) {
+	return exportSchedulerK3sScopedPairs("labels", "", true, func(processType, resourceType string, pairs map[string]string) interface{} {
+		return SchedulerK3sLabelsTask{
+			Global:       true,
+			ProcessType:  processType,
+			ResourceType: resourceType,
+			Labels:       pairs,
+		}
+	})
 }
 
 // init registers the SchedulerK3sLabelsTask with the task registry

--- a/tasks/scheduler_k3s_scoped_pairs.go
+++ b/tasks/scheduler_k3s_scoped_pairs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/dokku/docket/subprocess"
@@ -153,4 +154,88 @@ func renderedSchedulerK3sProcessType(processType string) string {
 // user-facing messages: "labels" -> "label", "annotations" -> "annotation".
 func singularizeSchedulerK3sKind(kind string) string {
 	return strings.TrimSuffix(kind, "s")
+}
+
+// schedulerK3sReportProcessTypeToTask is the inverse of
+// renderedSchedulerK3sProcessType: it maps a report-rendered process type back
+// to the value the task carries. The rendered global sentinel "global" becomes
+// an empty ProcessType (the task's default/global-process form); real process
+// types pass through unchanged. Like the forward mapping, this shares dokku's
+// pathological ambiguity - a real process literally named "global" is
+// indistinguishable from the sentinel and round-trips to an empty ProcessType.
+func schedulerK3sReportProcessTypeToTask(rendered string) string {
+	if rendered == "global" {
+		return ""
+	}
+	return rendered
+}
+
+// exportSchedulerK3sScopedPairs reconstructs the annotations or labels task
+// bodies for one scope (a single app, or the global scope when global is true)
+// from `scheduler-k3s:<kind>:report --format json`. The report is called
+// without --process-type/--resource-type filters so it returns every scope; the
+// flat `<processType>.<resourceType>.<key>` payload is grouped into one task
+// body per (process_type, resource_type) pair and build turns each group into
+// the task struct. Non-SSH errors and unparseable output are swallowed (return
+// nil) so a host without scheduler-k3s state does not fail the whole export,
+// mirroring the profile and chart exporters.
+func exportSchedulerK3sScopedPairs(kind, app string, global bool, build func(processType, resourceType string, pairs map[string]string) interface{}) ([]interface{}, error) {
+	target := app
+	if global {
+		target = "--global"
+	}
+
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "scheduler-k3s:" + kind + ":report", target, "--format", "json"},
+	})
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return nil, err
+		}
+		return nil, nil
+	}
+
+	payload := map[string]string{}
+	if err := json.Unmarshal(result.StdoutBytes(), &payload); err != nil {
+		return nil, nil
+	}
+
+	type scope struct{ processType, resourceType string }
+	groups := map[scope]map[string]string{}
+	for composed, value := range payload {
+		// processType and resourceType never contain dots, but an annotation or
+		// label key frequently does (e.g. "prometheus.io/scrape"), so split off
+		// exactly the first two segments and keep the remainder as the key.
+		parts := strings.SplitN(composed, ".", 3)
+		if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+			continue
+		}
+		s := scope{
+			processType:  schedulerK3sReportProcessTypeToTask(parts[0]),
+			resourceType: parts[1],
+		}
+		if groups[s] == nil {
+			groups[s] = map[string]string{}
+		}
+		groups[s][parts[2]] = value
+	}
+
+	scopes := make([]scope, 0, len(groups))
+	for s := range groups {
+		scopes = append(scopes, s)
+	}
+	sort.Slice(scopes, func(i, j int) bool {
+		if scopes[i].resourceType != scopes[j].resourceType {
+			return scopes[i].resourceType < scopes[j].resourceType
+		}
+		return scopes[i].processType < scopes[j].processType
+	})
+
+	var out []interface{}
+	for _, s := range scopes {
+		out = append(out, build(s.processType, s.resourceType, groups[s]))
+	}
+	return out, nil
 }


### PR DESCRIPTION
The structured scheduler-k3s tasks `scheduler_k3s_annotations`, `scheduler_k3s_labels`, and `scheduler_k3s_autoscaling_auth` were declared export-unsupported because scheduler-k3s exposed no way to read their state back. dokku/dokku#8806 resolves that by adding `--format json` read-back for the annotations, labels, and trigger authentication reports, so this wires `docket export` for all three.

Annotations and labels are exported inline, one task per process-type and resource-type scope. Trigger authentication metadata are credentials, so they are lifted into the companion vars-file like config values rather than written into the recipe. The trigger authentication read-back is also aligned with the flat `{trigger}.{key}` JSON key format that the aligned report uses.

The three reports ship in dokku 0.38.22, so the minimum supported dokku version and the CI dokku pin both move from 0.38.15 to 0.38.22. That release also changes `docker-options:report` to add parallel structured-list keys (dokku/dokku#8799), so docket's docker-options parsing is made tolerant of the added array-valued keys.

Closes #287.