### PR TITLE
fix: correct idempotency probe comparisons across tasks

### DIFF
--- a/tasks/buildpacks_task.go
+++ b/tasks/buildpacks_task.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/dokku/docket/subprocess"
@@ -106,36 +107,33 @@ func (t BuildpacksTask) Plan() PlanResult {
 }
 
 func planBuildpacksAdd(t BuildpacksTask) PlanResult {
-	current, err := getBuildpacks(t.App)
+	current, err := getOrderedBuildpacks(t.App)
 	if err != nil {
 		return PlanResult{Status: PlanStatusError, Error: err}
 	}
-	toAdd := []string{}
-	mutations := []string{}
-	for _, bp := range t.Buildpacks {
-		if !current[bp] {
-			toAdd = append(toAdd, bp)
-			mutations = append(mutations, "add "+bp)
-		}
-	}
-	if len(toAdd) == 0 {
+	// Buildpack order determines build precedence, so the current and desired
+	// lists must match as ordered slices: a reorder or a partial set is real
+	// drift, not in sync (issue #356). Validate() already guarantees the desired
+	// list is non-empty for state present.
+	if slices.Equal(current, t.Buildpacks) {
 		return PlanResult{InSync: true, Status: PlanStatusOK}
 	}
 	status := PlanStatusModify
 	if len(current) == 0 {
 		status = PlanStatusCreate
 	}
-	inputs := make([]subprocess.ExecCommandInput, 0, len(toAdd))
-	for _, bp := range toAdd {
-		inputs = append(inputs, subprocess.ExecCommandInput{
-			Command: "dokku",
-			Args:    []string{"--quiet", "buildpacks:add", t.App, bp},
-		})
+	// dokku has no atomic ordered-set for the list; buildpacks:set --replace
+	// replaces the whole list in one call, applied in the given precedence order.
+	args := append([]string{"--quiet", "buildpacks:set", "--replace", t.App}, t.Buildpacks...)
+	inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
+	mutations := make([]string, 0, len(t.Buildpacks))
+	for i, bp := range t.Buildpacks {
+		mutations = append(mutations, fmt.Sprintf("set %s (position %d)", bp, i))
 	}
 	return PlanResult{
 		InSync:    false,
 		Status:    status,
-		Reason:    fmt.Sprintf("%d buildpack(s) to add", len(toAdd)),
+		Reason:    fmt.Sprintf("set %d buildpack(s) in order", len(t.Buildpacks)),
 		Mutations: mutations,
 		Commands:  resolveCommands(inputs),
 		apply: func() TaskOutputState {
@@ -203,14 +201,9 @@ func planBuildpacksRemove(t BuildpacksTask) PlanResult {
 }
 
 // ExportApp reads the app's buildpacks and returns a dokku_buildpacks task, or
-// nil when none are set. It reads the `list` key from buildpacks:report, which
-// preserves build-precedence order (getBuildpacks returns an unordered set, so
-// it cannot be used here).
+// nil when none are set.
 func (t BuildpacksTask) ExportApp(app string) ([]interface{}, error) {
-	response, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    []string{"--quiet", "buildpacks:report", app, "--format", "json"},
-	})
+	list, err := getOrderedBuildpacks(app)
 	if err != nil {
 		var sshErr *subprocess.SSHError
 		if errors.As(err, &sshErr) {
@@ -218,12 +211,29 @@ func (t BuildpacksTask) ExportApp(app string) ([]interface{}, error) {
 		}
 		return nil, nil
 	}
+	if len(list) == 0 {
+		return nil, nil
+	}
+	return []interface{}{BuildpacksTask{App: app, Buildpacks: list, State: StatePresent}}, nil
+}
+
+// getOrderedBuildpacks fetches the app's buildpacks in build-precedence order
+// from the `list` key of buildpacks:report. Unlike getBuildpacks (an unordered
+// set) this preserves order, which the plan probe and export both require.
+func getOrderedBuildpacks(app string) ([]string, error) {
+	response, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "buildpacks:report", app, "--format", "json"},
+	})
+	if err != nil {
+		return nil, err
+	}
 
 	var report struct {
 		List string `json:"list"`
 	}
 	if err := json.Unmarshal(response.StdoutBytes(), &report); err != nil {
-		return nil, nil
+		return nil, err
 	}
 	// The list key is a comma-separated string in build-precedence order.
 	var list []string
@@ -232,10 +242,7 @@ func (t BuildpacksTask) ExportApp(app string) ([]interface{}, error) {
 			list = append(list, bp)
 		}
 	}
-	if len(list) == 0 {
-		return nil, nil
-	}
-	return []interface{}{BuildpacksTask{App: app, Buildpacks: list, State: StatePresent}}, nil
+	return list, nil
 }
 
 // getBuildpacks fetches the current buildpacks list for an app

--- a/tasks/buildpacks_task_integration_test.go
+++ b/tasks/buildpacks_task_integration_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"slices"
 	"testing"
 )
 
@@ -123,4 +124,69 @@ func TestIntegrationBuildpacks(t *testing.T) {
 		t.Errorf("expected Changed=false on idempotent clear")
 	}
 	assertListed(t, "after idempotent clear", map[string]bool{})
+}
+
+// TestIntegrationBuildpacksOrder verifies that a multi-buildpack list is applied
+// and reported in build-precedence order, that a matching ordered list is a
+// no-op, and that reordering is detected and converges (issue #356).
+func TestIntegrationBuildpacksOrder(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-buildpacks-order"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	nodejs := "https://github.com/heroku/heroku-buildpack-nodejs.git"
+	nginx := "https://github.com/heroku/heroku-buildpack-nginx.git"
+
+	assertOrder := func(label string, want []string) {
+		t.Helper()
+		got, err := getOrderedBuildpacks(appName)
+		if err != nil {
+			t.Fatalf("%s: getOrderedBuildpacks failed: %v", label, err)
+		}
+		if !slices.Equal(got, want) {
+			t.Errorf("%s: buildpacks = %v, want %v", label, got, want)
+		}
+	}
+
+	setTask := BuildpacksTask{App: appName, Buildpacks: []string{nodejs, nginx}, State: StatePresent}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set ordered buildpacks: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected Changed=true on first ordered set")
+	}
+	assertOrder("after set", []string{nodejs, nginx})
+
+	result = setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent set failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected Changed=false when the ordered list already matches")
+	}
+	assertOrder("after idempotent set", []string{nodejs, nginx})
+
+	reorderTask := BuildpacksTask{App: appName, Buildpacks: []string{nginx, nodejs}, State: StatePresent}
+	result = reorderTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to reorder buildpacks: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected Changed=true when buildpack order changes")
+	}
+	assertOrder("after reorder", []string{nginx, nodejs})
+
+	result = reorderTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent reorder failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected Changed=false after the reorder converged")
+	}
+	assertOrder("after idempotent reorder", []string{nginx, nodejs})
 }

--- a/tasks/buildpacks_task_test.go
+++ b/tasks/buildpacks_task_test.go
@@ -3,7 +3,34 @@ package tasks
 import (
 	"strings"
 	"testing"
+
+	"github.com/dokku/docket/subprocess"
 )
+
+// assertBuildpacksReplaceInOrder asserts the plan issues a single
+// buildpacks:set --replace command listing the desired buildpacks in order.
+func assertBuildpacksReplaceInOrder(t *testing.T, plan PlanResult, want []string) {
+	t.Helper()
+	if len(plan.Commands) != 1 {
+		t.Fatalf("expected exactly one replace command, got %v", plan.Commands)
+	}
+	cmd := plan.Commands[0]
+	if !strings.Contains(cmd, "buildpacks:set") || !strings.Contains(cmd, "--replace") {
+		t.Errorf("expected a buildpacks:set --replace command, got %q", cmd)
+	}
+	last := -1
+	for _, bp := range want {
+		idx := strings.Index(cmd, bp)
+		if idx < 0 {
+			t.Errorf("buildpack %q missing from command %q", bp, cmd)
+			continue
+		}
+		if idx < last {
+			t.Errorf("buildpack %q is out of order in command %q", bp, cmd)
+		}
+		last = idx
+	}
+}
 
 func TestBuildpacksTaskInvalidState(t *testing.T) {
 	task := BuildpacksTask{App: "test-app", Buildpacks: []string{"https://example.com/bp.git"}, State: "invalid"}
@@ -43,6 +70,71 @@ func TestBuildpacksTaskPresentEmptyBuildpacks(t *testing.T) {
 	}
 	if !strings.Contains(result.Error.Error(), "must not be empty") {
 		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestBuildpacksSameOrderInSync(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet buildpacks:report test-app --format json": `{"list":"nodejs,nginx"}`,
+	}))()
+
+	plan := BuildpacksTask{App: "test-app", Buildpacks: []string{"nodejs", "nginx"}, State: StatePresent}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if !plan.InSync {
+		t.Fatalf("expected in-sync when the ordered lists match, got %#v", plan)
+	}
+}
+
+func TestBuildpacksReorderReportsDrift(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet buildpacks:report test-app --format json": `{"list":"nginx,nodejs"}`,
+	}))()
+
+	plan := BuildpacksTask{App: "test-app", Buildpacks: []string{"nodejs", "nginx"}, State: StatePresent}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Fatal("expected drift when the buildpack order differs (order sets build precedence)")
+	}
+	if plan.Status != PlanStatusModify {
+		t.Errorf("expected Modify status when buildpacks already exist, got %q", plan.Status)
+	}
+	assertBuildpacksReplaceInOrder(t, plan, []string{"nodejs", "nginx"})
+}
+
+func TestBuildpacksPartialSetUsesReplaceInOrder(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet buildpacks:report test-app --format json": `{"list":"nginx"}`,
+	}))()
+
+	plan := BuildpacksTask{App: "test-app", Buildpacks: []string{"nodejs", "nginx"}, State: StatePresent}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Fatal("expected drift when the current list is incomplete")
+	}
+	// A plain append would have yielded [nginx, nodejs]; --replace restores order.
+	assertBuildpacksReplaceInOrder(t, plan, []string{"nodejs", "nginx"})
+}
+
+func TestBuildpacksCreateWhenEmpty(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet buildpacks:report test-app --format json": `{"list":""}`,
+	}))()
+
+	plan := BuildpacksTask{App: "test-app", Buildpacks: []string{"nodejs"}, State: StatePresent}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Fatal("expected drift when no buildpacks are set")
+	}
+	if plan.Status != PlanStatusCreate {
+		t.Errorf("expected Create status on a fresh app, got %q", plan.Status)
 	}
 }
 

--- a/tasks/domains_task.go
+++ b/tasks/domains_task.go
@@ -133,7 +133,7 @@ func planDomainsPresent(t DomainsTask) PlanResult {
 	appName := t.App
 	if t.Global {
 		subcommand = "domains:add-global"
-		appName = "--global"
+		appName = ""
 	}
 	inputs := dokkuArgsInputs(subcommand, appName, toAdd)
 	return PlanResult{
@@ -167,7 +167,7 @@ func planDomainsAbsent(t DomainsTask) PlanResult {
 	appName := t.App
 	if t.Global {
 		subcommand = "domains:remove-global"
-		appName = "--global"
+		appName = ""
 	}
 	inputs := dokkuArgsInputs(subcommand, appName, toRemove)
 	return PlanResult{
@@ -208,7 +208,7 @@ func planDomainsSet(t DomainsTask) PlanResult {
 	appName := t.App
 	if t.Global {
 		subcommand = "domains:set-global"
-		appName = "--global"
+		appName = ""
 	}
 	inputs := dokkuArgsInputs(subcommand, appName, t.Domains)
 	return PlanResult{
@@ -238,7 +238,7 @@ func planDomainsClear(t DomainsTask) PlanResult {
 	appName := t.App
 	if t.Global {
 		subcommand = "domains:clear-global"
-		appName = "--global"
+		appName = ""
 	}
 	inputs := dokkuArgsInputs(subcommand, appName, nil)
 	return PlanResult{
@@ -252,9 +252,14 @@ func planDomainsClear(t DomainsTask) PlanResult {
 }
 
 // dokkuArgsInputs returns the subprocess inputs that run `dokku --quiet
-// <subcommand> <target> <extra...>`.
+// <subcommand> [<target>] <extra...>`. An empty target is omitted, which is
+// what the domains `*-global` subcommands require: they take no positional app
+// slot, so passing the literal "--global" there would be written as a domain.
 func dokkuArgsInputs(subcommand, target string, extra []string) []subprocess.ExecCommandInput {
-	args := []string{"--quiet", subcommand, target}
+	args := []string{"--quiet", subcommand}
+	if target != "" {
+		args = append(args, target)
+	}
 	args = append(args, extra...)
 	return []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
 }

--- a/tasks/domains_task_test.go
+++ b/tasks/domains_task_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dokku/docket/subprocess"
 	_ "github.com/gliderlabs/sigil/builtin"
 )
 
@@ -51,6 +52,94 @@ func TestDomainsTaskClearNoDomains(t *testing.T) {
 	// Should fail because dokku isn't running, but NOT because of missing domains
 	if result.Error != nil && strings.Contains(result.Error.Error(), "must not be empty") {
 		t.Error("clear state should not require domains")
+	}
+}
+
+// assertNoGlobalPositional fails when any planned command carries the literal
+// "--global" token, which the *-global domains subcommands would write as a
+// real domain (issue #309).
+func assertNoGlobalPositional(t *testing.T, commands []string) {
+	t.Helper()
+	if len(commands) == 0 {
+		t.Fatal("expected at least one planned command")
+	}
+	for _, cmd := range commands {
+		for _, field := range strings.Fields(cmd) {
+			if field == "--global" {
+				t.Errorf("planned command must not pass --global as a positional: %q", cmd)
+			}
+		}
+	}
+}
+
+func TestDomainsGlobalSetOmitsGlobalPositional(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"domains:report --global --domains-global-vhosts": "",
+	}))()
+
+	plan := DomainsTask{Global: true, Domains: []string{"global.example.com"}, State: StateSet}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Fatal("expected drift when the global vhost is unset")
+	}
+	assertNoGlobalPositional(t, plan.Commands)
+	if !strings.Contains(plan.Commands[0], "domains:set-global") {
+		t.Errorf("expected domains:set-global command, got %q", plan.Commands[0])
+	}
+	if !strings.Contains(plan.Commands[0], "global.example.com") {
+		t.Errorf("expected the desired domain in the command, got %q", plan.Commands[0])
+	}
+}
+
+func TestDomainsGlobalSetConvergesWhenReportMatches(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"domains:report --global --domains-global-vhosts": "global.example.com",
+	}))()
+
+	plan := DomainsTask{Global: true, Domains: []string{"global.example.com"}, State: StateSet}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if !plan.InSync {
+		t.Fatalf("expected in-sync once the global vhost matches, got %#v", plan)
+	}
+}
+
+func TestDomainsGlobalAddOmitsGlobalPositional(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"domains:report --global --domains-global-vhosts": "",
+	}))()
+
+	plan := DomainsTask{Global: true, Domains: []string{"global.example.com"}, State: StatePresent}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Fatal("expected drift when the global vhost is unset")
+	}
+	assertNoGlobalPositional(t, plan.Commands)
+	if !strings.Contains(plan.Commands[0], "domains:add-global") {
+		t.Errorf("expected domains:add-global command, got %q", plan.Commands[0])
+	}
+}
+
+func TestDomainsGlobalClearOmitsGlobalPositional(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"domains:report --global --domains-global-vhosts": "old.example.com",
+	}))()
+
+	plan := DomainsTask{Global: true, State: StateClear}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Fatal("expected drift when a global vhost is present")
+	}
+	assertNoGlobalPositional(t, plan.Commands)
+	if !strings.Contains(plan.Commands[0], "domains:clear-global") {
+		t.Errorf("expected domains:clear-global command, got %q", plan.Commands[0])
 	}
 }
 

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -87,7 +88,7 @@ func (t GitSyncTask) Execute() TaskOutputState {
 func (t GitSyncTask) Plan() PlanResult {
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
-			match, err := checkAppSyncState(t.App, t.Remote, t.GitRef)
+			match, err := checkAppSyncState(t.App, t.Remote, t.GitRef, t.SkipDeployBranch)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -127,11 +128,16 @@ func (t GitSyncTask) Plan() PlanResult {
 	})
 }
 
-// checkAppSyncState checks if the app is already synced from the
-// expected remote and ref. A transport-level failure
-// (`*subprocess.SSHError`) is propagated; any other error is treated
-// as "no match" so the planner proposes a re-sync.
-func checkAppSyncState(app, expectedRemote, expectedRef string) (bool, error) {
+// checkAppSyncState checks if the app is already synced from the expected
+// remote and ref. dokku records the deploy source as "<remote>#<resolved SHA>"
+// (and only after a build), so the stored SHA cannot be compared against a
+// branch or tag name. Instead the remote portion of the metadata is compared,
+// and the ref is compared against the deploy-branch git:sync persists from it
+// (unless the caller opted out with skip_deploy_branch, or pinned no ref, in
+// which case a matching remote is the most that can be verified offline). A
+// transport-level failure (`*subprocess.SSHError`) is propagated; any other
+// error is treated as "no match" so the planner proposes a re-sync.
+func checkAppSyncState(app, expectedRemote, expectedRef string, skipDeployBranch bool) (bool, error) {
 	source, err := getAppDeploySource(app)
 	if err != nil {
 		var sshErr *subprocess.SSHError
@@ -140,14 +146,59 @@ func checkAppSyncState(app, expectedRemote, expectedRef string) (bool, error) {
 		}
 		return false, nil
 	}
+	if source.Source != "git-sync" {
+		return false, nil
+	}
 
-	expectedMetadata := fmt.Sprintf("%s#%s", expectedRemote, expectedRef)
-	return source.Source == "git-sync" && source.SourceMetadata == expectedMetadata, nil
+	remote := source.SourceMetadata
+	if i := strings.LastIndex(source.SourceMetadata, "#"); i >= 0 {
+		remote = source.SourceMetadata[:i]
+	}
+	if remote != expectedRemote {
+		return false, nil
+	}
+
+	if expectedRef == "" || skipDeployBranch {
+		return true, nil
+	}
+
+	deployBranch, err := getGitDeployBranch(app)
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return false, err
+		}
+		return false, nil
+	}
+	return deployBranch == expectedRef, nil
 }
 
-// ExportApp reconstructs a git-sync deploy source from apps:report. The
-// metadata is "<remote>#<ref>"; it only emits when the app was last deployed
-// via git:sync.
+// getGitDeployBranch returns the deploy-branch dokku has stored for the app,
+// read from `git:report --format json` (JSON key `deploy-branch`). git:sync
+// sets it from the synced ref by default, so it is the offline signal for which
+// ref the app currently tracks.
+func getGitDeployBranch(app string) (string, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"git:report", app, "--format", "json"},
+	})
+	if err != nil {
+		return "", err
+	}
+	var report struct {
+		DeployBranch string `json:"deploy-branch"`
+	}
+	if err := json.Unmarshal(result.StdoutBytes(), &report); err != nil {
+		return "", err
+	}
+	return report.DeployBranch, nil
+}
+
+// ExportApp reconstructs a git-sync deploy source from apps:report. The metadata
+// records "<remote>#<resolved SHA>", so the remote is taken from the portion
+// before the last "#" and the ref from the deploy-branch git:sync persisted -
+// not the SHA, which the probe cannot match against a branch or tag. It only
+// emits when the app was last deployed via git:sync.
 func (t GitSyncTask) ExportApp(app string) ([]interface{}, error) {
 	source, err := getAppDeploySource(app)
 	if err != nil {
@@ -156,9 +207,13 @@ func (t GitSyncTask) ExportApp(app string) ([]interface{}, error) {
 	if source.Source != "git-sync" {
 		return nil, nil
 	}
-	remote, ref := source.SourceMetadata, ""
+	remote := source.SourceMetadata
 	if i := strings.LastIndex(source.SourceMetadata, "#"); i >= 0 {
-		remote, ref = source.SourceMetadata[:i], source.SourceMetadata[i+1:]
+		remote = source.SourceMetadata[:i]
+	}
+	ref, err := getGitDeployBranch(app)
+	if err != nil {
+		return nil, err
 	}
 	return []interface{}{GitSyncTask{App: app, Remote: remote, GitRef: ref}}, nil
 }

--- a/tasks/git_sync_task_integration_test.go
+++ b/tasks/git_sync_task_integration_test.go
@@ -13,9 +13,12 @@ func TestIntegrationGitSync(t *testing.T) {
 	createApp(appName)
 	defer destroyApp(appName)
 
+	// Build so dokku records the git-sync deploy source (its metadata is only
+	// written when a build is triggered), which is what the probe reads back.
 	task := GitSyncTask{
 		App:    appName,
-		Remote: "https://github.com/dokku/smoke-test-app",
+		Remote: "https://github.com/dokku/smoke-test-app.git",
+		Build:  true,
 		State:  StatePresent,
 	}
 	result := task.Execute()
@@ -27,5 +30,15 @@ func TestIntegrationGitSync(t *testing.T) {
 	}
 	if !result.Changed {
 		t.Error("expected changed=true for git sync")
+	}
+
+	// A second apply with no pinned ref must converge on the matching remote
+	// rather than re-syncing every time (issue #310).
+	result = task.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent git sync failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false when the app is already synced from the same remote")
 	}
 }

--- a/tasks/git_sync_task_test.go
+++ b/tasks/git_sync_task_test.go
@@ -2,6 +2,8 @@ package tasks
 
 import (
 	"testing"
+
+	"github.com/dokku/docket/subprocess"
 )
 
 func TestGitSyncTaskInvalidState(t *testing.T) {
@@ -13,5 +15,114 @@ func TestGitSyncTaskInvalidState(t *testing.T) {
 	result := task.Execute()
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+func TestGitSyncInSyncOnRemoteAndDeployBranch(t *testing.T) {
+	// The stored metadata SHA differs from the pinned ref, but the remote and
+	// the persisted deploy-branch match, so the app is in sync.
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"apps:report test-app --format json": `{"app-deploy-source":"git-sync","app-deploy-source-metadata":"https://github.com/org/repo.git#abc123def456"}`,
+		"git:report test-app --format json":  `{"deploy-branch":"main"}`,
+	}))()
+
+	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "main", Build: true, State: StatePresent}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if !plan.InSync {
+		t.Fatalf("expected in-sync when remote and deploy-branch match, got %#v", plan)
+	}
+}
+
+func TestGitSyncDriftOnRefChange(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"apps:report test-app --format json": `{"app-deploy-source":"git-sync","app-deploy-source-metadata":"https://github.com/org/repo.git#abc123"}`,
+		"git:report test-app --format json":  `{"deploy-branch":"main"}`,
+	}))()
+
+	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "develop", Build: true, State: StatePresent}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Fatal("expected drift when the pinned ref differs from the stored deploy-branch")
+	}
+}
+
+func TestGitSyncDriftOnRemoteChange(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"apps:report test-app --format json": `{"app-deploy-source":"git-sync","app-deploy-source-metadata":"https://github.com/org/other.git#abc123"}`,
+	}))()
+
+	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "main", State: StatePresent}.Plan()
+	if plan.InSync {
+		t.Fatal("expected drift when the remote differs")
+	}
+}
+
+func TestGitSyncInSyncWithoutRef(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"apps:report test-app --format json": `{"app-deploy-source":"git-sync","app-deploy-source-metadata":"https://github.com/org/repo.git#abc123"}`,
+	}))()
+
+	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", State: StatePresent}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if !plan.InSync {
+		t.Fatalf("expected in-sync on a remote match when no ref is pinned, got %#v", plan)
+	}
+}
+
+func TestGitSyncSkipDeployBranchMatchesOnRemote(t *testing.T) {
+	// With skip_deploy_branch the ref is not persisted, so a matching remote is
+	// treated as in sync rather than re-syncing forever.
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"apps:report test-app --format json": `{"app-deploy-source":"git-sync","app-deploy-source-metadata":"https://github.com/org/repo.git#abc123"}`,
+	}))()
+
+	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "main", SkipDeployBranch: true, State: StatePresent}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if !plan.InSync {
+		t.Fatalf("expected in-sync via remote-only match when skip_deploy_branch is set, got %#v", plan)
+	}
+}
+
+func TestGitSyncDriftWhenNotGitSyncSource(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"apps:report test-app --format json": `{"app-deploy-source":"","app-deploy-source-metadata":""}`,
+	}))()
+
+	plan := GitSyncTask{App: "test-app", Remote: "https://github.com/org/repo.git", GitRef: "main", State: StatePresent}.Plan()
+	if plan.InSync {
+		t.Fatal("expected drift when the app has no git-sync deploy source")
+	}
+}
+
+func TestGitSyncExportUsesDeployBranchAsRef(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"apps:report test-app --format json": `{"app-deploy-source":"git-sync","app-deploy-source-metadata":"https://github.com/org/repo.git#abc123def"}`,
+		"git:report test-app --format json":  `{"deploy-branch":"main"}`,
+	}))()
+
+	bodies, err := GitSyncTask{}.ExportApp("test-app")
+	if err != nil {
+		t.Fatalf("ExportApp error: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 exported task, got %d", len(bodies))
+	}
+	got, ok := bodies[0].(GitSyncTask)
+	if !ok {
+		t.Fatalf("unexpected exported type %T", bodies[0])
+	}
+	if got.Remote != "https://github.com/org/repo.git" {
+		t.Errorf("Remote = %q, want the metadata remote", got.Remote)
+	}
+	if got.GitRef != "main" {
+		t.Errorf("GitRef = %q, want the deploy-branch 'main' rather than the SHA", got.GitRef)
 	}
 }

--- a/tasks/resource_limit_task_test.go
+++ b/tasks/resource_limit_task_test.go
@@ -1,8 +1,10 @@
 package tasks
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/dokku/docket/subprocess"
 	_ "github.com/gliderlabs/sigil/builtin"
 )
 
@@ -31,6 +33,83 @@ func TestResourceLimitTaskNilResources(t *testing.T) {
 	result := task.Execute()
 	if result.Error == nil {
 		t.Fatal("Execute with nil resources and state=present should return an error")
+	}
+}
+
+func TestResourceLimitClearBeforeConvergesWhenMatched(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet resource:limit test-app": "cpu: 100",
+	}))()
+
+	plan := ResourceLimitTask{
+		App:         "test-app",
+		Resources:   map[string]string{"cpu": "100"},
+		ClearBefore: true,
+		State:       StatePresent,
+	}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if !plan.InSync {
+		t.Fatalf("clear_before should be a no-op when the server already matches, got %#v", plan)
+	}
+}
+
+func TestResourceLimitClearBeforeIgnoresEmptyExtraResource(t *testing.T) {
+	// memory reads as "0" (unset), so clearing before setting cpu changes nothing.
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet resource:limit test-app": "cpu: 100\nmemory: 0",
+	}))()
+
+	plan := ResourceLimitTask{
+		App:         "test-app",
+		Resources:   map[string]string{"cpu": "100"},
+		ClearBefore: true,
+		State:       StatePresent,
+	}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if !plan.InSync {
+		t.Fatalf("clear_before should stay a no-op when non-desired keys are empty, got %#v", plan)
+	}
+}
+
+func TestResourceLimitClearBeforeClearsNonDesiredResource(t *testing.T) {
+	// memory holds a real value outside the desired map, so the clear must run.
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet resource:limit test-app": "cpu: 100\nmemory: 256",
+	}))()
+
+	plan := ResourceLimitTask{
+		App:         "test-app",
+		Resources:   map[string]string{"cpu": "100"},
+		ClearBefore: true,
+		State:       StatePresent,
+	}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Fatal("expected drift: a non-desired resource must be cleared")
+	}
+	foundClear := false
+	for _, cmd := range plan.Commands {
+		if strings.Contains(cmd, "resource:limit-clear") {
+			foundClear = true
+		}
+	}
+	if !foundClear {
+		t.Errorf("expected a resource:limit-clear command, got %v", plan.Commands)
+	}
+	foundClearMutation := false
+	for _, m := range plan.Mutations {
+		if m == "clear before set" {
+			foundClearMutation = true
+		}
+	}
+	if !foundClearMutation {
+		t.Errorf("expected a 'clear before set' mutation, got %v", plan.Mutations)
 	}
 }
 

--- a/tasks/resources.go
+++ b/tasks/resources.go
@@ -168,8 +168,16 @@ func planSetResource(subcommand string, rctx ResourceContext) PlanResult {
 		}
 	}
 
+	// A clear-before-set only changes anything when the server still holds a
+	// resource outside the desired map that is not already empty; otherwise the
+	// clear is a no-op and must not force perpetual drift (issue #333). Fold the
+	// decision into an effective context so the plan Commands and the apply drop
+	// the redundant clear identically.
+	effective := rctx
+	effective.ClearBefore = rctx.ClearBefore && clearBeforeChanges(currentResources, rctx.Resources)
+
 	mutations := []string{}
-	if rctx.ClearBefore {
+	if effective.ClearBefore {
 		mutations = append(mutations, "clear before set")
 	}
 	for k, v := range rctx.Resources {
@@ -181,15 +189,36 @@ func planSetResource(subcommand string, rctx ResourceContext) PlanResult {
 	if len(mutations) == 0 {
 		return PlanResult{InSync: true, Status: PlanStatusOK}
 	}
-	inputs := resourceSetInputs(subcommand, rctx)
+	inputs := resourceSetInputs(subcommand, effective)
 	return PlanResult{
 		InSync:    false,
 		Status:    PlanStatusModify,
 		Reason:    fmt.Sprintf("%d resource(s) to set", len(mutations)),
 		Mutations: mutations,
 		Commands:  resolveCommands(inputs),
-		apply:     applyResourceSet(subcommand, rctx),
+		apply:     applyResourceSet(subcommand, effective),
 	}
+}
+
+// resourceValueIsSet reports whether a resource report value represents an
+// actually-set limit/reservation. dokku reports an unset resource as "" or "0".
+func resourceValueIsSet(v string) bool {
+	return v != "" && v != "0"
+}
+
+// clearBeforeChanges reports whether a clear-before-set would actually remove
+// anything. The clear wipes every current resource that is not in the desired
+// map, so it is a no-op unless one of those keys still holds a set value.
+func clearBeforeChanges(current, desired map[string]string) bool {
+	for k, v := range current {
+		if _, ok := desired[k]; ok {
+			continue
+		}
+		if resourceValueIsSet(v) {
+			return true
+		}
+	}
+	return false
 }
 
 // planClearResource reports drift for an absent-state resource clear.
@@ -201,7 +230,7 @@ func planClearResource(subcommand string, rctx ResourceContext) PlanResult {
 
 	hasResources := false
 	for _, v := range currentResources {
-		if v != "" && v != "0" {
+		if resourceValueIsSet(v) {
 			hasResources = true
 			break
 		}

--- a/tasks/scheduler_k3s_annotations_task_test.go
+++ b/tasks/scheduler_k3s_annotations_task_test.go
@@ -110,3 +110,31 @@ func TestSchedulerK3sAnnotationsTaskEmptyAnnotationKey(t *testing.T) {
 		t.Errorf("unexpected error: %v", result.Error)
 	}
 }
+
+func TestSchedulerK3sAnnotationsTaskPresentEmptyValueRejected(t *testing.T) {
+	task := SchedulerK3sAnnotationsTask{
+		App:          "test-app",
+		ResourceType: "deployment",
+		Annotations:  map[string]string{"prometheus.io/scrape": ""},
+		State:        StatePresent,
+	}
+	err := task.Validate()
+	if err == nil {
+		t.Fatal("expected error when a present-state annotation value is empty")
+	}
+	if !strings.Contains(err.Error(), "annotation values must not be empty for state 'present'") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSchedulerK3sAnnotationsTaskAbsentEmptyValueAllowed(t *testing.T) {
+	task := SchedulerK3sAnnotationsTask{
+		App:          "test-app",
+		ResourceType: "deployment",
+		Annotations:  map[string]string{"prometheus.io/scrape": ""},
+		State:        StateAbsent,
+	}
+	if err := task.Validate(); err != nil {
+		t.Fatalf("absent-state empty value should be allowed (clears the key), got %v", err)
+	}
+}

--- a/tasks/scheduler_k3s_autoscaling_auth.go
+++ b/tasks/scheduler_k3s_autoscaling_auth.go
@@ -24,7 +24,7 @@ type schedulerK3sAutoscalingAuthSpec struct {
 // validateSchedulerK3sAutoscalingAuth checks the common fields prior to any
 // subprocess call. Both present and absent states require Metadata: present
 // sets the listed keys, absent names which keys to clear.
-func validateSchedulerK3sAutoscalingAuth(spec schedulerK3sAutoscalingAuthSpec) error {
+func validateSchedulerK3sAutoscalingAuth(spec schedulerK3sAutoscalingAuthSpec, state State) error {
 	if err := validateAppGlobalExclusive(spec.App, spec.Global); err != nil {
 		return err
 	}
@@ -34,9 +34,18 @@ func validateSchedulerK3sAutoscalingAuth(spec schedulerK3sAutoscalingAuthSpec) e
 	if len(spec.Metadata) == 0 {
 		return errors.New("'metadata' must not be empty")
 	}
-	for key := range spec.Metadata {
+	effective := state
+	if effective == "" {
+		effective = StatePresent
+	}
+	for key, value := range spec.Metadata {
 		if key == "" {
 			return errors.New("metadata keys must not be empty")
+		}
+		// dokku clears a metadata key set to an empty value, so a present-state
+		// empty value can never converge (issue #358); clear via state 'absent'.
+		if effective == StatePresent && value == "" {
+			return errors.New("metadata values must not be empty for state 'present'; use state 'absent' to clear a key")
 		}
 	}
 	return nil

--- a/tasks/scheduler_k3s_autoscaling_auth_task.go
+++ b/tasks/scheduler_k3s_autoscaling_auth_task.go
@@ -112,7 +112,7 @@ func (t SchedulerK3sAutoscalingAuthTask) Execute() TaskOutputState {
 
 // Validate checks the SchedulerK3sAutoscalingAuthTask's inputs without contacting the server.
 func (t SchedulerK3sAutoscalingAuthTask) Validate() error {
-	return validateSchedulerK3sAutoscalingAuth(t.spec())
+	return validateSchedulerK3sAutoscalingAuth(t.spec(), t.State)
 }
 
 // Plan reports the drift the SchedulerK3sAutoscalingAuthTask would produce.

--- a/tasks/scheduler_k3s_autoscaling_auth_task_test.go
+++ b/tasks/scheduler_k3s_autoscaling_auth_task_test.go
@@ -188,3 +188,31 @@ func TestSchedulerK3sAutoscalingAuthTaskEmptyMetadataKey(t *testing.T) {
 		t.Errorf("unexpected error: %v", result.Error)
 	}
 }
+
+func TestSchedulerK3sAutoscalingAuthTaskPresentEmptyValueRejected(t *testing.T) {
+	task := SchedulerK3sAutoscalingAuthTask{
+		App:      "test-app",
+		Trigger:  "aws-secret-manager",
+		Metadata: map[string]string{"secretName": ""},
+		State:    StatePresent,
+	}
+	err := task.Validate()
+	if err == nil {
+		t.Fatal("expected error when a present-state metadata value is empty")
+	}
+	if !strings.Contains(err.Error(), "metadata values must not be empty for state 'present'") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSchedulerK3sAutoscalingAuthTaskAbsentEmptyValueAllowed(t *testing.T) {
+	task := SchedulerK3sAutoscalingAuthTask{
+		App:      "test-app",
+		Trigger:  "aws-secret-manager",
+		Metadata: map[string]string{"secretName": ""},
+		State:    StateAbsent,
+	}
+	if err := task.Validate(); err != nil {
+		t.Fatalf("absent-state empty value should be allowed (clears the key), got %v", err)
+	}
+}

--- a/tasks/scheduler_k3s_chart_task.go
+++ b/tasks/scheduler_k3s_chart_task.go
@@ -122,15 +122,25 @@ func (t SchedulerK3sChartTask) Validate() error {
 	if t.Chart == "" {
 		return errors.New("chart is required")
 	}
+	state := t.State
+	if state == "" {
+		state = StatePresent
+	}
 	if len(t.Values) == 0 {
-		state := t.State
-		if state == "" {
-			state = StatePresent
-		}
 		return fmt.Errorf("'values' must not be empty for state '%s'", state)
 	}
-	if _, err := flattenChartValues(t.Values); err != nil {
+	flattened, err := flattenChartValues(t.Values)
+	if err != nil {
 		return err
+	}
+	// dokku clears a chart value set to an empty string, so a present-state
+	// empty value can never converge (issue #358); clearing uses state 'absent'.
+	if state == StatePresent {
+		for key, value := range flattened {
+			if value == "" {
+				return fmt.Errorf("chart value %q must not be empty for state 'present'; use state 'absent' to clear it", key)
+			}
+		}
 	}
 	return nil
 }

--- a/tasks/scheduler_k3s_chart_task_test.go
+++ b/tasks/scheduler_k3s_chart_task_test.go
@@ -62,6 +62,32 @@ func TestSchedulerK3sChartTaskAbsentWithoutValues(t *testing.T) {
 	}
 }
 
+func TestSchedulerK3sChartTaskPresentEmptyValueRejected(t *testing.T) {
+	task := SchedulerK3sChartTask{
+		Chart:  "ingress-nginx",
+		Values: map[string]any{"controller.replicaCount": ""},
+		State:  StatePresent,
+	}
+	err := task.Validate()
+	if err == nil {
+		t.Fatal("expected error when a present-state chart value is empty")
+	}
+	if !strings.Contains(err.Error(), "must not be empty for state 'present'") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSchedulerK3sChartTaskAbsentEmptyValueAllowed(t *testing.T) {
+	task := SchedulerK3sChartTask{
+		Chart:  "ingress-nginx",
+		Values: map[string]any{"controller.replicaCount": ""},
+		State:  StateAbsent,
+	}
+	if err := task.Validate(); err != nil {
+		t.Fatalf("absent-state empty value should be allowed (clears the value), got %v", err)
+	}
+}
+
 func TestSchedulerK3sChartTaskRejectsListValue(t *testing.T) {
 	task := SchedulerK3sChartTask{
 		Chart:  "ingress-nginx",

--- a/tasks/scheduler_k3s_labels_task_test.go
+++ b/tasks/scheduler_k3s_labels_task_test.go
@@ -110,3 +110,31 @@ func TestSchedulerK3sLabelsTaskEmptyLabelKey(t *testing.T) {
 		t.Errorf("unexpected error: %v", result.Error)
 	}
 }
+
+func TestSchedulerK3sLabelsTaskPresentEmptyValueRejected(t *testing.T) {
+	task := SchedulerK3sLabelsTask{
+		App:          "test-app",
+		ResourceType: "deployment",
+		Labels:       map[string]string{"tier": ""},
+		State:        StatePresent,
+	}
+	err := task.Validate()
+	if err == nil {
+		t.Fatal("expected error when a present-state label value is empty")
+	}
+	if !strings.Contains(err.Error(), "label values must not be empty for state 'present'") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSchedulerK3sLabelsTaskAbsentEmptyValueAllowed(t *testing.T) {
+	task := SchedulerK3sLabelsTask{
+		App:          "test-app",
+		ResourceType: "deployment",
+		Labels:       map[string]string{"tier": ""},
+		State:        StateAbsent,
+	}
+	if err := task.Validate(); err != nil {
+		t.Fatalf("absent-state empty value should be allowed (clears the key), got %v", err)
+	}
+}

--- a/tasks/scheduler_k3s_scoped_pairs.go
+++ b/tasks/scheduler_k3s_scoped_pairs.go
@@ -35,17 +35,23 @@ func validateSchedulerK3sScopedPairs(spec schedulerK3sScopedPairsSpec, state Sta
 	if spec.ResourceType == "" {
 		return errors.New("resource_type is required")
 	}
+	effective := state
+	if effective == "" {
+		effective = StatePresent
+	}
 	if len(spec.Pairs) == 0 {
-		effective := state
-		if effective == "" {
-			effective = StatePresent
-		}
 		return fmt.Errorf("'%s' must not be empty for state '%s'", spec.Kind, effective)
 	}
 	singular := singularizeSchedulerK3sKind(spec.Kind)
-	for key := range spec.Pairs {
+	for key, value := range spec.Pairs {
 		if key == "" {
 			return fmt.Errorf("%s keys must not be empty", singular)
+		}
+		// dokku interprets an empty value on the :set subcommand as a clear, so
+		// a present-state empty value can never be stored and would drift on
+		// every run (issue #358). Clearing is expressed with state 'absent'.
+		if effective == StatePresent && value == "" {
+			return fmt.Errorf("%s values must not be empty for state 'present'; use state 'absent' to clear a %s", singular, singular)
 		}
 	}
 	return nil

--- a/tasks/service_expose_task.go
+++ b/tasks/service_expose_task.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/dokku/docket/subprocess"
@@ -132,15 +133,14 @@ func (t ServiceExposeTask) Plan() PlanResult {
 			if !exists {
 				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("service %s %s does not exist", t.Service, t.Name)}
 			}
-			current, err := serviceExposedPorts(t.Service, t.Name)
+			current, err := serviceExposedPortList(t.Service, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
-			desired := map[string]bool{}
-			for _, p := range t.Ports {
-				desired[p] = true
-			}
-			if portSetEqual(current, desired) {
+			// dokku maps expose arguments positionally to the plugin's container
+			// ports, so the comparison must be order-sensitive: a reorder of the
+			// same ports is a real change (issue #332).
+			if slices.Equal(current, t.Ports) {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
 			inputs := []subprocess.ExecCommandInput{}
@@ -179,7 +179,7 @@ func (t ServiceExposeTask) Plan() PlanResult {
 			if !exists {
 				return PlanResult{Status: PlanStatusError, Error: fmt.Errorf("service %s %s does not exist", t.Service, t.Name)}
 			}
-			current, err := serviceExposedPorts(t.Service, t.Name)
+			current, err := serviceExposedPortList(t.Service, t.Name)
 			if err != nil {
 				return PlanResult{Status: PlanStatusError, Error: err}
 			}
@@ -244,34 +244,6 @@ func serviceExposedPortList(service, name string) ([]string, error) {
 		}
 	}
 	return ports, nil
-}
-
-// serviceExposedPorts returns the set of host ports a dokku service is currently
-// exposed on, derived from serviceExposedPortList for order-insensitive
-// comparison against the desired ports in Plan.
-func serviceExposedPorts(service, name string) (map[string]bool, error) {
-	list, err := serviceExposedPortList(service, name)
-	if err != nil {
-		return nil, err
-	}
-	ports := map[string]bool{}
-	for _, p := range list {
-		ports[p] = true
-	}
-	return ports, nil
-}
-
-// portSetEqual reports whether two port sets contain the same elements.
-func portSetEqual(a, b map[string]bool) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for k := range a {
-		if !b[k] {
-			return false
-		}
-	}
-	return true
 }
 
 // init registers the ServiceExposeTask with the task registry

--- a/tasks/service_expose_task_integration_test.go
+++ b/tasks/service_expose_task_integration_test.go
@@ -1,0 +1,71 @@
+package tasks
+
+import "testing"
+
+// TestIntegrationServiceExposeIdempotent drives a real dokku service through
+// expose, an idempotent re-expose, and unexpose. Redis exposes a single
+// container port so a positional reorder cannot be reproduced here (that path
+// is covered by the unit tests); this guards that the ordered-slice probe still
+// converges end-to-end.
+func TestIntegrationServiceExposeIdempotent(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "redis")
+
+	serviceType := "redis"
+	serviceName := "docket-test-expose-svc"
+
+	destroyService(serviceType, serviceName)
+	if r := (ServiceCreateTask{Service: serviceType, Name: serviceName, State: StatePresent}).Execute(); r.Error != nil {
+		t.Fatalf("failed to create service: %v", r.Error)
+	}
+	defer destroyService(serviceType, serviceName)
+
+	exposeTask := ServiceExposeTask{Service: serviceType, Name: serviceName, Ports: []string{"11111"}, State: StatePresent}
+
+	result := exposeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to expose service: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for a new expose")
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got %q", result.State)
+	}
+
+	result = exposeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent expose failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false when the service is already exposed on the same ports")
+	}
+
+	ports, err := serviceExposedPortList(serviceType, serviceName)
+	if err != nil {
+		t.Fatalf("failed to read exposed ports: %v", err)
+	}
+	if len(ports) != 1 || ports[0] != "11111" {
+		t.Errorf("expected exposed ports [11111], got %v", ports)
+	}
+
+	unexposeTask := ServiceExposeTask{Service: serviceType, Name: serviceName, State: StateAbsent}
+	result = unexposeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to unexpose service: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for unexpose")
+	}
+	if result.State != StateAbsent {
+		t.Errorf("expected state 'absent', got %q", result.State)
+	}
+
+	result = unexposeTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent unexpose failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false when the service is already unexposed")
+	}
+}

--- a/tasks/service_expose_task_test.go
+++ b/tasks/service_expose_task_test.go
@@ -1,8 +1,10 @@
 package tasks
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/dokku/docket/subprocess"
 	_ "github.com/gliderlabs/sigil/builtin"
 )
 
@@ -67,23 +69,71 @@ func TestGetTasksServiceExposeTaskParsedCorrectly(t *testing.T) {
 	}
 }
 
-func TestServiceExposePortSetEqual(t *testing.T) {
-	cases := []struct {
-		name string
-		a    map[string]bool
-		b    map[string]bool
-		want bool
-	}{
-		{"empty", map[string]bool{}, map[string]bool{}, true},
-		{"same", map[string]bool{"5432": true}, map[string]bool{"5432": true}, true},
-		{"different-len", map[string]bool{"5432": true}, map[string]bool{}, false},
-		{"different-members", map[string]bool{"5432": true}, map[string]bool{"6379": true}, false},
+func TestServiceExposeSameOrderInSync(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet redis:info my-svc --exposed-ports": "1111->1111 2222->2222",
+	}))()
+
+	plan := ServiceExposeTask{Service: "redis", Name: "my-svc", Ports: []string{"1111", "2222"}, State: StatePresent}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := portSetEqual(tc.a, tc.b); got != tc.want {
-				t.Errorf("portSetEqual(%v, %v) = %v, want %v", tc.a, tc.b, got, tc.want)
-			}
-		})
+	if !plan.InSync {
+		t.Fatalf("expected in-sync when ports match in order, got %#v", plan)
+	}
+}
+
+func TestServiceExposeReorderReportsDrift(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet redis:info my-svc --exposed-ports": "1111->1111 2222->2222",
+	}))()
+
+	plan := ServiceExposeTask{Service: "redis", Name: "my-svc", Ports: []string{"2222", "1111"}, State: StatePresent}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Fatal("expected drift when the same ports are reordered (dokku maps them positionally)")
+	}
+	if plan.Status != PlanStatusModify {
+		t.Errorf("expected Modify status when already exposed, got %q", plan.Status)
+	}
+	foundUnexpose := false
+	foundOrderedExpose := false
+	for _, m := range plan.Mutations {
+		if m == "redis:unexpose my-svc" {
+			foundUnexpose = true
+		}
+		if m == "redis:expose my-svc 2222 1111" {
+			foundOrderedExpose = true
+		}
+	}
+	if !foundUnexpose {
+		t.Errorf("expected an unexpose before re-expose, got %v", plan.Mutations)
+	}
+	if !foundOrderedExpose {
+		t.Errorf("expected re-expose in the desired order, got %v", plan.Mutations)
+	}
+}
+
+func TestServiceExposeCreatesWhenNotExposed(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet redis:info my-svc --exposed-ports": "",
+	}))()
+
+	plan := ServiceExposeTask{Service: "redis", Name: "my-svc", Ports: []string{"1111", "2222"}, State: StatePresent}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Fatal("expected drift when the service is not exposed")
+	}
+	if plan.Status != PlanStatusCreate {
+		t.Errorf("expected Create status when not yet exposed, got %q", plan.Status)
+	}
+	for _, m := range plan.Mutations {
+		if strings.Contains(m, "unexpose") {
+			t.Errorf("did not expect an unexpose when nothing is exposed, got %v", plan.Mutations)
+		}
 	}
 }

--- a/tests/bats/output.bats
+++ b/tests/bats/output.bats
@@ -59,10 +59,11 @@ EOF
 }
 
 @test "docket apply --verbose echoes every command for multi-command tasks" {
-  # dokku_buildpacks invokes `dokku buildpacks:add` once per buildpack URL,
-  # which exercises the per-task multi-command append path. The URLs are
-  # only recorded in the buildpacks file (no network fetch happens at
-  # add-time) so this stays a pure docket+dokku test.
+  # dokku_buildpacks sets the list with a single `buildpacks:set --replace`, but
+  # removing a multi-entry list issues one `buildpacks:remove` per buildpack,
+  # which exercises the per-task multi-command append path. The URLs are only
+  # recorded in the buildpacks file (no network fetch happens) so this stays a
+  # pure docket+dokku test.
   write_tasks_file <<EOF
 ---
 - tasks:
@@ -75,18 +76,26 @@ EOF
         buildpacks:
           - https://github.com/heroku/heroku-buildpack-nodejs.git
           - https://github.com/heroku/heroku-buildpack-nginx.git
+    - name: remove buildpacks
+      dokku_buildpacks:
+        app: docket-test-output
+        state: absent
+        buildpacks:
+          - https://github.com/heroku/heroku-buildpack-nodejs.git
+          - https://github.com/heroku/heroku-buildpack-nginx.git
 EOF
   run "$(docket_bin)" apply --tasks "$TASKS_FILE" --verbose
   assert_success
   assert_output --partial "→ dokku"
-  assert_output --partial "buildpacks:add"
+  assert_output --partial "buildpacks:set --replace"
+  assert_output --partial "buildpacks:remove"
   assert_output --partial "heroku-buildpack-nodejs"
   assert_output --partial "heroku-buildpack-nginx"
-  # One -> line per buildpack add.
+  # One -> line per buildpack removed.
   local arrow_count
-  arrow_count="$(printf '%s\n' "${output}" | grep -c "→ dokku.*buildpacks:add" || true)"
+  arrow_count="$(printf '%s\n' "${output}" | grep -c "→ dokku.*buildpacks:remove" || true)"
   if [ "${arrow_count}" -lt 2 ]; then
-    fail "expected at least 2 '→ dokku ... buildpacks:add' continuation lines, got ${arrow_count} in:${output}"
+    fail "expected at least 2 '→ dokku ... buildpacks:remove' continuation lines, got ${arrow_count} in:${output}"
   fi
 }
 

--- a/tests/bats/validate.bats
+++ b/tests/bats/validate.bats
@@ -57,6 +57,22 @@ EOF
   assert_output --partial "'users' must not be empty"
 }
 
+@test "docket validate exits 1 on a present-state empty pair value" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_scheduler_k3s_labels:
+        app: docket-test-validate
+        resource_type: deployment
+        labels:
+          tier: ""
+        state: present
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "label values must not be empty for state 'present'"
+}
+
 @test "docket validate --json emits invalid_task_input" {
   write_tasks_file <<EOF
 ---


### PR DESCRIPTION
Several tasks compared desired state against actual state incorrectly in their plan probe, so they either re-ran on every apply without ever converging or reported in sync while the server had actually drifted. Standardizing what each probe compares addresses the whole class: global domains stop writing a literal `--global` hostname, `dokku_resource_limit` and `dokku_resource_reserve` recognize a `clear_before` no-op instead of always reporting a change, the scheduler-k3s labels, annotations, chart-values, and autoscaling trigger-auth tasks reject present-state empty values that dokku cannot store, `dokku_service_expose` compares its ports in order, `dokku_buildpacks` compares and applies buildpacks in build-precedence order, and `dokku_git_sync` recognizes an app already synced from the pinned remote and ref rather than matching against a resolved commit SHA.

Addresses #364. Closes #309, closes #310, closes #332, closes #333, closes #356, closes #358.