### PR TITLE
Fix docket fmt idempotency and corruption bugs

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -109,6 +109,10 @@ The diff is a standard unified diff (`--- / +++ / @@` headers) and applies with 
 `patch -p0` once colors are stripped. Before writing, `fmt` re-parses its own output and aborts if
 the result does not match the input, so a formatting bug can never corrupt a recipe.
 
+`fmt` operates on single-document recipes. An empty or comment-only file is left untouched, and a
+YAML file containing more than one document (separated by `---`) is rejected rather than having its
+trailing documents silently dropped.
+
 ## docket plan
 
 `docket plan` reads each task's current state from the live server and reports what `apply` would

--- a/tasks/format.go
+++ b/tasks/format.go
@@ -73,6 +73,18 @@ func Format(data []byte) ([]byte, error) {
 		return data, nil
 	}
 
+	// docket recipes are single-document. Reject a file with more than one
+	// document rather than silently formatting the first and truncating the
+	// rest. A trailing empty document (a bare `---`) is ignored.
+	var extra yaml.Node
+	if extraErr := dec.Decode(&extra); extraErr == nil {
+		if !isEmptyDocument(documentBody(&extra)) {
+			return nil, fmt.Errorf("fmt supports single-document recipes only; the file contains multiple YAML documents separated by ---")
+		}
+	} else if extraErr != io.EOF {
+		return nil, fmt.Errorf("yaml parse error: %w", extraErr)
+	}
+
 	if doc.Kind == yaml.SequenceNode {
 		canonicalizeRecipe(doc)
 	}

--- a/tasks/format.go
+++ b/tasks/format.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"strings"
 
 	yaml "gopkg.in/yaml.v3"
@@ -57,13 +58,22 @@ var envelopeKeySet = func() map[string]bool {
 //     canonical AST trees are structurally equivalent (defends against
 //     yaml.v3 emitter edge cases with anchors / complex flow scalars).
 func Format(data []byte) ([]byte, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
 	var root yaml.Node
-	if err := yaml.Unmarshal(data, &root); err != nil {
+	err := dec.Decode(&root)
+	if err != nil && err != io.EOF {
 		return nil, fmt.Errorf("yaml parse error: %w", err)
 	}
 
 	doc := documentBody(&root)
-	if doc != nil && doc.Kind == yaml.SequenceNode {
+	if err == io.EOF || isEmptyDocument(doc) {
+		// Empty or comment-only file: there is nothing to canonicalize.
+		// Return the input untouched so `docket fmt` is a no-op and
+		// `fmt --check` passes rather than failing the round-trip guard.
+		return data, nil
+	}
+
+	if doc.Kind == yaml.SequenceNode {
 		canonicalizeRecipe(doc)
 	}
 
@@ -416,6 +426,16 @@ func equivalentNodes(a, b *yaml.Node) bool {
 		return true
 	}
 	return true
+}
+
+// isEmptyDocument reports whether a decoded document body carries nothing to
+// format: either no body node at all (a truly empty stream) or a null scalar,
+// which is what a comment-only file with an explicit `---` marker decodes to.
+func isEmptyDocument(body *yaml.Node) bool {
+	if body == nil {
+		return true
+	}
+	return body.Kind == yaml.ScalarNode && body.Tag == "!!null"
 }
 
 // hasDocumentMarker reports whether the byte slice begins with a YAML

--- a/tasks/format.go
+++ b/tasks/format.go
@@ -256,9 +256,17 @@ func insertBlankLinesBetweenSequenceEntries(lines []string) []string {
 
 	for _, line := range lines {
 		switch {
+		case isCommentLine(line):
+			// A comment line is emitted verbatim without touching the
+			// trackers: it is the head comment of the entry that
+			// follows, so the inter-entry blank line must land above
+			// it (handled by spliceSeparatorBlank), and a top-level
+			// comment must not suppress the next play's separator.
+			out = append(out, line)
+			continue
 		case strings.HasPrefix(line, "- "):
 			if seenTopDash {
-				out = append(out, "")
+				out = spliceSeparatorBlank(out, 0)
 			}
 			seenTopDash = true
 			seenTaskDash = false
@@ -276,7 +284,7 @@ func insertBlankLinesBetweenSequenceEntries(lines []string) []string {
 			continue
 		case strings.HasPrefix(line, "    - ") && inTasksBlock:
 			if seenTaskDash {
-				out = append(out, "")
+				out = spliceSeparatorBlank(out, 4)
 			}
 			seenTaskDash = true
 			out = append(out, line)
@@ -297,6 +305,49 @@ func insertBlankLinesBetweenSequenceEntries(lines []string) []string {
 		out = append(out, line)
 	}
 	return out
+}
+
+// spliceSeparatorBlank inserts a single blank line into out to separate the
+// previous sequence entry from the next one. The blank is placed above the
+// contiguous run of the next entry's head-comment lines already appended to
+// out, so a comment stays attached to the entry it documents.
+//
+// dashIndent is the column of the upcoming entry's "- " dash (0 for a
+// top-level play, 4 for a task). Only comment lines whose "#" sits at
+// exactly that column are treated as head comments; a more deeply indented
+// "#" line is block-scalar content (e.g. a "# ..." line inside script: |),
+// not a YAML comment, and must not be crossed - doing so would splice a
+// blank line into the middle of the block scalar and corrupt it.
+func spliceSeparatorBlank(out []string, dashIndent int) []string {
+	at := len(out)
+	for at > 0 && isCommentAtColumn(out[at-1], dashIndent) {
+		at--
+	}
+	res := make([]string, 0, len(out)+1)
+	res = append(res, out[:at]...)
+	res = append(res, "")
+	res = append(res, out[at:]...)
+	return res
+}
+
+// isCommentLine reports whether line, ignoring leading whitespace, is a YAML
+// comment (or block-scalar content that happens to start with "#").
+func isCommentLine(line string) bool {
+	return strings.HasPrefix(strings.TrimLeft(line, " \t"), "#")
+}
+
+// isCommentAtColumn reports whether line is a comment whose "#" sits at
+// exactly column col (col leading spaces followed immediately by "#").
+func isCommentAtColumn(line string, col int) bool {
+	if len(line) <= col {
+		return false
+	}
+	for i := 0; i < col; i++ {
+		if line[i] != ' ' {
+			return false
+		}
+	}
+	return line[col] == '#'
 }
 
 // equivalentNodes compares two YAML AST trees structurally. Mapping

--- a/tasks/format_json5.go
+++ b/tasks/format_json5.go
@@ -267,6 +267,11 @@ func normaliseJSON5Scalar(raw string) string {
 	return strings.TrimPrefix(raw, "+")
 }
 
+// decodeJSON5String decodes a quoted JSON5 string token (single or double
+// quoted) into its actual character content, resolving every JSON5 escape
+// to the character it denotes. ok is false on a malformed escape (bad hex,
+// lone surrogate, truncated sequence); callers treat that as "leave the
+// original quoting untouched" so a formatting bug can never corrupt a recipe.
 func decodeJSON5String(raw string) (string, bool) {
 	if len(raw) < 2 {
 		return "", false
@@ -294,16 +299,108 @@ func decodeJSON5String(raw string) (string, bool) {
 			b.WriteByte('\t')
 		case 'r':
 			b.WriteByte('\r')
+		case 'b':
+			b.WriteByte('\b')
+		case 'f':
+			b.WriteByte('\f')
+		case 'v':
+			b.WriteByte('\v')
+		case '0':
+			// JSON5 NUL escape. A following decimal digit would form an
+			// (unsupported) octal-looking sequence, so refuse it.
+			if i+1 < len(body) && body[i+1] >= '0' && body[i+1] <= '9' {
+				return "", false
+			}
+			b.WriteByte(0)
+		case 'x':
+			if i+2 >= len(body) {
+				return "", false
+			}
+			hi, ok1 := hexDigitValue(body[i+1])
+			lo, ok2 := hexDigitValue(body[i+2])
+			if !ok1 || !ok2 {
+				return "", false
+			}
+			b.WriteByte(hi<<4 | lo)
+			i += 2
+		case 'u':
+			r, adv, ok := decodeJSON5Unicode(body, i)
+			if !ok {
+				return "", false
+			}
+			b.WriteRune(r)
+			i += adv
 		case '"', '\'', '\\', '/':
 			b.WriteByte(body[i])
 		case '\n':
-			// JSON5 line continuation; keep nothing.
+			// Line continuation; emit nothing.
+		case '\r':
+			// Line continuation, possibly a CRLF pair.
+			if i+1 < len(body) && body[i+1] == '\n' {
+				i++
+			}
 		default:
-			b.WriteByte('\\')
+			// Any other escaped character represents itself in JSON5.
 			b.WriteByte(body[i])
 		}
 	}
 	return b.String(), true
+}
+
+// decodeJSON5Unicode decodes a \uXXXX escape whose 'u' is at body[i]
+// (the leading backslash already consumed). A high surrogate immediately
+// followed by \uYYYY that is a valid low surrogate is combined into the
+// astral code point. adv is the number of bytes consumed after the 'u'.
+// ok is false for a lone/invalid surrogate or truncated sequence.
+func decodeJSON5Unicode(body string, i int) (r rune, adv int, ok bool) {
+	hi, ok := readHex4(body, i+1)
+	if !ok {
+		return 0, 0, false
+	}
+	if hi >= 0xD800 && hi <= 0xDBFF {
+		if i+6 < len(body) && body[i+5] == '\\' && body[i+6] == 'u' {
+			lo, ok := readHex4(body, i+7)
+			if ok && lo >= 0xDC00 && lo <= 0xDFFF {
+				combined := 0x10000 + (rune(hi-0xD800) << 10) + rune(lo-0xDC00)
+				return combined, 10, true
+			}
+		}
+		return 0, 0, false
+	}
+	if hi >= 0xDC00 && hi <= 0xDFFF {
+		return 0, 0, false
+	}
+	return rune(hi), 4, true
+}
+
+// readHex4 reads exactly four hex digits at body[start:] and returns their
+// value. ok is false when fewer than four digits remain or one is invalid.
+func readHex4(body string, start int) (int, bool) {
+	if start+3 >= len(body) {
+		return 0, false
+	}
+	v := 0
+	for k := 0; k < 4; k++ {
+		d, ok := hexDigitValue(body[start+k])
+		if !ok {
+			return 0, false
+		}
+		v = v<<4 | int(d)
+	}
+	return v, true
+}
+
+// hexDigitValue returns the numeric value of a single hex digit byte.
+func hexDigitValue(c byte) (byte, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', true
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, true
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, true
+	}
+	return 0, false
 }
 
 // ---------------------------------------------------------------------
@@ -864,9 +961,13 @@ func formatJSON5Key(key string) string {
 	return quoteJSON5String(key)
 }
 
-// quoteJSON5String wraps s in double quotes, escaping the canonical
-// JSON5 escape characters. Used when emitting object keys; string
-// values keep their original quote form via canonicaliseScalarRaw.
+// quoteJSON5String wraps s (already-decoded character content) in double
+// quotes, re-escaping only what must be escaped: the backslash and quote,
+// the common control characters as their short escapes, and any other
+// sub-U+0020 control as \uXXXX. Printable runes, including non-ASCII such
+// as é, are written verbatim as UTF-8. Used for object keys and for
+// single-quoted string values converted to double quotes by
+// canonicaliseScalarRaw.
 func quoteJSON5String(s string) string {
 	var b strings.Builder
 	b.WriteByte('"')
@@ -882,8 +983,16 @@ func quoteJSON5String(s string) string {
 			b.WriteString(`\t`)
 		case '\r':
 			b.WriteString(`\r`)
+		case '\b':
+			b.WriteString(`\b`)
+		case '\f':
+			b.WriteString(`\f`)
 		default:
-			b.WriteRune(r)
+			if r < 0x20 {
+				fmt.Fprintf(&b, `\u%04x`, r)
+			} else {
+				b.WriteRune(r)
+			}
 		}
 	}
 	b.WriteByte('"')

--- a/tasks/format_json5.go
+++ b/tasks/format_json5.go
@@ -78,6 +78,13 @@ type json5Node struct {
 	// FootComments are trailing comments inside a container after the
 	// last member / element but before the closing brace / bracket.
 	FootComments []string
+
+	// AfterComments are comments that follow the value entirely. Only the
+	// root node uses this (comments after the closing bracket / brace, or
+	// after a scalar root). Kept distinct from FootComments so a container
+	// root's foot comments are emitted once inside the brackets and its
+	// after-value comments once afterwards, rather than both being doubled.
+	AfterComments []string
 }
 
 // json5Kind enumerates AST node variants.
@@ -656,7 +663,10 @@ func parseJSON5(src []byte) (*json5Node, error) {
 	}
 	footComments := p.consumeComments()
 	if root != nil {
-		root.FootComments = append(root.FootComments, footComments...)
+		// These sit after the root value entirely; keep them separate from
+		// a container root's inside-the-bracket foot comments so the emitter
+		// does not print both slices twice.
+		root.AfterComments = footComments
 	}
 	if p.peek().Kind != tokEOF {
 		return nil, fmt.Errorf("unexpected token %q after root value", p.peek().Raw)
@@ -808,8 +818,11 @@ const json5Indent = "  "
 
 func emitJSON5(buf *bytes.Buffer, node *json5Node, depth int) {
 	emitJSON5HeadComments(buf, node.HeadComments, depth)
+	// A container's foot comments are emitted inside its brackets by
+	// emitJSON5Value; only the root's after-value comments are emitted here,
+	// so they are never printed twice.
 	emitJSON5Value(buf, node, depth)
-	emitJSON5FootComments(buf, node.FootComments, depth)
+	emitJSON5FootComments(buf, node.AfterComments, depth)
 	if buf.Len() == 0 || buf.Bytes()[buf.Len()-1] != '\n' {
 		buf.WriteByte('\n')
 	}

--- a/tasks/format_json5_test.go
+++ b/tasks/format_json5_test.go
@@ -266,3 +266,56 @@ func TestFormatJSON5DecodesUnicodeKey(t *testing.T) {
 		t.Errorf("output still carries the raw unicode escape in the key:\n%s", out)
 	}
 }
+
+func TestFormatJSON5RootAfterCommentNotDoubled(t *testing.T) {
+	in := []byte("[\n  { name: \"a\" },\n]\n// trailing note\n")
+	out, err := FormatJSON5(in)
+	if err != nil {
+		t.Fatalf("FormatJSON5: %v", err)
+	}
+	body := string(out)
+	if got := strings.Count(body, "// trailing note"); got != 1 {
+		t.Errorf("after-root comment appears %d times, want 1:\n%s", got, body)
+	}
+	// It must sit after the closing bracket, not inside the array.
+	if strings.Index(body, "// trailing note") < strings.LastIndex(body, "]") {
+		t.Errorf("after-root comment placed inside the array:\n%s", body)
+	}
+	// Idempotent across passes (the doubling bug quadrupled it each run).
+	again, err := FormatJSON5(out)
+	if err != nil {
+		t.Fatalf("FormatJSON5 second pass: %v", err)
+	}
+	if string(again) != body {
+		t.Errorf("not idempotent:\nfirst:\n%s\nsecond:\n%s", body, again)
+	}
+}
+
+func TestFormatJSON5RootInsideAndAfterComments(t *testing.T) {
+	in := []byte("[\n  { name: \"a\" },\n  // inside foot\n]\n// after root\n")
+	out, err := FormatJSON5(in)
+	if err != nil {
+		t.Fatalf("FormatJSON5: %v", err)
+	}
+	body := string(out)
+	if c := strings.Count(body, "// inside foot"); c != 1 {
+		t.Errorf("inside foot comment appears %d times, want 1:\n%s", c, body)
+	}
+	if c := strings.Count(body, "// after root"); c != 1 {
+		t.Errorf("after-root comment appears %d times, want 1:\n%s", c, body)
+	}
+	// inside foot before the closing bracket, after-root after it.
+	idxInside := strings.Index(body, "// inside foot")
+	idxBracket := strings.LastIndex(body, "]")
+	idxAfter := strings.Index(body, "// after root")
+	if !(idxInside < idxBracket && idxBracket < idxAfter) {
+		t.Errorf("comment positions wrong (inside=%d bracket=%d after=%d):\n%s", idxInside, idxBracket, idxAfter, body)
+	}
+	again, err := FormatJSON5(out)
+	if err != nil {
+		t.Fatalf("FormatJSON5 second pass: %v", err)
+	}
+	if string(again) != body {
+		t.Errorf("not idempotent:\nfirst:\n%s\nsecond:\n%s", body, again)
+	}
+}

--- a/tasks/format_json5_test.go
+++ b/tasks/format_json5_test.go
@@ -166,3 +166,103 @@ func TestFormatJSON5SigilTemplatesSurvive(t *testing.T) {
 		t.Errorf("sigil template lost:\n%s", out)
 	}
 }
+
+// bs is a single backslash. Test inputs that must contain a \uXXXX escape
+// are built by concatenating bs with the following characters so the source
+// of this file never contains a valid \uXXXX sequence (which a text pipeline
+// could fold into the decoded character, silently defeating the test). The
+// expected values use the actual decoded characters (e.g. é, 😀).
+const bs = "\\"
+
+func TestDecodeJSON5StringUnicodeAndControlEscapes(t *testing.T) {
+	cases := []struct {
+		name   string
+		raw    string
+		want   string
+		wantOK bool
+	}{
+		{"unicode bmp single quoted", "'caf" + bs + "u00e9'", "café", true},
+		{"unicode bmp double quoted", "\"caf" + bs + "u00e9\"", "café", true},
+		{"hex escape", `"\x41"`, "A", true},
+		{"backspace formfeed vtab", `'\b\f\v'`, "\b\f\v", true},
+		{"nul escape", `'\0'`, "\x00", true},
+		{"surrogate pair", "'" + bs + "ud83d" + bs + "ude00'", "😀", true},
+		{"simple escapes", `"\t\n\r"`, "\t\n\r", true},
+		{"line continuation lf", "'a\\\nb'", "ab", true},
+		{"unknown escape is literal", `'\q'`, "q", true},
+		{"bad hex", `'\xzz'`, "", false},
+		{"lone high surrogate", "'" + bs + "ud83d'", "", false},
+		{"truncated unicode", "'" + bs + "u00'", "", false},
+		{"nul followed by digit", `'\05'`, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := decodeJSON5String(tc.raw)
+			if ok != tc.wantOK {
+				t.Fatalf("decodeJSON5String(%q) ok=%v, want %v", tc.raw, ok, tc.wantOK)
+			}
+			if ok && got != tc.want {
+				t.Errorf("decodeJSON5String(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestQuoteJSON5StringReEncodesControls(t *testing.T) {
+	// A decoded string with control characters must round-trip: quoting it
+	// and decoding again yields the original content.
+	in := "café\t\n\b\f\v\x00\x1f\"back\\slash"
+	quoted := quoteJSON5String(in)
+	got, ok := decodeJSON5String(quoted)
+	if !ok {
+		t.Fatalf("decodeJSON5String(%q) failed", quoted)
+	}
+	if got != in {
+		t.Errorf("round-trip mismatch: quoted=%q decoded=%q want=%q", quoted, got, in)
+	}
+	// A printable non-ASCII rune stays verbatim, not escaped.
+	if !strings.Contains(quoted, "café") {
+		t.Errorf("expected verbatim UTF-8 in %q", quoted)
+	}
+}
+
+func TestFormatJSON5ReQuotesUnicodeValueWithoutCorruption(t *testing.T) {
+	// Input carries a literal é escape inside a single-quoted string.
+	in := []byte("[{ tasks: [{ dokku_app: { app: 'caf" + bs + "u00e9' } }] }]")
+	out, err := FormatJSON5(in)
+	if err != nil {
+		t.Fatalf("FormatJSON5: %v", err)
+	}
+	if !strings.Contains(string(out), `"café"`) {
+		t.Errorf("expected decoded unicode value in output:\n%s", out)
+	}
+	if strings.Contains(string(out), bs+"u00e9") {
+		t.Errorf("output still carries the raw unicode escape (corruption):\n%s", out)
+	}
+	// The formatted output must still be valid JSON5.
+	if _, err := parseJSON5(out); err != nil {
+		t.Fatalf("formatted output does not re-parse: %v\n%s", err, out)
+	}
+	// Idempotent on the formatted output.
+	again, err := FormatJSON5(out)
+	if err != nil {
+		t.Fatalf("FormatJSON5 second pass: %v", err)
+	}
+	if string(again) != string(out) {
+		t.Errorf("not idempotent:\nfirst:\n%s\nsecond:\n%s", out, again)
+	}
+}
+
+func TestFormatJSON5DecodesUnicodeKey(t *testing.T) {
+	in := []byte("[{ tasks: [{ dokku_config: { 'caf" + bs + "u00e9': \"x\" } }] }]")
+	out, err := FormatJSON5(in)
+	if err != nil {
+		t.Fatalf("FormatJSON5: %v", err)
+	}
+	if !strings.Contains(string(out), "café:") {
+		t.Errorf("expected decoded unicode key in output:\n%s", out)
+	}
+	if strings.Contains(string(out), bs+"u00e9") {
+		t.Errorf("output still carries the raw unicode escape in the key:\n%s", out)
+	}
+}

--- a/tasks/format_test.go
+++ b/tasks/format_test.go
@@ -255,6 +255,79 @@ func TestFormatRejectsBrokenYAML(t *testing.T) {
 	}
 }
 
+func TestFormatKeepsTaskHeadCommentAttached(t *testing.T) {
+	in := `---
+- tasks:
+    - dokku_app:
+        app: a
+    # comment for b
+    - dokku_app:
+        app: b
+`
+	body := string(mustFormat(t, in))
+	// The blank separator must sit above the comment, keeping it attached to
+	// the task it documents.
+	if !strings.Contains(body, "\n\n    # comment for b\n") {
+		t.Errorf("expected a blank line above the head comment:\n%s", body)
+	}
+	if strings.Contains(body, "# comment for b\n\n") {
+		t.Errorf("blank line was inserted between the comment and its task:\n%s", body)
+	}
+	// Idempotent: fmt --check right after fmt must pass.
+	if again := string(mustFormat(t, body)); again != body {
+		t.Errorf("formatter is not idempotent:\nfirst:\n%s\nsecond:\n%s", body, again)
+	}
+}
+
+func TestFormatKeepsPlayHeadCommentAttached(t *testing.T) {
+	in := `---
+- name: play1
+  tasks:
+    - dokku_app:
+        app: a
+# comment for play2
+- name: play2
+  tasks:
+    - dokku_app:
+        app: b
+`
+	body := string(mustFormat(t, in))
+	if !strings.Contains(body, "\n\n# comment for play2\n") {
+		t.Errorf("expected a blank line above the play head comment:\n%s", body)
+	}
+	if strings.Contains(body, "# comment for play2\n\n") {
+		t.Errorf("blank line was inserted between the comment and its play:\n%s", body)
+	}
+	if again := string(mustFormat(t, body)); again != body {
+		t.Errorf("formatter is not idempotent:\nfirst:\n%s\nsecond:\n%s", body, again)
+	}
+}
+
+func TestFormatDoesNotSplitBlockScalarWithHashLine(t *testing.T) {
+	// A block scalar whose last line starts with "#" is content, not a YAML
+	// comment; the inter-task blank must go between the two tasks, never
+	// inside the block scalar.
+	in := `---
+- tasks:
+    - dokku_command:
+        command: |
+          echo hi
+          # not a yaml comment
+    - dokku_app:
+        app: b
+`
+	body := string(mustFormat(t, in))
+	if strings.Contains(body, "echo hi\n\n") {
+		t.Errorf("blank line was spliced into the block scalar:\n%s", body)
+	}
+	if !strings.Contains(body, "# not a yaml comment") {
+		t.Errorf("block scalar content was lost:\n%s", body)
+	}
+	if again := string(mustFormat(t, body)); again != body {
+		t.Errorf("formatter is not idempotent:\nfirst:\n%s\nsecond:\n%s", body, again)
+	}
+}
+
 func mustFormat(t *testing.T, in string) []byte {
 	t.Helper()
 	out, err := Format([]byte(in))

--- a/tasks/format_test.go
+++ b/tasks/format_test.go
@@ -328,6 +328,23 @@ func TestFormatDoesNotSplitBlockScalarWithHashLine(t *testing.T) {
 	}
 }
 
+func TestFormatEmptyOrCommentOnlyIsNoOp(t *testing.T) {
+	cases := []string{
+		"",
+		"# just a note\n",
+		"---\n# only a comment\n",
+	}
+	for _, in := range cases {
+		out, err := Format([]byte(in))
+		if err != nil {
+			t.Fatalf("Format(%q) errored: %v", in, err)
+		}
+		if string(out) != in {
+			t.Errorf("Format(%q) = %q, want the input returned unchanged", in, out)
+		}
+	}
+}
+
 func mustFormat(t *testing.T, in string) []byte {
 	t.Helper()
 	out, err := Format([]byte(in))

--- a/tasks/format_test.go
+++ b/tasks/format_test.go
@@ -328,6 +328,34 @@ func TestFormatDoesNotSplitBlockScalarWithHashLine(t *testing.T) {
 	}
 }
 
+func TestFormatRejectsMultiDocument(t *testing.T) {
+	in := `---
+- tasks:
+    - dokku_app:
+        app: a
+---
+- tasks:
+    - dokku_app:
+        app: b
+`
+	_, err := Format([]byte(in))
+	if err == nil {
+		t.Fatal("expected an error for a multi-document file, got nil")
+	}
+	if !strings.Contains(err.Error(), "multiple YAML documents") {
+		t.Errorf("error should mention multiple documents, got: %v", err)
+	}
+}
+
+func TestFormatAllowsTrailingDocumentMarker(t *testing.T) {
+	// A single recipe followed by a bare `---` (an empty trailing document)
+	// must not be rejected as multi-document.
+	in := "---\n- tasks:\n    - dokku_app:\n        app: a\n---\n"
+	if _, err := Format([]byte(in)); err != nil {
+		t.Errorf("trailing bare --- should not be rejected: %v", err)
+	}
+}
+
 func TestFormatEmptyOrCommentOnlyIsNoOp(t *testing.T) {
 	cases := []string{
 		"",

--- a/tests/bats/fmt.bats
+++ b/tests/bats/fmt.bats
@@ -128,3 +128,48 @@ EOF
   "$(docket_bin)" fmt - <tasks.orig >tasks.expected
   cmp tasks.yml tasks.expected
 }
+
+@test "docket fmt rejects a multi-document file" {
+  cd "$BATS_TEST_TMPDIR"
+  cat >tasks.yml <<'EOF'
+---
+- tasks:
+    - dokku_app:
+        app: a
+---
+- tasks:
+    - dokku_app:
+        app: b
+EOF
+  run "$(docket_bin)" fmt
+  assert_failure
+  assert_output --partial "multiple YAML documents"
+}
+
+@test "docket fmt on an empty file is a no-op" {
+  cd "$BATS_TEST_TMPDIR"
+  : >tasks.yml
+  run "$(docket_bin)" fmt
+  assert_success
+  run "$(docket_bin)" fmt --check
+  assert_success
+  assert [ ! -s tasks.yml ]
+}
+
+@test "docket fmt is idempotent with per-task head comments" {
+  cd "$BATS_TEST_TMPDIR"
+  cat >tasks.yml <<'EOF'
+---
+- tasks:
+    - dokku_app:
+        app: a
+    # configure the second app
+    - dokku_app:
+        app: b
+EOF
+  "$(docket_bin)" fmt
+  run "$(docket_bin)" fmt --check
+  assert_success
+  run grep -c "configure the second app" tasks.yml
+  assert_output "1"
+}


### PR DESCRIPTION
docket fmt promises idempotent formatting that can never corrupt a recipe, but several bugs in the YAML and JSON5 formatters violated that contract. Two silently corrupted recipes while reporting success: single-quoted JSON5 strings containing unicode, hex, or control escapes were written back with the escape mangled, and multi-document YAML files were truncated to their first document. Three broke the documented `fmt --check` after `fmt` CI gate: head comments were detached from their play or task by the inter-entry blank line, root-level JSON5 foot comments were doubled on every run, and an empty or comment-only file failed with a misleading round-trip error.

Each formatter now honors the contract: JSON5 unicode and control escapes survive a re-quote, head comments stay attached to their play or task, root-level trailing comments are no longer duplicated, empty and comment-only files are left untouched, and a multi-document file is rejected with a clear error instead of being truncated. Because docket recipes are single-document, rejecting extra documents matches how the recipe loader already treats them.

Closes #304, closes #319, closes #316, closes #317, closes #339, closes #362
