### PR TITLE
fix: pass --global to the global-cert enabled probe

### DIFF
--- a/tasks/certs_task.go
+++ b/tasks/certs_task.go
@@ -274,7 +274,10 @@ func buildCertTarball(certPEM, keyPEM string) ([]byte, error) {
 func certsEnabled(t CertsTask) (bool, error) {
 	args := []string{"--quiet", "certs:report", t.App, "--ssl-enabled"}
 	if t.Global {
-		args = []string{"--quiet", "global-cert:report", "--global-cert-enabled"}
+		// The `--global` scope is required: dokku-global-cert standardized
+		// global-cert:report so a bare info flag now reports per-app; `--global`
+		// targets the global certificate itself, which returns "true"/"false".
+		args = []string{"--quiet", "global-cert:report", "--global", "--global-cert-enabled"}
 	}
 
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{

--- a/tasks/certs_task_test.go
+++ b/tasks/certs_task_test.go
@@ -3,9 +3,12 @@ package tasks
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"io"
 	"strings"
 	"testing"
+
+	"github.com/dokku/docket/subprocess"
 )
 
 func TestCertsTaskInvalidState(t *testing.T) {
@@ -217,5 +220,29 @@ func TestGetTasksCertsTaskParsedCorrectly(t *testing.T) {
 	}
 	if certsTask.State != StatePresent {
 		t.Errorf("State = %q, want %q", certsTask.State, StatePresent)
+	}
+}
+
+// TestCertsEnabledGlobalUsesGlobalScope locks the global certsEnabled probe to
+// the `--global` report scope. dokku-global-cert standardized
+// global-cert:report so a bare `--global-cert-enabled` flag now reports
+// per-app; only `--global` targets the global certificate itself.
+func TestCertsEnabledGlobalUsesGlobalScope(t *testing.T) {
+	var gotArgs []string
+	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		gotArgs = in.Args
+		return subprocess.ExecCommandResponse{Stdout: "true"}, nil
+	})()
+
+	enabled, err := certsEnabled(CertsTask{Global: true})
+	if err != nil {
+		t.Fatalf("certsEnabled: %v", err)
+	}
+	if !enabled {
+		t.Errorf("expected enabled=true when report returns \"true\"")
+	}
+	want := "--quiet global-cert:report --global --global-cert-enabled"
+	if got := strings.Join(gotArgs, " "); got != want {
+		t.Errorf("global certsEnabled args = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
The dokku-global-cert plugin standardized `global-cert:report`, so a bare `--global-cert-enabled` flag now reports per-app status instead of the global certificate. docket read that as disabled even after a successful global add, breaking idempotency for `dokku_certs` with `global: true`. Passing `--global` targets the global certificate itself again.

This surfaced as `TestIntegrationCertsGlobal` and `TestIntegrationCertsGlobalInline` failing in CI after the plugin change landed upstream (dokku-community/dokku-global-cert#17), unrelated to the change under test at the time.