### PR TITLE
fix: close recipe validation gaps via a shared parser

### DIFF
--- a/commands/apply.go
+++ b/commands/apply.go
@@ -139,7 +139,12 @@ func (c *ApplyCommand) Run(args []string) int {
 
 	resolvedHost := resolveSshFlags(c.host, c.sudo, c.acceptNewHostKeys)
 
-	resolvedPath, resolvedFormat, err := resolveTaskFilePath(c.tasksFile)
+	taskFile, err := resolveTaskFileArg(c.tasksFile, flags.Args())
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+	resolvedPath, resolvedFormat, err := resolveTaskFilePath(taskFile)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("read error: %v", err))
 		return 1

--- a/commands/apply_args.go
+++ b/commands/apply_args.go
@@ -129,6 +129,8 @@ func getTaskYamlFilename(s []string) string {
 // path still fires with the familiar message. Format is keyed by file
 // extension; see detectTaskFileFormat.
 func resolveTaskFileFromArgs(s []string) (string, string) {
+	positional := ""
+	skipNext := false
 	for i, arg := range s {
 		if arg == "--tasks" {
 			if len(s) > i+1 {
@@ -139,6 +141,30 @@ func resolveTaskFileFromArgs(s []string) (string, string) {
 		if taskFile, found := strings.CutPrefix(arg, "--tasks="); found {
 			return taskFile, detectTaskFileFormat(taskFile)
 		}
+		// Best-effort positional detection so recipe input flags still
+		// preregister when the file is given as `docket validate x.yml`
+		// (the authoritative selection is flags.Args() in Run). A token
+		// counts only if it carries a task-file extension and is not the
+		// value of a preceding value-taking flag, so `--vars-file prod.yml`
+		// never wins.
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		if strings.HasPrefix(arg, "-") {
+			if valueTakingFlags[arg] {
+				skipNext = true
+			}
+			continue
+		}
+		if positional == "" && hasTaskFileExtension(arg) {
+			positional = arg
+		}
+	}
+	if positional != "" {
+		if _, err := os.Stat(positional); err == nil {
+			return positional, detectTaskFileFormat(positional)
+		}
 	}
 	for _, candidate := range defaultTaskFileCandidates {
 		if _, err := os.Stat(candidate); err == nil {
@@ -146,6 +172,21 @@ func resolveTaskFileFromArgs(s []string) (string, string) {
 		}
 	}
 	return defaultTaskFileCandidates[0], detectTaskFileFormat(defaultTaskFileCandidates[0])
+}
+
+// valueTakingFlags are the built-in flags that consume the following argv
+// token as their value, used by resolveTaskFileFromArgs so a flag value
+// with a task-file extension is not mistaken for a positional recipe path.
+var valueTakingFlags = map[string]bool{
+	"--tasks":         true,
+	"--vars-file":     true,
+	"--host":          true,
+	"--tags":          true,
+	"--skip-tags":     true,
+	"--play":          true,
+	"--start-at-task": true,
+	"--output":        true,
+	"--color":         true,
 }
 
 func getInputVariables(data []byte, format string) (map[string]*tasks.Input, error) {

--- a/commands/apply_args.go
+++ b/commands/apply_args.go
@@ -175,7 +175,12 @@ func registerInputFlags(f *flag.FlagSet, data []byte, format string) (map[string
 	}
 
 	for _, input := range inputs {
-		if input.Name == "tasks" {
+		// Skip any input whose name collides with a built-in flag. pflag
+		// panics with "flag redefined" if we register it, so the loader /
+		// validator reject it as reserved_input_name instead (#302); here
+		// we just avoid the panic and let the input fall back to its
+		// default. validate is the gate that surfaces the error.
+		if tasks.ReservedInputNames[input.Name] {
 			continue
 		}
 		arg := &Argument{Required: input.Required, Sensitive: input.Sensitive}

--- a/commands/init.go
+++ b/commands/init.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -17,6 +18,7 @@ import (
 	"github.com/josegonzalez/cli-skeleton/command"
 	"github.com/posener/complete"
 	flag "github.com/spf13/pflag"
+	yaml "gopkg.in/yaml.v3"
 )
 
 // InitCommand scaffolds a starter tasks.yml from an embedded template.
@@ -142,6 +144,15 @@ func (c *InitCommand) Run(args []string) int {
 		return 1
 	}
 
+	// Parse-check the rendered scaffold before writing it anywhere, so a
+	// scaffold that fails to parse is never left on disk (or streamed to
+	// stdout as a broken file).
+	taskCount, playCount, err := countTasks(rendered, format)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("internal error: rendered scaffold did not parse: %v", err))
+		return 1
+	}
+
 	if toStdout {
 		if _, err := os.Stdout.Write(rendered); err != nil {
 			c.Ui.Error(fmt.Sprintf("write error: %v", err))
@@ -152,12 +163,6 @@ func (c *InitCommand) Run(args []string) int {
 
 	if err := os.WriteFile(c.output, rendered, 0o644); err != nil {
 		c.Ui.Error(fmt.Sprintf("write error: %v", err))
-		return 1
-	}
-
-	taskCount, playCount, err := countTasks(rendered, format)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("internal error: rendered scaffold did not parse: %v", err))
 		return 1
 	}
 
@@ -203,7 +208,15 @@ func renderInit(opts initOptions) ([]byte, error) {
 		return nil, fmt.Errorf("read template %s: %w", templateName, err)
 	}
 
-	tmpl, err := template.New(templateName).Delims("<<", ">>").Parse(string(raw))
+	// yamlStr / jsonStr emit a value as a correctly quoted-and-escaped
+	// scalar so a name with YAML- or JSON-special characters (@web,
+	// "foo: bar", an embedded quote) produces a valid scaffold instead of
+	// a broken one. yamlStr leaves simple names unquoted, matching the
+	// previous output for ordinary names.
+	tmpl, err := template.New(templateName).Delims("<<", ">>").Funcs(template.FuncMap{
+		"yamlStr": yamlScalar,
+		"jsonStr": jsonScalar,
+	}).Parse(string(raw))
 	if err != nil {
 		return nil, fmt.Errorf("parse template %s: %w", templateName, err)
 	}
@@ -222,6 +235,28 @@ func renderInit(opts initOptions) ([]byte, error) {
 	}
 	out.Write(body.Bytes())
 	return out.Bytes(), nil
+}
+
+// yamlScalar renders s as a YAML scalar, quoting and escaping only when
+// necessary so ordinary names stay unquoted. Used by the YAML init
+// templates so a name with YAML-special characters cannot break the
+// scaffold.
+func yamlScalar(s string) (string, error) {
+	b, err := yaml.Marshal(s)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(b), "\n"), nil
+}
+
+// jsonScalar renders s as a JSON string literal (valid JSON5), used by the
+// JSON5 init templates so an embedded quote or backslash is escaped.
+func jsonScalar(s string) (string, error) {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }
 
 // selectInitTemplate returns the embedded template name for (format,

--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -256,6 +256,82 @@ func TestInitDefaultPassesValidate(t *testing.T) {
 	}
 }
 
+func TestInitSpecialCharacterNamesParse(t *testing.T) {
+	// A --name with YAML/JSON-special characters used to render a scaffold
+	// that would not parse; the escaping helpers now emit a correctly
+	// quoted scalar for every format, so init's parse check (which uses
+	// UnmarshalRecipe) accepts the scaffold instead of writing a broken
+	// file (#355).
+	names := []string{"@web", "foo: bar", `has"quote`, "*star", "- dash", "#hash", "key: value: nested"}
+	for _, name := range names {
+		for _, tc := range []struct {
+			label  string
+			opts   initOptions
+			format string
+		}{
+			{"yaml", initOptions{Name: name}, tasks.FormatYAML},
+			{"yaml-minimal", initOptions{Name: name, Minimal: true}, tasks.FormatYAML},
+			{"json5", initOptions{Name: name, Format: tasks.FormatNameJSON5}, tasks.FormatNameJSON5},
+			{"json5-minimal", initOptions{Name: name, Minimal: true, Format: tasks.FormatNameJSON5}, tasks.FormatNameJSON5},
+		} {
+			out, err := renderInit(tc.opts)
+			if err != nil {
+				t.Fatalf("renderInit(%q, %s): %v", name, tc.label, err)
+			}
+			if _, err := tasks.UnmarshalRecipe(out, tc.format); err != nil {
+				t.Errorf("name %q (%s) scaffold should parse, got: %v\n%s", name, tc.label, err, out)
+			}
+		}
+	}
+}
+
+func TestInitYAMLSpecialNamesFullyValidate(t *testing.T) {
+	// The names the issue calls out (@web, a `: `-containing name) also
+	// round-trip through full validate, including the sigil render that
+	// substitutes the name into the task bodies (#355).
+	names := []string{"@web", "foo: bar", "*star", "- dash"}
+	for _, name := range names {
+		out, err := renderInit(initOptions{Name: name})
+		if err != nil {
+			t.Fatalf("renderInit(%q): %v", name, err)
+		}
+		if problems := tasks.Validate(out, tasks.ValidateOptions{}); len(problems) != 0 {
+			t.Errorf("name %q scaffold should validate, got %+v\n%s", name, problems, out)
+		}
+	}
+}
+
+func TestInitSimpleNameStaysUnquoted(t *testing.T) {
+	// The escaping helper must not quote ordinary names, keeping the
+	// scaffold output stable for the common case.
+	out, err := renderInit(initOptions{Name: "billing"})
+	if err != nil {
+		t.Fatalf("renderInit: %v", err)
+	}
+	if !strings.Contains(string(out), "default: billing") {
+		t.Errorf("simple name should stay unquoted:\n%s", out)
+	}
+}
+
+func TestInitSpecialCharacterNameWritesValidFile(t *testing.T) {
+	// End-to-end: a special-character --name writes a file that round-trips
+	// through validate, and the parse check (which now runs before the
+	// write) does not reject it (#355).
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.yml")
+	c := newTestInitCommand()
+	if exit := c.Run([]string{"--output", path, "--name", "@web", "--repo", "https://example.com/r.git"}); exit != 0 {
+		t.Fatalf("init --name @web exit = %d, want 0", exit)
+	}
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if problems := tasks.Validate(out, tasks.ValidateOptions{}); len(problems) != 0 {
+		t.Errorf("written scaffold should validate, got %+v\n%s", problems, out)
+	}
+}
+
 func TestInitMinimalPassesValidate(t *testing.T) {
 	out, err := renderInit(initOptions{Name: "demo", Minimal: true})
 	if err != nil {

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -148,7 +148,12 @@ func (c *PlanCommand) Run(args []string) int {
 
 	resolvedHost := resolveSshFlags(c.host, c.sudo, c.acceptNewHostKeys)
 
-	resolvedPath, resolvedFormat, err := resolveTaskFilePath(c.tasksFile)
+	taskFile, err := resolveTaskFileArg(c.tasksFile, flags.Args())
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+	resolvedPath, resolvedFormat, err := resolveTaskFilePath(taskFile)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("read error: %v", err))
 		return 1

--- a/commands/reserved_input_test.go
+++ b/commands/reserved_input_test.go
@@ -1,0 +1,62 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/dokku/docket/tasks"
+
+	flag "github.com/spf13/pflag"
+)
+
+// flagSetter is implemented by every command whose FlagSet may register
+// dynamic recipe-input flags on top of its built-ins.
+type flagSetter interface {
+	FlagSet() *flag.FlagSet
+}
+
+// TestReservedInputNamesCoversBuiltinFlags keeps tasks.ReservedInputNames
+// in sync with the real flag sets: every built-in flag on an
+// input-accepting command must be reserved so a recipe input with that
+// name is rejected offline instead of panicking pflag with "flag
+// redefined" (#302). Adding a new built-in flag without reserving it
+// fails this test.
+func TestReservedInputNamesCoversBuiltinFlags(t *testing.T) {
+	cmds := map[string]flagSetter{
+		"apply":    &ApplyCommand{},
+		"plan":     &PlanCommand{},
+		"validate": &ValidateCommand{},
+	}
+	for name, c := range cmds {
+		c.FlagSet().VisitAll(func(f *flag.Flag) {
+			if !tasks.ReservedInputNames[f.Name] {
+				t.Errorf("%s built-in flag %q is not in tasks.ReservedInputNames; a recipe input with that name would collide", name, f.Name)
+			}
+		})
+	}
+}
+
+// TestRegisterInputFlagsSkipsReservedNames verifies that building a
+// command's flag set with a reserved input name does not panic (pflag
+// would otherwise abort with "flag redefined") - the input is silently
+// skipped and the offline validator is left to report it.
+func TestRegisterInputFlagsSkipsReservedNames(t *testing.T) {
+	data := []byte(`---
+- inputs:
+    - name: verbose
+      default: x
+  tasks:
+    - dokku_app:
+        app: my-app
+`)
+	f := flag.NewFlagSet("apply", flag.ContinueOnError)
+	f.Bool("verbose", false, "built-in verbose flag")
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("registerInputFlags panicked on a reserved input name: %v", r)
+		}
+	}()
+	if _, err := registerInputFlags(f, data, tasks.FormatYAML); err != nil {
+		t.Fatalf("registerInputFlags returned error: %v", err)
+	}
+}

--- a/commands/task_file.go
+++ b/commands/task_file.go
@@ -38,6 +38,18 @@ func detectTaskFileFormat(path string) string {
 	}
 }
 
+// hasTaskFileExtension reports whether path carries one of the recipe
+// file extensions. Used to spot a positional recipe path in an argv the
+// flag parser has not yet processed.
+func hasTaskFileExtension(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".yml", ".yaml", ".json", ".json5":
+		return true
+	default:
+		return false
+	}
+}
+
 // resolveTaskFilePath returns the path to use as the task file plus its
 // detected format. When explicit is non-empty it is used as-is and the
 // format is inferred from its extension; the file's existence is not
@@ -58,6 +70,26 @@ func resolveTaskFilePath(explicit string) (string, string, error) {
 		}
 	}
 	return "", "", fmt.Errorf("no task file found; looked for %s", strings.Join(defaultTaskFileCandidates, ", "))
+}
+
+// resolveTaskFileArg reconciles the --tasks flag value with any positional
+// file arguments left after flag parsing. A positional recipe path (e.g.
+// `docket validate staging/tasks.yml`) is honored the way `docket fmt`
+// honors one, so a CI lint that names the file checks that file rather
+// than silently falling back to ./tasks.yml. Passing both --tasks and a
+// positional, or more than one positional, is rejected. An empty return
+// with a nil error means "use the default probe" (neither was given).
+func resolveTaskFileArg(explicit string, positional []string) (string, error) {
+	if len(positional) == 0 {
+		return explicit, nil
+	}
+	if len(positional) > 1 {
+		return "", fmt.Errorf("only one task file may be specified, got %d", len(positional))
+	}
+	if explicit != "" {
+		return "", fmt.Errorf("cannot specify both --tasks and a positional task file argument")
+	}
+	return positional[0], nil
 }
 
 // taskFileAutocompleteGlob is the shared file glob for the --tasks flag

--- a/commands/task_file_test.go
+++ b/commands/task_file_test.go
@@ -26,6 +26,64 @@ func TestDetectTaskFileFormat(t *testing.T) {
 	}
 }
 
+func TestResolveTaskFileArg(t *testing.T) {
+	tests := []struct {
+		name       string
+		explicit   string
+		positional []string
+		want       string
+		wantErr    string
+	}{
+		{name: "neither given", want: ""},
+		{name: "flag only", explicit: "flag.yml", want: "flag.yml"},
+		{name: "positional only", positional: []string{"pos.yml"}, want: "pos.yml"},
+		{name: "both given is an error", explicit: "flag.yml", positional: []string{"pos.yml"}, wantErr: "both --tasks and a positional"},
+		{name: "multiple positionals is an error", positional: []string{"a.yml", "b.yml"}, wantErr: "only one task file"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveTaskFileArg(tt.explicit, tt.positional)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error %q, got: %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveTaskFileFromArgsPositional(t *testing.T) {
+	dir := t.TempDir()
+	recipe := filepath.Join(dir, "staging.yml")
+	if err := os.WriteFile(recipe, []byte("---\n- tasks: []\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	vars := filepath.Join(dir, "prod.yml")
+	if err := os.WriteFile(vars, []byte("app: api\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// A --vars-file value that looks like a recipe must not be picked as
+	// the positional; the real positional recipe path should win.
+	got, _ := resolveTaskFileFromArgs([]string{"docket", "validate", "--vars-file", vars, recipe})
+	if got != recipe {
+		t.Errorf("expected positional %q, got %q", recipe, got)
+	}
+
+	// --tasks still takes precedence for preregistration.
+	got, _ = resolveTaskFileFromArgs([]string{"docket", "validate", "--tasks", recipe})
+	if got != recipe {
+		t.Errorf("expected --tasks %q, got %q", recipe, got)
+	}
+}
+
 func TestResolveTaskFilePathExplicit(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "custom.json")

--- a/commands/templates/default.json5.tmpl
+++ b/commands/templates/default.json5.tmpl
@@ -3,7 +3,7 @@
     inputs: [
       {
         name: "app",
-        default: "<<.Name>>",
+        default: <<jsonStr .Name>>,
         description: "Application name",
       },
       {

--- a/commands/templates/default.yml.tmpl
+++ b/commands/templates/default.yml.tmpl
@@ -1,6 +1,6 @@
 - inputs:
     - name: app
-      default: <<.Name>>
+      default: <<yamlStr .Name>>
       description: "Application name"
     - name: repo
       <<if .Repo>>default: "<<.Repo>>"<<else>>required: true<<end>>

--- a/commands/templates/minimal.json5.tmpl
+++ b/commands/templates/minimal.json5.tmpl
@@ -4,7 +4,7 @@
       {
         name: "create app",
         dokku_app: {
-          app: "<<.Name>>",
+          app: <<jsonStr .Name>>,
           state: "present",
         },
       },

--- a/commands/templates/minimal.yml.tmpl
+++ b/commands/templates/minimal.yml.tmpl
@@ -1,5 +1,5 @@
 - tasks:
     - name: create app
       dokku_app:
-        app: <<.Name>>
+        app: <<yamlStr .Name>>
         state: present

--- a/commands/validate.go
+++ b/commands/validate.go
@@ -130,7 +130,20 @@ func (c *ValidateCommand) Run(args []string) int {
 		return 1
 	}
 
-	resolvedPath, resolvedFormat, err := resolveTaskFilePath(c.tasksFile)
+	taskFile, err := resolveTaskFileArg(c.tasksFile, flags.Args())
+	if err != nil {
+		if c.json {
+			c.emitJSONProblem(tasks.Problem{
+				Code:    "argument_error",
+				Message: err.Error(),
+			})
+		} else {
+			c.Ui.Error(err.Error())
+		}
+		return 1
+	}
+
+	resolvedPath, resolvedFormat, err := resolveTaskFilePath(taskFile)
 	if err != nil {
 		if c.json {
 			c.emitJSONProblem(tasks.Problem{

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -14,6 +14,9 @@ docket has seven commands. Running `docket` with no subcommand prints the list:
 
 `apply`, `plan`, `validate`, and `fmt` all accept either YAML or JSON5 recipes. When `--tasks` is
 omitted they probe `tasks.yml`, then `tasks.yaml`, then `tasks.json`, and use the first that exists.
+`apply`, `plan`, and `validate` also accept the recipe as a single positional argument (for example
+`docket validate staging/tasks.yml`); passing both a positional path and `--tasks`, or more than one
+positional path, is an error.
 
 ## docket init
 

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -57,12 +57,29 @@ default and no supplied value renders as an empty string; `docket validate --str
 that case so a recipe that cannot run without a runtime override fails the lint instead of deploying
 with a blank value.
 
-These input names are reserved for docket's own flags and cannot be used as input names:
+These input names collide with docket's own command flags and cannot be used as input names.
+Declaring one is reported as `reserved_input_name` by `docket validate` (and rejected by `plan` /
+`apply`) rather than silently shadowing the flag:
 
-- `help`
+- `accept-new-host-keys`
+- `detailed-exitcode`
+- `fail-fast`
+- `host`
+- `json`
+- `list-tasks`
+- `no-color`
+- `play`
+- `skip-tags`
+- `start-at-task`
+- `strict`
+- `sudo`
+- `tags`
 - `tasks`
-- `v`
-- `version`
+- `vars-file`
+- `verbose`
+
+`help`, `v`, and `version` are handled by the CLI framework rather than registered as flags, so
+they are usable as input names.
 
 ## Layered values with `--vars-file`
 

--- a/docs/tasks/dokku_git_from_image.md
+++ b/docs/tasks/dokku_git_from_image.md
@@ -15,8 +15,8 @@ Partial - the image reference is written to the companion vars-file.
 | `app` | string | yes |  |  | Name of the app |
 | `image` | string | yes |  |  | Docker image to deploy (sensitive) |
 | `build_dir` | string | no |  |  | Directory to build the git repository |
-| `git_username` | string | no |  |  | Username to use for the git repository |
-| `git_email` | string | no |  |  | Email to use for the git repository |
+| `git_username` | string | no |  |  | Username to use for the git repository (requires git_email) |
+| `git_email` | string | no |  |  | Email to use for the git repository (requires git_username) |
 | `state` | string | no | deployed | deployed | Desired state of the git repository |
 
 ## Examples

--- a/docs/tasks/dokku_service_backup.md
+++ b/docs/tasks/dokku_service_backup.md
@@ -24,8 +24,8 @@ Partial - the backup schedule, bucket, and use_iam flag are exported; the AWS cr
 | `aws_access_key_id` | string | no |  |  | AWS access key id for backup auth (requires aws_secret_access_key) |
 | `aws_secret_access_key` | string | no |  |  | AWS secret access key for backup auth (requires aws_access_key_id) (sensitive) |
 | `aws_default_region` | string | no |  |  | AWS region used for backup auth |
-| `aws_signature_version` | string | no |  |  | AWS signature version used for backup auth |
-| `endpoint_url` | string | no |  |  | S3-compatible endpoint url used for backup auth |
+| `aws_signature_version` | string | no |  |  | AWS signature version used for backup auth (requires aws_default_region) |
+| `endpoint_url` | string | no |  |  | S3-compatible endpoint url used for backup auth (requires aws_signature_version) |
 | `encryption_passphrase` | string | no |  |  | Passphrase used to encrypt future backups (sensitive) |
 | `state` | string | no | present | present, absent | Desired state of the backup configuration |
 

--- a/tasks/git_from_image_task.go
+++ b/tasks/git_from_image_task.go
@@ -22,10 +22,10 @@ type GitFromImageTask struct {
 	BuildDir string `required:"false" yaml:"build_dir,omitempty" description:"Directory to build the git repository"`
 
 	// GitUsername is the username to use for the git repository
-	GitUsername string `required:"false" yaml:"git_username,omitempty" description:"Username to use for the git repository"`
+	GitUsername string `required:"false" yaml:"git_username,omitempty" description:"Username to use for the git repository (requires git_email)"`
 
 	// GitEmail is the email to use for the git repository
-	GitEmail string `required:"false" yaml:"git_email,omitempty" description:"Email to use for the git repository"`
+	GitEmail string `required:"false" yaml:"git_email,omitempty" description:"Email to use for the git repository (requires git_username)"`
 
 	// State is the desired state of the git repository
 	State State `required:"false" yaml:"state,omitempty" default:"deployed" options:"deployed" description:"Desired state of the git repository"`
@@ -83,8 +83,29 @@ func (t GitFromImageTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// Validate checks the GitFromImageTask's inputs without contacting the server.
+func (t GitFromImageTask) Validate() error {
+	if t.App == "" {
+		return fmt.Errorf("'app' is required")
+	}
+	if t.Image == "" {
+		return fmt.Errorf("'image' is required")
+	}
+	// git:from-image takes <git-username> and <git-email> as an adjacent
+	// positional pair, so an email supplied without a username would be
+	// passed in the username slot. Require them together, matching
+	// GitFromArchiveTask.
+	if (t.GitUsername == "") != (t.GitEmail == "") {
+		return fmt.Errorf("'git_username' and 'git_email' must be set together")
+	}
+	return nil
+}
+
 // Plan reports the drift the GitFromImageTask would produce.
 func (t GitFromImageTask) Plan() PlanResult {
+	if err := t.Validate(); err != nil {
+		return planErr(err)
+	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StateDeployed: func() PlanResult {
 			match, err := checkAppSourceImage(t.App, t.Image)
@@ -99,11 +120,10 @@ func (t GitFromImageTask) Plan() PlanResult {
 				args = append(args, "--build-dir", t.BuildDir)
 			}
 			args = append(args, t.App, t.Image)
+			// Validate guarantees username and email are set together, so
+			// append them as a unit to keep them in their positional slots.
 			if t.GitUsername != "" {
-				args = append(args, t.GitUsername)
-			}
-			if t.GitEmail != "" {
-				args = append(args, t.GitEmail)
+				args = append(args, t.GitUsername, t.GitEmail)
 			}
 			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
 			return PlanResult{

--- a/tasks/git_from_image_task_test.go
+++ b/tasks/git_from_image_task_test.go
@@ -13,6 +13,52 @@ func TestGitFromImageTaskInvalidState(t *testing.T) {
 	}
 }
 
+func TestGitFromImageTaskValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		task    GitFromImageTask
+		wantErr string
+	}{
+		{
+			name: "app and image only is valid",
+			task: GitFromImageTask{App: "web", Image: "org/app:1.0"},
+		},
+		{
+			name: "username and email together is valid",
+			task: GitFromImageTask{App: "web", Image: "org/app:1.0", GitUsername: "deploy", GitEmail: "deploy@example.com"},
+		},
+		{
+			name:    "email without username is rejected",
+			task:    GitFromImageTask{App: "web", Image: "org/app:1.0", GitEmail: "deploy@example.com"},
+			wantErr: "'git_username' and 'git_email' must be set together",
+		},
+		{
+			name:    "username without email is rejected",
+			task:    GitFromImageTask{App: "web", Image: "org/app:1.0", GitUsername: "deploy"},
+			wantErr: "'git_username' and 'git_email' must be set together",
+		},
+		{
+			name:    "missing image is rejected",
+			task:    GitFromImageTask{App: "web"},
+			wantErr: "'image' is required",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.task.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error %q, got: %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
 func TestGitFromImageTaskNonDeployedStates(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/tasks/json5_dup.go
+++ b/tasks/json5_dup.go
@@ -1,0 +1,276 @@
+package tasks
+
+import "strconv"
+
+// jsonDupKey describes a duplicate object key found in a JSON5 document.
+type jsonDupKey struct {
+	Key    string
+	Line   int
+	Column int
+}
+
+// detectJSON5DuplicateKeys scans JSON5 bytes for an object key that appears
+// more than once within the same object and returns the first such
+// duplicate (nil when there is none).
+//
+// titanous/json5 decodes duplicate keys last-wins with no error, unlike
+// yaml.v3 which rejects them outright. Without this scan a copy-pasted
+// task-type key in a JSON5 recipe would be silently deduped on both the
+// validate and apply paths. The input is assumed syntactically valid
+// (normalizeRecipeBytes runs the real json5 parse first); on any
+// unexpected byte the scan stops and returns nil, deferring to the real
+// parser's error.
+func detectJSON5DuplicateKeys(data []byte) *jsonDupKey {
+	s := &json5Scanner{data: data, line: 1, col: 1}
+	s.parseValue()
+	return s.dup
+}
+
+// json5Scanner is a minimal JSON5 walker whose only job is to find a
+// duplicated object key. It tracks nothing about values beyond skipping
+// past them so nested braces / colons inside strings and comments do not
+// confuse the object-key detection.
+type json5Scanner struct {
+	data []byte
+	pos  int
+	line int
+	col  int
+	dup  *jsonDupKey
+}
+
+func (s *json5Scanner) atEnd() bool { return s.pos >= len(s.data) }
+
+func (s *json5Scanner) peek() byte {
+	if s.atEnd() {
+		return 0
+	}
+	return s.data[s.pos]
+}
+
+func (s *json5Scanner) peekAt(offset int) byte {
+	if s.pos+offset >= len(s.data) {
+		return 0
+	}
+	return s.data[s.pos+offset]
+}
+
+func (s *json5Scanner) advance() byte {
+	c := s.data[s.pos]
+	s.pos++
+	if c == '\n' {
+		s.line++
+		s.col = 1
+	} else {
+		s.col++
+	}
+	return c
+}
+
+// skipWsComments consumes whitespace and JSON5 line / block comments.
+func (s *json5Scanner) skipWsComments() {
+	for !s.atEnd() && s.dup == nil {
+		switch c := s.peek(); {
+		case c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '\f' || c == '\v':
+			s.advance()
+		case c == '/' && s.peekAt(1) == '/':
+			for !s.atEnd() && s.peek() != '\n' {
+				s.advance()
+			}
+		case c == '/' && s.peekAt(1) == '*':
+			s.advance()
+			s.advance()
+			for !s.atEnd() {
+				if s.peek() == '*' && s.peekAt(1) == '/' {
+					s.advance()
+					s.advance()
+					break
+				}
+				s.advance()
+			}
+		default:
+			return
+		}
+	}
+}
+
+// parseValue dispatches on the next non-trivia byte.
+func (s *json5Scanner) parseValue() {
+	if s.dup != nil {
+		return
+	}
+	s.skipWsComments()
+	if s.atEnd() {
+		return
+	}
+	switch s.peek() {
+	case '{':
+		s.parseObject()
+	case '[':
+		s.parseArray()
+	case '"', '\'':
+		s.readString()
+	default:
+		s.skipPrimitive()
+	}
+}
+
+// parseObject consumes an object and reports the first key that repeats
+// within it. Nested objects recurse and get their own key set.
+func (s *json5Scanner) parseObject() {
+	s.advance() // consume '{'
+	seen := map[string]bool{}
+	for s.dup == nil {
+		s.skipWsComments()
+		if s.atEnd() {
+			return
+		}
+		if s.peek() == '}' {
+			s.advance()
+			return
+		}
+		keyLine, keyCol := s.line, s.col
+		key, ok := s.readKey()
+		if !ok {
+			return
+		}
+		if seen[key] {
+			s.dup = &jsonDupKey{Key: key, Line: keyLine, Column: keyCol}
+			return
+		}
+		seen[key] = true
+
+		s.skipWsComments()
+		if s.peek() != ':' {
+			return
+		}
+		s.advance() // consume ':'
+		s.parseValue()
+
+		s.skipWsComments()
+		switch s.peek() {
+		case ',':
+			s.advance()
+		case '}':
+			s.advance()
+			return
+		default:
+			return
+		}
+	}
+}
+
+// parseArray consumes an array, recursing into each element.
+func (s *json5Scanner) parseArray() {
+	s.advance() // consume '['
+	for s.dup == nil {
+		s.skipWsComments()
+		if s.atEnd() {
+			return
+		}
+		if s.peek() == ']' {
+			s.advance()
+			return
+		}
+		s.parseValue()
+
+		s.skipWsComments()
+		switch s.peek() {
+		case ',':
+			s.advance()
+		case ']':
+			s.advance()
+			return
+		default:
+			return
+		}
+	}
+}
+
+// readKey reads an object key: a quoted string or an unquoted identifier.
+// The returned key is the canonical (unquoted, unescaped) form so a
+// quoted and an unquoted spelling of the same key compare equal. ok is
+// false on malformed input so the caller can defer to the real parser.
+func (s *json5Scanner) readKey() (string, bool) {
+	switch s.peek() {
+	case '"', '\'':
+		return s.readString(), true
+	}
+	start := s.pos
+	for !s.atEnd() {
+		switch c := s.peek(); c {
+		case ':', ' ', '\t', '\r', '\n', '\f', '\v', '/':
+			goto done
+		default:
+			s.advance()
+		}
+	}
+done:
+	if s.pos == start {
+		return "", false
+	}
+	return string(s.data[start:s.pos]), true
+}
+
+// readString consumes a quoted string (single or double quote) and returns
+// its decoded content. Only escape handling that matters for correctly
+// finding the closing quote is guaranteed; other escapes decode
+// best-effort, which is sufficient for key comparison.
+func (s *json5Scanner) readString() string {
+	quote := s.advance() // consume opening quote
+	var b []byte
+	for !s.atEnd() {
+		c := s.advance()
+		if c == '\\' {
+			if s.atEnd() {
+				break
+			}
+			esc := s.advance()
+			switch esc {
+			case 'n':
+				b = append(b, '\n')
+			case 't':
+				b = append(b, '\t')
+			case 'r':
+				b = append(b, '\r')
+			case 'b':
+				b = append(b, '\b')
+			case 'f':
+				b = append(b, '\f')
+			case '\n', '\r':
+				// line continuation: the newline is elided
+			case 'u':
+				if s.pos+4 <= len(s.data) {
+					if r, err := strconv.ParseUint(string(s.data[s.pos:s.pos+4]), 16, 32); err == nil {
+						for i := 0; i < 4; i++ {
+							s.advance()
+						}
+						b = append(b, []byte(string(rune(r)))...)
+						continue
+					}
+				}
+				b = append(b, esc)
+			default:
+				b = append(b, esc)
+			}
+			continue
+		}
+		if c == quote {
+			break
+		}
+		b = append(b, c)
+	}
+	return string(b)
+}
+
+// skipPrimitive consumes a bare scalar (number, true / false / null,
+// Infinity, NaN, ...) up to the next structural delimiter.
+func (s *json5Scanner) skipPrimitive() {
+	for !s.atEnd() {
+		switch s.peek() {
+		case ',', '}', ']', ' ', '\t', '\r', '\n', '\f', '\v', '/':
+			return
+		default:
+			s.advance()
+		}
+	}
+}

--- a/tasks/json5_dup_test.go
+++ b/tasks/json5_dup_test.go
@@ -1,0 +1,120 @@
+package tasks
+
+import "testing"
+
+func TestDetectJSON5DuplicateKeys(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		dup     bool
+		wantKey string
+	}{
+		{
+			name:  "no duplicates",
+			input: `{a: 1, b: 2, c: {a: 3}}`,
+			dup:   false,
+		},
+		{
+			name:    "simple unquoted duplicate",
+			input:   `{a: 1, a: 2}`,
+			dup:     true,
+			wantKey: "a",
+		},
+		{
+			name:    "quoted and unquoted spelling collide",
+			input:   `{"dokku_app": {}, dokku_app: {}}`,
+			dup:     true,
+			wantKey: "dokku_app",
+		},
+		{
+			name:    "single quoted duplicate",
+			input:   `{'x': 1, x: 2}`,
+			dup:     true,
+			wantKey: "x",
+		},
+		{
+			name:  "same key in different objects is fine",
+			input: `[{a: 1}, {a: 2}]`,
+			dup:   false,
+		},
+		{
+			name:  "nested object with distinct keys",
+			input: `{outer: {a: 1, b: 2}, other: {a: 1}}`,
+			dup:   false,
+		},
+		{
+			name:    "duplicate in a nested object",
+			input:   `{outer: {a: 1, a: 2}}`,
+			dup:     true,
+			wantKey: "a",
+		},
+		{
+			name:  "braces and colons inside a string value do not confuse",
+			input: `{a: "b: {not a key}", b: "c: d"}`,
+			dup:   false,
+		},
+		{
+			name:    "duplicate after a string with braces",
+			input:   `{a: "x: {y}", a: 2}`,
+			dup:     true,
+			wantKey: "a",
+		},
+		{
+			name:  "line and block comments skipped",
+			input: "{\n  a: 1, // a comment: not a key\n  /* b: block */ b: 2\n}",
+			dup:   false,
+		},
+		{
+			name:    "duplicate across comments",
+			input:   "{\n  a: 1,\n  // filler\n  a: 2\n}",
+			dup:     true,
+			wantKey: "a",
+		},
+		{
+			name:  "trailing comma is fine",
+			input: `{a: 1, b: 2,}`,
+			dup:   false,
+		},
+		{
+			name:  "array of numbers and literals",
+			input: `{list: [1, 2, true, null, Infinity], done: false}`,
+			dup:   false,
+		},
+		{
+			name:    "escaped quote inside a value does not end the string early",
+			input:   `{a: "he said \"hi\"", a: 2}`,
+			dup:     true,
+			wantKey: "a",
+		},
+		{
+			name:  "key that is a substring of another is not a duplicate",
+			input: `{app: 1, application: 2}`,
+			dup:   false,
+		},
+		{
+			name:    "recipe-shaped duplicate task-type key",
+			input:   `[{tasks: [{dokku_app: {app: "a"}, dokku_app: {app: "b"}}]}]`,
+			dup:     true,
+			wantKey: "dokku_app",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectJSON5DuplicateKeys([]byte(tt.input))
+			if tt.dup {
+				if got == nil {
+					t.Fatalf("expected duplicate key %q, got none", tt.wantKey)
+				}
+				if got.Key != tt.wantKey {
+					t.Errorf("duplicate key = %q, want %q", got.Key, tt.wantKey)
+				}
+				if got.Line == 0 {
+					t.Errorf("expected a non-zero line for the duplicate")
+				}
+			} else if got != nil {
+				t.Fatalf("expected no duplicate, got %q at line %d", got.Key, got.Line)
+			}
+		})
+	}
+}

--- a/tasks/loop.go
+++ b/tasks/loop.go
@@ -3,11 +3,9 @@ package tasks
 import (
 	"fmt"
 	"io"
-	"reflect"
 	"strings"
 
 	sigil "github.com/gliderlabs/sigil"
-	defaults "github.com/mcuadros/go-defaults"
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -17,10 +15,10 @@ const loopItemNameLimit = 40
 
 // expandLoop produces one TaskEnvelope per iteration the envelope's loop
 // resolves to. The base envelope already carries the resolved Loop value
-// (literal list or expr source); body is the raw YAML body associated
-// with the registered task type, decoded once at the file level. context
-// is the file-level sigil context used to populate `.item` and `.index`
-// during the second-pass render.
+// (literal list or expr source); bodyBytes is the task body re-marshalled
+// from the parsed entry's body node. context is the file-level sigil
+// context used to populate `.item` and `.index` during the second-pass
+// render.
 //
 // The Loop value is resolved as follows:
 //
@@ -29,20 +27,15 @@ const loopItemNameLimit = 40
 //     given expr context (file-level inputs); the result must be a list.
 //   - anything else: returns an error.
 //
-// For each item, the body is YAML-marshalled, sigil-rendered with
-// `.item`/`.index` set, then YAML-unmarshalled into a fresh registered
-// task struct. The expanded envelope inherits Tags / When / Register
-// from the base; LoopItem / LoopIndex carry the iteration value so the
-// per-task `when:` evaluation can see them.
-func expandLoop(base *TaskEnvelope, body interface{}, registered Task, sigilContext map[string]interface{}, exprContext map[string]interface{}) ([]*TaskEnvelope, error) {
+// For each item, the body is sigil-rendered with `.item`/`.index` set,
+// then decoded into a fresh registered task struct via decodeTaskBytes.
+// The expanded envelope inherits Tags / When / Register from the base;
+// LoopItem / LoopIndex carry the iteration value so the per-task `when:`
+// evaluation can see them.
+func expandLoop(base *TaskEnvelope, bodyBytes []byte, typeKey string, sigilContext map[string]interface{}, exprContext map[string]interface{}) ([]*TaskEnvelope, error) {
 	items, err := resolveLoopList(base.Loop, exprContext)
 	if err != nil {
 		return nil, err
-	}
-
-	bodyBytes, err := yaml.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal loop body: %w", err)
 	}
 
 	out := make([]*TaskEnvelope, 0, len(items))
@@ -63,12 +56,10 @@ func expandLoop(base *TaskEnvelope, body interface{}, registered Task, sigilCont
 			return nil, fmt.Errorf("loop iteration %d: read error: %w", i, err)
 		}
 
-		taskValue := reflect.New(reflect.TypeOf(registered))
-		if err := yaml.Unmarshal(renderedBytes, taskValue.Interface()); err != nil {
+		task, err := decodeTaskBytes(typeKey, renderedBytes)
+		if err != nil {
 			return nil, fmt.Errorf("loop iteration %d: decode error: %w", i, err)
 		}
-		task := taskValue.Elem().Interface().(Task)
-		defaults.SetDefaults(task)
 
 		expanded := *base
 		expanded.Task = task
@@ -85,35 +76,35 @@ func expandLoop(base *TaskEnvelope, body interface{}, registered Task, sigilCont
 
 // expandLoopGroup produces one group TaskEnvelope per iteration the
 // envelope's loop resolves to. The base envelope already carries the
-// resolved Loop value; blockBody / rescueBody / alwaysBody are the raw
-// YAML lists of nested task entries decoded once at the file level.
+// resolved Loop value; blockNode / rescueNode / alwaysNode are the raw
+// YAML sequence nodes of nested task entries from the parsed entry.
 //
-// For each iteration, the three lists are YAML-marshalled, sigil-rendered
-// with `.item` / `.index` set, then unmarshalled back into
-// []map[string]interface{} and recursed through buildEnvelopesForEntry
+// For each iteration, the three clause nodes are YAML-marshalled,
+// sigil-rendered with `.item` / `.index` set, then re-parsed through the
+// shared structural parser and recursed through buildEnvelopesFromEntry
 // so child envelopes inherit the iteration's `.item` / `.index` in
 // every nested task body. The expanded group envelope inherits Tags /
 // When / Register from the base; LoopItem / LoopIndex carry the
 // iteration value so the per-group `when:` evaluation can see them.
-func expandLoopGroup(base *TaskEnvelope, blockBody, rescueBody, alwaysBody interface{}, sigilContext, exprContext map[string]interface{}) ([]*TaskEnvelope, error) {
+func expandLoopGroup(base *TaskEnvelope, blockNode, rescueNode, alwaysNode *yaml.Node, sigilContext, exprContext map[string]interface{}) ([]*TaskEnvelope, error) {
 	items, err := resolveLoopList(base.Loop, exprContext)
 	if err != nil {
 		return nil, err
 	}
 
-	blockBytes, err := yaml.Marshal(blockBody)
+	blockBytes, err := yaml.Marshal(blockNode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal block body: %w", err)
 	}
 	var rescueBytes, alwaysBytes []byte
-	if rescueBody != nil {
-		rescueBytes, err = yaml.Marshal(rescueBody)
+	if rescueNode != nil {
+		rescueBytes, err = yaml.Marshal(rescueNode)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal rescue body: %w", err)
 		}
 	}
-	if alwaysBody != nil {
-		alwaysBytes, err = yaml.Marshal(alwaysBody)
+	if alwaysNode != nil {
+		alwaysBytes, err = yaml.Marshal(alwaysNode)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal always body: %w", err)
 		}
@@ -183,14 +174,14 @@ func renderAndDecodeGroupClause(body []byte, clause string, iterCtx, sigilContex
 		return nil, fmt.Errorf("loop iteration %d %s: read error: %w", iter, clause, err)
 	}
 
-	var rawList []map[string]interface{}
-	if err := yaml.Unmarshal(renderedBytes, &rawList); err != nil {
-		return nil, fmt.Errorf("loop iteration %d %s: decode error: %w", iter, clause, err)
+	entries, err := parseTaskEntrySeq(renderedBytes, "")
+	if err != nil {
+		return nil, fmt.Errorf("loop iteration %d %s: %s", iter, clause, err)
 	}
 
-	out := make([]*TaskEnvelope, 0, len(rawList))
-	for i, entry := range rawList {
-		envelopes, err := buildEnvelopesForEntry(i+1, entry, sigilContext, exprContext)
+	out := make([]*TaskEnvelope, 0, len(entries))
+	for i, entry := range entries {
+		envelopes, err := buildEnvelopesFromEntry(entry, sigilContext, exprContext)
 		if err != nil {
 			return nil, fmt.Errorf("loop iteration %d %s[%d]: %s", iter, clause, i, err)
 		}

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -559,6 +559,13 @@ func GetPlaysWithFormat(data []byte, format string, context map[string]interface
 				return nil, err
 			}
 			for _, env := range envelopes {
+				if play.Tasks.GetEnvelope(env.Name) != nil {
+					// Duplicate literal names are already rejected at parse
+					// time; reaching here means two loop expansions produced
+					// the same suffixed name (#307), which would otherwise
+					// silently drop the earlier iteration.
+					return nil, fmt.Errorf("task parse error: duplicate task name %q in play %q", env.Name, play.Name)
+				}
 				if len(play.Tags) > 0 {
 					env.Tags = mergePlayTags(env.Tags, play.Tags)
 				}

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/dokku/docket/subprocess"
 	sigil "github.com/gliderlabs/sigil"
 	"github.com/gobuffalo/flect"
-	defaults "github.com/mcuadros/go-defaults"
 	json5 "github.com/titanous/json5"
 	yaml "gopkg.in/yaml.v3"
 )
@@ -470,31 +469,42 @@ func GetPlays(data []byte, context map[string]interface{}, userSet map[string]bo
 }
 
 // GetPlaysWithFormat is the format-aware variant of GetPlays. format is
-// one of "yaml" / "json5"; the empty string is treated as YAML. The
-// per-format dispatch happens at every parse point inside the function
-// so sigil templates render uniformly across both surfaces.
+// one of "yaml" / "json5"; the empty string is treated as YAML. Parsing
+// goes through the shared structural parser (tasks/parse.go) that also
+// powers `docket validate`, so the loader and the validator agree on
+// structural validity by construction; the first structural problem is
+// converted into the loader's fail-fast error.
 func GetPlaysWithFormat(data []byte, format string, context map[string]interface{}, userSet map[string]bool) ([]*Play, error) {
 	baseRendered, err := renderRecipeBytes(data, context)
 	if err != nil {
 		return nil, err
 	}
 
-	baseRecipe, err := UnmarshalRecipe(baseRendered, format)
+	baseAST, err := parseRecipeForLoader(baseRendered, format)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(baseRecipe) == 0 {
+	if len(baseAST.Plays) == 0 {
 		return nil, fmt.Errorf("parse error: no recipe found in tasks file")
 	}
 
-	plays := make([]*Play, 0, len(baseRecipe))
-	singleUnnamed := len(baseRecipe) == 1 && baseRecipe[0].Name == ""
-	for i, raw := range baseRecipe {
+	plays := make([]*Play, 0, len(baseAST.Plays))
+	singleUnnamed := len(baseAST.Plays) == 1 && baseAST.Plays[0].Name == ""
+	for i, rawPlay := range baseAST.Plays {
+		if len(rawPlay.Problems) > 0 {
+			return nil, problemToError(rawPlay.Problems[0])
+		}
+
+		meta, err := decodePlayMeta(rawPlay.Node)
+		if err != nil {
+			return nil, fmt.Errorf("play parse error: play #%d: %s", i+1, err)
+		}
+
 		play := &Play{
-			Name:   raw.Name,
-			When:   raw.When,
-			Inputs: raw.Inputs,
+			Name:   meta.Name,
+			When:   meta.When,
+			Inputs: meta.Inputs,
 		}
 		if play.Name == "" {
 			// Single-play recipes without a name keep the legacy
@@ -508,8 +518,8 @@ func GetPlaysWithFormat(data []byte, format string, context map[string]interface
 			}
 		}
 
-		if raw.Tags != nil {
-			tags, err := decodeTags(raw.Tags)
+		if meta.Tags != nil {
+			tags, err := decodeTags(meta.Tags)
 			if err != nil {
 				return nil, fmt.Errorf("play parse error: play #%d %q: %s", i+1, play.Name, err)
 			}
@@ -525,18 +535,26 @@ func GetPlaysWithFormat(data []byte, format string, context map[string]interface
 		}
 
 		playCtx := BuildPerPlayContext(context, play.Inputs, userSet)
-		perPlayRecipe, err := renderRecipeWithFormat(data, format, playCtx)
+		perRendered, err := renderRecipeBytes(data, playCtx)
 		if err != nil {
 			return nil, err
 		}
-		if i >= len(perPlayRecipe) {
+		perAST, err := parseRecipeForLoader(perRendered, format)
+		if err != nil {
+			return nil, err
+		}
+		if i >= len(perAST.Plays) {
 			return nil, fmt.Errorf("play parse error: play #%d %q: per-play render produced fewer plays than the structure pass", i+1, play.Name)
+		}
+		perPlay := perAST.Plays[i]
+		if len(perPlay.Problems) > 0 {
+			return nil, problemToError(perPlay.Problems[0])
 		}
 
 		exprCtx := buildExprContext(playCtx)
 		play.Tasks = OrderedStringEnvelopeMap{}
-		for j, t := range perPlayRecipe[i].Tasks {
-			envelopes, err := buildEnvelopesForEntry(j+1, t, playCtx, exprCtx)
+		for _, entry := range perPlay.Entries {
+			envelopes, err := buildEnvelopesFromEntry(entry, playCtx, exprCtx)
 			if err != nil {
 				return nil, err
 			}
@@ -554,6 +572,44 @@ func GetPlaysWithFormat(data []byte, format string, context map[string]interface
 	return plays, nil
 }
 
+// parseRecipeForLoader normalizes data's surface syntax, runs the shared
+// structural parser, and fails fast on document-level problems. Play- and
+// entry-level problems are left on the AST so GetPlaysWithFormat can
+// surface them in the play order the legacy loader used.
+func parseRecipeForLoader(data []byte, format string) (*parsedRecipe, error) {
+	normalized, normalizeProblems := normalizeRecipeBytes(data, format)
+	if len(normalizeProblems) > 0 {
+		return nil, problemToError(normalizeProblems[0])
+	}
+	ast := parseRecipe(normalized)
+	if len(ast.Problems) > 0 {
+		return nil, problemToError(ast.Problems[0])
+	}
+	return ast, nil
+}
+
+// playMeta is the loader's play-metadata projection, decoded from the
+// play's mapping node. Task entries are parsed separately through the
+// shared structural parser, so this struct deliberately omits `tasks:`.
+type playMeta struct {
+	Name   string      `yaml:"name"`
+	Tags   interface{} `yaml:"tags"`
+	When   string      `yaml:"when"`
+	Inputs []Input     `yaml:"inputs"`
+}
+
+// decodePlayMeta decodes a play mapping node's metadata fields.
+func decodePlayMeta(node *yaml.Node) (playMeta, error) {
+	var meta playMeta
+	if node == nil {
+		return meta, nil
+	}
+	if err := node.Decode(&meta); err != nil {
+		return meta, err
+	}
+	return meta, nil
+}
+
 // renderRecipeBytes runs the loop-var-safe sigil render over data with the
 // given context and returns the rendered bytes. Pulled out of the legacy
 // GetTasks so GetPlays can reuse it across the structure pass and per-play
@@ -569,21 +625,6 @@ func renderRecipeBytes(data []byte, context map[string]interface{}) ([]byte, err
 		return nil, fmt.Errorf("read error: %v", err.Error())
 	}
 	return unescapeLoopVars(rendered, captured), nil
-}
-
-// renderRecipe is the convenience wrapper that renders data with context
-// and unmarshals the result into a Recipe.
-func renderRecipe(data []byte, context map[string]interface{}) (Recipe, error) {
-	return renderRecipeWithFormat(data, FormatYAML, context)
-}
-
-// renderRecipeWithFormat is renderRecipe's format-aware variant.
-func renderRecipeWithFormat(data []byte, format string, context map[string]interface{}) (Recipe, error) {
-	rendered, err := renderRecipeBytes(data, context)
-	if err != nil {
-		return nil, err
-	}
-	return UnmarshalRecipe(rendered, format)
 }
 
 // BuildPerPlayContext layers the play's `inputs:` defaults above the
@@ -640,92 +681,26 @@ func mergePlayTags(envTags, playTags []string) []string {
 	return out
 }
 
-// buildEnvelopesForEntry walks a single task entry, partitions envelope
-// keys vs the task-type key, decodes the body, pre-compiles `when:`, and
-// expands `loop:` if present. Returns one or more envelopes ready for
-// insertion into the ordered map. When the entry carries `block:`, it is
-// decoded as a try/catch/finally group: child envelopes are produced
-// recursively from the block / rescue / always lists and the wrapping
-// envelope's Task is left nil.
-func buildEnvelopesForEntry(index int, entry map[string]interface{}, sigilContext, exprContext map[string]interface{}) ([]*TaskEnvelope, error) {
-	envelope := &TaskEnvelope{}
-
-	var (
-		taskTypeKey  string
-		taskBody     interface{}
-		taskTypeKeys []string
-		unknownKeys  []string
-		blockRaw     interface{}
-		rescueRaw    interface{}
-		alwaysRaw    interface{}
-		hasBlock     bool
-		hasRescue    bool
-		hasAlways    bool
-	)
-
-	for key, value := range entry {
-		switch key {
-		case "name":
-			if s, ok := value.(string); ok {
-				envelope.Name = s
-			}
-		case "tags":
-			tags, err := decodeTags(value)
-			if err != nil {
-				return nil, fmt.Errorf("task parse error: task #%d: %s", index, err)
-			}
-			envelope.Tags = tags
-		case "when":
-			s, ok := value.(string)
-			if !ok {
-				return nil, fmt.Errorf("task parse error: task #%d: when must be a string expression, got %T", index, value)
-			}
-			envelope.When = s
-		case "loop":
-			envelope.Loop = value
-		case "register":
-			s, ok := value.(string)
-			if !ok {
-				return nil, fmt.Errorf("task parse error: task #%d: register must be a string, got %T", index, value)
-			}
-			envelope.Register = s
-		case "changed_when":
-			s, ok := value.(string)
-			if !ok {
-				return nil, fmt.Errorf("task parse error: task #%d: changed_when must be a string expression, got %T", index, value)
-			}
-			envelope.ChangedWhen = s
-		case "failed_when":
-			s, ok := value.(string)
-			if !ok {
-				return nil, fmt.Errorf("task parse error: task #%d: failed_when must be a string expression, got %T", index, value)
-			}
-			envelope.FailedWhen = s
-		case "ignore_errors":
-			b, ok := value.(bool)
-			if !ok {
-				return nil, fmt.Errorf("task parse error: task #%d: ignore_errors must be a bool, got %T", index, value)
-			}
-			envelope.IgnoreErrors = b
-		case "block":
-			blockRaw = value
-			hasBlock = true
-		case "rescue":
-			rescueRaw = value
-			hasRescue = true
-		case "always":
-			alwaysRaw = value
-			hasAlways = true
-		default:
-			if _, registered := RegisteredTasks[key]; registered {
-				taskTypeKeys = append(taskTypeKeys, key)
-				taskTypeKey = key
-				taskBody = value
-				continue
-			}
-			unknownKeys = append(unknownKeys, key)
-		}
+// buildEnvelopesFromEntry converts one parsed task entry into one or more
+// runtime envelopes: it pre-compiles predicates, expands `loop:`, decodes
+// the task body via decodeTaskBytes, and recurses through group children.
+// Structural problems the shared parser collected on the entry fail fast
+// here, so the loader rejects exactly what `docket validate` flags.
+func buildEnvelopesFromEntry(e *parsedTaskEntry, sigilContext, exprContext map[string]interface{}) ([]*TaskEnvelope, error) {
+	if len(e.Problems) > 0 {
+		return nil, problemToError(e.Problems[0])
 	}
+
+	envelope := &TaskEnvelope{
+		Name:         e.Name,
+		Tags:         e.Tags,
+		When:         e.When,
+		Register:     e.Register,
+		ChangedWhen:  e.ChangedWhen,
+		FailedWhen:   e.FailedWhen,
+		IgnoreErrors: e.IgnoreErrors,
+	}
+	index := e.Index
 
 	if envelope.Name == "" {
 		generated, err := generateTaskName(index)
@@ -735,29 +710,12 @@ func buildEnvelopesForEntry(index int, entry map[string]interface{}, sigilContex
 		envelope.Name = generated
 	}
 
-	if len(unknownKeys) > 0 {
-		return nil, unknownKeyError(index, envelope.Name, unknownKeys)
-	}
-
-	isGroup := hasBlock
-	if hasRescue && !hasBlock {
-		return nil, fmt.Errorf("task parse error: task #%d %q has rescue: without block:", index, envelope.Name)
-	}
-	if hasAlways && !hasBlock {
-		return nil, fmt.Errorf("task parse error: task #%d %q has always: without block:", index, envelope.Name)
-	}
-
-	if isGroup {
-		if len(taskTypeKeys) > 0 {
-			return nil, fmt.Errorf("task parse error: task #%d %q is a block: group and cannot also carry task-type key %q", index, envelope.Name, taskTypeKeys[0])
+	if e.LoopNode != nil {
+		var loop interface{}
+		if err := e.LoopNode.Decode(&loop); err != nil {
+			return nil, fmt.Errorf("task parse error: task #%d %q: loop decode error: %s", index, envelope.Name, err)
 		}
-	} else {
-		if len(taskTypeKeys) == 0 {
-			return nil, fmt.Errorf("task parse error: task #%d %q was not a valid task - valid_tasks=%v", index, envelope.Name, registeredTaskNamesSorted())
-		}
-		if len(taskTypeKeys) > 1 {
-			return nil, fmt.Errorf("task parse error: task #%d %q has %d task-type keys (%s); exactly one is allowed", index, envelope.Name, len(taskTypeKeys), strings.Join(taskTypeKeys, ", "))
-		}
+		envelope.Loop = loop
 	}
 
 	if envelope.When != "" {
@@ -784,9 +742,9 @@ func buildEnvelopesForEntry(index int, entry map[string]interface{}, sigilContex
 		envelope.failedWhenProgram = prog
 	}
 
-	if isGroup {
+	if e.IsGroup {
 		if envelope.Loop != nil {
-			expanded, err := expandLoopGroup(envelope, blockRaw, rescueRaw, alwaysRaw, sigilContext, exprContext)
+			expanded, err := expandLoopGroup(envelope, e.BlockNode, e.RescueNode, e.AlwaysNode, sigilContext, exprContext)
 			if err != nil {
 				return nil, fmt.Errorf("task parse error: task #%d %q: %s", index, envelope.Name, err)
 			}
@@ -794,7 +752,7 @@ func buildEnvelopesForEntry(index int, entry map[string]interface{}, sigilContex
 		}
 
 		envelope.TypeName = ""
-		blockChildren, err := decodeGroupClause(blockRaw, "block", envelope.Name, sigilContext, exprContext)
+		blockChildren, err := buildGroupClause(e.Block, "block", sigilContext, exprContext)
 		if err != nil {
 			return nil, fmt.Errorf("task parse error: task #%d %q: %s", index, envelope.Name, err)
 		}
@@ -803,34 +761,30 @@ func buildEnvelopesForEntry(index int, entry map[string]interface{}, sigilContex
 		}
 		envelope.Block = blockChildren
 
-		if hasRescue {
-			rescueChildren, err := decodeGroupClause(rescueRaw, "rescue", envelope.Name, sigilContext, exprContext)
-			if err != nil {
-				return nil, fmt.Errorf("task parse error: task #%d %q: %s", index, envelope.Name, err)
-			}
-			envelope.Rescue = rescueChildren
+		rescueChildren, err := buildGroupClause(e.Rescue, "rescue", sigilContext, exprContext)
+		if err != nil {
+			return nil, fmt.Errorf("task parse error: task #%d %q: %s", index, envelope.Name, err)
 		}
-		if hasAlways {
-			alwaysChildren, err := decodeGroupClause(alwaysRaw, "always", envelope.Name, sigilContext, exprContext)
-			if err != nil {
-				return nil, fmt.Errorf("task parse error: task #%d %q: %s", index, envelope.Name, err)
-			}
-			envelope.Always = alwaysChildren
+		envelope.Rescue = rescueChildren
+
+		alwaysChildren, err := buildGroupClause(e.Always, "always", sigilContext, exprContext)
+		if err != nil {
+			return nil, fmt.Errorf("task parse error: task #%d %q: %s", index, envelope.Name, err)
 		}
+		envelope.Always = alwaysChildren
 
 		return []*TaskEnvelope{envelope}, nil
 	}
 
-	envelope.TypeName = taskTypeKey
-	registered := RegisteredTasks[taskTypeKey]
+	envelope.TypeName = e.TypeKey
 
-	bodyBytes, err := yaml.Marshal(taskBody)
+	bodyBytes, err := yaml.Marshal(e.BodyNode)
 	if err != nil {
 		return nil, fmt.Errorf("task parse error: task #%d %q failed to marshal config to yaml - %s", index, envelope.Name, err)
 	}
 
 	if envelope.Loop != nil {
-		expanded, err := expandLoop(envelope, taskBody, registered, sigilContext, exprContext)
+		expanded, err := expandLoop(envelope, bodyBytes, e.TypeKey, sigilContext, exprContext)
 		if err != nil {
 			return nil, fmt.Errorf("task parse error: task #%d %q: %s", index, envelope.Name, err)
 		}
@@ -842,12 +796,10 @@ func buildEnvelopesForEntry(index int, entry map[string]interface{}, sigilContex
 		return expanded, nil
 	}
 
-	taskValue := reflect.New(reflect.TypeOf(registered))
-	if err := yaml.Unmarshal(bodyBytes, taskValue.Interface()); err != nil {
-		return nil, fmt.Errorf("task parse error: task #%d %q failed to decode to %s - %s", index, envelope.Name, taskTypeKey, err)
+	task, err := decodeTaskBytes(e.TypeKey, bodyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("task parse error: task #%d %q failed to decode to %s - %s", index, envelope.Name, e.TypeKey, err)
 	}
-	task := taskValue.Elem().Interface().(Task)
-	defaults.SetDefaults(task)
 	envelope.Task = task
 
 	if err := rejectLoopVarsInTask(index, envelope.Name, task); err != nil {
@@ -857,60 +809,19 @@ func buildEnvelopesForEntry(index int, entry map[string]interface{}, sigilContex
 	return []*TaskEnvelope{envelope}, nil
 }
 
-// decodeGroupClause decodes one of `block:` / `rescue:` / `always:` into
-// a flat slice of child envelopes. The clause value must be a sequence
-// of YAML mappings (`[]interface{}` of `map[string]interface{}` after
-// the YAML unmarshal); each mapping is recursed through
-// buildEnvelopesForEntry so child entries themselves may carry envelope
-// keys, loop expansions, or nested groups.
-func decodeGroupClause(raw interface{}, clause, parentName string, sigilContext, exprContext map[string]interface{}) ([]*TaskEnvelope, error) {
-	if raw == nil {
-		return nil, nil
-	}
-	rawList, ok := raw.([]interface{})
-	if !ok {
-		return nil, fmt.Errorf("%s: must be a list of task entries, got %T", clause, raw)
-	}
-	out := make([]*TaskEnvelope, 0, len(rawList))
-	for i, item := range rawList {
-		entry, ok := item.(map[string]interface{})
-		if !ok {
-			if mapped, mapOk := coerceStringKeyMap(item); mapOk {
-				entry = mapped
-			} else {
-				return nil, fmt.Errorf("%s[%d]: child entry must be a yaml mapping, got %T", clause, i, item)
-			}
-		}
-		childEnvelopes, err := buildEnvelopesForEntry(i+1, entry, sigilContext, exprContext)
+// buildGroupClause builds the child envelopes for one already-parsed
+// block / rescue / always clause, prefixing child errors with the clause
+// name and child position the way the legacy group decoder did.
+func buildGroupClause(children []*parsedTaskEntry, clause string, sigilContext, exprContext map[string]interface{}) ([]*TaskEnvelope, error) {
+	out := make([]*TaskEnvelope, 0, len(children))
+	for i, child := range children {
+		childEnvelopes, err := buildEnvelopesFromEntry(child, sigilContext, exprContext)
 		if err != nil {
 			return nil, fmt.Errorf("%s[%d]: %s", clause, i, err)
 		}
 		out = append(out, childEnvelopes...)
 	}
 	return out, nil
-}
-
-// coerceStringKeyMap converts a yaml-decoded map[interface{}]interface{}
-// into a map[string]interface{} so nested entries match the shape
-// buildEnvelopesForEntry expects. yaml.v3 produces map[string]interface{}
-// out of the box, but defensive code keeps the loader robust against
-// custom unmarshallers.
-func coerceStringKeyMap(item interface{}) (map[string]interface{}, bool) {
-	if entry, ok := item.(map[string]interface{}); ok {
-		return entry, true
-	}
-	if entry, ok := item.(map[interface{}]interface{}); ok {
-		out := make(map[string]interface{}, len(entry))
-		for k, v := range entry {
-			ks, ok := k.(string)
-			if !ok {
-				return nil, false
-			}
-			out[ks] = v
-		}
-		return out, true
-	}
-	return nil, false
 }
 
 // decodeTags coerces a yaml-parsed tags value into a []string. Supports
@@ -945,19 +856,6 @@ func generateTaskName(index int) (string, error) {
 	return fmt.Sprintf("task #%d %X", index, b), nil
 }
 
-// unknownKeyError builds a parse error for an entry with one or more
-// unknown keys, including a "did you mean" suggestion when the closest
-// match is within Levenshtein distance 2.
-func unknownKeyError(index int, name string, unknown []string) error {
-	primary := unknown[0]
-	suggestion := nearestEnvelopeOrTaskKey(primary)
-	hint := ""
-	if suggestion != "" {
-		hint = fmt.Sprintf(" - did you mean %q?", suggestion)
-	}
-	return fmt.Errorf("task parse error: task #%d %q has unknown envelope key %q (allowed: %s, or any registered task type)%s", index, name, primary, strings.Join(envelopeAllowlistKeys, ", "), hint)
-}
-
 // nearestEnvelopeOrTaskKey returns the envelope-allowlist or registered
 // task name with the lowest Levenshtein distance to candidate, but only
 // if that distance is at most 2.
@@ -982,24 +880,6 @@ func nearestEnvelopeOrTaskKey(candidate string) string {
 		return best
 	}
 	return ""
-}
-
-// registeredTaskNamesSorted returns the registered task names sorted
-// alphabetically. Used for error messages so the output is stable.
-func registeredTaskNamesSorted() []string {
-	names := make([]string, 0, len(RegisteredTasks))
-	for k := range RegisteredTasks {
-		names = append(names, k)
-	}
-	// Bubble-sort works fine for ~50 entries and avoids the import cost.
-	for i := 0; i < len(names); i++ {
-		for j := i + 1; j < len(names); j++ {
-			if names[j] < names[i] {
-				names[i], names[j] = names[j], names[i]
-			}
-		}
-	}
-	return names
 }
 
 // buildExprContext returns the file-level expr context. Today this is

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -298,6 +298,36 @@ type InputValidator interface {
 // Global registry for Tasks.
 var RegisteredTasks map[string]Task
 
+// ReservedInputNames is the set of recipe input names that collide with a
+// built-in CLI flag on apply, plan, or validate. Declaring an input with
+// one of these names used to make pflag panic with "flag redefined"
+// before flag parsing even began; the loader and validator now reject it
+// as reserved_input_name instead, and registerInputFlags skips it so no
+// command panics. The set is the union of the built-in flags across the
+// input-accepting commands, so validate flags the same names apply and
+// plan would collide with. help / v / version are intentionally absent -
+// they are handled by the CLI framework, not registered on the flag set,
+// so they work as input names. A commands-package test keeps this set in
+// sync with the real flag sets.
+var ReservedInputNames = map[string]bool{
+	"tasks":                true,
+	"host":                 true,
+	"verbose":              true,
+	"json":                 true,
+	"no-color":             true,
+	"tags":                 true,
+	"skip-tags":            true,
+	"sudo":                 true,
+	"play":                 true,
+	"vars-file":            true,
+	"fail-fast":            true,
+	"list-tasks":           true,
+	"start-at-task":        true,
+	"accept-new-host-keys": true,
+	"detailed-exitcode":    true,
+	"strict":               true,
+}
+
 // envelopeAllowlistKeys are the cross-cutting envelope keys the loader
 // admits alongside the single task-type key. name / tags / when / loop
 // are activated by #205; register / changed_when / failed_when /

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -381,6 +381,25 @@ func TestGetTasksRejectsNullTaskBodyUnderLoop(t *testing.T) {
 	}
 }
 
+func TestGetTasksRejectsNonStringName(t *testing.T) {
+	// A non-string name (`name: 123`) used to be silently dropped and a
+	// random auto-name used; it now returns a typed parse error like the
+	// other envelope keys (#342).
+	data := []byte(`---
+- tasks:
+    - name: 123
+      dokku_app:
+        app: x
+`)
+	_, err := GetTasks(data, map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected error for non-string name, got nil")
+	}
+	if !strings.Contains(err.Error(), "name must be a string") {
+		t.Errorf("expected name-type error, got: %v", err)
+	}
+}
+
 func TestGetTasksAllowsEmptyMappingBody(t *testing.T) {
 	// An empty mapping `{}` is not a null body: it decodes to a zero
 	// struct so a missing required field surfaces at apply, not a parse

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -381,6 +381,68 @@ func TestGetTasksRejectsNullTaskBodyUnderLoop(t *testing.T) {
 	}
 }
 
+func TestGetTasksRejectsDuplicateTaskNames(t *testing.T) {
+	// Two tasks sharing a name used to silently drop all but the last
+	// when keyed into the ordered map; the loader now rejects them (#307).
+	data := []byte(`---
+- tasks:
+    - name: same
+      dokku_app:
+        app: first-app
+    - name: same
+      dokku_app:
+        app: second-app
+`)
+	_, err := GetTasks(data, map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected error for duplicate task names, got nil")
+	}
+	if !strings.Contains(err.Error(), `duplicate task name "same"`) {
+		t.Errorf("expected duplicate-name error, got: %v", err)
+	}
+}
+
+func TestGetTasksRejectsLoopSuffixCollision(t *testing.T) {
+	// Loop item names are trimmed for the (item=<value>) suffix, so two
+	// items that differ only by surrounding whitespace collapse to the
+	// same envelope name. The runtime guard rejects the collision instead
+	// of silently dropping an iteration (#307).
+	data := []byte(`---
+- tasks:
+    - name: dup
+      loop: ["a", " a "]
+      dokku_app:
+        app: "app-{{ .item }}"
+`)
+	_, err := GetTasks(data, map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected error for colliding loop suffixes, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate task name") {
+		t.Errorf("expected duplicate-name error, got: %v", err)
+	}
+}
+
+func TestGetTasksAllowsDuplicateNameAcrossPlays(t *testing.T) {
+	// Each play has its own ordered map, so the same name in two plays is
+	// fine and must not be flagged.
+	data := []byte(`---
+- name: play-a
+  tasks:
+    - name: shared
+      dokku_app:
+        app: a
+- name: play-b
+  tasks:
+    - name: shared
+      dokku_app:
+        app: b
+`)
+	if _, err := GetPlays(data, map[string]interface{}{}, nil); err != nil {
+		t.Fatalf("same name across plays should be allowed, got: %v", err)
+	}
+}
+
 func TestGetTasksRejectsNonStringName(t *testing.T) {
 	// A non-string name (`name: 123`) used to be silently dropped and a
 	// random auto-name used; it now returns a typed parse error like the

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -381,6 +381,26 @@ func TestGetTasksRejectsNullTaskBodyUnderLoop(t *testing.T) {
 	}
 }
 
+func TestGetPlaysRejectsReservedInputName(t *testing.T) {
+	// An input named after a built-in flag is rejected by the loader with
+	// a clean error instead of panicking pflag (#302).
+	data := []byte(`---
+- inputs:
+    - name: no-color
+      default: x
+  tasks:
+    - dokku_app:
+        app: my-app
+`)
+	_, err := GetPlays(data, map[string]interface{}{}, nil)
+	if err == nil {
+		t.Fatal("expected error for reserved input name, got nil")
+	}
+	if !strings.Contains(err.Error(), "reserved for a built-in flag") {
+		t.Errorf("expected reserved-name error, got: %v", err)
+	}
+}
+
 func TestGetTasksRejectsDuplicateTaskNames(t *testing.T) {
 	// Two tasks sharing a name used to silently drop all but the last
 	// when keyed into the ordered map; the loader now rejects them (#307).

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -80,11 +80,10 @@ func TestGetTasksInvalidTaskType(t *testing.T) {
 		t.Fatal("GetTasks with invalid task type should return an error")
 	}
 
-	// An unknown task type lands in the unknown-envelope-key bucket and
-	// is reported with a "did you mean" hint pointing at the closest
-	// registered task name.
-	if !strings.Contains(err.Error(), "unknown envelope key") {
-		t.Errorf("expected 'unknown envelope key' error, got: %v", err)
+	// An unknown task type is reported with the validator's diagnostic
+	// (shared parser) including the source line.
+	if !strings.Contains(err.Error(), "unknown task type") {
+		t.Errorf("expected 'unknown task type' error, got: %v", err)
 	}
 }
 
@@ -802,8 +801,8 @@ func TestGetTasksRejectsRescueWithoutBlock(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for rescue without block, got nil")
 	}
-	if !strings.Contains(err.Error(), "rescue: without block:") {
-		t.Errorf("expected 'rescue: without block:' error, got: %v", err)
+	if !strings.Contains(err.Error(), "rescue: requires a block: in the same task entry") {
+		t.Errorf("expected 'rescue: requires a block:' error, got: %v", err)
 	}
 }
 
@@ -821,7 +820,7 @@ func TestGetTasksRejectsBlockAlongsideTaskType(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for block alongside task-type, got nil")
 	}
-	if !strings.Contains(err.Error(), "is a block: group and cannot also carry task-type key") {
+	if !strings.Contains(err.Error(), "block: group entry cannot also carry task-type key") {
 		t.Errorf("expected block+task-type error, got: %v", err)
 	}
 }

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -345,6 +345,56 @@ func TestGetTasksTwoPropertiesNoName(t *testing.T) {
 	}
 }
 
+func TestGetTasksRejectsNullTaskBody(t *testing.T) {
+	// A task-type key with no body (`dokku_app:` and nothing after it)
+	// used to panic in defaults.SetDefaults on the loader path; it now
+	// returns a clean parse error (#306).
+	data := []byte(`---
+- tasks:
+    - name: x
+      dokku_app:
+`)
+	_, err := GetTasks(data, map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected error for null task body, got nil")
+	}
+	if !strings.Contains(err.Error(), "dokku_app body must not be empty") {
+		t.Errorf("expected empty-body error, got: %v", err)
+	}
+}
+
+func TestGetTasksRejectsNullTaskBodyUnderLoop(t *testing.T) {
+	// The loop path shares the same decode helper, so a null body under a
+	// loop is rejected the same way instead of panicking per iteration.
+	data := []byte(`---
+- tasks:
+    - name: x
+      loop: [a, b]
+      dokku_app:
+`)
+	_, err := GetTasks(data, map[string]interface{}{})
+	if err == nil {
+		t.Fatal("expected error for null task body under loop, got nil")
+	}
+	if !strings.Contains(err.Error(), "dokku_app body must not be empty") {
+		t.Errorf("expected empty-body error, got: %v", err)
+	}
+}
+
+func TestGetTasksAllowsEmptyMappingBody(t *testing.T) {
+	// An empty mapping `{}` is not a null body: it decodes to a zero
+	// struct so a missing required field surfaces at apply, not a parse
+	// error. The loader accepts it (validate reports the missing field).
+	data := []byte(`---
+- tasks:
+    - name: x
+      dokku_app: {}
+`)
+	if _, err := GetTasks(data, map[string]interface{}{}); err != nil {
+		t.Fatalf("empty mapping body should parse, got: %v", err)
+	}
+}
+
 func TestGetTasksFromRealExample(t *testing.T) {
 	data := []byte(`---
 - inputs:

--- a/tasks/parse.go
+++ b/tasks/parse.go
@@ -225,6 +225,8 @@ func parsePlay(play *yaml.Node, index int) *parsedPlay {
 		}
 	}
 
+	flagReservedInputNames(pp, play)
+
 	tasksNode := mappingValue(play, "tasks")
 	if tasksNode == nil {
 		return pp
@@ -282,6 +284,33 @@ func flagDuplicateTaskNames(pp *parsedPlay) {
 			Column:  anchor.Column,
 			Message: fmt.Sprintf("duplicate task name %q", entry.Name),
 			Hint:    hint,
+		})
+	}
+}
+
+// flagReservedInputNames rejects any input in the play whose name
+// collides with a built-in CLI flag (see ReservedInputNames). Such a name
+// used to make pflag panic before flag parsing began; both the loader and
+// the validator now reject it offline (#302).
+func flagReservedInputNames(pp *parsedPlay, play *yaml.Node) {
+	inputsNode := mappingValue(play, "inputs")
+	if inputsNode == nil || inputsNode.Kind != yaml.SequenceNode {
+		return
+	}
+	for _, in := range inputsNode.Content {
+		nameNode := mappingValue(in, "name")
+		if nameNode == nil || nameNode.Kind != yaml.ScalarNode {
+			continue
+		}
+		if !ReservedInputNames[nameNode.Value] {
+			continue
+		}
+		pp.Problems = append(pp.Problems, Problem{
+			Code:    "reserved_input_name",
+			Play:    pp.Label,
+			Line:    nameNode.Line,
+			Column:  nameNode.Column,
+			Message: fmt.Sprintf("input name %q is reserved for a built-in flag and cannot be used as an input name", nameNode.Value),
 		})
 	}
 }

--- a/tasks/parse.go
+++ b/tasks/parse.go
@@ -1,0 +1,508 @@
+package tasks
+
+import (
+	"fmt"
+	"strings"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// parse.go is the shared, position-carrying recipe parser used by both the
+// offline validator (tasks.Validate) and the runtime loader
+// (GetPlaysWithFormat). One structural walk over the yaml.v3 node tree
+// produces a parsedRecipe AST plus a list of Problems anchored to source
+// positions. The validator consumes every problem at once; the loader
+// converts the first problem into its fail-fast error via recipeParseError,
+// so both commands agree on what is structurally valid by construction.
+
+// parsedRecipe is the parsed form of one rendered recipe document.
+type parsedRecipe struct {
+	// Doc is the document body node (the top-level sequence of plays).
+	// nil when the document failed to parse or was empty.
+	Doc *yaml.Node
+
+	// Plays holds one entry per top-level play, in source order.
+	Plays []*parsedPlay
+
+	// Problems are document-level findings (yaml parse errors, recipe
+	// shape violations). Play- and entry-level findings live on the
+	// parsedPlay / parsedTaskEntry they anchor to.
+	Problems []Problem
+}
+
+// parsedPlay is the parsed form of one play mapping.
+type parsedPlay struct {
+	// Node is the play's mapping node; positions anchor here.
+	Node *yaml.Node
+
+	// Index is the play's 1-based position in the recipe.
+	Index int
+
+	// Label is the diagnostic label ("play #N"), matching the validator's
+	// historical labelling.
+	Label string
+
+	// Name is the play's scalar `name:` value, "" when absent.
+	Name string
+
+	// TasksNode is the play's `tasks:` sequence node, nil when absent.
+	TasksNode *yaml.Node
+
+	// Entries holds the parsed task entries, in source order.
+	Entries []*parsedTaskEntry
+
+	// Problems are play-level findings (non-mapping play, unexpected play
+	// keys, non-sequence tasks value).
+	Problems []Problem
+}
+
+// parsedTaskEntry is the parsed form of one task entry mapping, including
+// its typed envelope values and the partitioned task-type key. Group
+// entries (block / rescue / always) carry their children recursively.
+type parsedTaskEntry struct {
+	// Node is the entry's mapping node; positions anchor here.
+	Node *yaml.Node
+
+	// Index is the entry's 1-based position within its task list (or
+	// group clause).
+	Index int
+
+	// Label is the diagnostic label ("task #N" or `task #N "name"`).
+	Label string
+
+	// Name is the entry's `name:` value, "" when absent.
+	Name string
+
+	// NameNode is the value node of `name:`, nil when absent.
+	NameNode *yaml.Node
+
+	// Typed envelope values. Decoded during the walk; a wrong type is
+	// reported as a Problem and leaves the zero value here.
+	Tags         []string
+	When         string
+	Register     string
+	ChangedWhen  string
+	FailedWhen   string
+	IgnoreErrors bool
+
+	// LoopNode is the raw `loop:` value node (list literal or expr
+	// string); nil when absent. The loader decodes it at envelope-build
+	// time, the validator checks the scalar form compiles.
+	LoopNode *yaml.Node
+
+	// TypeKey / TypeNode / BodyNode identify the single registered
+	// task-type key and its body. All zero for group entries and for
+	// entries whose structure was rejected.
+	TypeKey  string
+	TypeNode *yaml.Node
+	BodyNode *yaml.Node
+
+	// Group clause nodes and their recursively parsed children.
+	IsGroup    bool
+	BlockNode  *yaml.Node
+	RescueNode *yaml.Node
+	AlwaysNode *yaml.Node
+	Block      []*parsedTaskEntry
+	Rescue     []*parsedTaskEntry
+	Always     []*parsedTaskEntry
+
+	// Problems are the structural findings anchored to this entry.
+	Problems []Problem
+
+	// Valid is false when a structural problem prevents the entry from
+	// being decoded further (body validation and envelope building skip
+	// invalid entries).
+	Valid bool
+}
+
+// normalizeRecipeBytes converts a recipe's on-disk surface syntax to YAML
+// bytes. JSON5 input is converted via json5ToYAMLBytes; YAML (and any
+// unknown format value) passes through unchanged. A conversion failure is
+// returned as a json5_parse problem.
+func normalizeRecipeBytes(data []byte, format string) ([]byte, []Problem) {
+	if !IsJSON5Format(format) {
+		return data, nil
+	}
+	converted, err := json5ToYAMLBytes(data)
+	if err != nil {
+		return nil, []Problem{{
+			Code:    "json5_parse",
+			Message: err.Error(),
+		}}
+	}
+	return converted, nil
+}
+
+// parseRecipe parses data (YAML bytes, already sigil-rendered and
+// format-normalized) into a parsedRecipe. Structural findings are
+// collected as Problems rather than returned as an error so the validator
+// can report all of them; the loader uses recipeParseError to fail fast on
+// the first one.
+func parseRecipe(data []byte) *parsedRecipe {
+	out := &parsedRecipe{}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		line, col := parseYAMLErrorPosition(err.Error())
+		out.Problems = append(out.Problems, Problem{
+			Code:    "yaml_parse",
+			Line:    line,
+			Column:  col,
+			Message: err.Error(),
+		})
+		return out
+	}
+
+	doc := documentBody(&root)
+	if doc == nil {
+		out.Problems = append(out.Problems, Problem{
+			Code:    "recipe_shape",
+			Message: "no recipe found in tasks file",
+		})
+		return out
+	}
+	if doc.Kind != yaml.SequenceNode {
+		out.Problems = append(out.Problems, Problem{
+			Code:    "recipe_shape",
+			Line:    doc.Line,
+			Column:  doc.Column,
+			Message: "recipe must be a yaml list of plays",
+		})
+		return out
+	}
+	out.Doc = doc
+
+	for i, play := range doc.Content {
+		out.Plays = append(out.Plays, parsePlay(play, i+1))
+	}
+	return out
+}
+
+// parsePlay walks one play mapping into a parsedPlay.
+func parsePlay(play *yaml.Node, index int) *parsedPlay {
+	pp := &parsedPlay{
+		Node:  play,
+		Index: index,
+		Label: fmt.Sprintf("play #%d", index),
+	}
+
+	if play.Kind != yaml.MappingNode {
+		pp.Problems = append(pp.Problems, Problem{
+			Code:    "recipe_shape",
+			Play:    pp.Label,
+			Line:    play.Line,
+			Column:  play.Column,
+			Message: "play must be a yaml mapping with inputs and/or tasks",
+		})
+		return pp
+	}
+
+	pp.Name = scalarChild(play, "name")
+
+	for i := 0; i < len(play.Content); i += 2 {
+		key := play.Content[i].Value
+		if !allowedPlayKeys[key] {
+			pp.Problems = append(pp.Problems, Problem{
+				Code:    "recipe_shape",
+				Play:    pp.Label,
+				Line:    play.Content[i].Line,
+				Column:  play.Content[i].Column,
+				Message: fmt.Sprintf("unexpected play key %q (expected: %s)", key, allowedPlayKeysList),
+			})
+		}
+	}
+
+	tasksNode := mappingValue(play, "tasks")
+	if tasksNode == nil {
+		return pp
+	}
+	if tasksNode.Kind != yaml.SequenceNode {
+		pp.Problems = append(pp.Problems, Problem{
+			Code:    "recipe_shape",
+			Play:    pp.Label,
+			Line:    tasksNode.Line,
+			Column:  tasksNode.Column,
+			Message: "tasks must be a yaml list",
+		})
+		return pp
+	}
+	pp.TasksNode = tasksNode
+
+	for i, task := range tasksNode.Content {
+		pp.Entries = append(pp.Entries, parseTaskEntry(task, i+1, pp.Label))
+	}
+	return pp
+}
+
+// parseTaskEntry walks one task entry mapping into a parsedTaskEntry,
+// partitioning envelope keys from the task-type key, decoding typed
+// envelope values, and recursing into group clauses.
+func parseTaskEntry(task *yaml.Node, index int, playLabel string) *parsedTaskEntry {
+	e := &parsedTaskEntry{
+		Node:  task,
+		Index: index,
+		Label: fmt.Sprintf("task #%d", index),
+		Valid: true,
+	}
+
+	problem := func(code, message, hint string, node *yaml.Node) {
+		p := Problem{
+			Code:    code,
+			Play:    playLabel,
+			Task:    e.Label,
+			Message: message,
+			Hint:    hint,
+		}
+		if node != nil {
+			p.Line = node.Line
+			p.Column = node.Column
+		}
+		e.Problems = append(e.Problems, p)
+		e.Valid = false
+	}
+
+	if task.Kind != yaml.MappingNode {
+		problem("task_entry_shape", "task entry must be a yaml mapping", "", task)
+		return e
+	}
+
+	var (
+		taskTypeKeys []string
+		unknownKeys  []string
+		unknownNodes []*yaml.Node
+	)
+
+	for i := 0; i < len(task.Content); i += 2 {
+		keyNode := task.Content[i]
+		valueNode := task.Content[i+1]
+		key := keyNode.Value
+
+		switch key {
+		case "name":
+			e.NameNode = valueNode
+			if valueNode.Kind == yaml.ScalarNode {
+				e.Name = valueNode.Value
+			}
+		case "tags":
+			var raw interface{}
+			if err := valueNode.Decode(&raw); err != nil {
+				problem("envelope_key_type", fmt.Sprintf("tags decode error: %v", err), "", valueNode)
+				continue
+			}
+			tags, err := decodeTags(raw)
+			if err != nil {
+				problem("envelope_key_type", err.Error(), "", valueNode)
+				continue
+			}
+			e.Tags = tags
+		case "when":
+			s, ok, typeName := scalarString(valueNode)
+			if !ok {
+				problem("envelope_key_type", fmt.Sprintf("when must be a string expression, got %s", typeName), "", valueNode)
+				continue
+			}
+			e.When = s
+		case "register":
+			s, ok, typeName := scalarString(valueNode)
+			if !ok {
+				problem("envelope_key_type", fmt.Sprintf("register must be a string, got %s", typeName), "", valueNode)
+				continue
+			}
+			e.Register = s
+		case "changed_when":
+			s, ok, typeName := scalarString(valueNode)
+			if !ok {
+				problem("envelope_key_type", fmt.Sprintf("changed_when must be a string expression, got %s", typeName), "", valueNode)
+				continue
+			}
+			e.ChangedWhen = s
+		case "failed_when":
+			s, ok, typeName := scalarString(valueNode)
+			if !ok {
+				problem("envelope_key_type", fmt.Sprintf("failed_when must be a string expression, got %s", typeName), "", valueNode)
+				continue
+			}
+			e.FailedWhen = s
+		case "ignore_errors":
+			var b bool
+			if err := valueNode.Decode(&b); err != nil {
+				problem("envelope_key_type", fmt.Sprintf("ignore_errors must be a bool, got %s", scalarTypeName(valueNode)), "", valueNode)
+				continue
+			}
+			e.IgnoreErrors = b
+		case "loop":
+			e.LoopNode = valueNode
+		case "block":
+			e.BlockNode = valueNode
+			e.IsGroup = true
+		case "rescue":
+			e.RescueNode = valueNode
+		case "always":
+			e.AlwaysNode = valueNode
+		default:
+			if dependentIssue, reserved := reservedEnvelopeKeys[key]; reserved {
+				problem("envelope_key_unsupported",
+					fmt.Sprintf("envelope key %q is reserved but not yet supported", key),
+					fmt.Sprintf("activates with %s", dependentIssue), keyNode)
+				continue
+			}
+			if _, registered := RegisteredTasks[key]; registered {
+				taskTypeKeys = append(taskTypeKeys, key)
+				e.TypeKey = key
+				e.TypeNode = keyNode
+				e.BodyNode = valueNode
+				continue
+			}
+			unknownKeys = append(unknownKeys, key)
+			unknownNodes = append(unknownNodes, keyNode)
+		}
+	}
+
+	if e.Name != "" {
+		e.Label = fmt.Sprintf("task #%d %q", index, e.Name)
+		for i := range e.Problems {
+			e.Problems[i].Task = e.Label
+		}
+	}
+
+	if e.RescueNode != nil && e.BlockNode == nil {
+		problem("block_orphan_clause", "rescue: requires a block: in the same task entry", "", e.RescueNode)
+		return e
+	}
+	if e.AlwaysNode != nil && e.BlockNode == nil {
+		problem("block_orphan_clause", "always: requires a block: in the same task entry", "", e.AlwaysNode)
+		return e
+	}
+
+	if e.IsGroup {
+		if len(taskTypeKeys) > 0 {
+			problem("block_with_task_type",
+				fmt.Sprintf("block: group entry cannot also carry task-type key %q", taskTypeKeys[0]), "", e.TypeNode)
+		}
+		for i, key := range unknownKeys {
+			problem("unknown_key", unknownKeyMessage(key), unknownKeyHint(key), unknownNodes[i])
+		}
+		if e.BlockNode.Kind != yaml.SequenceNode {
+			problem("block_shape", "block: must be a yaml list of task entries", "", e.BlockNode)
+			return e
+		}
+		if len(e.BlockNode.Content) == 0 {
+			problem("block_empty", "block: must contain at least one child task", "", e.BlockNode)
+		}
+		e.TypeKey = ""
+		e.TypeNode = nil
+		e.BodyNode = nil
+		e.Block = parseGroupClause(e.BlockNode, playLabel)
+		e.Rescue = parseGroupClause(e.RescueNode, playLabel)
+		e.Always = parseGroupClause(e.AlwaysNode, playLabel)
+		return e
+	}
+
+	switch {
+	case len(taskTypeKeys) == 0 && len(unknownKeys) == 1:
+		problem("unknown_task_type",
+			fmt.Sprintf("unknown task type %q", unknownKeys[0]),
+			unknownKeyHint(unknownKeys[0]), unknownNodes[0])
+		return e
+	case len(unknownKeys) > 0:
+		for i, key := range unknownKeys {
+			problem("unknown_key", unknownKeyMessage(key), unknownKeyHint(key), unknownNodes[i])
+		}
+		return e
+	case len(taskTypeKeys) == 0:
+		problem("task_entry_shape", "task entry must contain exactly one task-type key", "", task)
+		return e
+	case len(taskTypeKeys) > 1:
+		problem("task_entry_shape",
+			fmt.Sprintf("task entry has %d task-type keys (%s); exactly one is allowed", len(taskTypeKeys), strings.Join(taskTypeKeys, ", ")), "", task)
+		e.TypeKey = ""
+		e.TypeNode = nil
+		e.BodyNode = nil
+		return e
+	}
+
+	return e
+}
+
+// parseGroupClause parses the children of a block / rescue / always
+// sequence node. A nil or non-sequence clause yields no children (the
+// group-level shape problems are reported by parseTaskEntry).
+func parseGroupClause(clause *yaml.Node, playLabel string) []*parsedTaskEntry {
+	if clause == nil || clause.Kind != yaml.SequenceNode {
+		return nil
+	}
+	out := make([]*parsedTaskEntry, 0, len(clause.Content))
+	for i, child := range clause.Content {
+		out = append(out, parseTaskEntry(child, i+1, playLabel))
+	}
+	return out
+}
+
+// scalarString decodes node into a string, reporting whether the value
+// really was a string plus a human-readable name of the actual type for
+// diagnostics. Matches the loader's historical `got %T` phrasing by
+// naming the Go type the value would decode to.
+func scalarString(node *yaml.Node) (string, bool, string) {
+	var raw interface{}
+	if err := node.Decode(&raw); err != nil {
+		return "", false, scalarTypeName(node)
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return "", false, fmt.Sprintf("%T", raw)
+	}
+	return s, true, "string"
+}
+
+// scalarTypeName renders a best-effort Go-style type name for a node used
+// in envelope-type diagnostics when the value cannot be decoded.
+func scalarTypeName(node *yaml.Node) string {
+	var raw interface{}
+	if err := node.Decode(&raw); err != nil {
+		return node.Tag
+	}
+	return fmt.Sprintf("%T", raw)
+}
+
+// unknownKeyMessage renders the diagnostic for a key that is neither an
+// envelope key nor a registered task type, on an entry that already has
+// (or lacks) a task-type key. The allowlist text mirrors the loader's
+// historical message.
+func unknownKeyMessage(key string) string {
+	return fmt.Sprintf("unknown envelope key %q (allowed: %s, or any registered task type)", key, strings.Join(envelopeAllowlistKeys, ", "))
+}
+
+// unknownKeyHint returns a did-you-mean hint for an unknown key, searching
+// both the envelope allowlist and the registered task names.
+func unknownKeyHint(key string) string {
+	if suggestion := nearestEnvelopeOrTaskKey(key); suggestion != "" {
+		return fmt.Sprintf("did you mean %q?", suggestion)
+	}
+	return ""
+}
+
+// allProblems flattens every problem in the parse result: document-level
+// first, then per play in source order (play problems, then each entry's
+// problems including group children, depth-first).
+func (r *parsedRecipe) allProblems() []Problem {
+	out := append([]Problem(nil), r.Problems...)
+	for _, play := range r.Plays {
+		out = append(out, play.Problems...)
+		for _, entry := range play.Entries {
+			out = append(out, entryProblems(entry)...)
+		}
+	}
+	return out
+}
+
+// entryProblems returns the entry's own problems followed by its group
+// children's, depth-first.
+func entryProblems(e *parsedTaskEntry) []Problem {
+	out := append([]Problem(nil), e.Problems...)
+	for _, group := range [][]*parsedTaskEntry{e.Block, e.Rescue, e.Always} {
+		for _, child := range group {
+			out = append(out, entryProblems(child)...)
+		}
+	}
+	return out
+}

--- a/tasks/parse.go
+++ b/tasks/parse.go
@@ -247,7 +247,7 @@ func parseTaskEntry(task *yaml.Node, index int, playLabel string) *parsedTaskEnt
 		Valid: true,
 	}
 
-	problem := func(code, message, hint string, node *yaml.Node) {
+	addProblem := func(code, message, hint string, node *yaml.Node) {
 		p := Problem{
 			Code:    code,
 			Play:    playLabel,
@@ -260,6 +260,12 @@ func parseTaskEntry(task *yaml.Node, index int, playLabel string) *parsedTaskEnt
 			p.Column = node.Column
 		}
 		e.Problems = append(e.Problems, p)
+	}
+	// problem records a structural finding and marks the entry invalid so
+	// downstream body validation / envelope building skips it. Envelope-key
+	// type errors that do not block body decoding use addProblem instead.
+	problem := func(code, message, hint string, node *yaml.Node) {
+		addProblem(code, message, hint, node)
 		e.Valid = false
 	}
 
@@ -282,8 +288,18 @@ func parseTaskEntry(task *yaml.Node, index int, playLabel string) *parsedTaskEnt
 		switch key {
 		case "name":
 			e.NameNode = valueNode
-			if valueNode.Kind == yaml.ScalarNode {
+			switch {
+			case valueNode.Kind == yaml.ScalarNode && valueNode.Tag == "!!null":
+				// A bare `name:` (null value) means "no name" - the
+				// loader auto-generates one, matching an omitted key.
+			case valueNode.Kind == yaml.ScalarNode && valueNode.Tag == "!!str":
 				e.Name = valueNode.Value
+			default:
+				// A non-string name (e.g. `name: 123`) used to be silently
+				// dropped and replaced with a random auto-name; reject it
+				// with a typed error like when:/register: (#342).
+				addProblem("envelope_key_type",
+					fmt.Sprintf("name must be a string, got %s", scalarTypeName(valueNode)), "", valueNode)
 			}
 		case "tags":
 			var raw interface{}

--- a/tasks/parse.go
+++ b/tasks/parse.go
@@ -2,8 +2,10 @@ package tasks
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
+	defaults "github.com/mcuadros/go-defaults"
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -154,7 +156,7 @@ func parseRecipe(data []byte) *parsedRecipe {
 	}
 
 	doc := documentBody(&root)
-	if doc == nil {
+	if doc == nil || (doc.Kind == yaml.ScalarNode && doc.Tag == "!!null") {
 		out.Problems = append(out.Problems, Problem{
 			Code:    "recipe_shape",
 			Message: "no recipe found in tasks file",
@@ -505,4 +507,77 @@ func entryProblems(e *parsedTaskEntry) []Problem {
 		}
 	}
 	return out
+}
+
+// parseTaskEntrySeq parses data (rendered YAML bytes) as a bare list of
+// task entries. Used by loop-group expansion, which re-renders a group
+// clause's YAML per iteration and needs the children parsed through the
+// same structural walk the recipe-level parse uses.
+func parseTaskEntrySeq(data []byte, playLabel string) ([]*parsedTaskEntry, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("decode error: %v", err)
+	}
+	seq := documentBody(&root)
+	if seq == nil {
+		return nil, nil
+	}
+	if seq.Kind != yaml.SequenceNode {
+		return nil, fmt.Errorf("must be a list of task entries")
+	}
+	out := make([]*parsedTaskEntry, 0, len(seq.Content))
+	for i, child := range seq.Content {
+		out = append(out, parseTaskEntry(child, i+1, playLabel))
+	}
+	return out, nil
+}
+
+// problemToError renders a Problem as the loader's fail-fast error. The
+// historical `task parse error:` / `parse error:` prefixes are preserved
+// so operator-facing errors stay recognizable, now enriched with the
+// problem's source position and did-you-mean hint.
+func problemToError(p Problem) error {
+	var b strings.Builder
+	if p.Task != "" {
+		b.WriteString("task parse error: ")
+		b.WriteString(p.Task)
+		if p.Line > 0 {
+			fmt.Fprintf(&b, " (line %d)", p.Line)
+		}
+		b.WriteString(": ")
+	} else {
+		b.WriteString("parse error: ")
+		if p.Line > 0 {
+			fmt.Fprintf(&b, "line %d: ", p.Line)
+		}
+	}
+	b.WriteString(p.Message)
+	if p.Hint != "" {
+		fmt.Fprintf(&b, " - %s", p.Hint)
+	}
+	return fmt.Errorf("%s", b.String())
+}
+
+// decodeTaskBytes decodes a marshaled task body into a fresh instance of
+// the registered task type and applies its struct-tag defaults. The
+// concrete struct is allocated with reflect on the registered pointer's
+// element type, so a null body decodes to the zero struct instead of a
+// nil pointer (the historical loader allocation panicked in SetDefaults
+// on `dokku_app:` with no body). Shared by the loader's direct and loop
+// decode paths and by the validator's body checks.
+func decodeTaskBytes(typeKey string, body []byte) (Task, error) {
+	registered, ok := RegisteredTasks[typeKey]
+	if !ok {
+		return nil, fmt.Errorf("unknown task type %q", typeKey)
+	}
+	v := reflect.New(reflect.TypeOf(registered).Elem())
+	if err := yaml.Unmarshal(body, v.Interface()); err != nil {
+		return nil, err
+	}
+	defaults.SetDefaults(v.Interface())
+	task, ok := v.Interface().(Task)
+	if !ok {
+		return nil, fmt.Errorf("registered type for %q does not implement Task", typeKey)
+	}
+	return task, nil
 }

--- a/tasks/parse.go
+++ b/tasks/parse.go
@@ -423,7 +423,29 @@ func parseTaskEntry(task *yaml.Node, index int, playLabel string) *parsedTaskEnt
 		return e
 	}
 
+	// A task-type key with a null body (`dokku_app:` with nothing after
+	// it) leaves the value node as a !!null scalar. The old loader
+	// allocated a nil struct pointer here and panicked in SetDefaults;
+	// the old validator decoded it to a zero struct and reported confusing
+	// missing_required_field noise. Reject the empty body directly so both
+	// paths agree on a single, clear diagnostic.
+	if isNullNode(e.BodyNode) {
+		problem("empty_task_body", fmt.Sprintf("%s body must not be empty", e.TypeKey), "", e.TypeNode)
+		e.TypeKey = ""
+		e.TypeNode = nil
+		e.BodyNode = nil
+		return e
+	}
+
 	return e
+}
+
+// isNullNode reports whether node is absent or an explicit/implicit YAML
+// null scalar. An empty mapping (`{}`) is not null, so a task with an
+// intentionally empty body still decodes and surfaces its missing
+// required fields as usual.
+func isNullNode(node *yaml.Node) bool {
+	return node == nil || (node.Kind == yaml.ScalarNode && node.Tag == "!!null")
 }
 
 // parseGroupClause parses the children of a block / rescue / always

--- a/tasks/parse.go
+++ b/tasks/parse.go
@@ -233,7 +233,46 @@ func parsePlay(play *yaml.Node, index int) *parsedPlay {
 	for i, task := range tasksNode.Content {
 		pp.Entries = append(pp.Entries, parseTaskEntry(task, i+1, pp.Label))
 	}
+	flagDuplicateTaskNames(pp)
 	return pp
+}
+
+// flagDuplicateTaskNames rejects two top-level entries in a play that
+// share a literal name. At runtime such entries collapse onto the same
+// ordered-map key, silently dropping the earlier task (#307). loop:
+// entries are skipped because their names gain a per-item suffix at
+// expansion time (loop-suffix collisions are caught by the runtime guard
+// in GetPlaysWithFormat instead). The problem is recorded on the
+// duplicate entry so both the loader and the validator surface it.
+func flagDuplicateTaskNames(pp *parsedPlay) {
+	seen := map[string]*parsedTaskEntry{}
+	for _, entry := range pp.Entries {
+		if entry.Name == "" || entry.LoopNode != nil {
+			continue
+		}
+		first, dup := seen[entry.Name]
+		if !dup {
+			seen[entry.Name] = entry
+			continue
+		}
+		hint := fmt.Sprintf("first declared on %s", first.Label)
+		if first.NameNode != nil {
+			hint = fmt.Sprintf("first declared on %s (line %d)", first.Label, first.NameNode.Line)
+		}
+		anchor := entry.NameNode
+		if anchor == nil {
+			anchor = entry.Node
+		}
+		entry.Problems = append(entry.Problems, Problem{
+			Code:    "duplicate_task_name",
+			Play:    pp.Label,
+			Task:    entry.Label,
+			Line:    anchor.Line,
+			Column:  anchor.Column,
+			Message: fmt.Sprintf("duplicate task name %q", entry.Name),
+			Hint:    hint,
+		})
+	}
 }
 
 // parseTaskEntry walks one task entry mapping into a parsedTaskEntry,

--- a/tasks/parse.go
+++ b/tasks/parse.go
@@ -132,6 +132,17 @@ func normalizeRecipeBytes(data []byte, format string) ([]byte, []Problem) {
 			Message: err.Error(),
 		}}
 	}
+	// json5.Unmarshal deduped any duplicate keys during the conversion
+	// above; scan the original bytes so a copy-pasted key is rejected the
+	// way yaml.v3 rejects a duplicate YAML key (#318).
+	if dup := detectJSON5DuplicateKeys(data); dup != nil {
+		return nil, []Problem{{
+			Code:    "duplicate_key",
+			Line:    dup.Line,
+			Column:  dup.Column,
+			Message: fmt.Sprintf("duplicate key %q", dup.Key),
+		}}
+	}
 	return converted, nil
 }
 

--- a/tasks/play_json5_test.go
+++ b/tasks/play_json5_test.go
@@ -178,3 +178,43 @@ func TestValidateRejectsMalformedJSON5(t *testing.T) {
 		t.Errorf("first problem code = %q, want json5_parse", problems[0].Code)
 	}
 }
+
+func TestValidateRejectsDuplicateJSON5Key(t *testing.T) {
+	// A JSON5 task entry with two identical task-type keys is silently
+	// deduped by json5.Unmarshal; validate now rejects it the same way it
+	// rejects a duplicate YAML key (#318).
+	data := []byte(`[
+  {
+    tasks: [
+      { dokku_app: { app: "a" }, dokku_app: { app: "b" } },
+    ],
+  },
+]`)
+	problems := Validate(data, ValidateOptions{Format: FormatNameJSON5})
+	p := findProblem(problems, "duplicate_key")
+	if p == nil {
+		t.Fatalf("expected duplicate_key problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, `"dokku_app"`) {
+		t.Errorf("unexpected message: %q", p.Message)
+	}
+}
+
+func TestUnmarshalRecipeRejectsDuplicateJSON5KeyViaLoader(t *testing.T) {
+	// The loader shares the same normalization step, so apply / plan reject
+	// the duplicate key too instead of silently dropping the first body.
+	data := []byte(`[
+  {
+    tasks: [
+      { dokku_app: { app: "a" }, dokku_app: { app: "b" } },
+    ],
+  },
+]`)
+	_, err := GetPlaysWithFormat(data, FormatNameJSON5, map[string]interface{}{}, nil)
+	if err == nil {
+		t.Fatal("expected loader error for duplicate JSON5 key, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate key") {
+		t.Errorf("expected duplicate-key error, got: %v", err)
+	}
+}

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -104,8 +104,26 @@ func (t PortsTask) Execute() TaskOutputState {
 
 // Validate checks the PortsTask's inputs without contacting the server.
 func (t PortsTask) Validate() error {
+	if t.App == "" {
+		return errors.New("'app' is required")
+	}
 	if len(t.PortMappings) == 0 {
 		return errors.New("no port mappings provided")
+	}
+	// Each mapping renders as scheme:host:container, so an unknown or
+	// misspelled key (silently ignored by the YAML decode) or a missing
+	// port would otherwise reach dokku as a malformed argument. Enforce
+	// the per-item required fields the docs mark required.
+	for i, m := range t.PortMappings {
+		if m.Scheme == "" {
+			return fmt.Errorf("'scheme' is required for port_mappings[%d]", i)
+		}
+		if m.Host < 1 || m.Host > 65535 {
+			return fmt.Errorf("'host' must be a port between 1 and 65535 for port_mappings[%d]", i)
+		}
+		if m.Container < 1 || m.Container > 65535 {
+			return fmt.Errorf("'container' must be a port between 1 and 65535 for port_mappings[%d]", i)
+		}
 	}
 	return nil
 }

--- a/tasks/ports_task_test.go
+++ b/tasks/ports_task_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"strings"
 	"testing"
 
 	_ "github.com/gliderlabs/sigil/builtin"
@@ -23,6 +24,53 @@ func TestPortsTaskEmptyPortMappings(t *testing.T) {
 	result := task.Execute()
 	if result.Error == nil {
 		t.Fatal("Execute with empty port mappings should return an error")
+	}
+}
+
+func TestPortsTaskValidatePerItem(t *testing.T) {
+	tests := []struct {
+		name    string
+		task    PortsTask
+		wantErr string
+	}{
+		{
+			name: "valid mapping",
+			task: PortsTask{App: "web", PortMappings: []PortMapping{{Scheme: "http", Host: 80, Container: 5000}}},
+		},
+		{
+			name:    "missing scheme is rejected",
+			task:    PortsTask{App: "web", PortMappings: []PortMapping{{Host: 80, Container: 5000}}},
+			wantErr: "'scheme' is required for port_mappings[0]",
+		},
+		{
+			name:    "missing host is rejected",
+			task:    PortsTask{App: "web", PortMappings: []PortMapping{{Scheme: "http", Container: 5000}}},
+			wantErr: "'host' must be a port",
+		},
+		{
+			name:    "missing container is rejected",
+			task:    PortsTask{App: "web", PortMappings: []PortMapping{{Scheme: "http", Host: 80}}},
+			wantErr: "'container' must be a port",
+		},
+		{
+			name:    "missing app is rejected",
+			task:    PortsTask{PortMappings: []PortMapping{{Scheme: "http", Host: 80, Container: 5000}}},
+			wantErr: "'app' is required",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.task.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error %q, got: %v", tt.wantErr, err)
+			}
+		})
 	}
 }
 

--- a/tasks/service_backup_task.go
+++ b/tasks/service_backup_task.go
@@ -43,10 +43,10 @@ type ServiceBackupTask struct {
 	AwsDefaultRegion string `required:"false" yaml:"aws_default_region,omitempty" description:"AWS region used for backup auth"`
 
 	// AwsSignatureVersion is the AWS signature version used for backup auth.
-	AwsSignatureVersion string `required:"false" yaml:"aws_signature_version,omitempty" description:"AWS signature version used for backup auth"`
+	AwsSignatureVersion string `required:"false" yaml:"aws_signature_version,omitempty" description:"AWS signature version used for backup auth (requires aws_default_region)"`
 
 	// EndpointURL is the S3-compatible endpoint url used for backup auth.
-	EndpointURL string `required:"false" yaml:"endpoint_url,omitempty" description:"S3-compatible endpoint url used for backup auth"`
+	EndpointURL string `required:"false" yaml:"endpoint_url,omitempty" description:"S3-compatible endpoint url used for backup auth (requires aws_signature_version)"`
 
 	// EncryptionPassphrase is the passphrase used to encrypt future backups.
 	EncryptionPassphrase string `required:"false" sensitive:"true" yaml:"encryption_passphrase,omitempty" description:"Passphrase used to encrypt future backups"`
@@ -212,6 +212,21 @@ func (t ServiceBackupTask) Validate() error {
 		}
 		if t.hasAuth() && (t.AwsAccessKeyID == "" || t.AwsSecretAccessKey == "") {
 			return fmt.Errorf("'aws_access_key_id' and 'aws_secret_access_key' are both required to configure backup auth")
+		}
+		// backup-auth is a fixed positional argv:
+		//   <access-key> <secret> <region> <signature-version> <endpoint>
+		// dokku cannot receive a later positional without every earlier
+		// one, and the argv builder stops at the first empty field, so
+		// reject the combinations that would silently drop a trailing
+		// value rather than passing it.
+		if (t.AwsDefaultRegion != "" || t.AwsSignatureVersion != "" || t.EndpointURL != "") && !t.hasAuth() {
+			return fmt.Errorf("'aws_access_key_id' and 'aws_secret_access_key' are required when 'aws_default_region', 'aws_signature_version', or 'endpoint_url' is set")
+		}
+		if t.EndpointURL != "" && t.AwsSignatureVersion == "" {
+			return fmt.Errorf("'aws_signature_version' is required when 'endpoint_url' is set")
+		}
+		if t.AwsSignatureVersion != "" && t.AwsDefaultRegion == "" {
+			return fmt.Errorf("'aws_default_region' is required when 'aws_signature_version' is set")
 		}
 		if t.Schedule == "" && !t.hasAuth() && t.EncryptionPassphrase == "" {
 			return fmt.Errorf("at least one of 'schedule', aws credentials, or 'encryption_passphrase' is required when state is 'present'")

--- a/tasks/service_backup_task_test.go
+++ b/tasks/service_backup_task_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"strings"
 	"testing"
 
 	_ "github.com/gliderlabs/sigil/builtin"
@@ -35,6 +36,56 @@ func TestServiceBackupTaskPartialAuthRejected(t *testing.T) {
 	result := task.Plan()
 	if result.Error == nil {
 		t.Fatal("Plan with only an access key id should return an error")
+	}
+}
+
+func TestServiceBackupTaskValidateAuthChain(t *testing.T) {
+	base := ServiceBackupTask{Service: "postgres", Name: "my-db", State: StatePresent, AwsAccessKeyID: "AKIA", AwsSecretAccessKey: "secret"}
+
+	tests := []struct {
+		name    string
+		mutate  func(*ServiceBackupTask)
+		wantErr string
+	}{
+		{
+			name:   "full chain is valid",
+			mutate: func(b *ServiceBackupTask) { b.AwsDefaultRegion = "us-east-1"; b.AwsSignatureVersion = "s3v4"; b.EndpointURL = "https://s3.example.com" },
+		},
+		{
+			name:   "region alone with keys is valid",
+			mutate: func(b *ServiceBackupTask) { b.AwsDefaultRegion = "us-east-1" },
+		},
+		{
+			name:    "endpoint without signature version is rejected",
+			mutate:  func(b *ServiceBackupTask) { b.AwsDefaultRegion = "us-east-1"; b.EndpointURL = "https://s3.example.com" },
+			wantErr: "'aws_signature_version' is required when 'endpoint_url' is set",
+		},
+		{
+			name:    "signature version without region is rejected",
+			mutate:  func(b *ServiceBackupTask) { b.AwsSignatureVersion = "s3v4" },
+			wantErr: "'aws_default_region' is required when 'aws_signature_version' is set",
+		},
+		{
+			name:    "endpoint without keys is rejected",
+			mutate:  func(b *ServiceBackupTask) { b.AwsAccessKeyID = ""; b.AwsSecretAccessKey = ""; b.EndpointURL = "https://s3.example.com" },
+			wantErr: "are required when 'aws_default_region', 'aws_signature_version', or 'endpoint_url' is set",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := base
+			tt.mutate(&task)
+			err := task.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error %q, got: %v", tt.wantErr, err)
+			}
+		})
 	}
 }
 

--- a/tasks/validate.go
+++ b/tasks/validate.go
@@ -911,25 +911,6 @@ func scalarChild(node *yaml.Node, key string) string {
 	return v.Value
 }
 
-// nearestTaskName returns the registered task name with the lowest Levenshtein
-// distance to candidate, but only if that distance is at most 2. Returning ""
-// means "no useful suggestion".
-func nearestTaskName(candidate string) string {
-	best := ""
-	bestDist := 3
-	for name := range RegisteredTasks {
-		d := levenshtein(candidate, name)
-		if d < bestDist {
-			bestDist = d
-			best = name
-		}
-	}
-	if bestDist <= 2 {
-		return best
-	}
-	return ""
-}
-
 // levenshtein returns the edit distance between a and b. Small strings only;
 // a 2D allocation is fine.
 func levenshtein(a, b string) int {

--- a/tasks/validate.go
+++ b/tasks/validate.go
@@ -149,16 +149,11 @@ func Validate(data []byte, opts ValidateOptions) []Problem {
 	// yaml.v3-only. The JSON5 parse runs after the sigil syntax check so
 	// a broken template surfaces as a template_error rather than a
 	// confusing json5 parse error.
-	if IsJSON5Format(opts.Format) {
-		converted, err := json5ToYAMLBytes(data)
-		if err != nil {
-			return []Problem{{
-				Code:    "json5_parse",
-				Message: err.Error(),
-			}}
-		}
-		data = converted
+	normalized, normalizeProblems := normalizeRecipeBytes(data, opts.Format)
+	if len(normalizeProblems) > 0 {
+		return normalizeProblems
 	}
+	data = normalized
 
 	var rawRoot yaml.Node
 	if err := yaml.Unmarshal(data, &rawRoot); err != nil {
@@ -205,42 +200,30 @@ func Validate(data []byte, opts ValidateOptions) []Problem {
 		return problems
 	}
 
-	var renderedRoot yaml.Node
-	if err := yaml.Unmarshal(rendered, &renderedRoot); err != nil {
-		line, col := parseYAMLErrorPosition(err.Error())
-		return []Problem{{
-			Code:    "yaml_parse",
-			Line:    line,
-			Column:  col,
-			Message: fmt.Sprintf("rendered recipe parse error: %v", err),
-		}}
-	}
+	// The shared structural parser walks the rendered tree once, collecting
+	// shape / envelope / task-type problems with source positions. The
+	// loader (GetPlaysWithFormat) runs the same parser, so apply, plan, and
+	// validate agree on structural validity by construction. The passes
+	// below this point are validate-only: they need placeholder-aware body
+	// decoding or offline-only cross-reference auditing.
+	ast := parseRecipe(rendered)
+	problems := append([]Problem(nil), ast.Problems...)
 
-	doc := documentBody(&renderedRoot)
-	if doc == nil || doc.Kind != yaml.SequenceNode {
-		return []Problem{{
-			Code:    "recipe_shape",
-			Message: "rendered recipe is not a yaml list of plays",
-		}}
-	}
-
-	var problems []Problem
 	// registerSeen tracks register names across the whole recipe so a
 	// duplicate `register: foo` in two different plays surfaces as a
 	// single register_duplicate problem. The registered map is run-wide
 	// at apply / plan time, so the validator's uniqueness check is
 	// recipe-wide too.
 	registerSeen := map[string]registerHit{}
-	for i, play := range doc.Content {
-		label := fmt.Sprintf("play #%d", i+1)
+	for i, play := range ast.Plays {
 		var inputs []inputWithNode
 		if i < len(playsInputs) {
 			inputs = playsInputs[i]
 		}
-		problems = append(problems, validatePlay(play, label, inputs, opts, registerSeen)...)
+		problems = append(problems, validatePlay(play, inputs, opts, registerSeen)...)
 	}
 
-	problems = append(problems, validateCLIReferences(doc, opts)...)
+	problems = append(problems, validateCLIReferences(ast.Doc, opts)...)
 
 	return problems
 }
@@ -256,7 +239,7 @@ func Validate(data []byte, opts ValidateOptions) []Problem {
 // here because their per-iteration suffix is only resolved at apply
 // time; the runtime check in commands/apply.go is authoritative.
 func validateCLIReferences(doc *yaml.Node, opts ValidateOptions) []Problem {
-	if !opts.Strict {
+	if doc == nil || !opts.Strict {
 		return nil
 	}
 	if opts.PlayName == "" && opts.StartAtTask == "" {
@@ -364,44 +347,24 @@ type registerHit struct {
 	Line int
 }
 
-// validatePlay walks one play (one MappingNode within the recipe sequence).
-func validatePlay(play *yaml.Node, label string, inputs []inputWithNode, opts ValidateOptions, registerSeen map[string]registerHit) []Problem {
-	var problems []Problem
-
-	if play.Kind != yaml.MappingNode {
-		return append(problems, Problem{
-			Code:    "recipe_shape",
-			Play:    label,
-			Line:    play.Line,
-			Column:  play.Column,
-			Message: "play must be a yaml mapping with inputs and/or tasks",
-		})
-	}
-
-	tasksNode := mappingValue(play, "tasks")
-
-	for i := 0; i < len(play.Content); i += 2 {
-		key := play.Content[i].Value
-		if !allowedPlayKeys[key] {
-			problems = append(problems, Problem{
-				Code:    "recipe_shape",
-				Play:    label,
-				Line:    play.Content[i].Line,
-				Column:  play.Content[i].Column,
-				Message: fmt.Sprintf("unexpected play key %q (expected: %s)", key, allowedPlayKeysList),
-			})
-		}
-	}
+// validatePlay runs the validate-only passes over one parsed play: the
+// play-level when: compile check, the strict input audit, expr predicate
+// compilation, register uniqueness, loop-var placement, and per-entry body
+// validation. The structural checks (play shape, allowed keys, envelope
+// typing, task-type resolution) were already collected by parseRecipe and
+// live on the parsedPlay / parsedTaskEntry problems.
+func validatePlay(play *parsedPlay, inputs []inputWithNode, opts ValidateOptions, registerSeen map[string]registerHit) []Problem {
+	problems := append([]Problem(nil), play.Problems...)
 
 	// Compile the play-level when: predicate so a typo surfaces at validate
 	// time. The play's when: sees the file-level merged context only - the
 	// play's own inputs are not visible to its own when - but for parse
 	// validation we only care that the source compiles.
-	if whenNode := mappingValue(play, "when"); whenNode != nil && whenNode.Kind == yaml.ScalarNode && whenNode.Value != "" {
+	if whenNode := mappingValue(play.Node, "when"); whenNode != nil && whenNode.Kind == yaml.ScalarNode && whenNode.Value != "" {
 		if _, err := CompilePredicate(whenNode.Value); err != nil {
 			problems = append(problems, Problem{
 				Code:    "expr_compile",
-				Play:    label,
+				Play:    play.Label,
 				Line:    whenNode.Line,
 				Column:  whenNode.Column,
 				Message: fmt.Sprintf("play when expression compile error: %v", err),
@@ -410,179 +373,48 @@ func validatePlay(play *yaml.Node, label string, inputs []inputWithNode, opts Va
 	}
 
 	if opts.Strict {
-		problems = append(problems, validateStrictInputs(inputs, opts.InputOverrides, label)...)
+		problems = append(problems, validateStrictInputs(inputs, opts.InputOverrides, play.Label)...)
 	}
 
-	// Stub checks: present so future PRs (#205/#208/#211/#212) can wire
-	// real bodies without touching the call site.
-	problems = append(problems, validateBlockStructure(tasksNode, label)...)
-	problems = append(problems, validateExprPredicates(tasksNode, label)...)
-	problems = append(problems, validateRegisterReferences(tasksNode, label, registerSeen)...)
-	problems = append(problems, validateTargetReferences(tasksNode, label)...)
+	problems = append(problems, validateExprPredicates(play.TasksNode, play.Label)...)
+	problems = append(problems, validateRegisterReferences(play.TasksNode, play.Label, registerSeen)...)
+	problems = append(problems, validateTargetReferences(play.TasksNode, play.Label)...)
 
-	if tasksNode == nil {
-		return problems
-	}
-	if tasksNode.Kind != yaml.SequenceNode {
-		return append(problems, Problem{
-			Code:    "recipe_shape",
-			Play:    label,
-			Line:    tasksNode.Line,
-			Column:  tasksNode.Column,
-			Message: "tasks must be a yaml list",
-		})
-	}
-
-	for i, task := range tasksNode.Content {
-		problems = append(problems, validateTaskEntry(task, label, i+1)...)
+	for _, entry := range play.Entries {
+		problems = append(problems, validateEntry(entry, play.Label)...)
 	}
 
 	return problems
 }
 
-// validateTaskEntry covers checks 3-5: envelope shape, registered task type,
-// and required-field decode. For group entries (those carrying `block:`),
-// it recurses through every child of block / rescue / always so nested
-// entries surface the same diagnostics.
-func validateTaskEntry(task *yaml.Node, playLabel string, idx int) []Problem {
-	var problems []Problem
-	taskLabel := fmt.Sprintf("task #%d", idx)
+// validateEntry emits one parsed entry's structural problems followed by
+// its body validation (required fields plus the task's InputValidator),
+// recursing through group children so nested entries surface the same
+// diagnostics. Entries whose structure was rejected skip body validation:
+// the structural problem is the primary finding and the body checks
+// depend on a resolved task type.
+func validateEntry(entry *parsedTaskEntry, playLabel string) []Problem {
+	problems := append([]Problem(nil), entry.Problems...)
 
-	if task.Kind != yaml.MappingNode {
-		return []Problem{{
-			Code:    "task_entry_shape",
-			Play:    playLabel,
-			Task:    taskLabel,
-			Line:    task.Line,
-			Column:  task.Column,
-			Message: "task entry must be a yaml mapping",
-		}}
-	}
-
-	var (
-		taskTypeKey  string
-		taskTypeNode *yaml.Node
-		taskBodyNode *yaml.Node
-		taskTypeKeys []string
-		nameValue    string
-	)
-
-	for i := 0; i < len(task.Content); i += 2 {
-		keyNode := task.Content[i]
-		valueNode := task.Content[i+1]
-		key := keyNode.Value
-
-		if key == "name" {
-			if valueNode.Kind == yaml.ScalarNode {
-				nameValue = valueNode.Value
+	if entry.IsGroup {
+		for _, group := range [][]*parsedTaskEntry{entry.Block, entry.Rescue, entry.Always} {
+			for _, child := range group {
+				problems = append(problems, validateEntry(child, playLabel)...)
 			}
-			continue
 		}
-
-		if activeEnvelopeKeys[key] {
-			continue
-		}
-
-		if dependentIssue, reserved := reservedEnvelopeKeys[key]; reserved {
-			problems = append(problems, Problem{
-				Code:    "envelope_key_unsupported",
-				Play:    playLabel,
-				Task:    taskLabel,
-				Line:    keyNode.Line,
-				Column:  keyNode.Column,
-				Message: fmt.Sprintf("envelope key %q is reserved but not yet supported", key),
-				Hint:    fmt.Sprintf("activates with %s", dependentIssue),
-			})
-			continue
-		}
-
-		taskTypeKeys = append(taskTypeKeys, key)
-		taskTypeKey = key
-		taskTypeNode = keyNode
-		taskBodyNode = valueNode
-	}
-
-	if nameValue != "" {
-		taskLabel = fmt.Sprintf("task #%d %q", idx, nameValue)
-	}
-
-	blockNode := mappingValue(task, "block")
-	rescueNode := mappingValue(task, "rescue")
-	alwaysNode := mappingValue(task, "always")
-
-	if blockNode != nil || rescueNode != nil || alwaysNode != nil {
-		problems = append(problems, validateGroupEntry(task, blockNode, rescueNode, alwaysNode, taskTypeKeys, taskTypeNode, playLabel, taskLabel)...)
 		return problems
 	}
 
-	if len(taskTypeKeys) == 0 {
-		return append(problems, Problem{
-			Code:    "task_entry_shape",
-			Play:    playLabel,
-			Task:    taskLabel,
-			Line:    task.Line,
-			Column:  task.Column,
-			Message: "task entry must contain exactly one task-type key",
-		})
-	}
-	if len(taskTypeKeys) > 1 {
-		return append(problems, Problem{
-			Code:    "task_entry_shape",
-			Play:    playLabel,
-			Task:    taskLabel,
-			Line:    task.Line,
-			Column:  task.Column,
-			Message: fmt.Sprintf("task entry has %d task-type keys (%s); exactly one is allowed", len(taskTypeKeys), strings.Join(taskTypeKeys, ", ")),
-		})
+	if !entry.Valid || entry.TypeKey == "" {
+		return problems
 	}
 
-	registered, ok := RegisteredTasks[taskTypeKey]
+	registered, ok := RegisteredTasks[entry.TypeKey]
 	if !ok {
-		hint := ""
-		if suggestion := nearestTaskName(taskTypeKey); suggestion != "" {
-			hint = fmt.Sprintf("did you mean %q?", suggestion)
-		}
-		return append(problems, Problem{
-			Code:    "unknown_task_type",
-			Play:    playLabel,
-			Task:    taskLabel,
-			Line:    taskTypeNode.Line,
-			Column:  taskTypeNode.Column,
-			Message: fmt.Sprintf("unknown task type %q", taskTypeKey),
-			Hint:    hint,
-		})
+		return problems
 	}
 
-	problems = append(problems, validateTaskBody(registered, taskTypeKey, taskBodyNode, playLabel, taskLabel)...)
-	return problems
-}
-
-// validateGroupEntry recurses through block / rescue / always children
-// of a try/catch/finally group (#211) entry so each nested entry
-// receives the per-task validation (envelope shape, registered task
-// type, required-field decode). The group's structural diagnostics
-// (empty block, orphan rescue/always, block alongside a task-type
-// key) live in validateBlockStructure so they are emitted exactly
-// once per recipe walk.
-func validateGroupEntry(task *yaml.Node, blockNode, rescueNode, alwaysNode *yaml.Node, taskTypeKeys []string, taskTypeNode *yaml.Node, playLabel, taskLabel string) []Problem {
-	var problems []Problem
-
-	if blockNode != nil && blockNode.Kind == yaml.SequenceNode {
-		for i, child := range blockNode.Content {
-			problems = append(problems, validateTaskEntry(child, playLabel, i+1)...)
-		}
-	}
-	if rescueNode != nil && rescueNode.Kind == yaml.SequenceNode {
-		for i, child := range rescueNode.Content {
-			problems = append(problems, validateTaskEntry(child, playLabel, i+1)...)
-		}
-	}
-	if alwaysNode != nil && alwaysNode.Kind == yaml.SequenceNode {
-		for i, child := range alwaysNode.Content {
-			problems = append(problems, validateTaskEntry(child, playLabel, i+1)...)
-		}
-	}
-
+	problems = append(problems, validateTaskBody(registered, entry.TypeKey, entry.BodyNode, playLabel, entry.Label)...)
 	return problems
 }
 
@@ -725,83 +557,6 @@ func validateStrictInputs(inputs []inputWithNode, overrides map[string]bool, lab
 			Message: fmt.Sprintf("input %q is required and has no default; pass --%s to override", in.Name, in.Name),
 		})
 	}
-	return problems
-}
-
-// validateBlockStructure walks every task entry under tasksNode and
-// flags malformed try/catch/finally groups: empty `block:`, `rescue:` /
-// `always:` without a sibling `block:`, a group entry that also carries
-// a task-type key, and non-sequence clause values. Per-child structural
-// checks are handled by validateTaskEntry through its recursion into
-// group children, so this helper only emits the group-level diagnostics.
-func validateBlockStructure(tasksNode *yaml.Node, playLabel string) []Problem {
-	if tasksNode == nil || tasksNode.Kind != yaml.SequenceNode {
-		return nil
-	}
-	var problems []Problem
-	walkGroupEntries(tasksNode, playLabel, func(task *yaml.Node, label string) {
-		blockNode := mappingValue(task, "block")
-		rescueNode := mappingValue(task, "rescue")
-		alwaysNode := mappingValue(task, "always")
-		if blockNode == nil && rescueNode == nil && alwaysNode == nil {
-			return
-		}
-		if blockNode == nil {
-			clauseNode := rescueNode
-			clauseName := "rescue"
-			if rescueNode == nil {
-				clauseNode = alwaysNode
-				clauseName = "always"
-			}
-			problems = append(problems, Problem{
-				Code:    "block_orphan_clause",
-				Play:    playLabel,
-				Task:    label,
-				Line:    clauseNode.Line,
-				Column:  clauseNode.Column,
-				Message: fmt.Sprintf("%s: requires a block: in the same task entry", clauseName),
-			})
-			return
-		}
-		if blockNode.Kind != yaml.SequenceNode {
-			problems = append(problems, Problem{
-				Code:    "block_shape",
-				Play:    playLabel,
-				Task:    label,
-				Line:    blockNode.Line,
-				Column:  blockNode.Column,
-				Message: "block: must be a yaml list of task entries",
-			})
-			return
-		}
-		if len(blockNode.Content) == 0 {
-			problems = append(problems, Problem{
-				Code:    "block_empty",
-				Play:    playLabel,
-				Task:    label,
-				Line:    blockNode.Line,
-				Column:  blockNode.Column,
-				Message: "block: must contain at least one child task",
-			})
-		}
-		for i := 0; i < len(task.Content); i += 2 {
-			key := task.Content[i].Value
-			keyNode := task.Content[i]
-			if activeEnvelopeKeys[key] || key == "name" {
-				continue
-			}
-			if _, registered := RegisteredTasks[key]; registered {
-				problems = append(problems, Problem{
-					Code:    "block_with_task_type",
-					Play:    playLabel,
-					Task:    label,
-					Line:    keyNode.Line,
-					Column:  keyNode.Column,
-					Message: fmt.Sprintf("block: group entry cannot also carry task-type key %q", key),
-				})
-			}
-		}
-	})
 	return problems
 }
 

--- a/tasks/validate.go
+++ b/tasks/validate.go
@@ -865,6 +865,13 @@ func buildSigilContext(plays [][]inputWithNode) map[string]interface{} {
 			if in.Name == "" {
 				continue
 			}
+			// A reserved input name (e.g. no-color) is rejected as
+			// reserved_input_name by the parser; keep it out of the sigil
+			// context so a dash in the name cannot break the template
+			// render before that clearer diagnostic is reported (#302).
+			if ReservedInputNames[in.Name] {
+				continue
+			}
 			if in.Default != "" {
 				context[in.Name] = in.Default
 			} else if _, ok := context[in.Name]; !ok {

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -152,6 +152,31 @@ func TestValidateRejectsNullTaskBody(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsDuplicateTaskNames(t *testing.T) {
+	// validate flags duplicate task names offline so a recipe that would
+	// silently drop a task fails the CI lint (#307).
+	data := []byte(`---
+- tasks:
+    - name: same
+      dokku_app:
+        app: first-app
+    - name: same
+      dokku_app:
+        app: second-app
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "duplicate_task_name")
+	if p == nil {
+		t.Fatalf("expected duplicate_task_name problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, `"same"`) {
+		t.Errorf("unexpected message: %q", p.Message)
+	}
+	if !strings.Contains(p.Hint, "first declared") {
+		t.Errorf("expected first-declared hint, got: %q", p.Hint)
+	}
+}
+
 func TestValidateRejectsNonStringName(t *testing.T) {
 	// validate agrees with the loader that a non-string name is an error
 	// rather than treating `name: 123` as the string "123" (#342).

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -152,6 +152,46 @@ func TestValidateRejectsNullTaskBody(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsReservedInputName(t *testing.T) {
+	// An input named after a built-in flag (here no-color) used to panic
+	// the CLI; validate now rejects it offline (#302).
+	data := []byte(`---
+- inputs:
+    - name: no-color
+      default: x
+  tasks:
+    - dokku_app:
+        app: my-app
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "reserved_input_name")
+	if p == nil {
+		t.Fatalf("expected reserved_input_name problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, `"no-color"`) {
+		t.Errorf("unexpected message: %q", p.Message)
+	}
+}
+
+func TestValidateAllowsHelpVersionInputNames(t *testing.T) {
+	// help / v / version are handled by the CLI framework, not registered
+	// on the flag set, so they remain valid input names (#302).
+	for _, name := range []string{"help", "v", "version"} {
+		data := []byte(`---
+- inputs:
+    - name: ` + name + `
+      default: x
+  tasks:
+    - dokku_app:
+        app: my-app
+`)
+		problems := Validate(data, ValidateOptions{})
+		if p := findProblem(problems, "reserved_input_name"); p != nil {
+			t.Errorf("input name %q should be allowed, got: %+v", name, *p)
+		}
+	}
+}
+
 func TestValidateRejectsDuplicateTaskNames(t *testing.T) {
 	// validate flags duplicate task names offline so a recipe that would
 	// silently drop a task fails the CI lint (#307).

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -127,6 +127,31 @@ func TestValidateUnknownTaskTypeNoSuggestion(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsNullTaskBody(t *testing.T) {
+	// A task-type key with a null body is reported as a single
+	// empty_task_body problem rather than the missing_required_field
+	// noise the old zero-struct decode produced (#306).
+	data := []byte(`---
+- tasks:
+    - name: x
+      dokku_app:
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "empty_task_body")
+	if p == nil {
+		t.Fatalf("expected empty_task_body problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, "dokku_app body must not be empty") {
+		t.Errorf("unexpected message: %q", p.Message)
+	}
+	if p.Line == 0 {
+		t.Errorf("expected non-zero line, got: %d", p.Line)
+	}
+	if n := countProblems(problems, "missing_required_field"); n != 0 {
+		t.Errorf("null body should not also report missing_required_field, got %d", n)
+	}
+}
+
 func TestValidateMissingRequiredField(t *testing.T) {
 	data := []byte(`---
 - tasks:

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -439,9 +439,9 @@ func TestValidateNearestTaskName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got := nearestTaskName(tt.input)
+			got := nearestEnvelopeOrTaskKey(tt.input)
 			if got != tt.expect {
-				t.Errorf("nearestTaskName(%q) = %q, want %q", tt.input, got, tt.expect)
+				t.Errorf("nearestEnvelopeOrTaskKey(%q) = %q, want %q", tt.input, got, tt.expect)
 			}
 		})
 	}

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -152,6 +152,25 @@ func TestValidateRejectsNullTaskBody(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsNonStringName(t *testing.T) {
+	// validate agrees with the loader that a non-string name is an error
+	// rather than treating `name: 123` as the string "123" (#342).
+	data := []byte(`---
+- tasks:
+    - name: 123
+      dokku_app:
+        app: x
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "envelope_key_type")
+	if p == nil {
+		t.Fatalf("expected envelope_key_type problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, "name must be a string") {
+		t.Errorf("unexpected message: %q", p.Message)
+	}
+}
+
 func TestValidateMissingRequiredField(t *testing.T) {
 	data := []byte(`---
 - tasks:

--- a/tests/bats/block.bats
+++ b/tests/bats/block.bats
@@ -56,7 +56,7 @@ EOF
       block:
         - dokku_ports:
             app: nonexistent-block-target-zzz
-            port_mappings: [{ scheme: http, host_port: 80, container_port: 5000 }]
+            port_mappings: [{ scheme: http, host: 80, container: 5000 }]
             state: present
       rescue:
         - dokku_app: { app: docket-test-block-rescue, state: absent }
@@ -95,7 +95,7 @@ EOF
           ignore_errors: true
           dokku_ports:
             app: nonexistent-block-swallow-zzz
-            port_mappings: [{ scheme: http, host_port: 80, container_port: 5000 }]
+            port_mappings: [{ scheme: http, host: 80, container: 5000 }]
             state: present
         - dokku_app: { app: docket-test-block-swallowed-after }
       rescue:

--- a/tests/bats/init.bats
+++ b/tests/bats/init.bats
@@ -76,6 +76,28 @@ CFG
   assert_output --partial 'default: "git@example.com:owner/repo.git"'
 }
 
+@test "docket init --name with YAML-special characters writes a valid scaffold" {
+  cd "$BATS_TEST_TMPDIR"
+  run "$(docket_bin)" init --name '@web'
+  assert_success
+  assert [ -f tasks.yml ]
+  run cat tasks.yml
+  assert_output --partial "default: '@web'"
+
+  run "$(docket_bin)" validate --tasks tasks.yml
+  assert_success
+  assert_output --partial "is valid"
+}
+
+@test "docket init defaults an unquoted name for ordinary basenames" {
+  mkdir -p "$BATS_TEST_TMPDIR/plain-svc"
+  cd "$BATS_TEST_TMPDIR/plain-svc"
+  run "$(docket_bin)" init
+  assert_success
+  run cat tasks.yml
+  assert_output --partial "default: plain-svc"
+}
+
 @test "docket init --output - writes to stdout and creates no file" {
   cd "$BATS_TEST_TMPDIR"
   run "$(docket_bin)" init --output -

--- a/tests/bats/list_resume.bats
+++ b/tests/bats/list_resume.bats
@@ -60,6 +60,21 @@ EOF
   assert_failure # never created
 }
 
+@test "--list-tasks reports a null task body without panicking" {
+  # apply --list-tasks is offline; a null task body used to panic the
+  # loader (#306). It must now surface a clean parse error instead.
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: x
+      dokku_app:
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_failure
+  assert_output --partial "body must not be empty"
+  refute_output --partial "panic:"
+}
+
 @test "--list-tasks honors --tags filter" {
   write_tasks_file <<EOF
 ---

--- a/tests/bats/output.bats
+++ b/tests/bats/output.bats
@@ -107,7 +107,7 @@ EOF
       dokku_ports:
         app: docket-test-output-missing
         port_mappings:
-          - { scheme: http, host_port: 80, container_port: 5000 }
+          - { scheme: http, host: 80, container: 5000 }
         state: present
 EOF
   run "$(docket_bin)" apply --tasks "$TASKS_FILE"
@@ -125,7 +125,7 @@ EOF
       dokku_ports:
         app: docket-test-output-missing
         port_mappings:
-          - { scheme: http, host_port: 80, container_port: 5000 }
+          - { scheme: http, host: 80, container: 5000 }
         state: present
 EOF
   run "$(docket_bin)" apply --tasks "$TASKS_FILE" --json

--- a/tests/bats/task_file_json.bats
+++ b/tests/bats/task_file_json.bats
@@ -51,6 +51,36 @@ EOF
   assert_output --partial '"code":"json5_parse"'
 }
 
+@test "docket validate reports duplicate_key on a duplicated JSON5 key" {
+  write_tasks_file tasks.json <<'EOF'
+[
+  {
+    tasks: [
+      { dokku_app: { app: "a" }, dokku_app: { app: "b" } },
+    ],
+  },
+]
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE" --json
+  assert_failure
+  assert_output --partial '"code":"duplicate_key"'
+}
+
+@test "docket apply --list-tasks rejects a duplicated JSON5 key" {
+  write_tasks_file tasks.json <<'EOF'
+[
+  {
+    tasks: [
+      { dokku_app: { app: "a" }, dokku_app: { app: "b" } },
+    ],
+  },
+]
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_failure
+  assert_output --partial "duplicate key"
+}
+
 @test "docket apply --list-tasks works against tasks.json" {
   write_tasks_file tasks.json <<'EOF'
 [

--- a/tests/bats/validate.bats
+++ b/tests/bats/validate.bats
@@ -43,6 +43,21 @@ EOF
   assert_output --partial 'missing required field "app"'
 }
 
+@test "docket validate exits 1 on a port mapping missing its scheme" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_ports:
+        app: web
+        port_mappings:
+          - host: 80
+            container: 5000
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "'scheme' is required"
+}
+
 @test "docket validate exits 1 on git_from_image email without username" {
   write_tasks_file <<EOF
 ---

--- a/tests/bats/validate.bats
+++ b/tests/bats/validate.bats
@@ -87,6 +87,40 @@ EOF
   assert_output --partial '"code":"invalid_task_input"'
 }
 
+@test "docket validate exits 1 on an input named after a built-in flag" {
+  write_tasks_file <<EOF
+---
+- inputs:
+    - name: no-color
+      default: x
+  tasks:
+    - dokku_app:
+        app: my-app
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "reserved for a built-in flag"
+}
+
+@test "docket apply does not panic on an input named after a built-in flag" {
+  # An input named after a built-in flag used to make pflag panic before
+  # flag parsing began (#302). apply must now fail cleanly instead.
+  write_tasks_file <<EOF
+---
+- inputs:
+    - name: verbose
+      default: x
+  tasks:
+    - dokku_app:
+        app: my-app
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_failure
+  assert_output --partial "reserved for a built-in flag"
+  refute_output --partial "panic:"
+  refute_output --partial "flag redefined"
+}
+
 @test "docket validate exits 1 on duplicate task names" {
   write_tasks_file <<EOF
 ---

--- a/tests/bats/validate.bats
+++ b/tests/bats/validate.bats
@@ -57,6 +57,22 @@ EOF
   assert_output --partial "'git_username' and 'git_email' must be set together"
 }
 
+@test "docket validate exits 1 on service_backup endpoint without region" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_service_backup:
+        service: postgres
+        name: my-db
+        aws_access_key_id: AKIA
+        aws_secret_access_key: secret
+        endpoint_url: https://s3.example.com
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "'aws_signature_version' is required when 'endpoint_url' is set"
+}
+
 @test "docket validate exits 1 on a conditional input error" {
   write_tasks_file <<EOF
 ---

--- a/tests/bats/validate.bats
+++ b/tests/bats/validate.bats
@@ -233,6 +233,56 @@ EOF
   assert_output --partial '"version":1'
 }
 
+@test "docket validate checks a positional file argument" {
+  mkdir -p "$BATS_TEST_TMPDIR/staging"
+  cat >"$BATS_TEST_TMPDIR/staging/tasks.yml" <<EOF
+---
+- tasks:
+    - dokku_appp:
+        app: broken
+EOF
+  # A valid default tasks.yml in the cwd must not mask the broken
+  # positional file (the bug: the positional was ignored, #331).
+  cat >"$BATS_TEST_TMPDIR/tasks.yml" <<EOF
+---
+- tasks:
+    - dokku_app:
+        app: ok
+EOF
+  cd "$BATS_TEST_TMPDIR"
+  run "$(docket_bin)" validate staging/tasks.yml
+  assert_failure
+  assert_output --partial "staging/tasks.yml"
+  assert_output --partial "unknown task type"
+}
+
+@test "docket validate rejects both --tasks and a positional file" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_app:
+        app: ok
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE" "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "cannot specify both --tasks and a positional"
+}
+
+@test "docket apply --list-tasks honors a positional file argument" {
+  mkdir -p "$BATS_TEST_TMPDIR/staging"
+  cat >"$BATS_TEST_TMPDIR/staging/tasks.yml" <<EOF
+---
+- tasks:
+    - name: staging-only
+      dokku_app:
+        app: api
+EOF
+  cd "$BATS_TEST_TMPDIR"
+  run "$(docket_bin)" apply --list-tasks staging/tasks.yml
+  assert_success
+  assert_output --partial "staging-only"
+}
+
 @test "docket validate --strict flags required input without default" {
   write_tasks_file <<EOF
 ---

--- a/tests/bats/validate.bats
+++ b/tests/bats/validate.bats
@@ -87,6 +87,18 @@ EOF
   assert_output --partial '"code":"invalid_task_input"'
 }
 
+@test "docket validate exits 1 on a null task body" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: x
+      dokku_app:
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "body must not be empty"
+}
+
 @test "docket validate exits 1 on broken sigil template" {
   write_tasks_file <<EOF
 ---

--- a/tests/bats/validate.bats
+++ b/tests/bats/validate.bats
@@ -99,6 +99,19 @@ EOF
   assert_output --partial "body must not be empty"
 }
 
+@test "docket validate exits 1 on a non-string task name" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: 123
+      dokku_app:
+        app: x
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "name must be a string"
+}
+
 @test "docket validate exits 1 on broken sigil template" {
   write_tasks_file <<EOF
 ---

--- a/tests/bats/validate.bats
+++ b/tests/bats/validate.bats
@@ -87,6 +87,22 @@ EOF
   assert_output --partial '"code":"invalid_task_input"'
 }
 
+@test "docket validate exits 1 on duplicate task names" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: same
+      dokku_app:
+        app: first-app
+    - name: same
+      dokku_app:
+        app: second-app
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "duplicate task name"
+}
+
 @test "docket validate exits 1 on a null task body" {
   write_tasks_file <<EOF
 ---

--- a/tests/bats/validate.bats
+++ b/tests/bats/validate.bats
@@ -43,6 +43,20 @@ EOF
   assert_output --partial 'missing required field "app"'
 }
 
+@test "docket validate exits 1 on git_from_image email without username" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_git_from_image:
+        app: web
+        image: org/app:1.0
+        git_email: deploy@example.com
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "'git_username' and 'git_email' must be set together"
+}
+
 @test "docket validate exits 1 on a conditional input error" {
   write_tasks_file <<EOF
 ---


### PR DESCRIPTION
docket's parser and several task `Validate()` methods accepted, or crashed on, input that should have been rejected cleanly and offline, so `docket validate` could not reliably catch a broken recipe before `apply` reached a server. The root cause of the parser-level cases was that apply/plan and validate ran two independent pipelines over the same recipe, which disagreed on malformed input, so this change first unifies them onto one shared, position-carrying parser and then closes each gap on top of it. apply, plan, and validate now agree on structural validity by construction.

A task-type key with a null body no longer panics the CLI, and a task name that is not a string, a task name that is reused within a play, and an input name that collides with a built-in flag are all rejected offline instead of being silently dropped or crashing flag parsing. Duplicate keys in a JSON5 recipe are rejected the way a duplicate YAML key already was. `dokku_git_from_image` now requires its git username and email together and keeps them in their positional slots, `dokku_service_backup` validates the fixed positional order of its backup-auth arguments, and `dokku_ports` enforces the per-item fields its mappings require. `docket validate`, `plan`, and `apply` now check a recipe given as a positional path rather than silently falling back to the default file, and `docket init` writes a scaffold that stays valid when the name contains special characters, parsing it before it is written so a broken scaffold is never left on disk. Loader parse errors now carry the same line and column positions and did-you-mean hints the validator produces.

Closes #302. Closes #306. Closes #307. Closes #318. Closes #324. Closes #325. Closes #331. Closes #342. Closes #355. Closes #359. Closes #365. While working through these, two further independent recipe-templating defects surfaced and were filed separately as #370 and #371.
