### PR TITLE
fix: shell-quote dokku arguments sent over ssh

### DIFF
--- a/docs/remote-execution.md
+++ b/docs/remote-execution.md
@@ -34,6 +34,16 @@ the key yourself:
 ssh-keyscan dokku.example.com >> ~/.ssh/known_hosts
 ```
 
+## Argument quoting
+
+OpenSSH joins the words of a remote command into a single string that the remote login shell
+re-parses, so docket shell-quotes each `dokku` argument before sending it. Values containing spaces
+or shell metacharacters - a `start-cmd` like `npm run start`, an nginx `access-log-format` with
+`$remote_addr`, or a backup schedule like `0 3 * * *` - reach the remote `dokku` verbatim, exactly
+as they would when running locally. An argument that cannot be represented for a POSIX shell (one
+containing a tab, newline, or null byte) is rejected with an `ssh:` error rather than sent in a
+corrupted form.
+
 ## Reading errors
 
 Errors are categorized so you can tell which side failed. SSH-level failures (refused connection,

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/posener/complete v1.2.3
 	github.com/spf13/pflag v1.0.10
 	gopkg.in/yaml.v3 v3.0.1
+	mvdan.cc/sh/v3 v3.13.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,7 @@ github.com/gobuffalo/flect v1.0.3 h1:xeWBM2nui+qnVvNM4S3foBhCAL2XgPU+a7FdpelbTq4
 github.com/gobuffalo/flect v1.0.3/go.mod h1:A5msMlrHtLqh9umBSnvabjsMrCcCpAyzglnDvkbYKHs=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -98,6 +99,7 @@ github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXq
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rs/zerolog v1.35.1 h1:m7xQeoiLIiV0BCEY4Hs+j2NG4Gp2o2KPKmhnnLiazKI=
 github.com/rs/zerolog v1.35.1/go.mod h1:EjML9kdfa/RMA7h/6z6pYmq1ykOuA8/mjWaEvGI+jcw=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
@@ -146,3 +148,5 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+mvdan.cc/sh/v3 v3.13.1 h1:DP3TfgZhDkT7lerUdnp6PTGKyxxzz6T+cOlY/xEvfWk=
+mvdan.cc/sh/v3 v3.13.1/go.mod h1:lXJ8SexMvEVcHCoDvAGLZgFJ9Wsm2sulmoNEXGhYZD0=

--- a/subprocess/ssh.go
+++ b/subprocess/ssh.go
@@ -54,6 +54,7 @@ import (
 
 	execute "github.com/alexellis/go-execute/v2"
 	"github.com/fatih/color"
+	"mvdan.cc/sh/v3/syntax"
 )
 
 // SSHError wraps a transport-level failure of the ssh subprocess
@@ -159,14 +160,19 @@ func controlPath(host string, pid int) string {
 	return filepath.Join(os.TempDir(), "docket-"+hex.EncodeToString(sum[:])[:16]+".sock")
 }
 
-// buildSshArgv assembles the full argv for the `ssh` subprocess. The
-// remote command is passed as separate argv elements; OpenSSH handles
-// quoting so callers must not pre-quote.
+// buildSshArgv assembles the full argv for the `ssh` subprocess. OpenSSH
+// does not preserve argv boundaries for the remote command: it space-joins
+// the remote tokens into a single string that the remote login shell
+// re-parses. So each remote token is POSIX-shell-quoted here (via
+// syntax.Quote with syntax.LangPOSIX) to survive that re-parse intact on
+// any POSIX shell. An argument that cannot be represented for a POSIX
+// shell (a non-printable byte such as a tab, newline, or null) yields an
+// error rather than a corrupted remote command.
 //
 // Reads two env vars at build time: DOKKU_SSH_ACCEPT_NEW_HOST_KEYS=1
 // adds `-o StrictHostKeyChecking=accept-new`; DOKKU_SUDO=1 wraps the
 // remote command in `sudo -n`.
-func buildSshArgv(target sshTarget, remote []string) []string {
+func buildSshArgv(target sshTarget, remote []string) ([]string, error) {
 	argv := []string{
 		"-o", "ControlMaster=auto",
 		"-o", "ControlPath=" + controlPath(target.UserHost(), os.Getpid()),
@@ -183,8 +189,14 @@ func buildSshArgv(target sshTarget, remote []string) []string {
 	if os.Getenv("DOKKU_SUDO") == "1" {
 		argv = append(argv, "sudo", "-n")
 	}
-	argv = append(argv, remote...)
-	return argv
+	for _, arg := range remote {
+		quoted, err := syntax.Quote(arg, syntax.LangPOSIX)
+		if err != nil {
+			return nil, fmt.Errorf("cannot send argument %q to remote shell: %w", arg, err)
+		}
+		argv = append(argv, quoted)
+	}
+	return argv, nil
 }
 
 // sshLookPathOnce caches the result of looking up the `ssh` binary so
@@ -302,7 +314,10 @@ func CallSshCommandWithContext(ctx context.Context, host string, input ExecComma
 	}
 
 	remote := append([]string{input.Command}, input.Args...)
-	argv := buildSshArgv(target, remote)
+	argv, err := buildSshArgv(target, remote)
+	if err != nil {
+		return ExecCommandResponse{}, &SSHError{Host: target.UserHost(), Command: remote, Err: err}
+	}
 
 	cmd := execute.ExecTask{
 		Command:            "ssh",

--- a/subprocess/ssh_test.go
+++ b/subprocess/ssh_test.go
@@ -113,7 +113,10 @@ func TestBuildSshArgvDefault(t *testing.T) {
 	t.Setenv("DOKKU_SUDO", "")
 
 	target := sshTarget{User: "alice", Host: "host", Port: "22"}
-	argv := buildSshArgv(target, []string{"dokku", "apps:list"})
+	argv, err := buildSshArgv(target, []string{"dokku", "apps:list"})
+	if err != nil {
+		t.Fatalf("buildSshArgv returned error: %v", err)
+	}
 
 	wantOpts := []string{
 		"ControlMaster=auto",
@@ -156,7 +159,10 @@ func TestBuildSshArgvNonStandardPort(t *testing.T) {
 	t.Setenv("DOKKU_SUDO", "")
 
 	target := sshTarget{User: "alice", Host: "host", Port: "2222"}
-	argv := buildSshArgv(target, []string{"dokku", "version"})
+	argv, err := buildSshArgv(target, []string{"dokku", "version"})
+	if err != nil {
+		t.Fatalf("buildSshArgv returned error: %v", err)
+	}
 	if !containsExact(argv, "-p") {
 		t.Errorf("argv missing -p flag: %v", argv)
 	}
@@ -170,7 +176,10 @@ func TestBuildSshArgvAcceptNewHostKeys(t *testing.T) {
 	t.Setenv("DOKKU_SUDO", "")
 
 	target := sshTarget{User: "alice", Host: "host", Port: "22"}
-	argv := buildSshArgv(target, []string{"dokku", "version"})
+	argv, err := buildSshArgv(target, []string{"dokku", "version"})
+	if err != nil {
+		t.Fatalf("buildSshArgv returned error: %v", err)
+	}
 	joined := strings.Join(argv, " ")
 	if !strings.Contains(joined, "StrictHostKeyChecking=accept-new") {
 		t.Errorf("argv missing StrictHostKeyChecking=accept-new: %v", argv)
@@ -182,7 +191,10 @@ func TestBuildSshArgvDokkuSudo(t *testing.T) {
 	t.Setenv("DOKKU_SUDO", "1")
 
 	target := sshTarget{User: "alice", Host: "host", Port: "22"}
-	argv := buildSshArgv(target, []string{"dokku", "version"})
+	argv, err := buildSshArgv(target, []string{"dokku", "version"})
+	if err != nil {
+		t.Fatalf("buildSshArgv returned error: %v", err)
+	}
 
 	// sudo must appear after `--`, not before (we never run `sudo ssh`).
 	dashIdx := indexOf(argv, "--")
@@ -200,7 +212,10 @@ func TestBuildSshArgvDokkuSudo(t *testing.T) {
 
 func TestBuildSshArgvDoubleDashSeparator(t *testing.T) {
 	target := sshTarget{User: "alice", Host: "host", Port: "22"}
-	argv := buildSshArgv(target, []string{"dokku", "config:set", "--no-restart"})
+	argv, err := buildSshArgv(target, []string{"dokku", "config:set", "--no-restart"})
+	if err != nil {
+		t.Fatalf("buildSshArgv returned error: %v", err)
+	}
 	dashIdx := indexOf(argv, "--")
 	if dashIdx < 0 {
 		t.Fatalf("argv missing -- separator: %v", argv)
@@ -208,6 +223,74 @@ func TestBuildSshArgvDoubleDashSeparator(t *testing.T) {
 	post := argv[dashIdx+1:]
 	if len(post) < 3 || post[0] != "dokku" || post[1] != "config:set" || post[2] != "--no-restart" {
 		t.Errorf("remote command not preserved across --: %v", post)
+	}
+}
+
+func TestBuildSshArgvQuotesRemoteArgs(t *testing.T) {
+	t.Setenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS", "")
+	t.Setenv("DOKKU_SUDO", "")
+
+	target := sshTarget{User: "alice", Host: "host", Port: "22"}
+	argv, err := buildSshArgv(target, []string{"dokku", "ps:set", "app", "start-cmd", "npm run start"})
+	if err != nil {
+		t.Fatalf("buildSshArgv returned error: %v", err)
+	}
+	dashIdx := indexOf(argv, "--")
+	if dashIdx < 0 {
+		t.Fatalf("argv missing -- separator: %v", argv)
+	}
+	post := argv[dashIdx+1:]
+	// Metacharacter-free tokens stay bare; the value with a space is
+	// single-quoted so OpenSSH's space-joined string re-parses to one
+	// argument on the remote login shell.
+	want := []string{"dokku", "ps:set", "app", "start-cmd", "'npm run start'"}
+	if !equalStrings(post, want) {
+		t.Errorf("post-`--` argv = %v, want %v", post, want)
+	}
+}
+
+func TestBuildSshArgvQuotesInjection(t *testing.T) {
+	t.Setenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS", "")
+	t.Setenv("DOKKU_SUDO", "")
+
+	target := sshTarget{User: "alice", Host: "host", Port: "22"}
+	argv, err := buildSshArgv(target, []string{"dokku", "config:set", "app", "x; rm -rf ~"})
+	if err != nil {
+		t.Fatalf("buildSshArgv returned error: %v", err)
+	}
+	// The payload must survive as a single quoted token so the remote shell
+	// cannot execute the `;` or expand `~`.
+	if !containsExact(argv, "'x; rm -rf ~'") {
+		t.Errorf("injection payload not single-quoted as one token: %v", argv)
+	}
+	if containsExact(argv, "x; rm -rf ~") {
+		t.Errorf("injection payload present unquoted: %v", argv)
+	}
+}
+
+func TestBuildSshArgvRejectsUnquotable(t *testing.T) {
+	t.Setenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS", "")
+	t.Setenv("DOKKU_SUDO", "")
+
+	target := sshTarget{User: "alice", Host: "host", Port: "22"}
+	// A newline has no POSIX-shell escape, so we refuse to build the remote
+	// command rather than corrupt it.
+	if _, err := buildSshArgv(target, []string{"dokku", "config:set", "app", "a\nb"}); err == nil {
+		t.Fatal("expected error for argument containing a newline")
+	}
+
+	// The same failure surfaces through the dispatcher as a transport-level
+	// *SSHError so plan/apply render it with the `ssh:` prefix.
+	_, err := CallSshCommand("alice@host", ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"config:set", "app", "a\nb"},
+	})
+	if err == nil {
+		t.Fatal("expected error from CallSshCommand for unquotable argument")
+	}
+	var sshErr *SSHError
+	if !errors.As(err, &sshErr) {
+		t.Fatalf("expected *SSHError, got %T (%v)", err, err)
 	}
 }
 
@@ -377,4 +460,16 @@ func indexOf(haystack []string, needle string) int {
 		}
 	}
 	return -1
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/tests/bats/ssh.bats
+++ b/tests/bats/ssh.bats
@@ -96,3 +96,35 @@ EOF
   assert_output --partial "(host: $DOCKET_TEST_REMOTE_HOST)"
   refute_output --partial "(host: bogus-should-not-be-used)"
 }
+
+@test "ssh transmits argument values with spaces verbatim" {
+  # A value with spaces exercises the transport quoting: OpenSSH space-joins
+  # the remote argv and the remote login shell re-parses it, so without
+  # quoting "npm run start" would reach dokku as three arguments.
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: ensure docket-test-ssh
+      dokku_app:
+        app: docket-test-ssh
+    - name: set the start command
+      dokku_ps_property:
+        app: docket-test-ssh
+        property: start-cmd
+        value: npm run start
+EOF
+  DOKKU_HOST="$DOCKET_TEST_REMOTE_HOST" run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_success
+
+  # The value round-tripped intact, so a re-plan reports no drift instead of
+  # looping forever on a truncated "npm" (the "never converges" symptom).
+  DOKKU_HOST="$DOCKET_TEST_REMOTE_HOST" run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "(in sync)"
+  refute_output --partial "[~]"
+
+  # And the raw value stored on the server is exactly what we set.
+  run ssh -o BatchMode=yes "$DOCKET_TEST_REMOTE_HOST" "dokku ps:report docket-test-ssh --format json"
+  assert_success
+  assert_output --partial "npm run start"
+}


### PR DESCRIPTION
The SSH transport appended each `dokku` argument as a bare word, and OpenSSH space-joins those words into one string that the remote login shell re-parses. Any value containing spaces or shell metacharacters was therefore word-split, glob-expanded, or executed on the remote host, so tasks such as `dokku_ps_property` never converged and a crafted value could inject remote commands. Arguments are now quoted for the remote shell so they reach the remote `dokku` verbatim.

Fixes #301.