### PR TITLE
feat: export the global SSL certificate

### DIFF
--- a/docs/tasks/dokku_certs.md
+++ b/docs/tasks/dokku_certs.md
@@ -10,7 +10,7 @@ Manages SSL certificates for a dokku app or globally.
 
 ## Export support
 
-Partial - app certs are exported via certs:show; the global cert has no show command in the dokku-global-cert plugin, so it is not exported (docket#283).
+Partial - app and global certificate PEM material is exported (via certs:show and global-cert:show) and written to the companion vars-file.
 
 ## Parameters
 

--- a/tasks/certs_task.go
+++ b/tasks/certs_task.go
@@ -58,7 +58,7 @@ func (t CertsTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t CertsTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportPartial, Caveat: "app certs are exported via certs:show; the global cert has no show command in the dokku-global-cert plugin, so it is not exported (docket#283)"}
+	return ExportSupport{Status: ExportPartial, Caveat: "app and global certificate PEM material is exported (via certs:show and global-cert:show) and written to the companion vars-file"}
 }
 
 // Requirements lists the non-core dokku plugins this task depends on.
@@ -291,12 +291,26 @@ func certsEnabled(t CertsTask) (bool, error) {
 	return strings.TrimSpace(result.StdoutContents()) == "true", nil
 }
 
-// ExportApp reconstructs an app's SSL certificate. certs:show streams the cert
-// and key PEM, which are sensitive and lifted into the vars-file by the engine.
-// The global cert (dokku-global-cert plugin) has no show command, so it is not
-// exported (docket#283).
+// ExportApp reconstructs an app's SSL certificate via certs:show. The cert and
+// key PEM are sensitive and lifted into the vars-file by the engine.
 func (t CertsTask) ExportApp(app string) ([]interface{}, error) {
-	enabled, err := certsEnabled(CertsTask{App: app})
+	return exportCert(CertsTask{App: app})
+}
+
+// ExportGlobal reconstructs the global SSL certificate via global-cert:show
+// (dokku-global-cert 0.4.x+). The cert and key PEM are sensitive and lifted into
+// the vars-file by the engine.
+func (t CertsTask) ExportGlobal() ([]interface{}, error) {
+	return exportCert(CertsTask{Global: true})
+}
+
+// exportCert probes whether a certificate is installed for the given scope (app
+// or global) and, if so, reads its PEM back via certs:show / global-cert:show.
+// A transport failure aborts the export; any other probe error (for example the
+// dokku-global-cert plugin not being installed) is swallowed so the scope is
+// skipped silently.
+func exportCert(t CertsTask) ([]interface{}, error) {
+	enabled, err := certsEnabled(t)
 	if err != nil {
 		var sshErr *subprocess.SSHError
 		if errors.As(err, &sshErr) {
@@ -308,25 +322,31 @@ func (t CertsTask) ExportApp(app string) ([]interface{}, error) {
 		return nil, nil
 	}
 
-	crt, err := certsShow(app, "crt")
+	crt, err := certsShow(t, "crt")
 	if err != nil {
 		return nil, err
 	}
-	key, err := certsShow(app, "key")
+	key, err := certsShow(t, "key")
 	if err != nil {
 		return nil, err
 	}
 	if crt == "" || key == "" {
 		return nil, nil
 	}
-	return []interface{}{CertsTask{App: app, CertContent: crt, KeyContent: key}}, nil
+	return []interface{}{CertsTask{App: t.App, Global: t.Global, CertContent: crt, KeyContent: key}}, nil
 }
 
-// certsShow returns the app's server.crt or server.key PEM via certs:show.
-func certsShow(app, kind string) (string, error) {
+// certsShow returns the scope's server.crt or server.key PEM. The per-app scope
+// uses core certs:show; the global scope uses global-cert:show (dokku-global-cert
+// 0.4.x+), mirroring the app/global branch in certsEnabled.
+func certsShow(t CertsTask, kind string) (string, error) {
+	args := []string{"--quiet", "certs:show", t.App, kind}
+	if t.Global {
+		args = []string{"--quiet", "global-cert:show", kind}
+	}
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
-		Args:    []string{"--quiet", "certs:show", app, kind},
+		Args:    args,
 	})
 	if err != nil {
 		return "", err

--- a/tasks/export.go
+++ b/tasks/export.go
@@ -38,6 +38,10 @@ var globalExportOrder = []string{
 	// (dokku_network_property, emitted in the app plays) bind to.
 	"dokku_network",
 	"dokku_ssh_key",
+	// global SSL certificate: requires the dokku-global-cert plugin, installed
+	// by the dokku_plugin tasks emitted first. dokku_certs also appears in
+	// appExportOrder, where it emits the per-app scope.
+	"dokku_certs",
 	"dokku_storage_entry",
 	"dokku_scheduler_k3s_profile",
 	"dokku_scheduler_k3s_chart",

--- a/tasks/export_integration_test.go
+++ b/tasks/export_integration_test.go
@@ -119,6 +119,52 @@ func TestIntegrationExportCerts(t *testing.T) {
 	}
 }
 
+// TestIntegrationExportGlobalCerts verifies the global certificate exporter:
+// global-cert:show streams the cert/key back (dokku-global-cert 0.4.x+), so the
+// exported task round-trips with no drift. Requires the dokku-global-cert plugin.
+func TestIntegrationExportGlobalCerts(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "global-cert")
+
+	certPath, keyPath := generateSelfSignedCert(t, "global-export.example.com")
+
+	// best-effort cleanup before and after
+	cleanup := func() {
+		(CertsTask{Global: true, State: StateAbsent}).Execute()
+	}
+	cleanup()
+	defer cleanup()
+
+	if r := (CertsTask{Global: true, Cert: certPath, Key: keyPath, State: StatePresent}).Execute(); r.Error != nil {
+		t.Fatalf("add global cert: %v", r.Error)
+	}
+
+	bodies, err := CertsTask{}.ExportGlobal()
+	if err != nil {
+		t.Fatalf("ExportGlobal: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 certs task, got %d", len(bodies))
+	}
+	c := bodies[0].(CertsTask)
+	if !c.Global {
+		t.Errorf("exported global cert task should set global: true")
+	}
+	if c.App != "" {
+		t.Errorf("exported global cert task should not set app, got %q", c.App)
+	}
+	if !strings.Contains(c.CertContent, "BEGIN CERTIFICATE") {
+		t.Errorf("exported cert_content missing PEM: %q", c.CertContent)
+	}
+	if !strings.Contains(c.KeyContent, "BEGIN") {
+		t.Errorf("exported key_content missing PEM: %q", c.KeyContent)
+	}
+	c.State = StatePresent
+	if plan := c.Plan(); !plan.InSync {
+		t.Errorf("exported global certs should report no drift, got status %v reason %q", plan.Status, plan.Reason)
+	}
+}
+
 // TestIntegrationExportSchedulerK3sProfile verifies the global profile exporter
 // against a real dokku. scheduler-k3s is a core plugin and profiles are stored
 // on disk (no cluster or deploy needed), so only dokku itself is required.

--- a/tasks/export_test.go
+++ b/tasks/export_test.go
@@ -317,3 +317,69 @@ func TestExportRecipeAppFilter(t *testing.T) {
 		t.Errorf("filtered export should not include app-one:\n%s", recipe)
 	}
 }
+
+func TestExportGlobalCertBecomesGlobalTask(t *testing.T) {
+	certPEM := "-----BEGIN CERTIFICATE-----\nMIIFAKECERT\n-----END CERTIFICATE-----"
+	keyPEM := "-----BEGIN PRIVATE KEY-----\nMIIFAKEKEY\n-----END PRIVATE KEY-----"
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list": "",
+		"--quiet global-cert:report --global --global-cert-enabled": "true",
+		"--quiet global-cert:show crt":                              certPEM,
+		"--quiet global-cert:show key":                              keyPEM,
+	}))()
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+
+	// global-cert:show streams the real PEM, so it is lifted into the vars map
+	// under the global scope (not blanked like an unreadable secret).
+	if got := res.Vars["global_cert_content"]; got != certPEM {
+		t.Errorf("vars[global_cert_content] = %q, want the cert PEM", got)
+	}
+	if got := res.Vars["global_key_content"]; got != keyPEM {
+		t.Errorf("vars[global_key_content] = %q, want the key PEM", got)
+	}
+
+	recipe, _ := res.MarshalRecipe("yaml")
+	out := string(recipe)
+	for _, want := range []string{
+		"name: global",
+		"dokku_certs",
+		"global: true",
+		"{{ .global_cert_content }}",
+		"{{ .global_key_content }}",
+		"name: global_cert_content",
+		"name: global_key_content",
+		"sensitive: true",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("recipe missing %q:\n%s", want, out)
+		}
+	}
+	// The PEM is lifted into the vars-file, never left inline in the recipe body.
+	if strings.Contains(out, "MIIFAKECERT") || strings.Contains(out, "MIIFAKEKEY") {
+		t.Errorf("recipe leaked the certificate PEM:\n%s", out)
+	}
+}
+
+func TestExportGlobalCertDisabledEmitsNoTask(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list": "",
+		"--quiet global-cert:report --global --global-cert-enabled": "false",
+	}))()
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+
+	if res.HasVars() {
+		t.Errorf("expected no lifted vars when no global cert is set, got %v", res.Vars)
+	}
+	recipe, _ := res.MarshalRecipe("yaml")
+	if strings.Contains(string(recipe), "dokku_certs") {
+		t.Errorf("recipe should not contain a certs task when the global cert is disabled:\n%s", recipe)
+	}
+}


### PR DESCRIPTION
The dokku-global-cert plugin now ships a `global-cert:show` command, so the global certificate's PEM material can be read back and reconstructed faithfully like a per-app certificate, with the cert and key lifted into the companion vars-file.

Closes #283
