### PR TITLE
Fix secret exposure in plan and apply output

### DIFF
--- a/commands/apply.go
+++ b/commands/apply.go
@@ -168,11 +168,18 @@ func (c *ApplyCommand) Run(args []string) int {
 		}
 	}
 
+	// Register the sensitive CLI/vars-file input values before the recipe is
+	// parsed and rendered, so a template or parse error that interpolated one
+	// of them is masked. Task-declared sensitive values are added once the
+	// recipe parses (below).
+	subprocess.SetGlobalSensitive(sensitiveValues)
+	defer subprocess.SetGlobalSensitive(nil)
+
 	userSet := userSetKeys(flags, varsFileKeys, c.arguments)
 
 	plays, err := tasks.GetPlaysWithFormat(data, c.tasksFormat, context, userSet)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("task error: %v", err))
+		c.Ui.Error(subprocess.MaskString(fmt.Sprintf("task error: %v", err)))
 		return 1
 	}
 
@@ -189,10 +196,10 @@ func (c *ApplyCommand) Run(args []string) int {
 
 	if c.startAtTask != "" {
 		if !startAtTaskMatches(plays, c.startAtTask) {
-			c.Ui.Error(fmt.Sprintf(
+			c.Ui.Error(subprocess.MaskString(fmt.Sprintf(
 				"--start-at-task %q: no task matched name; available names: %s",
 				c.startAtTask, formatStartAtTaskNames(plays),
-			))
+			)))
 			return 1
 		}
 	}
@@ -209,9 +216,7 @@ func (c *ApplyCommand) Run(args []string) int {
 		})
 	}
 
-	sensitiveValues = append(sensitiveValues, tasks.CollectPlaySensitiveValues(plays)...)
-	subprocess.SetGlobalSensitive(sensitiveValues)
-	defer subprocess.SetGlobalSensitive(nil)
+	subprocess.AddGlobalSensitive(tasks.CollectPlaySensitiveValues(plays)...)
 
 	if resolvedHost != "" {
 		defer subprocess.CloseSshControlMaster(resolvedHost)

--- a/commands/masking_command_test.go
+++ b/commands/masking_command_test.go
@@ -1,0 +1,94 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dokku/docket/subprocess"
+	"github.com/dokku/docket/tasks"
+	"github.com/josegonzalez/cli-skeleton/command"
+	"github.com/mitchellh/cli"
+)
+
+// parseErrorRecipe interpolates a sensitive input into an envelope key, which
+// renders to an unknown key and fails during GetPlaysWithFormat. The parse
+// error quotes the rendered (secret) key, so it must be masked - which only
+// works if the sensitive CLI value is registered before the recipe is parsed.
+const parseErrorRecipe = `---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - name: deploy
+      "{{ .secret_value }}": true
+      dokku_app: { app: x }
+`
+
+func TestApplyMasksSensitiveInputInParseError(t *testing.T) {
+	path := writeTasksFile(t, parseErrorRecipe)
+	_, stderr, exit := runApply(t, path, "--secret_value=envelopekey_secretzzz")
+	if exit == 0 {
+		t.Fatalf("expected non-zero exit for a parse error; stderr=%s", stderr)
+	}
+	if strings.Contains(stderr, "envelopekey_secretzzz") {
+		t.Errorf("parse error leaked the sensitive input: %s", stderr)
+	}
+	if !strings.Contains(stderr, "***") {
+		t.Errorf("expected mask placeholder in parse error, got: %s", stderr)
+	}
+}
+
+func TestPlanMasksSensitiveInputInParseError(t *testing.T) {
+	path := writeTasksFile(t, parseErrorRecipe)
+	_, stderr, exit := runPlan(t, path, "--secret_value=envelopekey_secretzzz")
+	if exit == 0 {
+		t.Fatalf("expected non-zero exit for a parse error; stderr=%s", stderr)
+	}
+	if strings.Contains(stderr, "envelopekey_secretzzz") {
+		t.Errorf("parse error leaked the sensitive input: %s", stderr)
+	}
+	if !strings.Contains(stderr, "***") {
+		t.Errorf("expected mask placeholder in parse error, got: %s", stderr)
+	}
+}
+
+func TestValidateMasksSensitiveInJSONProblem(t *testing.T) {
+	subprocess.SetGlobalSensitive([]string{"tok_secret"})
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+
+	ui := cli.NewMockUi()
+	c := &ValidateCommand{Meta: command.Meta{Ui: ui}}
+	c.emitJSONProblem(tasks.Problem{
+		Code:    "template_error",
+		Message: `cannot render "tok_secret"`,
+		Play:    "play tok_secret",
+		Task:    "task tok_secret",
+		Hint:    "check tok_secret",
+	})
+	out := ui.OutputWriter.String()
+	if strings.Contains(out, "tok_secret") {
+		t.Errorf("validate JSON problem leaked secret: %s", out)
+	}
+	if !strings.Contains(out, "***") {
+		t.Errorf("expected mask placeholder, got: %s", out)
+	}
+}
+
+func TestValidateMasksSensitiveInHumanProblem(t *testing.T) {
+	subprocess.SetGlobalSensitive([]string{"tok_secret"})
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+
+	ui := cli.NewMockUi()
+	c := &ValidateCommand{Meta: command.Meta{Ui: ui}}
+	c.renderHumanProblems([]tasks.Problem{{
+		Play:    "play tok_secret",
+		Task:    "task tok_secret",
+		Message: `bad value "tok_secret"`,
+	}})
+	out := ui.OutputWriter.String()
+	if strings.Contains(out, "tok_secret") {
+		t.Errorf("validate human problem leaked secret: %s", out)
+	}
+	if !strings.Contains(out, "***") {
+		t.Errorf("expected mask placeholder, got: %s", out)
+	}
+}

--- a/commands/output.go
+++ b/commands/output.go
@@ -223,7 +223,7 @@ func (f *Formatter) Verbose() bool { return f.verbose }
 // listing. Used once per play; until #208 lands, callers emit one
 // header per run.
 func (f *Formatter) PlayHeader(name string) {
-	f.ui.Output(fmt.Sprintf("==> Play: %s", name))
+	f.ui.Output(fmt.Sprintf("==> Play: %s", subprocess.MaskString(name)))
 }
 
 // PlayHeaderWithHost is like PlayHeader but appends a `(host: <name>)`
@@ -235,7 +235,7 @@ func (f *Formatter) PlayHeaderWithHost(name, host string) {
 		f.PlayHeader(name)
 		return
 	}
-	f.ui.Output(fmt.Sprintf("==> Play: %s  (host: %s)", name, host))
+	f.ui.Output(fmt.Sprintf("==> Play: %s  (host: %s)", subprocess.MaskString(name), host))
 }
 
 // PlayStart satisfies EventEmitter; delegates to PlayHeaderWithHost.
@@ -246,13 +246,18 @@ func (f *Formatter) PlayStart(name, host string) {
 // PlaySkipped renders a `==> Play: <name>  (skipped: when "<src>")`
 // line for a play whose `when:` predicate evaluated to false. whenSrc
 // is the raw expr source; the formatter quotes it back so the user can
-// see which predicate caused the skip.
+// see which predicate caused the skip. Both the name and whenSrc are
+// masked against the global sensitive value set: a play predicate can
+// sigil-interpolate a sensitive input, so whenSrc (and the same string
+// wrapped with an eval error by apply/plan) may contain the literal
+// secret.
 func (f *Formatter) PlaySkipped(name, whenSrc string) {
+	name = subprocess.MaskString(name)
 	if whenSrc == "" {
 		f.ui.Output(fmt.Sprintf("==> Play: %s  (skipped)", name))
 		return
 	}
-	f.ui.Output(fmt.Sprintf("==> Play: %s  (skipped: when %q)", name, whenSrc))
+	f.ui.Output(fmt.Sprintf("==> Play: %s  (skipped: when %q)", name, subprocess.MaskString(whenSrc)))
 }
 
 // ApplyTask renders one apply task line plus optional continuations,
@@ -388,12 +393,13 @@ func PrefixErrorMessage(err error) string {
 // appended after two spaces (matching the legacy plan-line layout).
 //
 // Errored task lines are routed through Ui.Error so they land on stderr
-// and inherit the cli-skeleton error styling. The suffix is masked
-// against the global sensitive value set so error contexts that include
-// stderr can't leak secrets.
+// and inherit the cli-skeleton error styling. Both the name and the
+// suffix are masked against the global sensitive value set: the name can
+// carry a secret via a loop expansion (`… (item=<value>)`), and the
+// suffix can carry a secret via a plan reason or stderr context.
 func (f *Formatter) TaskLine(m Marker, name, suffix string) {
 	marker := f.paintMarker(m)
-	line := marker + name
+	line := marker + subprocess.MaskString(name)
 	if suffix != "" {
 		line = line + "  " + subprocess.MaskString(suffix)
 	}

--- a/commands/output_json.go
+++ b/commands/output_json.go
@@ -32,7 +32,7 @@ func (e *JSONEmitter) PlayStart(name, host string) {
 	ev := map[string]interface{}{
 		"version": jsonSchemaVersion,
 		"type":    "play_start",
-		"name":    name,
+		"name":    subprocess.MaskString(name),
 		"ts":      nowRFC3339(),
 	}
 	if host != "" {
@@ -43,17 +43,22 @@ func (e *JSONEmitter) PlayStart(name, host string) {
 
 // PlaySkipped emits a `play_skipped` event for a play that was filtered
 // out by its `when:` predicate. The reason field carries the raw expr
-// source so consumers can correlate the skip with the recipe.
+// source so consumers can correlate the skip with the recipe. The name,
+// when, and reason are masked against the global sensitive value set: a
+// play predicate can sigil-interpolate a sensitive input, so whenSrc (and
+// the same string wrapped with an eval error by apply/plan) may contain
+// the literal secret.
 func (e *JSONEmitter) PlaySkipped(name, whenSrc string) {
 	ev := map[string]interface{}{
 		"version": jsonSchemaVersion,
 		"type":    "play_skipped",
-		"name":    name,
+		"name":    subprocess.MaskString(name),
 		"ts":      nowRFC3339(),
 	}
 	if whenSrc != "" {
-		ev["when"] = whenSrc
-		ev["reason"] = "when: " + whenSrc
+		masked := subprocess.MaskString(whenSrc)
+		ev["when"] = masked
+		ev["reason"] = "when: " + masked
 	}
 	e.write(ev)
 }
@@ -64,8 +69,8 @@ func (e *JSONEmitter) ApplyTask(ev ApplyTaskEvent) {
 	out := map[string]interface{}{
 		"version":       jsonSchemaVersion,
 		"type":          "task",
-		"play":          ev.Play,
-		"name":          ev.Name,
+		"play":          subprocess.MaskString(ev.Play),
+		"name":          subprocess.MaskString(ev.Name),
 		"changed":       ev.State.Changed,
 		"state":         string(ev.State.State),
 		"desired_state": string(ev.State.DesiredState),
@@ -79,7 +84,7 @@ func (e *JSONEmitter) ApplyTask(ev ApplyTaskEvent) {
 	case ev.Skipped:
 		out["status"] = "skipped"
 		if ev.SkipReason != "" {
-			out["skip_reason"] = ev.SkipReason
+			out["skip_reason"] = subprocess.MaskString(ev.SkipReason)
 		}
 	case ev.State.Error != nil:
 		out["status"] = "error"
@@ -123,8 +128,8 @@ func (e *JSONEmitter) PlanTask(ev PlanTaskEvent) {
 	out := map[string]interface{}{
 		"version":       jsonSchemaVersion,
 		"type":          "task",
-		"play":          ev.Play,
-		"name":          ev.Name,
+		"play":          subprocess.MaskString(ev.Play),
+		"name":          subprocess.MaskString(ev.Name),
 		"would_change":  !ev.Result.InSync && ev.Result.Error == nil && !ev.Skipped && ev.WhenError == nil,
 		"state":         string(ev.Result.DesiredState),
 		"desired_state": string(ev.Result.DesiredState),
@@ -180,8 +185,8 @@ func (e *JSONEmitter) TaskWarning(play, name, message string) {
 	e.write(map[string]interface{}{
 		"version": jsonSchemaVersion,
 		"type":    "warning",
-		"play":    play,
-		"name":    name,
+		"play":    subprocess.MaskString(play),
+		"name":    subprocess.MaskString(name),
 		"reason":  "deprecated",
 		"message": subprocess.MaskString(message),
 		"ts":      nowRFC3339(),

--- a/commands/output_json_test.go
+++ b/commands/output_json_test.go
@@ -387,6 +387,51 @@ func TestJSONEmitterMasksSensitiveValues(t *testing.T) {
 	}
 }
 
+func TestJSONEmitterMasksTaskNameAndPlay(t *testing.T) {
+	// A loop over a sensitive value expands the task name; the name and play
+	// fields must be masked in JSON too (#312).
+	subprocess.SetGlobalSensitive([]string{"hunter2"})
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+
+	e, ui := emitterTestUI()
+	e.ApplyTask(ApplyTaskEvent{
+		Play: "play-hunter2",
+		Name: "create auth users (item=hunter2)",
+		State: tasks.TaskOutputState{
+			Changed:      true,
+			State:        tasks.StatePresent,
+			DesiredState: tasks.StatePresent,
+		},
+	})
+	ev := decodeOnly(t, ui.OutputWriter.String())
+	if got := ev["name"].(string); strings.Contains(got, "hunter2") {
+		t.Errorf("name leaked secret: %q", got)
+	}
+	if got := ev["play"].(string); strings.Contains(got, "hunter2") {
+		t.Errorf("play leaked secret: %q", got)
+	}
+}
+
+func TestJSONEmitterPlaySkippedMasksWhen(t *testing.T) {
+	// The play_skipped when/reason fields carry the raw predicate source; a
+	// secret interpolated into it must be masked (#335).
+	subprocess.SetGlobalSensitive([]string{"tok_abc123"})
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+
+	e, ui := emitterTestUI()
+	e.PlaySkipped("deploy", `"tok_abc123" == "expected"`)
+	ev := decodeOnly(t, ui.OutputWriter.String())
+	if got := ev["when"].(string); strings.Contains(got, "tok_abc123") {
+		t.Errorf("when leaked secret: %q", got)
+	}
+	if got := ev["reason"].(string); strings.Contains(got, "tok_abc123") {
+		t.Errorf("reason leaked secret: %q", got)
+	}
+	if !strings.Contains(ev["when"].(string), "***") {
+		t.Errorf("expected mask placeholder in when, got %q", ev["when"])
+	}
+}
+
 func TestJSONEmitterEveryEventHasVersion1(t *testing.T) {
 	e, ui := emitterTestUI()
 	e.PlayStart("tasks", "")

--- a/commands/output_test.go
+++ b/commands/output_test.go
@@ -52,6 +52,55 @@ func TestFormatterPlayHeaderWithHostEmptyDelegates(t *testing.T) {
 	}
 }
 
+func TestFormatterTaskLineMasksSensitiveName(t *testing.T) {
+	// A loop over a sensitive value expands the task name to
+	// `<name> (item=<secret>)`; the name must be masked (#312).
+	subprocess.SetGlobalSensitive([]string{"hunter2"})
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+
+	f, ui := newTestFormatter(false)
+	f.TaskLine(MarkerChanged, "create auth users (item=hunter2)", "")
+	got := ui.OutputWriter.String()
+	if strings.Contains(got, "hunter2") {
+		t.Errorf("task name leaked secret: %q", got)
+	}
+	if !strings.Contains(got, "***") {
+		t.Errorf("expected mask placeholder in %q", got)
+	}
+}
+
+func TestFormatterPlaySkippedMasksWhenSource(t *testing.T) {
+	// A play predicate that interpolates a sensitive input has the secret
+	// substituted into the recipe text; the echoed when: source must be
+	// masked (#335).
+	subprocess.SetGlobalSensitive([]string{"tok_abc123"})
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+
+	f, ui := newTestFormatter(false)
+	f.PlaySkipped("deploy", `"tok_abc123" == "expected"`)
+	got := ui.OutputWriter.String()
+	if strings.Contains(got, "tok_abc123") {
+		t.Errorf("when source leaked secret: %q", got)
+	}
+	if !strings.Contains(got, "***") {
+		t.Errorf("expected mask placeholder in %q", got)
+	}
+}
+
+func TestFormatterPlaySkippedMasksWhenEvalError(t *testing.T) {
+	// apply/plan route play-level when-eval errors through PlaySkipped as
+	// `<when> (error: <err>)`; the same masking must cover them (#335).
+	subprocess.SetGlobalSensitive([]string{"tok_abc123"})
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+
+	f, ui := newTestFormatter(false)
+	f.PlaySkipped("deploy", `"tok_abc123" == foo (error: unknown name foo)`)
+	got := ui.OutputWriter.String()
+	if strings.Contains(got, "tok_abc123") {
+		t.Errorf("when eval error leaked secret: %q", got)
+	}
+}
+
 func TestFormatterErrorContinuationDokkuPrefix(t *testing.T) {
 	f, ui := newTestFormatter(false)
 	f.ErrorContinuation(errors.New("app foo does not exist"))

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -177,11 +177,18 @@ func (c *PlanCommand) Run(args []string) int {
 		}
 	}
 
+	// Register the sensitive CLI/vars-file input values before the recipe is
+	// parsed and rendered, so a template or parse error that interpolated one
+	// of them is masked. Task-declared sensitive values are added once the
+	// recipe parses (below).
+	subprocess.SetGlobalSensitive(sensitiveValues)
+	defer subprocess.SetGlobalSensitive(nil)
+
 	userSet := userSetKeys(flags, varsFileKeys, c.arguments)
 
 	plays, err := tasks.GetPlaysWithFormat(data, c.tasksFormat, context, userSet)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("task error: %v", err))
+		c.Ui.Error(subprocess.MaskString(fmt.Sprintf("task error: %v", err)))
 		return 1
 	}
 
@@ -208,9 +215,7 @@ func (c *PlanCommand) Run(args []string) int {
 		})
 	}
 
-	sensitiveValues = append(sensitiveValues, tasks.CollectPlaySensitiveValues(plays)...)
-	subprocess.SetGlobalSensitive(sensitiveValues)
-	defer subprocess.SetGlobalSensitive(nil)
+	subprocess.AddGlobalSensitive(tasks.CollectPlaySensitiveValues(plays)...)
 
 	if resolvedHost != "" {
 		defer subprocess.CloseSshControlMaster(resolvedHost)

--- a/commands/validate.go
+++ b/commands/validate.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/dokku/docket/subprocess"
 	"github.com/dokku/docket/tasks"
 
 	"github.com/josegonzalez/cli-skeleton/command"
@@ -158,11 +159,23 @@ func (c *ValidateCommand) Run(args []string) int {
 	}
 
 	overrides := map[string]bool{}
+	var sensitiveValues []string
 	for name, argument := range c.arguments {
 		if argument.HasValue() {
 			overrides[name] = true
 		}
+		if argument.Sensitive {
+			if v := argument.StringValue(); v != "" {
+				sensitiveValues = append(sensitiveValues, v)
+			}
+		}
 	}
+
+	// Register the sensitive input values so a problem message that quotes an
+	// interpolated secret (e.g. a template render error) is masked. validate is
+	// offline, so only input-derived values are available to collect.
+	subprocess.SetGlobalSensitive(sensitiveValues)
+	defer subprocess.SetGlobalSensitive(nil)
 
 	problems := tasks.Validate(data, tasks.ValidateOptions{
 		Strict:         c.strict,
@@ -200,13 +213,13 @@ func (c *ValidateCommand) emitJSONProblem(p tasks.Problem) {
 		"version": 1,
 		"type":    "validate_problem",
 		"code":    p.Code,
-		"message": p.Message,
+		"message": subprocess.MaskString(p.Message),
 	}
 	if p.Play != "" {
-		event["play"] = p.Play
+		event["play"] = subprocess.MaskString(p.Play)
 	}
 	if p.Task != "" {
-		event["task"] = p.Task
+		event["task"] = subprocess.MaskString(p.Task)
 	}
 	if p.Line > 0 {
 		event["line"] = p.Line
@@ -215,7 +228,7 @@ func (c *ValidateCommand) emitJSONProblem(p tasks.Problem) {
 		event["column"] = p.Column
 	}
 	if p.Hint != "" {
-		event["hint"] = p.Hint
+		event["hint"] = subprocess.MaskString(p.Hint)
 	}
 	b, err := json.Marshal(event)
 	if err != nil {
@@ -249,10 +262,10 @@ func (c *ValidateCommand) renderHumanProblems(problems []tasks.Problem) {
 
 	for _, play := range playOrder {
 		if play != "" {
-			c.Ui.Info(fmt.Sprintf("  %s", play))
+			c.Ui.Info(fmt.Sprintf("  %s", subprocess.MaskString(play)))
 		}
 		for _, p := range grouped[play] {
-			c.Ui.Info(fmt.Sprintf("    ! %s", formatProblem(p)))
+			c.Ui.Info(fmt.Sprintf("    ! %s", subprocess.MaskString(formatProblem(p))))
 		}
 		c.Ui.Info("")
 	}

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -6,7 +6,10 @@ consume the result programmatically instead of scraping text.
 
 Every event carries a `version` integer, pinned at `1`. Consumers should branch on `version` so a
 future schema change does not silently break them. Values marked sensitive - inputs declared
-`sensitive: true`, or task fields tagged `sensitive:"true"` - are masked as `***`.
+`sensitive: true`, or task fields tagged `sensitive:"true"` - are masked as `***`. Masking covers
+every string field a secret can reach, including `name` and `play` (a loop over a sensitive value
+expands the task name) and the `when` / `reason` fields on `play_skipped` (a play predicate can
+interpolate a sensitive input).
 
 ## Events
 

--- a/subprocess/mask.go
+++ b/subprocess/mask.go
@@ -25,6 +25,43 @@ var (
 // from input values declared `sensitive: true` and from task struct fields
 // tagged `sensitive:"true"` before any subprocess runs, then defer a clear.
 func SetGlobalSensitive(values []string) {
+	cleaned := cleanSensitive(values)
+
+	sensitiveMu.Lock()
+	defer sensitiveMu.Unlock()
+	if len(cleaned) == 0 {
+		sensitiveValues = nil
+		return
+	}
+	sensitiveValues = cleaned
+}
+
+// AddGlobalSensitive appends values to the sensitive registry, keeping the
+// entries already registered. Use it when a value that must be masked only
+// becomes known after the registry was first populated - typically a secret
+// read back from the server during Plan() (a drifted property's old value, or
+// scheduler-k3s trigger metadata), which the pre-run collection in
+// commands/apply.go and commands/plan.go cannot see. Values are de-duplicated
+// against the existing set, empties are dropped, and the whole registry is
+// re-sorted length-descending. A no-op when values contribute nothing new.
+func AddGlobalSensitive(values ...string) {
+	if len(values) == 0 {
+		return
+	}
+	sensitiveMu.Lock()
+	defer sensitiveMu.Unlock()
+	merged := cleanSensitive(append(append([]string{}, sensitiveValues...), values...))
+	if len(merged) == 0 {
+		sensitiveValues = nil
+		return
+	}
+	sensitiveValues = merged
+}
+
+// cleanSensitive drops empty and duplicate entries and returns the values
+// sorted by length descending so a longer secret is masked before any shorter
+// secret that is a substring of it would be.
+func cleanSensitive(values []string) []string {
 	cleaned := make([]string, 0, len(values))
 	seen := make(map[string]struct{}, len(values))
 	for _, v := range values {
@@ -37,19 +74,10 @@ func SetGlobalSensitive(values []string) {
 		seen[v] = struct{}{}
 		cleaned = append(cleaned, v)
 	}
-	// Sort by length descending so longer matches are masked before any
-	// shorter substring of them would be.
 	sort.SliceStable(cleaned, func(i, j int) bool {
 		return len(cleaned[i]) > len(cleaned[j])
 	})
-
-	sensitiveMu.Lock()
-	defer sensitiveMu.Unlock()
-	if len(cleaned) == 0 {
-		sensitiveValues = nil
-		return
-	}
-	sensitiveValues = cleaned
+	return cleaned
 }
 
 // GlobalSensitive returns a snapshot of the current sensitive value set.

--- a/subprocess/mask_test.go
+++ b/subprocess/mask_test.go
@@ -76,6 +76,70 @@ func TestSetGlobalSensitiveClear(t *testing.T) {
 	}
 }
 
+func TestAddGlobalSensitiveAppendsKeepingExisting(t *testing.T) {
+	SetGlobalSensitive([]string{"first"})
+	defer SetGlobalSensitive(nil)
+
+	AddGlobalSensitive("second")
+
+	got := MaskString("first and second")
+	if got != "*** and ***" {
+		t.Errorf("MaskString = %q, want both values masked", got)
+	}
+}
+
+func TestAddGlobalSensitiveDeduplicatesAgainstExisting(t *testing.T) {
+	SetGlobalSensitive([]string{"tok"})
+	defer SetGlobalSensitive(nil)
+
+	AddGlobalSensitive("tok", "", "tok")
+
+	count := 0
+	for _, v := range GlobalSensitive() {
+		if v == "tok" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("AddGlobalSensitive introduced duplicates: %v", GlobalSensitive())
+	}
+}
+
+func TestAddGlobalSensitiveKeepsLengthDescOrder(t *testing.T) {
+	// "ab" registered first; adding the longer "abcdef" must still mask the
+	// longer match first so a substring secret does not leak its remainder.
+	SetGlobalSensitive([]string{"ab"})
+	defer SetGlobalSensitive(nil)
+
+	AddGlobalSensitive("abcdef")
+
+	if got := MaskString("xabcdefy"); got != "x***y" {
+		t.Errorf("MaskString = %q, want %q (longer match first)", got, "x***y")
+	}
+}
+
+func TestAddGlobalSensitiveOnEmptyRegistry(t *testing.T) {
+	SetGlobalSensitive(nil)
+	defer SetGlobalSensitive(nil)
+
+	AddGlobalSensitive("late")
+
+	if got := MaskString("a late value"); got != "a *** value" {
+		t.Errorf("MaskString = %q, want the added value masked", got)
+	}
+}
+
+func TestAddGlobalSensitiveNoValuesIsNoop(t *testing.T) {
+	SetGlobalSensitive([]string{"keep"})
+	defer SetGlobalSensitive(nil)
+
+	AddGlobalSensitive()
+
+	if got := MaskString("keep"); got != "***" {
+		t.Errorf("MaskString = %q, want existing registry untouched", got)
+	}
+}
+
 func TestMaskStringConcurrent(t *testing.T) {
 	SetGlobalSensitive([]string{"secret"})
 	defer SetGlobalSensitive(nil)

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -19,9 +19,16 @@ import (
 // Values point at the canonical bare-key shape (no <plugin>- prefix). The
 // legacy <plugin>-prefixed keys remain emitted during the 0.38.x deprecation
 // window but are ignored by the lookup.
+//
+// Sensitive marks a property whose value is a secret (e.g. a password or a
+// cluster token). When set, planProperty registers both the desired value and
+// the server-probed current value with the masker, so the `(was %q)` drift
+// reason and the command echo are masked. It is a per-property flag because a
+// plugin usually has a mix of secret and benign properties.
 type PropertyKeys struct {
-	PerApp string
-	Global string
+	PerApp    string
+	Global    string
+	Sensitive bool
 }
 
 // pluginFromSubcommand returns the plugin component of a colon-separated
@@ -252,6 +259,16 @@ func planProperty(state State, app string, global bool, property, value, subcomm
 		target = "--global"
 	}
 
+	// A property flagged Sensitive carries a secret value. Register the desired
+	// value now so the command echo is masked; empties are dropped. The
+	// server-probed current value is registered after each probe below, since
+	// it is not known from the recipe (a hand-written recipe never tags it, and
+	// the `(was %q)` drift reason would otherwise leak the live server secret).
+	sensitive := keys[property].Sensitive
+	if sensitive {
+		subprocess.AddGlobalSensitive(value)
+	}
+
 	return DispatchPlan(state, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
 			// Dynamic property families have no probe key; treat as drift
@@ -264,6 +281,9 @@ func planProperty(state State, app string, global bool, property, value, subcomm
 			// (matches pre-probe behavior for unsupported plugins) but
 			// surface SSH transport failures so the user sees `! ssh:`.
 			current, probeErr := getProperty(subcommand, app, global, property, keys)
+			if sensitive {
+				subprocess.AddGlobalSensitive(current)
+			}
 			if probeErr != nil {
 				var sshErr *subprocess.SSHError
 				if errors.As(probeErr, &sshErr) {
@@ -302,6 +322,9 @@ func planProperty(state State, app string, global bool, property, value, subcomm
 			}
 
 			current, probeErr := getProperty(subcommand, app, global, property, keys)
+			if sensitive {
+				subprocess.AddGlobalSensitive(current)
+			}
 			if probeErr != nil {
 				var sshErr *subprocess.SSHError
 				if errors.As(probeErr, &sshErr) {

--- a/tasks/properties_test.go
+++ b/tasks/properties_test.go
@@ -27,6 +27,93 @@ func TestGetPropertyArgsGlobal(t *testing.T) {
 	}
 }
 
+func TestPlanPropertyMasksSensitiveDriftValue(t *testing.T) {
+	subprocess.SetGlobalSensitive(nil)
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+
+	keys := map[string]PropertyKeys{
+		"secret-prop": {PerApp: "", Global: "global-secret-prop", Sensitive: true},
+	}
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet myplugin:report --global --format json": `{"global-secret-prop":"oldsecret"}`,
+	}))()
+
+	res := planProperty(StatePresent, "", true, "secret-prop", "newsecret", "myplugin:set", keys)
+	if res.Error != nil {
+		t.Fatalf("planProperty error: %v", res.Error)
+	}
+
+	// The probed old value and the desired new value are both secrets and must
+	// be registered so the drift reason and command echo mask them.
+	if masked := subprocess.MaskString(res.Reason); strings.Contains(masked, "oldsecret") {
+		t.Errorf("drift reason leaked probed secret: %q -> %q", res.Reason, masked)
+	}
+	if !strings.Contains(res.Reason, "oldsecret") {
+		t.Fatalf("expected reason to embed the probed value pre-masking, got %q", res.Reason)
+	}
+	if masked := subprocess.MaskString(res.Reason); !strings.Contains(masked, "***") {
+		t.Errorf("expected mask placeholder in masked reason, got %q", masked)
+	}
+	for _, cmd := range res.Commands {
+		if masked := subprocess.MaskString(cmd); strings.Contains(masked, "newsecret") {
+			t.Errorf("command leaked desired secret after masking: %q -> %q", cmd, masked)
+		}
+	}
+}
+
+func TestPlanPropertyAbsentMasksSensitiveOldValue(t *testing.T) {
+	subprocess.SetGlobalSensitive(nil)
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+
+	keys := map[string]PropertyKeys{
+		"secret-prop": {PerApp: "", Global: "global-secret-prop", Sensitive: true},
+	}
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet myplugin:report --global --format json": `{"global-secret-prop":"livesecret"}`,
+	}))()
+
+	// The absent path leaks the current server secret even without a sensitive
+	// recipe value (the value must be empty for absent).
+	res := planProperty(StateAbsent, "", true, "secret-prop", "", "myplugin:set", keys)
+	if res.Error != nil {
+		t.Fatalf("planProperty error: %v", res.Error)
+	}
+	if masked := subprocess.MaskString(res.Reason); strings.Contains(masked, "livesecret") {
+		t.Errorf("unset reason leaked server secret: %q -> %q", res.Reason, masked)
+	}
+}
+
+func TestPlanPropertyDoesNotMaskBenignDriftValue(t *testing.T) {
+	subprocess.SetGlobalSensitive(nil)
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+
+	keys := map[string]PropertyKeys{
+		"timeout": {PerApp: "", Global: "global-timeout"},
+	}
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet myplugin:report --global --format json": `{"global-timeout":"60s"}`,
+	}))()
+
+	res := planProperty(StatePresent, "", true, "timeout", "90s", "myplugin:set", keys)
+	if res.Error != nil {
+		t.Fatalf("planProperty error: %v", res.Error)
+	}
+	// A non-sensitive property keeps its old value visible for a useful diff.
+	if masked := subprocess.MaskString(res.Reason); !strings.Contains(masked, "60s") {
+		t.Errorf("benign old value should not be masked, got %q", masked)
+	}
+}
+
+func TestSecretPropertiesAreMarkedSensitive(t *testing.T) {
+	// Guard the marks that close #336 so they are not accidentally dropped.
+	if !traefikPropertyKeys["basic-auth-password"].Sensitive {
+		t.Error("traefik basic-auth-password must be marked Sensitive")
+	}
+	if !schedulerK3sPropertyKeys["token"].Sensitive {
+		t.Error("scheduler-k3s token must be marked Sensitive")
+	}
+}
+
 func captureLog(t *testing.T) *bytes.Buffer {
 	t.Helper()
 	buf := &bytes.Buffer{}

--- a/tasks/scheduler_k3s_autoscaling_auth.go
+++ b/tasks/scheduler_k3s_autoscaling_auth.go
@@ -51,6 +51,7 @@ func planSchedulerK3sAutoscalingAuthSet(spec schedulerK3sAutoscalingAuthSpec) Pl
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
+	registerSensitiveMapValues(current)
 
 	drifted, allNew := driftedKeys(spec.Metadata, current)
 	if len(drifted) == 0 {
@@ -88,6 +89,7 @@ func planSchedulerK3sAutoscalingAuthUnset(spec schedulerK3sAutoscalingAuthSpec) 
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
+	registerSensitiveMapValues(current)
 
 	toClear := intersectingKeys(spec.Metadata, current)
 	if len(toClear) == 0 {

--- a/tasks/scheduler_k3s_autoscaling_auth_task.go
+++ b/tasks/scheduler_k3s_autoscaling_auth_task.go
@@ -87,6 +87,24 @@ func (t SchedulerK3sAutoscalingAuthTask) Examples() ([]Doc, error) {
 	})
 }
 
+// SensitiveValues returns the trigger-authentication metadata values so they
+// are masked in user-facing output. Every metadata value is a secret
+// regardless of its key (the same shape as dokku_config), and the tag-based
+// walker cannot reach a map on this task, so the values are collected here.
+// The absent state leaves the values empty; those are dropped by the masker.
+// Server-probed values (a drifted or surviving value) are registered
+// separately at plan time, since they are not known from the task struct.
+func (t SchedulerK3sAutoscalingAuthTask) SensitiveValues() []string {
+	out := make([]string, 0, len(t.Metadata))
+	for _, v := range t.Metadata {
+		if v == "" {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
 // Execute sets or clears the scheduler-k3s autoscaling trigger authentication metadata
 func (t SchedulerK3sAutoscalingAuthTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())

--- a/tasks/scheduler_k3s_autoscaling_auth_task_test.go
+++ b/tasks/scheduler_k3s_autoscaling_auth_task_test.go
@@ -3,7 +3,85 @@ package tasks
 import (
 	"strings"
 	"testing"
+
+	"github.com/dokku/docket/subprocess"
 )
+
+func TestSchedulerK3sAutoscalingAuthTaskSensitiveValues(t *testing.T) {
+	task := SchedulerK3sAutoscalingAuthTask{
+		App:     "test-app",
+		Trigger: "aws-secret-manager",
+		Metadata: map[string]string{
+			"awsRegion":          "us-east-1",
+			"awsSecretAccessKey": "REALSECRET",
+		},
+		State: StatePresent,
+	}
+	got := task.SensitiveValues()
+	// Every non-empty metadata value is masked, regardless of key.
+	if !sortedEqual(got, []string{"us-east-1", "REALSECRET"}) {
+		t.Errorf("SensitiveValues() = %v, want both metadata values", got)
+	}
+}
+
+func TestSchedulerK3sAutoscalingAuthTaskSensitiveValuesAbsentEmpty(t *testing.T) {
+	// On absent the values are empty (only keys matter), so nothing is
+	// contributed from the struct; probed values are registered at plan time.
+	task := SchedulerK3sAutoscalingAuthTask{
+		App:      "test-app",
+		Trigger:  "aws-secret-manager",
+		Metadata: map[string]string{"secretName": ""},
+		State:    StateAbsent,
+	}
+	if got := task.SensitiveValues(); len(got) != 0 {
+		t.Errorf("SensitiveValues() = %v, want empty for absent", got)
+	}
+}
+
+func TestSchedulerK3sAutoscalingAuthUnsetMasksProbedSecrets(t *testing.T) {
+	subprocess.SetGlobalSensitive(nil)
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+
+	// The server holds two metadata keys; the task clears one, so the other
+	// survives and is read back (with its secret value) for the restore call.
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet scheduler-k3s:autoscaling-auth:report test-app --format json": `{"aws-secret-manager.secretName":"my-secret","aws-secret-manager.awsSecretAccessKey":"REALSECRET"}`,
+	}))()
+
+	task := SchedulerK3sAutoscalingAuthTask{
+		App:      "test-app",
+		Trigger:  "aws-secret-manager",
+		Metadata: map[string]string{"secretName": ""},
+		State:    StateAbsent,
+	}
+	result := task.Plan()
+	if result.Error != nil {
+		t.Fatalf("Plan returned error: %v", result.Error)
+	}
+
+	// Both the cleared key's old value and the surviving key's value are
+	// server-probed secrets; they must be registered so every sink masks them.
+	registered := subprocess.GlobalSensitive()
+	for _, secret := range []string{"my-secret", "REALSECRET"} {
+		found := false
+		for _, v := range registered {
+			if v == secret {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("probed secret %q not registered with masker: %v", secret, registered)
+		}
+	}
+
+	// The rendered mutations (unset ... (was "my-secret"), restore ...=REALSECRET)
+	// must mask to *** once the probed values are registered.
+	for _, m := range result.Mutations {
+		if masked := subprocess.MaskString(m); strings.Contains(masked, "REALSECRET") || strings.Contains(masked, "my-secret") {
+			t.Errorf("mutation leaked a probed secret after masking: %q -> %q", m, masked)
+		}
+	}
+}
 
 func TestSchedulerK3sAutoscalingAuthTaskInvalidState(t *testing.T) {
 	task := SchedulerK3sAutoscalingAuthTask{

--- a/tasks/scheduler_k3s_property_task.go
+++ b/tasks/scheduler_k3s_property_task.go
@@ -109,7 +109,7 @@ var schedulerK3sPropertyKeys = map[string]PropertyKeys{
 	"network-interface":      {PerApp: "", Global: "global-network-interface"},
 	"rollback-on-failure":    {PerApp: "rollback-on-failure", Global: "global-rollback-on-failure"},
 	"shm-size":               {PerApp: "shm-size", Global: "global-shm-size"},
-	"token":                  {PerApp: "", Global: "global-token"},
+	"token":                  {PerApp: "", Global: "global-token", Sensitive: true},
 }
 
 // Validate checks the SchedulerK3sPropertyTask's inputs without contacting the server.

--- a/tasks/sensitive.go
+++ b/tasks/sensitive.go
@@ -2,6 +2,8 @@ package tasks
 
 import (
 	"reflect"
+
+	"github.com/dokku/docket/subprocess"
 )
 
 // SensitiveOverride is implemented by tasks whose sensitive values cannot be
@@ -24,16 +26,39 @@ type SensitiveOverride interface {
 //   - the task implements SensitiveOverride and the method returns it.
 //
 // String, []string, and map[string]string fields are supported. Nested
-// structs and pointers are walked recursively. Empty values are dropped by
-// the subprocess masker, not here.
+// structs and pointers are walked recursively. block/rescue/always group
+// envelopes carry no task of their own, so their child envelopes are walked
+// recursively to any depth. Empty values are dropped by the subprocess masker,
+// not here.
 func CollectSensitiveValues(tasks OrderedStringEnvelopeMap) []string {
 	var out []string
 	for _, name := range tasks.Keys() {
-		env := tasks.GetEnvelope(name)
-		if env == nil || env.Task == nil {
-			continue
-		}
+		out = append(out, sensitiveValuesFromEnvelope(tasks.GetEnvelope(name))...)
+	}
+	return out
+}
+
+// sensitiveValuesFromEnvelope returns the masked-value set for one envelope.
+// A leaf envelope contributes its task's values; a block/rescue/always group
+// (Task == nil) contributes the union of its children, recursing so a secret
+// declared only inside a nested group still surfaces. Mirrors the group
+// recursion in CollectEnvelopeNames.
+func sensitiveValuesFromEnvelope(env *TaskEnvelope) []string {
+	if env == nil {
+		return nil
+	}
+	var out []string
+	if env.Task != nil {
 		out = append(out, sensitiveValuesFromTask(env.Task)...)
+	}
+	for _, child := range env.Block {
+		out = append(out, sensitiveValuesFromEnvelope(child)...)
+	}
+	for _, child := range env.Rescue {
+		out = append(out, sensitiveValuesFromEnvelope(child)...)
+	}
+	for _, child := range env.Always {
+		out = append(out, sensitiveValuesFromEnvelope(child)...)
 	}
 	return out
 }
@@ -50,6 +75,23 @@ func CollectPlaySensitiveValues(plays []*Play) []string {
 		out = append(out, CollectSensitiveValues(play.Tasks)...)
 	}
 	return out
+}
+
+// registerSensitiveMapValues adds every non-empty value of m to the global
+// mask registry at plan time. It is for values that are secret but only become
+// known after a server probe - the pre-run collection in commands/apply.go and
+// commands/plan.go walks task structs, so it cannot see them (e.g. a
+// scheduler-k3s trigger's surviving metadata read back from the server). The
+// keys are not masked; only the values.
+func registerSensitiveMapValues(m map[string]string) {
+	if len(m) == 0 {
+		return
+	}
+	values := make([]string, 0, len(m))
+	for _, v := range m {
+		values = append(values, v)
+	}
+	subprocess.AddGlobalSensitive(values...)
 }
 
 // sensitiveValuesFromTask returns the masked-value set for a single task.

--- a/tasks/sensitive_test.go
+++ b/tasks/sensitive_test.go
@@ -154,6 +154,49 @@ func TestCollectSensitiveValuesAcrossTasks(t *testing.T) {
 	}
 }
 
+func TestCollectSensitiveValuesWalksGroupChildren(t *testing.T) {
+	// A block/rescue/always group carries no task of its own (Task == nil);
+	// its children hold the sensitive values and must still be collected.
+	m := OrderedStringEnvelopeMap{}
+	m.Set("group", &TaskEnvelope{
+		Name: "group",
+		Block: []*TaskEnvelope{
+			{Name: "b", Task: &fakeTask{Secret: "blockSecret"}},
+		},
+		Rescue: []*TaskEnvelope{
+			{Name: "r", Task: &taggedSliceTask{Tokens: []string{"rescueSecret"}}},
+		},
+		Always: []*TaskEnvelope{
+			{Name: "a", Task: &taggedMapTask{Headers: map[string]string{"X": "alwaysSecret"}}},
+		},
+	})
+	got := CollectSensitiveValues(m)
+	if !sortedEqual(got, []string{"blockSecret", "rescueSecret", "alwaysSecret"}) {
+		t.Errorf("got %v, want block/rescue/always secrets", got)
+	}
+}
+
+func TestCollectSensitiveValuesWalksNestedGroups(t *testing.T) {
+	// Groups nest: a group inside another group's block. The deepest child's
+	// secret must surface regardless of nesting depth.
+	m := OrderedStringEnvelopeMap{}
+	m.Set("outer", &TaskEnvelope{
+		Name: "outer",
+		Block: []*TaskEnvelope{
+			{
+				Name: "inner-group",
+				Block: []*TaskEnvelope{
+					{Name: "leaf", Task: &fakeTask{Secret: "deepSecret"}},
+				},
+			},
+		},
+	})
+	got := CollectSensitiveValues(m)
+	if !sortedEqual(got, []string{"deepSecret"}) {
+		t.Errorf("got %v, want [deepSecret]", got)
+	}
+}
+
 func TestConfigTaskSensitiveValuesReturnsMapValuesAndBase64(t *testing.T) {
 	ct := &ConfigTask{
 		App:    "myapp",

--- a/tasks/traefik_property_task.go
+++ b/tasks/traefik_property_task.go
@@ -85,7 +85,7 @@ var traefikPropertyKeys = map[string]PropertyKeys{
 	"api-entry-point":         {PerApp: "", Global: "global-api-entry-point"},
 	"api-entry-point-address": {PerApp: "", Global: "global-api-entry-point-address"},
 	"api-vhost":               {PerApp: "", Global: "global-api-vhost"},
-	"basic-auth-password":     {PerApp: "", Global: "global-basic-auth-password"},
+	"basic-auth-password":     {PerApp: "", Global: "global-basic-auth-password", Sensitive: true},
 	"basic-auth-username":     {PerApp: "", Global: "global-basic-auth-username"},
 	"challenge-mode":          {PerApp: "", Global: "global-challenge-mode"},
 	"dashboard-enabled":       {PerApp: "", Global: "global-dashboard-enabled"},

--- a/tests/bats/masking.bats
+++ b/tests/bats/masking.bats
@@ -74,6 +74,72 @@ EOF
   refute_output --partial "tracesecretzzz"
 }
 
+@test "docket apply --verbose masks a sensitive value nested in a block" {
+  # The config value lives on a task inside a block: group. Collecting it
+  # requires walking the group's children (#305); otherwise it leaks.
+  write_tasks_file <<'EOF'
+---
+- tasks:
+    - name: ensure docket-test-mask
+      dokku_app:
+        app: docket-test-mask
+    - name: group
+      block:
+        - name: set a literal config value in a block
+          dokku_config:
+            app: docket-test-mask
+            config:
+              MY_BLOCK_LITERAL: block-literal-zzz
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --verbose
+  assert_success
+  refute_output --partial "block-literal-zzz"
+  assert_output --partial "***"
+}
+
+@test "docket apply masks a sensitive loop item embedded in the task name" {
+  # Looping over a sensitive input names each expansion `<name> (item=<value>)`;
+  # the task name must be masked in the output (#312).
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  tasks:
+    - name: ensure docket-test-mask
+      dokku_app:
+        app: docket-test-mask
+    - name: set secret config
+      loop: 'split(secret_value, ",")'
+      dokku_config:
+        app: docket-test-mask
+        config:
+          LOOP_SECRET: "{{ .item }}"
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --secret_value=loopitemzzz
+  assert_success
+  refute_output --partial "loopitemzzz"
+  assert_output --partial "***"
+}
+
+@test "docket apply masks a sensitive value interpolated into a play when:" {
+  # A play predicate sigil-interpolates a sensitive input, so the recipe text
+  # (and the skip line echoing it) contains the literal secret (#335).
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: secret_value, required: true, sensitive: true }
+  when: '"{{ .secret_value }}" == "will-not-match"'
+  tasks:
+    - dokku_app:
+        app: docket-test-mask
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --secret_value=playwhenzzz
+  assert_success
+  assert_output --partial "(skipped:"
+  refute_output --partial "playwhenzzz"
+  assert_output --partial "***"
+}
+
 @test "docket plan output never echoes dokku_config map values" {
   # Create the app first so the dokku_config plan probe succeeds; otherwise
   # the missing-app probe error short-circuits the test before the masking


### PR DESCRIPTION
A recent full-codebase review grouped five findings where a sensitive value could reach terminal or CI output, either through a sink that skips masking or through a value that was never registered with the masker. They share the secret-exposure theme and are best fixed together so masking is consistent across every sink.

Two of the five are sinks that skipped masking a value that was already registered: a secret carried by a loop item was printed in the expanded task name, and a play `when:` predicate that interpolated a sensitive input was echoed verbatim when the play was skipped or its predicate errored. The other three are values that never reached the mask registry: a secret declared on a task nested inside a `block`, `rescue`, or `always` group was not collected, scheduler-k3s autoscaling-auth trigger metadata was never marked sensitive and was read back from the server when clearing keys, and `plan` embedded a drifted property's current server-side value in its reason for secret-valued properties such as traefik `basic-auth-password` and the scheduler-k3s cluster `token`. Values that only become known after a server probe are now registered while planning so every sink masks them.

An audit of the remaining output surfaces turned up two more gaps in the same theme, fixed here as well: the mask registry was installed only after the recipe parsed, so a sensitive input interpolated into a template or parse error leaked, and `validate` never masked its problem messages at all. The sensitive CLI inputs are now registered before parsing, and `validate` masks its output against them.

This completes the secret-exposure cluster tracked in #360; the unquoted-SSH cluster was already resolved.

Closes #305.
Closes #312.
Closes #326.
Closes #335.
Closes #336.
