### PR TITLE
feat: export dokku service tasks

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -292,8 +292,8 @@ The output format follows the `--output` extension (`.json` / `.json5` writes JS
 YAML), and the vars-file matches. Which task types export is a per-task property: each task's
 reference page carries an **Export support** section stating whether it is supported, partial (for
 example a value that is lifted into the vars-file), or not exportable (write-only credentials such
-as `dokku_git_auth`, or datastore services). Resources that cannot be read back are reported as
-warnings and left out of the recipe.
+as `dokku_git_auth`, or `dokku_service_property`, which no datastore plugin can read back).
+Resources that cannot be read back are reported as warnings and left out of the recipe.
 
 ## docket version
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -18,10 +18,10 @@ covered below.
 | Apps (`dokku_app`) | Database / service contents |
 | Config vars (`dokku_config`) | Persistent volume files |
 | Domains and ports (`dokku_domains`, `dokku_ports`) | DNS records |
-| Service *existence* (`dokku_service_create`) | letsencrypt-issued certificates |
+| Service structure (`dokku_service_create`, `dokku_service_expose`, `dokku_service_link`, backup schedule, `dokku_acl_service`) | letsencrypt-issued certificates |
 | Storage *mounts* (`dokku_storage_mount`) | Secret values not in the recipe |
 | Manual certs inlined via `dokku_certs` `cert_content` / `key_content` | Host-level OS configuration |
-| Buildpacks, scheduler and proxy config | |
+| Buildpacks, scheduler and proxy config | Datastore backup credentials and `dokku_service_property` values |
 | SSH keys (`dokku_ssh_key`) | |
 | App code (`dokku_git_sync`, `dokku_git_from_image`, `dokku_git_from_archive`) | |
 
@@ -49,14 +49,17 @@ docket export --host deploy@old-server
 
 This enumerates the apps and reconstructs their declarative state. It also reconstructs any
 git-installed third-party plugins into [`dokku_plugin`](tasks/dokku_plugin.md) tasks in a leading
-global play; core plugins and plugins installed from a tarball or local path are omitted. Sensitive
-values (config and other secrets) are lifted into `tasks.vars.yml`; the recipe references them
-through inputs, so the pair is applied together with `--vars-file`. If you already maintain a recipe
-as the source of truth for the old server, skip this and use it directly.
+global play; core plugins and plugins installed from a tarball or local path are omitted. Datastore
+services are reconstructed into that same global play - the service itself, its exposed ports, its
+backup schedule, and its dokku-acl access list - with each app's service links emitted into the
+app's own play. Sensitive values (config and other secrets) are lifted into `tasks.vars.yml`; the
+recipe references them through inputs, so the pair is applied together with `--vars-file`. If you
+already maintain a recipe as the source of truth for the old server, skip this and use it directly.
 
 Some state cannot be read back and is left out with a warning - notably write-only credentials
-(`dokku_git_auth`, `dokku_registry_auth`) and datastore service data, which you add by hand. Each
-task's [reference page](tasks/README.md) has an Export support section noting its limits.
+(`dokku_git_auth`, `dokku_registry_auth`, and datastore backup credentials), datastore service data,
+and service properties (`dokku_service_property`), which you add by hand. Each task's
+[reference page](tasks/README.md) has an Export support section noting its limits.
 
 ## Step 2: Apply the recipe to the new server
 
@@ -84,7 +87,9 @@ code onto the new server with whichever deploy source your recipe uses:
 
 [`dokku_service_create`](tasks/dokku_service_create.md) makes an *empty* service, and
 [`dokku_service_backup`](tasks/dokku_service_backup.md) only configures the S3 backup schedule and
-auth - there is no restore task. Move the actual contents with Dokku's native export/import:
+auth - there is no restore task. Export carries the schedule, bucket, and `use_iam` flag but not the
+AWS credentials or encryption passphrase (they cannot be read back), so re-add those before the
+schedule can run. Move the actual contents with Dokku's native export/import:
 
 ```bash
 # On the old server

--- a/docs/tasks/dokku_acl_service.md
+++ b/docs/tasks/dokku_acl_service.md
@@ -10,7 +10,7 @@ Manages the dokku-acl access list for a dokku service
 
 ## Export support
 
-Not supported - service export is not yet implemented; tracked in issue #279.
+Supported.
 
 ## Parameters
 

--- a/docs/tasks/dokku_service_backup.md
+++ b/docs/tasks/dokku_service_backup.md
@@ -10,7 +10,7 @@ Manages the S3 backup schedule, authentication, and encryption for a dokku servi
 
 ## Export support
 
-Not supported - service export is not yet implemented; tracked in issue #279.
+Partial - the backup schedule, bucket, and use_iam flag are exported; the AWS credentials and encryption passphrase are write-only and must be re-supplied before the recipe can back up.
 
 ## Parameters
 

--- a/docs/tasks/dokku_service_create.md
+++ b/docs/tasks/dokku_service_create.md
@@ -10,7 +10,7 @@ Creates or destroys a dokku service
 
 ## Export support
 
-Not supported - service export is not yet implemented; tracked in issue #279.
+Supported.
 
 ## Parameters
 

--- a/docs/tasks/dokku_service_expose.md
+++ b/docs/tasks/dokku_service_expose.md
@@ -10,7 +10,7 @@ Exposes or unexposes a dokku service on host ports
 
 ## Export support
 
-Not supported - service export is not yet implemented; tracked in issue #279.
+Supported.
 
 ## Parameters
 

--- a/docs/tasks/dokku_service_link.md
+++ b/docs/tasks/dokku_service_link.md
@@ -10,7 +10,7 @@ Links or unlinks a dokku service to an app
 
 ## Export support
 
-Not supported - service export is not yet implemented; tracked in issue #279.
+Supported.
 
 ## Parameters
 

--- a/docs/tasks/dokku_service_property.md
+++ b/docs/tasks/dokku_service_property.md
@@ -10,7 +10,7 @@ Manages a property for a given dokku service
 
 ## Export support
 
-Not supported - service export is not yet implemented; tracked in issue #279.
+Not supported - no datastore plugin exposes a machine-readable report of the properties set via <service>:set, so they cannot be read back (tracked upstream in dokku/dokku-datastore#98).
 
 ## Parameters
 

--- a/docs/tasks/dokku_service_property.md
+++ b/docs/tasks/dokku_service_property.md
@@ -10,7 +10,7 @@ Manages a property for a given dokku service
 
 ## Export support
 
-Not supported - no datastore plugin exposes a machine-readable report of the properties set via <service>:set, so they cannot be read back (tracked upstream in dokku/dokku-datastore#98).
+Not supported - no datastore plugin exposes a machine-readable report of the properties set via `<service>:set`, so they cannot be read back (tracked upstream in dokku/dokku-datastore#98).
 
 ## Parameters
 

--- a/tasks/acl_service_task.go
+++ b/tasks/acl_service_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -43,7 +44,44 @@ func (t AclServiceTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t AclServiceTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportUnsupported, Caveat: serviceExportCaveat}
+	return ExportSupport{Status: ExportSupported}
+}
+
+// ExportGlobal reconstructs the dokku-acl access list of every datastore
+// service on the server. Discovery is via listServices; the members are read
+// from `acl:list-service <type> <name>` (reusing getAclServiceUsers). Note the
+// field inversion versus the other service tasks: Service holds the instance
+// name and Type the datastore type. Services with no ACL entries - and every
+// service when the dokku-acl plugin is absent - are skipped.
+func (t AclServiceTask) ExportGlobal() ([]interface{}, error) {
+	services, err := listServices()
+	if err != nil {
+		return nil, err
+	}
+	var out []interface{}
+	for _, s := range services {
+		users, err := getAclServiceUsers(s.Type, s.Name)
+		if err != nil {
+			var sshErr *subprocess.SSHError
+			if errors.As(err, &sshErr) {
+				return nil, err
+			}
+			// acl:list-service fails when the dokku-acl plugin is not installed;
+			// treat that (and any other dokku-level failure) as "no ACL" so
+			// export stays quiet on servers without dokku-acl.
+			continue
+		}
+		if len(users) == 0 {
+			continue
+		}
+		out = append(out, AclServiceTask{
+			Service: s.Name,
+			Type:    s.Type,
+			Users:   sortedSetKeys(users),
+			State:   StatePresent,
+		})
+	}
+	return out, nil
 }
 
 // Requirements lists the non-core dokku plugins this task depends on.

--- a/tasks/config_task.go
+++ b/tasks/config_task.go
@@ -214,10 +214,30 @@ func planConfigUnset(t ConfigTask) PlanResult {
 // the current values, or nil when there are none. Restart mirrors the task
 // default so the emitted recipe matches apply's behaviour; the engine lifts
 // the values into the companion vars-file.
+//
+// Config vars injected by a datastore service link (the `<ALIAS>_URL` a link
+// sets to the service DSN) are dropped: dokku_service_link recreates them on
+// apply with the new server's credentials, so re-exporting the stale value
+// would clobber the fresh one. The exclusion happens here, before the engine
+// lifts values, so those DSNs never reach the vars-file.
 func (t ConfigTask) ExportApp(app string) ([]interface{}, error) {
 	config, err := getConfig(ConfigTask{App: app})
 	if err != nil {
 		return nil, err
+	}
+	if len(config) == 0 {
+		return nil, nil
+	}
+	dsns, err := linkedServiceDSNs(app)
+	if err != nil {
+		return nil, err
+	}
+	if len(dsns) > 0 {
+		for k, v := range config {
+			if dsns[v] {
+				delete(config, k)
+			}
+		}
 	}
 	if len(config) == 0 {
 		return nil, nil

--- a/tasks/export.go
+++ b/tasks/export.go
@@ -47,6 +47,13 @@ var globalExportOrder = []string{
 	"dokku_scheduler_k3s_annotations",
 	"dokku_scheduler_k3s_labels",
 	"dokku_scheduler_k3s_autoscaling_auth",
+	// datastore services: create must precede expose/backup/acl, which all
+	// operate on an existing service instance. The datastore plugins they rely
+	// on are installed by the dokku_plugin tasks emitted first.
+	"dokku_service_create",
+	"dokku_service_expose",
+	"dokku_service_backup",
+	"dokku_acl_service",
 }
 
 // appExportOrder is the fixed order in which app-scoped task types are emitted
@@ -110,6 +117,9 @@ var appExportOrder = []string{
 	"dokku_scheduler_k3s_labels",
 	"dokku_scheduler_k3s_autoscaling_auth",
 	"dokku_traefik_property",
+	// service links bind an already-created datastore service (from the leading
+	// global play) to the app.
+	"dokku_service_link",
 	// deploy source last: only one of these emits per app
 	"dokku_git_sync",
 	"dokku_git_from_image",

--- a/tasks/export_integration_test.go
+++ b/tasks/export_integration_test.go
@@ -363,6 +363,244 @@ func TestIntegrationSchedulerK3sAutoscalingAuthExport(t *testing.T) {
 	}
 }
 
+// TestIntegrationExportServiceCreate verifies the datastore service exporter
+// discovers a live service (via the service-list plugin trigger) and
+// reconstructs a dokku_service_create that re-plans with no drift. Gated on the
+// redis datastore plugin.
+func TestIntegrationExportServiceCreate(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "redis")
+
+	serviceType := "redis"
+	serviceName := "docket-test-export-svc-create"
+	destroyService(serviceType, serviceName)
+	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(); r.Error != nil {
+		t.Fatalf("create service: %v", r.Error)
+	}
+	defer destroyService(serviceType, serviceName)
+
+	bodies, err := ServiceCreateTask{}.ExportGlobal()
+	if err != nil {
+		t.Fatalf("ExportGlobal: %v", err)
+	}
+	var found *ServiceCreateTask
+	for i := range bodies {
+		if c, ok := bodies[i].(ServiceCreateTask); ok && c.Service == serviceType && c.Name == serviceName {
+			found = &c
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("exported services do not include %s:%s: %+v", serviceType, serviceName, bodies)
+	}
+	found.State = StatePresent
+	if plan := found.Plan(); !plan.InSync {
+		t.Errorf("exported service create should report no drift, got status %v reason %q", plan.Status, plan.Reason)
+	}
+}
+
+// TestIntegrationExportServiceExpose verifies the exposed-ports exporter reads
+// the host ports back (parsing dokku's `container->host` format) so the exported
+// task re-plans with no drift. Gated on the redis datastore plugin.
+func TestIntegrationExportServiceExpose(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "redis")
+
+	serviceType := "redis"
+	serviceName := "docket-test-export-svc-expose"
+	hostPort := "16379"
+	destroyService(serviceType, serviceName)
+	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(); r.Error != nil {
+		t.Fatalf("create service: %v", r.Error)
+	}
+	defer destroyService(serviceType, serviceName)
+	if r := (ServiceExposeTask{Service: serviceType, Name: serviceName, Ports: []string{hostPort}, State: StatePresent}).Execute(); r.Error != nil {
+		t.Fatalf("expose service: %v", r.Error)
+	}
+
+	bodies, err := ServiceExposeTask{}.ExportGlobal()
+	if err != nil {
+		t.Fatalf("ExportGlobal: %v", err)
+	}
+	var found *ServiceExposeTask
+	for i := range bodies {
+		if e, ok := bodies[i].(ServiceExposeTask); ok && e.Service == serviceType && e.Name == serviceName {
+			found = &e
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("exported exposes do not include %s:%s: %+v", serviceType, serviceName, bodies)
+	}
+	if len(found.Ports) != 1 || found.Ports[0] != hostPort {
+		t.Errorf("exported expose ports = %v, want [%s]", found.Ports, hostPort)
+	}
+	found.State = StatePresent
+	if plan := found.Plan(); !plan.InSync {
+		t.Errorf("exported service expose should report no drift, got status %v reason %q", plan.Status, plan.Reason)
+	}
+}
+
+// TestIntegrationExportServiceLink verifies the app-scoped link exporter emits a
+// dokku_service_link for a linked service, and that the config exporter drops
+// the `<ALIAS>_URL` the link injects (so the link stays the single source of
+// truth). Gated on the redis datastore plugin and docker links.
+func TestIntegrationExportServiceLink(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "redis")
+	skipIfDockerLinkUnsupportedT(t)
+
+	appName := "docket-test-export-svc-link-app"
+	serviceType := "redis"
+	serviceName := "docket-test-export-svc-link"
+	destroyApp(appName)
+	destroyService(serviceType, serviceName)
+	createApp(appName)
+	defer destroyApp(appName)
+	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(); r.Error != nil {
+		t.Fatalf("create service: %v", r.Error)
+	}
+	defer func() {
+		(ServiceLinkTask{App: appName, Service: serviceType, Name: serviceName, State: StateAbsent}).Execute()
+		destroyService(serviceType, serviceName)
+	}()
+	if r := (ServiceLinkTask{App: appName, Service: serviceType, Name: serviceName, State: StatePresent}).Execute(); r.Error != nil {
+		t.Fatalf("link service: %v", r.Error)
+	}
+
+	bodies, err := ServiceLinkTask{}.ExportApp(appName)
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+	var found *ServiceLinkTask
+	for i := range bodies {
+		if l, ok := bodies[i].(ServiceLinkTask); ok && l.Service == serviceType && l.Name == serviceName {
+			found = &l
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("exported links do not include %s:%s for %s: %+v", serviceType, serviceName, appName, bodies)
+	}
+	found.State = StatePresent
+	if plan := found.Plan(); !plan.InSync {
+		t.Errorf("exported service link should report no drift, got status %v reason %q", plan.Status, plan.Reason)
+	}
+
+	// The link injects REDIS_URL into the app's config; config export must drop
+	// it, since the link recreates it on apply with the new server's creds.
+	cfgBodies, err := ConfigTask{}.ExportApp(appName)
+	if err != nil {
+		t.Fatalf("config ExportApp: %v", err)
+	}
+	for _, b := range cfgBodies {
+		c := b.(ConfigTask)
+		if _, ok := c.Config["REDIS_URL"]; ok {
+			t.Errorf("REDIS_URL (a linked-service DSN) should be excluded from config export: %+v", c.Config)
+		}
+	}
+}
+
+// TestIntegrationExportServiceBackup verifies the backup exporter reconstructs
+// the schedule/bucket/use_iam from the cron file such that the exported task
+// re-plans with no drift; the write-only credentials are not read back. Gated on
+// the redis datastore plugin, and skipped if it does not implement backups.
+func TestIntegrationExportServiceBackup(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "redis")
+
+	serviceType := "redis"
+	serviceName := "docket-test-export-svc-backup"
+	destroyService(serviceType, serviceName)
+	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(); r.Error != nil {
+		t.Fatalf("create service: %v", r.Error)
+	}
+	defer destroyService(serviceType, serviceName)
+
+	schedule := "0 3 * * *"
+	bucket := "docket-test-bucket"
+	if r := (ServiceBackupTask{Service: serviceType, Name: serviceName, Schedule: schedule, Bucket: bucket, UseIam: true, State: StatePresent}).Execute(); r.Error != nil {
+		// not every datastore plugin implements backup-schedule
+		t.Skipf("skipping: could not schedule backup (%v)", r.Error)
+	}
+
+	bodies, err := ServiceBackupTask{}.ExportGlobal()
+	if err != nil {
+		t.Fatalf("ExportGlobal: %v", err)
+	}
+	var found *ServiceBackupTask
+	for i := range bodies {
+		if b, ok := bodies[i].(ServiceBackupTask); ok && b.Service == serviceType && b.Name == serviceName {
+			found = &b
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("exported backups do not include %s:%s: %+v", serviceType, serviceName, bodies)
+	}
+	if found.Schedule != schedule || found.Bucket != bucket || !found.UseIam {
+		t.Errorf("exported backup mismatch: %+v", *found)
+	}
+	if found.AwsSecretAccessKey != "" || found.EncryptionPassphrase != "" {
+		t.Errorf("backup export should not include write-only credentials: %+v", *found)
+	}
+	found.State = StatePresent
+	if plan := found.Plan(); !plan.InSync {
+		t.Errorf("exported service backup should report no drift, got status %v reason %q", plan.Status, plan.Reason)
+	}
+}
+
+// TestIntegrationExportAclService verifies the service-ACL exporter reads the
+// members back so the exported task re-plans with no drift. Gated on both the
+// redis datastore plugin and dokku-acl (the latter is not installed in the main
+// CI job, so this skips there).
+func TestIntegrationExportAclService(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "redis")
+	skipIfPluginMissingT(t, "acl")
+
+	serviceType := "redis"
+	serviceName := "docket-test-export-acl-svc"
+	user := "docket-test-acl-user"
+	destroyService(serviceType, serviceName)
+	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(); r.Error != nil {
+		t.Fatalf("create service: %v", r.Error)
+	}
+	defer destroyService(serviceType, serviceName)
+
+	if r := (AclServiceTask{Service: serviceName, Type: serviceType, Users: []string{user}, State: StatePresent}).Execute(); r.Error != nil {
+		t.Skipf("skipping: could not add acl user (%v)", r.Error)
+	}
+
+	bodies, err := AclServiceTask{}.ExportGlobal()
+	if err != nil {
+		t.Fatalf("ExportGlobal: %v", err)
+	}
+	var found *AclServiceTask
+	for i := range bodies {
+		if a, ok := bodies[i].(AclServiceTask); ok && a.Type == serviceType && a.Service == serviceName {
+			found = &a
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("exported acls do not include %s:%s: %+v", serviceType, serviceName, bodies)
+	}
+	foundUser := false
+	for _, u := range found.Users {
+		if u == user {
+			foundUser = true
+		}
+	}
+	if !foundUser {
+		t.Errorf("exported acl users %v missing %q", found.Users, user)
+	}
+	found.State = StatePresent
+	if plan := found.Plan(); !plan.InSync {
+		t.Errorf("exported acl service should report no drift, got status %v reason %q", plan.Status, plan.Reason)
+	}
+}
+
 // TestIntegrationExportLetsencrypt verifies the letsencrypt exporter reads the
 // active state. Gated on the letsencrypt plugin (not a dokku core plugin).
 // Enabling letsencrypt triggers a real ACME issuance, so this only asserts the

--- a/tasks/export_support.go
+++ b/tasks/export_support.go
@@ -48,9 +48,3 @@ func TaskExportSupport(t Task) (ExportSupport, bool) {
 	}
 	return ExportSupport{}, false
 }
-
-// serviceExportCaveat is the shared caveat for the datastore/service tasks,
-// whose export is deferred to a follow-up issue (it needs a per-service-type
-// `<service>:list` primitive that does not exist yet). Each service task's
-// ExportSupport() references this so the wording stays consistent.
-const serviceExportCaveat = "service export is not yet implemented; tracked in issue #279"

--- a/tasks/service_backup_task.go
+++ b/tasks/service_backup_task.go
@@ -76,7 +76,77 @@ func (t ServiceBackupTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t ServiceBackupTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportUnsupported, Caveat: serviceExportCaveat}
+	return ExportSupport{Status: ExportPartial, Caveat: "the backup schedule, bucket, and use_iam flag are exported; the AWS credentials and encryption passphrase are write-only and must be re-supplied before the recipe can back up"}
+}
+
+// ExportGlobal reconstructs the backup schedule of every datastore service on
+// the server. Discovery is via listServices; the schedule, bucket, and use_iam
+// flag are parsed from `<service>:backup-schedule-cat <name>`. The AWS
+// credentials and encryption passphrase have no read command, so they are
+// omitted (a partial export) and must be re-supplied before the recipe backs
+// up. Services without a schedule are skipped.
+func (t ServiceBackupTask) ExportGlobal() ([]interface{}, error) {
+	services, err := listServices()
+	if err != nil {
+		return nil, err
+	}
+	var out []interface{}
+	for _, s := range services {
+		content, scheduled, err := serviceBackupScheduled(s.Type, s.Name)
+		if err != nil {
+			return nil, err
+		}
+		if !scheduled {
+			continue
+		}
+		schedule, bucket, useIam, ok := parseBackupSchedule(content, s.Type)
+		if !ok {
+			continue
+		}
+		out = append(out, ServiceBackupTask{
+			Service:  s.Type,
+			Name:     s.Name,
+			Schedule: schedule,
+			Bucket:   bucket,
+			UseIam:   useIam,
+			State:    StatePresent,
+		})
+	}
+	return out, nil
+}
+
+// parseBackupSchedule extracts the cron schedule, bucket, and use-iam flag from
+// the cron file `<service>:backup-schedule-cat` prints, whose single line is:
+//
+//	<schedule...> dokku <bin> <type>:backup <name> <bucket> [--use-iam]
+//
+// The schedule is not always five fields (`@daily` and friends are valid cron
+// expressions), so the parse anchors on the `<type>:backup` token rather than
+// fixed offsets. Returns ok=false when the line does not match this shape.
+func parseBackupSchedule(content, service string) (schedule, bucket string, useIam, ok bool) {
+	fields := strings.Fields(content)
+	marker := fmt.Sprintf("%s:backup", service)
+	idx := -1
+	for i, f := range fields {
+		if f == marker {
+			idx = i
+			break
+		}
+	}
+	// The `dokku <bin>` prefix must precede the marker, and `<name> <bucket>`
+	// must follow it.
+	if idx < 2 || idx+2 >= len(fields) {
+		return "", "", false, false
+	}
+	schedule = strings.Join(fields[:idx-2], " ")
+	bucket = fields[idx+2]
+	if schedule == "" || bucket == "" {
+		return "", "", false, false
+	}
+	if idx+3 < len(fields) && fields[idx+3] == "--use-iam" {
+		useIam = true
+	}
+	return schedule, bucket, useIam, true
 }
 
 // Requirements lists the non-core dokku plugins this task depends on.

--- a/tasks/service_create_task.go
+++ b/tasks/service_create_task.go
@@ -38,7 +38,23 @@ func (t ServiceCreateTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t ServiceCreateTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportUnsupported, Caveat: serviceExportCaveat}
+	return ExportSupport{Status: ExportSupported}
+}
+
+// ExportGlobal reconstructs every datastore service instance on the server as a
+// dokku_service_create task. Discovery is via listServices (the `service-list`
+// plugin trigger); like dokku_storage_mount, only the resource's existence is
+// exported - the service's data is migrated separately.
+func (t ServiceCreateTask) ExportGlobal() ([]interface{}, error) {
+	services, err := listServices()
+	if err != nil {
+		return nil, err
+	}
+	var out []interface{}
+	for _, s := range services {
+		out = append(out, ServiceCreateTask{Service: s.Type, Name: s.Name, State: StatePresent})
+	}
+	return out, nil
 }
 
 // Requirements lists the non-core dokku plugins this task depends on.

--- a/tasks/service_export.go
+++ b/tasks/service_export.go
@@ -1,0 +1,136 @@
+package tasks
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// serviceInstance identifies a single datastore service instance discovered on
+// the server: its datastore type (the plugin command prefix, e.g. "postgres")
+// and its instance name.
+type serviceInstance struct {
+	Type string
+	Name string
+}
+
+// listServices enumerates every datastore service instance on the server.
+//
+// There is no single "list all services" command, but every datastore plugin
+// implements the `service-list` plugin trigger, so `plugin:trigger service-list`
+// fans the trigger out across all installed datastore plugins, each echoing
+// `<type>:<name>` for its own instances. A transport-level failure
+// (`*subprocess.SSHError`) is propagated; a dokku-level failure (no datastore
+// plugin installed, or an older dokku) degrades to "no services."
+func listServices() ([]serviceInstance, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "plugin:trigger", "service-list"},
+	})
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return nil, err
+		}
+		return nil, nil
+	}
+
+	var services []serviceInstance
+	for _, line := range strings.Split(result.StdoutContents(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Each line is `<type>:<name>`; service names cannot contain a colon,
+		// so split on the first one.
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			continue
+		}
+		services = append(services, serviceInstance{Type: parts[0], Name: parts[1]})
+	}
+	sort.Slice(services, func(i, j int) bool {
+		if services[i].Type != services[j].Type {
+			return services[i].Type < services[j].Type
+		}
+		return services[i].Name < services[j].Name
+	})
+	return services, nil
+}
+
+// serviceLinkedApps returns the set of apps linked to a datastore service,
+// read from `<service>:links <name>` (one app per line on stdout). A
+// transport-level failure is propagated; a dokku-level failure (the service is
+// gone) degrades to "no links."
+func serviceLinkedApps(service, name string) (map[string]bool, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", fmt.Sprintf("%s:links", service), name},
+	})
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return nil, err
+		}
+		return map[string]bool{}, nil
+	}
+	apps := map[string]bool{}
+	for _, line := range strings.Split(result.StdoutContents(), "\n") {
+		if app := strings.TrimSpace(line); app != "" {
+			apps[app] = true
+		}
+	}
+	return apps, nil
+}
+
+// serviceDSN returns a datastore service's connection string (the value a link
+// injects into an app's config), read from `<service>:info <name> --dsn`. A
+// transport-level failure is propagated; any other failure yields an empty DSN.
+func serviceDSN(service, name string) (string, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", fmt.Sprintf("%s:info", service), name, "--dsn"},
+	})
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return "", err
+		}
+		return "", nil
+	}
+	return result.StdoutContents(), nil
+}
+
+// linkedServiceDSNs returns the set of datastore DSNs that service links have
+// injected into an app's config, so the config exporter can omit them: the
+// dokku_service_link task recreates those `<ALIAS>_URL` vars on apply (with the
+// new server's credentials), and re-exporting the stale value would clobber the
+// fresh one. Enumerates services, keeps those linked to the app, and reads each
+// linked service's DSN.
+func linkedServiceDSNs(app string) (map[string]bool, error) {
+	services, err := listServices()
+	if err != nil {
+		return nil, err
+	}
+	dsns := map[string]bool{}
+	for _, s := range services {
+		apps, err := serviceLinkedApps(s.Type, s.Name)
+		if err != nil {
+			return nil, err
+		}
+		if !apps[app] {
+			continue
+		}
+		dsn, err := serviceDSN(s.Type, s.Name)
+		if err != nil {
+			return nil, err
+		}
+		if dsn != "" {
+			dsns[dsn] = true
+		}
+	}
+	return dsns, nil
+}

--- a/tasks/service_export_test.go
+++ b/tasks/service_export_test.go
@@ -1,0 +1,280 @@
+package tasks
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+func TestListServicesParsesTypeAndName(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		// well-formed lines, plus blank/malformed ones that must be dropped
+		"--quiet plugin:trigger service-list": "redis:cache\npostgres:my-db\npostgres:analytics\n\nmalformed-line\n:bad\nbad:",
+	}))()
+
+	services, err := listServices()
+	if err != nil {
+		t.Fatalf("listServices: %v", err)
+	}
+	// sorted by (type, name); malformed lines dropped
+	want := []serviceInstance{
+		{Type: "postgres", Name: "analytics"},
+		{Type: "postgres", Name: "my-db"},
+		{Type: "redis", Name: "cache"},
+	}
+	if !reflect.DeepEqual(services, want) {
+		t.Errorf("listServices = %+v, want %+v", services, want)
+	}
+}
+
+func TestExportServiceCreateEnumeratesInstances(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet plugin:trigger service-list": "postgres:my-db\nredis:cache",
+	}))()
+
+	bodies, err := ServiceCreateTask{}.ExportGlobal()
+	if err != nil {
+		t.Fatalf("ExportGlobal: %v", err)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("expected 2 create tasks, got %d", len(bodies))
+	}
+	got := map[string]string{}
+	for _, b := range bodies {
+		c := b.(ServiceCreateTask)
+		got[c.Name] = c.Service
+		if c.State != StatePresent {
+			t.Errorf("expected present state, got %q", c.State)
+		}
+	}
+	if got["my-db"] != "postgres" || got["cache"] != "redis" {
+		t.Errorf("unexpected create tasks: %+v", got)
+	}
+}
+
+func TestServiceExposedPortListParsesHostSide(t *testing.T) {
+	cases := []struct {
+		name   string
+		stdout string
+		want   []string
+	}{
+		{"single", "5432->5432", []string{"5432"}},
+		{"interface-bound", "5432->127.0.0.1:5433", []string{"127.0.0.1:5433"}},
+		{"multi", "5432->5432 6379->6380", []string{"5432", "6380"}},
+		{"not-exposed", "-", nil},
+		{"empty", "", nil},
+		{"plain-fallback", "5432", []string{"5432"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+				"--quiet postgres:info svc --exposed-ports": tc.stdout,
+			}))()
+			got, err := serviceExposedPortList("postgres", "svc")
+			if err != nil {
+				t.Fatalf("serviceExposedPortList: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("serviceExposedPortList(%q) = %v, want %v", tc.stdout, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExportServiceExposeReadsHostPorts(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet plugin:trigger service-list":         "postgres:my-db\nredis:cache",
+		"--quiet postgres:info my-db --exposed-ports": "5432->5433",
+		"--quiet redis:info cache --exposed-ports":    "-",
+	}))()
+
+	bodies, err := ServiceExposeTask{}.ExportGlobal()
+	if err != nil {
+		t.Fatalf("ExportGlobal: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 expose task (redis not exposed), got %d", len(bodies))
+	}
+	e := bodies[0].(ServiceExposeTask)
+	if e.Service != "postgres" || e.Name != "my-db" {
+		t.Errorf("unexpected expose target: %+v", e)
+	}
+	if len(e.Ports) != 1 || e.Ports[0] != "5433" {
+		t.Errorf("expected host port 5433, got %v", e.Ports)
+	}
+}
+
+func TestParseBackupSchedule(t *testing.T) {
+	cases := []struct {
+		name     string
+		content  string
+		service  string
+		schedule string
+		bucket   string
+		useIam   bool
+		ok       bool
+	}{
+		{"standard-iam", "0 3 * * * dokku /usr/bin/dokku postgres:backup my-db my-bucket --use-iam", "postgres", "0 3 * * *", "my-bucket", true, true},
+		{"standard-no-iam", "0 3 * * * dokku /usr/bin/dokku postgres:backup my-db my-bucket", "postgres", "0 3 * * *", "my-bucket", false, true},
+		{"named-schedule", "@daily dokku /usr/bin/dokku redis:backup cache backups", "redis", "@daily", "backups", false, true},
+		{"empty", "", "postgres", "", "", false, false},
+		{"no-marker", "0 3 * * * something else entirely here", "postgres", "", "", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			schedule, bucket, useIam, ok := parseBackupSchedule(tc.content, tc.service)
+			if ok != tc.ok || schedule != tc.schedule || bucket != tc.bucket || useIam != tc.useIam {
+				t.Errorf("parseBackupSchedule(%q, %q) = (%q, %q, %v, %v), want (%q, %q, %v, %v)",
+					tc.content, tc.service, schedule, bucket, useIam, ok, tc.schedule, tc.bucket, tc.useIam, tc.ok)
+			}
+		})
+	}
+}
+
+func TestExportServiceBackupParsesSchedule(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet plugin:trigger service-list":        "postgres:my-db\nredis:cache",
+		"--quiet postgres:backup-schedule-cat my-db": "0 3 * * * dokku /usr/bin/dokku postgres:backup my-db my-bucket --use-iam",
+		// redis has no schedule: unmapped -> empty content -> parse fails -> skipped
+	}))()
+
+	bodies, err := ServiceBackupTask{}.ExportGlobal()
+	if err != nil {
+		t.Fatalf("ExportGlobal: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 backup task, got %d", len(bodies))
+	}
+	b := bodies[0].(ServiceBackupTask)
+	if b.Service != "postgres" || b.Name != "my-db" {
+		t.Errorf("unexpected backup target: %+v", b)
+	}
+	if b.Schedule != "0 3 * * *" || b.Bucket != "my-bucket" || !b.UseIam {
+		t.Errorf("unexpected schedule fields: %+v", b)
+	}
+	// Write-only secrets are never read back.
+	if b.AwsSecretAccessKey != "" || b.EncryptionPassphrase != "" || b.AwsAccessKeyID != "" {
+		t.Errorf("backup export should not include credentials: %+v", b)
+	}
+}
+
+func TestExportServiceLinkEnumeratesForApp(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet plugin:trigger service-list": "postgres:my-db\nredis:cache",
+		"--quiet postgres:links my-db":        "web\nworker",
+		"--quiet redis:links cache":           "worker",
+	}))()
+
+	bodies, err := ServiceLinkTask{}.ExportApp("web")
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 link for web, got %d", len(bodies))
+	}
+	l := bodies[0].(ServiceLinkTask)
+	if l.App != "web" || l.Service != "postgres" || l.Name != "my-db" || l.State != StatePresent {
+		t.Errorf("unexpected link task: %+v", l)
+	}
+
+	bodies, err = ServiceLinkTask{}.ExportApp("worker")
+	if err != nil {
+		t.Fatalf("ExportApp worker: %v", err)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("expected 2 links for worker, got %d", len(bodies))
+	}
+}
+
+func TestExportAclServiceReadsUsers(t *testing.T) {
+	responses := map[string]string{
+		"--quiet plugin:trigger service-list": "postgres:my-db\nredis:cache",
+	}
+	// acl:list-service emits one username per line on STDERR, not stdout.
+	stderr := map[string]string{
+		"--quiet acl:list-service postgres my-db": "bob\nalice",
+		"--quiet acl:list-service redis cache":    "",
+	}
+	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		key := strings.Join(in.Args, " ")
+		return subprocess.ExecCommandResponse{Stdout: responses[key], Stderr: stderr[key]}, nil
+	})()
+
+	bodies, err := AclServiceTask{}.ExportGlobal()
+	if err != nil {
+		t.Fatalf("ExportGlobal: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 acl task (redis has none), got %d", len(bodies))
+	}
+	a := bodies[0].(AclServiceTask)
+	// Field inversion: Service holds the instance name, Type the datastore type.
+	if a.Service != "my-db" || a.Type != "postgres" {
+		t.Errorf("acl field inversion wrong: %+v", a)
+	}
+	// sortedSetKeys yields deterministic, sorted membership.
+	if !reflect.DeepEqual(a.Users, []string{"alice", "bob"}) {
+		t.Errorf("acl users = %v, want [alice bob]", a.Users)
+	}
+}
+
+func TestExportConfigExcludesLinkedServiceDSNs(t *testing.T) {
+	dsn := "postgres://postgres:pw@dokku-postgres-my-db:5432/my_db"
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list":                       "web",
+		"--quiet config:export --format json web": `{"DATABASE_URL":"` + dsn + `","SECRET_KEY":"s3cr3t"}`,
+		"--quiet plugin:trigger service-list":     "postgres:my-db",
+		"--quiet postgres:links my-db":            "web",
+		"--quiet postgres:info my-db --dsn":       dsn,
+	}))()
+
+	bodies, err := ConfigTask{}.ExportApp("web")
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 config task, got %d", len(bodies))
+	}
+	c := bodies[0].(ConfigTask)
+	if _, ok := c.Config["DATABASE_URL"]; ok {
+		t.Errorf("linked-service DSN should be excluded from config export: %+v", c.Config)
+	}
+	if c.Config["SECRET_KEY"] != "s3cr3t" {
+		t.Errorf("non-link config should be kept: %+v", c.Config)
+	}
+}
+
+func TestExportRecipeIncludesServiceTasks(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list":                           "web",
+		"--quiet config:export --format json web":     `{}`,
+		"domains:report web --domains-app-vhosts":     "",
+		"--quiet plugin:trigger service-list":         "postgres:my-db",
+		"--quiet postgres:info my-db --exposed-ports": "5432->5432",
+		"--quiet postgres:links my-db":                "web",
+		"--quiet postgres:info my-db --dsn":           "postgres://postgres:pw@dokku-postgres-my-db:5432/my_db",
+	}))()
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	recipe, err := res.MarshalRecipe("yaml")
+	if err != nil {
+		t.Fatalf("MarshalRecipe: %v", err)
+	}
+	out := string(recipe)
+	for _, want := range []string{
+		"name: global",
+		"dokku_service_create",
+		"dokku_service_expose",
+		"dokku_service_link",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("recipe missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/tasks/service_expose_task.go
+++ b/tasks/service_expose_task.go
@@ -44,7 +44,30 @@ func (t ServiceExposeTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t ServiceExposeTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportUnsupported, Caveat: serviceExportCaveat}
+	return ExportSupport{Status: ExportSupported}
+}
+
+// ExportGlobal reconstructs the exposed-ports state of every datastore service
+// on the server. Discovery is via listServices; the exposed host ports are read
+// from `<service>:info <name> --exposed-ports`. Services with no exposed ports
+// are skipped.
+func (t ServiceExposeTask) ExportGlobal() ([]interface{}, error) {
+	services, err := listServices()
+	if err != nil {
+		return nil, err
+	}
+	var out []interface{}
+	for _, s := range services {
+		ports, err := serviceExposedPortList(s.Type, s.Name)
+		if err != nil {
+			return nil, err
+		}
+		if len(ports) == 0 {
+			continue
+		}
+		out = append(out, ServiceExposeTask{Service: s.Type, Name: s.Name, Ports: ports, State: StatePresent})
+	}
+	return out, nil
 }
 
 // Requirements lists the non-core dokku plugins this task depends on.
@@ -181,11 +204,15 @@ func (t ServiceExposeTask) Plan() PlanResult {
 	})
 }
 
-// serviceExposedPorts returns the set of host ports a dokku service is
-// currently exposed on. A transport-level failure (`*subprocess.SSHError`)
-// is propagated; a dokku-level non-zero exit (e.g. service not exposed) is
-// treated as "no ports exposed."
-func serviceExposedPorts(service, name string) (map[string]bool, error) {
+// serviceExposedPortList returns the ordered host ports a dokku service is
+// currently exposed on, read from `<service>:info <name> --exposed-ports`. That
+// command reports `container->host` pairs (e.g. `5432->5432`, or `5432->127.0.0.1:5433`
+// when bound to a specific interface), so only the host side after the first
+// `->` is kept - which is what `<service>:expose` takes and what the task's
+// Ports field holds. A transport-level failure (`*subprocess.SSHError`) is
+// propagated; a dokku-level non-zero exit (e.g. service not exposed) is treated
+// as "no ports exposed."
+func serviceExposedPortList(service, name string) ([]string, error) {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{
@@ -200,14 +227,35 @@ func serviceExposedPorts(service, name string) (map[string]bool, error) {
 		if errors.As(err, &sshErr) {
 			return nil, err
 		}
-		return map[string]bool{}, nil
+		return nil, nil
 	}
 
-	ports := map[string]bool{}
-	for _, p := range strings.Fields(result.StdoutContents()) {
-		if p == "-" {
+	var ports []string
+	for _, field := range strings.Fields(result.StdoutContents()) {
+		if field == "-" {
 			continue
 		}
+		host := field
+		if i := strings.Index(field, "->"); i >= 0 {
+			host = field[i+len("->"):]
+		}
+		if host != "" {
+			ports = append(ports, host)
+		}
+	}
+	return ports, nil
+}
+
+// serviceExposedPorts returns the set of host ports a dokku service is currently
+// exposed on, derived from serviceExposedPortList for order-insensitive
+// comparison against the desired ports in Plan.
+func serviceExposedPorts(service, name string) (map[string]bool, error) {
+	list, err := serviceExposedPortList(service, name)
+	if err != nil {
+		return nil, err
+	}
+	ports := map[string]bool{}
+	for _, p := range list {
 		ports[p] = true
 	}
 	return ports, nil

--- a/tasks/service_link_task.go
+++ b/tasks/service_link_task.go
@@ -41,7 +41,31 @@ func (t ServiceLinkTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t ServiceLinkTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportUnsupported, Caveat: serviceExportCaveat}
+	return ExportSupport{Status: ExportSupported}
+}
+
+// ExportApp reconstructs an app's datastore service links: it enumerates
+// services (listServices) and emits a dokku_service_link for each service the
+// app appears in (serviceLinkedApps). The link, not dokku_config, is the source
+// of truth for the injected `<ALIAS>_URL`, so config export drops those values
+// (see linkedServiceDSNs).
+func (t ServiceLinkTask) ExportApp(app string) ([]interface{}, error) {
+	services, err := listServices()
+	if err != nil {
+		return nil, err
+	}
+	var out []interface{}
+	for _, s := range services {
+		apps, err := serviceLinkedApps(s.Type, s.Name)
+		if err != nil {
+			return nil, err
+		}
+		if !apps[app] {
+			continue
+		}
+		out = append(out, ServiceLinkTask{App: app, Service: s.Type, Name: s.Name, State: StatePresent})
+	}
+	return out, nil
 }
 
 // Requirements lists the non-core dokku plugins this task depends on.

--- a/tasks/service_property_task.go
+++ b/tasks/service_property_task.go
@@ -14,8 +14,10 @@ import (
 // per-service report JSON, and the `<service>:info` flags do not correspond
 // one-to-one to settable keys (e.g. restart-policy, shm-size, and image are
 // settable but not readable via info). The plan therefore reports drift
-// unconditionally. Once a no-change read is available, this task should
-// switch to probing instead of always reporting Changed=true.
+// unconditionally, and docket export cannot reconstruct these properties. Once
+// a machine-readable service property report exists (requested upstream in
+// dokku/dokku-datastore#98), this task should switch to probing instead of
+// always reporting Changed=true, and its export can move off unsupported.
 type ServicePropertyTask struct {
 	// Service is the type of service to configure (e.g. redis, postgres, mysql)
 	Service string `required:"true" yaml:"service" description:"Type of service to configure (e.g. redis, postgres, mysql)"`
@@ -54,7 +56,7 @@ func (t ServicePropertyTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t ServicePropertyTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportUnsupported, Caveat: serviceExportCaveat}
+	return ExportSupport{Status: ExportUnsupported, Caveat: "no datastore plugin exposes a machine-readable report of the properties set via <service>:set, so they cannot be read back (tracked upstream in dokku/dokku-datastore#98)"}
 }
 
 // Requirements lists the non-core dokku plugins this task depends on.

--- a/tasks/service_property_task.go
+++ b/tasks/service_property_task.go
@@ -56,7 +56,7 @@ func (t ServicePropertyTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t ServicePropertyTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportUnsupported, Caveat: "no datastore plugin exposes a machine-readable report of the properties set via <service>:set, so they cannot be read back (tracked upstream in dokku/dokku-datastore#98)"}
+	return ExportSupport{Status: ExportUnsupported, Caveat: "no datastore plugin exposes a machine-readable report of the properties set via `<service>:set`, so they cannot be read back (tracked upstream in dokku/dokku-datastore#98)"}
 }
 
 // Requirements lists the non-core dokku plugins this task depends on.


### PR DESCRIPTION
docket export now reconstructs each datastore service instance from a live server, covering the service, its exposed ports, its app links, its backup schedule, and its dokku-acl access list. Service properties remain unexportable because no datastore plugin can read them back, and backup credentials, encryption passphrases, and service data are omitted as secret or non-declarative.

The service property gap is tracked upstream in dokku/dokku-datastore#98.

Closes #279.