### PR TITLE
feat: consume docker-options structured-list report keys

### DIFF
--- a/docs/tasks/dokku_docker_options.md
+++ b/docs/tasks/dokku_docker_options.md
@@ -6,7 +6,7 @@ Manages docker-options for a given dokku application
 
 ## Export support
 
-Partial - docker-options:report space-joins each phase's options, so options whose values contain spaces cannot be split back into individual entries (dokku/dokku#8799).
+Supported.
 
 ## Parameters
 

--- a/tasks/docker_options_task.go
+++ b/tasks/docker_options_task.go
@@ -57,13 +57,14 @@ func (t DockerOptionsTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t DockerOptionsTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportPartial, Caveat: "docker-options:report space-joins each phase's options, so options whose values contain spaces cannot be split back into individual entries (dokku/dokku#8799)"}
+	return ExportSupport{Status: ExportSupported}
 }
 
 // ExportApp reconstructs the app's docker options as one task per individual
-// option, per (phase, process type). The report space-joins a phase's options,
-// so this splits on whitespace; options whose values contain spaces cannot be
-// recovered faithfully (dokku/dokku#8799).
+// option, per (phase, process type). Options are read from the structured
+// `<phase>-list` report keys (dokku/dokku#8799), so each stored option -
+// including values that contain spaces - is emitted as a discrete task without
+// whitespace splitting.
 func (t DockerOptionsTask) ExportApp(app string) ([]interface{}, error) {
 	scoped, err := getDockerOptions(app)
 	if err != nil {
@@ -87,7 +88,7 @@ func (t DockerOptionsTask) ExportApp(app string) ([]interface{}, error) {
 
 	var out []interface{}
 	for _, scope := range scopes {
-		for _, option := range strings.Fields(scoped[scope]) {
+		for _, option := range scoped[scope] {
 			out = append(out, DockerOptionsTask{
 				App:         app,
 				Phase:       scope.Phase,
@@ -259,14 +260,13 @@ func validateDockerOptionsTask(t DockerOptionsTask) error {
 }
 
 // getDockerOptions reads the docker-options JSON report and indexes it by
-// (phase, process type). The JSON payload carries one entry per
-// `<phase>` and one per `<phase>.<process_type>` for any process-scoped
-// option, plus legacy `docker-options-*` duplicates emitted during the
-// 0.38.x deprecation window which we discard. dokku 0.38.22+ additionally
-// emits parallel `<key>-list` companions whose values are JSON arrays
-// (dokku/dokku#8799); the payload is decoded loosely so those array values do
-// not break parsing.
-func getDockerOptions(app string) (map[dockerOptionsScope]string, error) {
+// (phase, process type). dokku 0.38.22+ emits structured `<phase>-list` and
+// `<phase>.<process_type>-list` companion keys whose values are JSON arrays
+// with one element per stored option (dokku/dokku#8799); these are the source
+// of truth here, so options are recovered as discrete entries even when their
+// values contain spaces. The space-joined shorthand keys and the legacy
+// `docker-options-*` duplicates are ignored.
+func getDockerOptions(app string) (map[dockerOptionsScope][]string, error) {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "docker-options:report", app, "--format", "json"},
@@ -283,27 +283,39 @@ func getDockerOptions(app string) (map[dockerOptionsScope]string, error) {
 	return parseDockerOptionsPayload(payload), nil
 }
 
-// parseDockerOptionsPayload turns the report JSON map into scope-keyed
-// options. Legacy plugin-prefixed keys and any unknown keys are dropped so
-// that future report additions do not surface as drift. Only string-valued
-// shorthand keys are consumed; the `<key>-list` structured-list companions
-// added in dokku 0.38.22 (dokku/dokku#8799) carry array values and are skipped
-// here, leaving the space-joined string keys as the source of truth.
-func parseDockerOptionsPayload(payload map[string]interface{}) map[dockerOptionsScope]string {
-	out := map[dockerOptionsScope]string{}
+// parseDockerOptionsPayload turns the report JSON map into scope-keyed option
+// lists. Only the structured `<key>-list` companions (dokku/dokku#8799) are
+// consumed: each carries a JSON array with one element per stored option, so
+// options are indexed as discrete entries in dokku's stored order. The
+// space-joined shorthand keys are ignored (a non `-list` suffix), and a
+// `docker-options-` prefix is dropped defensively - dokku ships no
+// `docker-options-*-list` companion today, matching the "drop unknown keys so
+// future report additions do not surface as drift" posture.
+func parseDockerOptionsPayload(payload map[string]interface{}) map[dockerOptionsScope][]string {
+	out := map[dockerOptionsScope][]string{}
 	for key, value := range payload {
-		if strings.HasPrefix(key, "docker-options-") {
-			continue
-		}
-		str, ok := value.(string)
+		shorthand, ok := strings.CutSuffix(key, "-list")
 		if !ok {
 			continue
 		}
-		phase, processType, ok := splitDockerOptionsKey(key)
+		if strings.HasPrefix(shorthand, "docker-options-") {
+			continue
+		}
+		items, ok := value.([]interface{})
 		if !ok {
 			continue
 		}
-		out[dockerOptionsScope{Phase: phase, ProcessType: processType}] = str
+		phase, processType, ok := splitDockerOptionsKey(shorthand)
+		if !ok {
+			continue
+		}
+		options := make([]string, 0, len(items))
+		for _, item := range items {
+			if str, ok := item.(string); ok {
+				options = append(options, str)
+			}
+		}
+		out[dockerOptionsScope{Phase: phase, ProcessType: processType}] = options
 	}
 	return out
 }
@@ -324,22 +336,13 @@ func splitDockerOptionsKey(key string) (phase, processType string, ok bool) {
 	return phase, processType, true
 }
 
-// optionPresent returns true if option appears as a contiguous token sequence in existing
-func optionPresent(existing, option string) bool {
-	optionTokens := strings.Fields(option)
-	if len(optionTokens) == 0 {
-		return false
-	}
-	existingTokens := strings.Fields(existing)
-	for i := 0; i+len(optionTokens) <= len(existingTokens); i++ {
-		match := true
-		for j, tok := range optionTokens {
-			if existingTokens[i+j] != tok {
-				match = false
-				break
-			}
-		}
-		if match {
+// optionPresent returns true if option appears as a discrete stored entry in
+// existing. Options are compared by exact string equality because dokku's
+// `<phase>-list` report keys expose each option as a discrete element
+// (dokku/dokku#8799); no token splitting is required.
+func optionPresent(existing []string, option string) bool {
+	for _, entry := range existing {
+		if entry == option {
 			return true
 		}
 	}

--- a/tasks/docker_options_task_integration_test.go
+++ b/tasks/docker_options_task_integration_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -82,6 +83,63 @@ func TestIntegrationDockerOptions(t *testing.T) {
 	}
 	if result.Changed {
 		t.Errorf("expected Changed=false on idempotent remove")
+	}
+}
+
+// TestIntegrationDockerOptionsExportRoundTrip verifies the exporter recovers
+// each stored option as a discrete task from the structured -list report keys
+// (dokku/dokku#8799), including an option whose value contains a space, and
+// that re-planning the exported bodies reports no drift.
+func TestIntegrationDockerOptionsExportRoundTrip(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-docker-options-export"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	phase := "deploy"
+	plainOption := "-v /tmp/docket-test:/tmp/docket-test"
+	// A value containing a space: the space-joined report string cannot split
+	// this back, but the -list companion carries it as one element.
+	spacedOption := "--label 'com.example.description=my app'"
+
+	for _, option := range []string{plainOption, spacedOption} {
+		add := DockerOptionsTask{App: appName, Phase: phase, Option: option, State: StatePresent}
+		if r := add.Execute(); r.Error != nil {
+			t.Fatalf("failed to add option %q: %v", option, r.Error)
+		}
+	}
+
+	bodies, err := DockerOptionsTask{}.ExportApp(appName)
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+
+	// The space-bearing option must surface as exactly one task, not tokenized
+	// into separate tasks per whitespace-separated word.
+	var spaced []DockerOptionsTask
+	for _, body := range bodies {
+		task, ok := body.(DockerOptionsTask)
+		if !ok {
+			t.Fatalf("exported body is not a DockerOptionsTask: %T", body)
+		}
+		if strings.Contains(task.Option, "com.example.description=my app") {
+			spaced = append(spaced, task)
+		}
+	}
+	if len(spaced) != 1 {
+		t.Fatalf("expected exactly one exported task carrying the space value, got %d: %+v", len(spaced), bodies)
+	}
+
+	// Every exported body must re-plan without drift, proving the round-trip.
+	for _, body := range bodies {
+		task := body.(DockerOptionsTask)
+		task.State = StatePresent
+		if plan := task.Plan(); !plan.InSync {
+			t.Errorf("exported task %+v should report no drift, got status %v reason %q", task, plan.Status, plan.Reason)
+		}
 	}
 }
 

--- a/tasks/docker_options_task_test.go
+++ b/tasks/docker_options_task_test.go
@@ -117,8 +117,10 @@ func TestDockerOptionsCommandArgs(t *testing.T) {
 
 func TestParseDockerOptionsPayload(t *testing.T) {
 	payload := map[string]interface{}{
+		// Space-joined shorthand keys are ignored in favor of the structured
+		// -list companions below.
 		"build":                     "",
-		"deploy":                    "-v /a:/a",
+		"deploy":                    "-v /a:/a --label com.example.description=my app",
 		"run":                       "",
 		"deploy.web":                "--memory=512m",
 		"deploy.worker":             "--cpus=1",
@@ -126,28 +128,41 @@ func TestParseDockerOptionsPayload(t *testing.T) {
 		"docker-options-deploy":     "-v /a:/a",
 		"docker-options-deploy.web": "--memory=512m",
 		"some-unrelated-key":        "ignored",
-		// dokku 0.38.22+ structured-list companions (dokku/dokku#8799): array
-		// values that must be skipped in favor of the string keys above.
-		"build-list":      []interface{}{},
-		"deploy-list":     []interface{}{"-v /a:/a"},
-		"run-list":        []interface{}{},
-		"deploy.web-list": []interface{}{"--memory=512m"},
+		// dokku 0.38.22+ structured-list companions (dokku/dokku#8799): one
+		// array element per stored option, consumed as discrete entries. A
+		// value with a space stays a single element (no whitespace splitting).
+		"build-list":         []interface{}{},
+		"deploy-list":        []interface{}{"-v /a:/a", "--label 'com.example.description=my app'"},
+		"run-list":           []interface{}{},
+		"deploy.web-list":    []interface{}{"--memory=512m"},
+		"deploy.worker-list": []interface{}{"--cpus=1"},
 	}
 	got := parseDockerOptionsPayload(payload)
 
-	want := map[dockerOptionsScope]string{
-		{Phase: "build"}:                         "",
-		{Phase: "deploy"}:                        "-v /a:/a",
-		{Phase: "run"}:                           "",
-		{Phase: "deploy", ProcessType: "web"}:    "--memory=512m",
-		{Phase: "deploy", ProcessType: "worker"}: "--cpus=1",
+	want := map[dockerOptionsScope][]string{
+		{Phase: "build"}:                         {},
+		{Phase: "deploy"}:                        {"-v /a:/a", "--label 'com.example.description=my app'"},
+		{Phase: "run"}:                           {},
+		{Phase: "deploy", ProcessType: "web"}:    {"--memory=512m"},
+		{Phase: "deploy", ProcessType: "worker"}: {"--cpus=1"},
 	}
 	if len(got) != len(want) {
 		t.Fatalf("got %d entries, want %d (got: %#v)", len(got), len(want), got)
 	}
 	for scope, expected := range want {
-		if got[scope] != expected {
-			t.Errorf("scope %+v: got %q, want %q", scope, got[scope], expected)
+		gotOptions, ok := got[scope]
+		if !ok {
+			t.Errorf("scope %+v: missing from result", scope)
+			continue
+		}
+		if len(gotOptions) != len(expected) {
+			t.Errorf("scope %+v: got %#v, want %#v", scope, gotOptions, expected)
+			continue
+		}
+		for i := range expected {
+			if gotOptions[i] != expected[i] {
+				t.Errorf("scope %+v: element %d got %q, want %q", scope, i, gotOptions[i], expected[i])
+			}
 		}
 	}
 }
@@ -178,23 +193,26 @@ func TestSplitDockerOptionsKey(t *testing.T) {
 
 func TestOptionPresent(t *testing.T) {
 	tests := []struct {
-		existing string
+		name     string
+		existing []string
 		option   string
 		want     bool
 	}{
-		{"", "-v /a:/a", false},
-		{"-v /a:/a", "-v /a:/a", true},
-		{"-v /a:/a -p 80:80", "-p 80:80", true},
-		{"-v /a:/a -p 80:80", "-v /a:/a", true},
-		{"-v /a:/aa", "-v /a:/a", false}, // exact token match, not substring
-		{"-v /a:/a", "-v /a:/aa", false}, // exact token match
-		{"-p 80:80 -v /a:/a", "-v /a:/a", true},
-		{"-p 8080:80", "-p 80:80", false}, // distinct tokens
+		{"empty list", nil, "-v /a:/a", false},
+		{"single match", []string{"-v /a:/a"}, "-v /a:/a", true},
+		{"match second entry", []string{"-v /a:/a", "-p 80:80"}, "-p 80:80", true},
+		{"match first entry", []string{"-v /a:/a", "-p 80:80"}, "-v /a:/a", true},
+		{"no substring match", []string{"-v /a:/aa"}, "-v /a:/a", false},
+		{"distinct entries", []string{"-p 8080:80"}, "-p 80:80", false},
+		// A discrete entry whose value contains a space matches only as a whole,
+		// never by any single whitespace-separated token.
+		{"space value whole match", []string{"--label 'com.example.description=my app'"}, "--label 'com.example.description=my app'", true},
+		{"space value token no match", []string{"--label 'com.example.description=my app'"}, "--label", false},
 	}
 	for _, tt := range tests {
 		got := optionPresent(tt.existing, tt.option)
 		if got != tt.want {
-			t.Errorf("optionPresent(%q, %q) = %v, want %v", tt.existing, tt.option, got, tt.want)
+			t.Errorf("%s: optionPresent(%#v, %q) = %v, want %v", tt.name, tt.existing, tt.option, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
dokku 0.38.22 exposes `<phase>-list` and `<phase>.<process>-list` companions in `docker-options:report --format json` whose values are JSON arrays with one element per stored option (dokku/dokku#8799). `DockerOptionsTask` now reads those arrays as the source of truth instead of splitting the space-joined shorthand strings with `strings.Fields`, so options whose values contain spaces are recovered as discrete entries and drift detection matches whole options rather than token subsequences. Export support flips from partial to supported.

Closes #296