### PR TITLE
fix: reject input names that break template rendering

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -58,9 +58,10 @@ The checks cover: the file parses; the recipe shape is a list of plays; each tas
 right envelope keys plus exactly one task-type key; the task type is registered (with a "did you
 mean" for typos); required fields decode; a task's conditional/semantic input rules hold (for
 example a list that must be non-empty when `state: present`, or mutually-exclusive fields) - the same
-checks `plan` and `apply` run, surfaced offline as `invalid_task_input`; sigil templates render
-against the input defaults; expr predicates parse; and `.item` / `.index` are only used inside a
-`loop:`.
+checks `plan` and `apply` run, surfaced offline as `invalid_task_input`; each input name is a valid
+`{{ .name }}` template variable (a hyphenated name is rejected as `invalid_input_name`); sigil
+templates render against the input defaults; expr predicates parse; and `.item` / `.index` are only
+used inside a `loop:`.
 
 ```bash
 docket validate --tasks path/to/tasks.yml

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -39,6 +39,25 @@ template library, which wraps Go's `text/template`. Anything sigil supports is a
 body. Inputs themselves must not reference other variables - they are resolved first, in a separate
 phase, and then injected.
 
+## Input names
+
+Because an input is referenced as `{{ .name }}`, its `name` must be a valid template variable: a
+letter or underscore followed by letters, digits, or underscores. A name with any other character -
+a hyphen is the common case (`my-app`, `db-host`) - cannot be used with `{{ .name }}` because Go's
+`text/template` rejects it. Such a name is reported as `invalid_input_name` by `docket validate`
+(and rejected by `plan` / `apply`) rather than failing later with a cryptic template error. Rename
+the input to use underscores, for example `my_app`:
+
+```yaml
+---
+- inputs:
+    - name: my_app       # not my-app
+      default: web
+  tasks:
+    - dokku_app:
+        app: "{{ .my_app }}"
+```
+
 ## Overriding inputs
 
 Override an input on the command line by passing its name as a flag. Omit it to use the default:

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -505,6 +505,14 @@ func GetPlays(data []byte, context map[string]interface{}, userSet map[string]bo
 // structural validity by construction; the first structural problem is
 // converted into the loader's fail-fast error.
 func GetPlaysWithFormat(data []byte, format string, context map[string]interface{}, userSet map[string]bool) ([]*Play, error) {
+	// An input name that is not a valid template variable (e.g. a hyphen)
+	// makes the render below fail with a cryptic "bad character" error;
+	// reject it up front with the clearer invalid_input_name diagnostic so
+	// plan and apply fail offline with the same message validate reports.
+	if nameProblems := checkInputNames(data, format); len(nameProblems) > 0 {
+		return nil, problemToError(nameProblems[0])
+	}
+
 	baseRendered, err := renderRecipeBytes(data, context)
 	if err != nil {
 		return nil, err

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -401,6 +401,28 @@ func TestGetPlaysRejectsReservedInputName(t *testing.T) {
 	}
 }
 
+func TestGetPlaysRejectsInvalidInputName(t *testing.T) {
+	// A hyphenated input name breaks `{{ .name }}` rendering; the loader
+	// rejects it up front with a clear error so plan and apply fail offline
+	// with the same message validate reports, not a cryptic render error
+	// (#370).
+	data := []byte(`---
+- inputs:
+    - name: my-app
+      default: web
+  tasks:
+    - dokku_app:
+        app: "{{ .my-app }}"
+`)
+	_, err := GetPlays(data, map[string]interface{}{}, nil)
+	if err == nil {
+		t.Fatal("expected error for invalid input name, got nil")
+	}
+	if !strings.Contains(err.Error(), "is not a valid template variable name") {
+		t.Errorf("expected invalid-input-name error, got: %v", err)
+	}
+}
+
 func TestGetTasksRejectsDuplicateTaskNames(t *testing.T) {
 	// Two tasks sharing a name used to silently drop all but the last
 	// when keyed into the ordered map; the loader now rejects them (#307).

--- a/tasks/validate.go
+++ b/tasks/validate.go
@@ -134,6 +134,14 @@ func Validate(data []byte, opts ValidateOptions) []Problem {
 		opts.InputOverrides = map[string]bool{}
 	}
 
+	// An input name that is not a valid template variable (e.g. a hyphen)
+	// would otherwise make the render below fail with a cryptic "bad
+	// character" error. Check names first so the clearer invalid_input_name
+	// diagnostic wins.
+	if nameProblems := checkInputNames(data, opts.Format); len(nameProblems) > 0 {
+		return nameProblems
+	}
+
 	// Sigil renders templates, so a malformed `{{ .x` is caught here even
 	// when the rest of the file is otherwise unparseable as YAML (the YAML
 	// parser would otherwise misread `{{` as a broken flow mapping). The
@@ -880,6 +888,55 @@ func buildSigilContext(plays [][]inputWithNode) map[string]interface{} {
 		}
 	}
 	return context
+}
+
+// inputNameRe matches an input name usable with the documented `{{ .name }}`
+// syntax. Go text/template lexes a field as a letter or underscore followed by
+// letters, digits, or underscores; any other character (notably a hyphen)
+// makes `{{ .name }}` fail at lex time with "bad character".
+var inputNameRe = regexp.MustCompile(`^[\p{L}_][\p{L}\p{N}_]*$`)
+
+// checkInputNames flags any declared input name that cannot be referenced with
+// the documented `{{ .name }}` syntax, so a hyphenated name surfaces as a clear
+// invalid_input_name diagnostic instead of a cryptic template render error. It
+// parses tolerantly: on any normalize/parse failure it returns nil so the
+// caller's existing parse-error path reports the underlying issue. Reserved
+// names are skipped here so they keep surfacing as the more specific
+// reserved_input_name diagnostic. Shared by Validate and the loader
+// (GetPlaysWithFormat), both of which render before any name check would
+// otherwise run.
+func checkInputNames(data []byte, format string) []Problem {
+	normalized, normProblems := normalizeRecipeBytes(data, format)
+	if len(normProblems) > 0 {
+		return nil
+	}
+	var root yaml.Node
+	if err := yaml.Unmarshal(normalized, &root); err != nil {
+		return nil
+	}
+	doc := documentBody(&root)
+	if doc == nil || doc.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var problems []Problem
+	for _, inputs := range extractPlayInputs(doc) {
+		for _, in := range inputs {
+			if in.Name == "" || ReservedInputNames[in.Name] {
+				continue
+			}
+			if inputNameRe.MatchString(in.Name) {
+				continue
+			}
+			problems = append(problems, Problem{
+				Code:    "invalid_input_name",
+				Line:    in.Line,
+				Column:  in.Column,
+				Message: fmt.Sprintf("input name %q is not a valid template variable name", in.Name),
+				Hint:    `use only letters, digits, and underscores (for example "my_app")`,
+			})
+		}
+	}
+	return problems
 }
 
 // documentBody returns the inner content node when root is a DocumentNode,

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -192,6 +192,91 @@ func TestValidateAllowsHelpVersionInputNames(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsInvalidInputName(t *testing.T) {
+	// A hyphenated input name cannot be referenced with `{{ .name }}` because
+	// Go text/template rejects the hyphen; validate reports a clear
+	// invalid_input_name instead of a cryptic template render error (#370).
+	data := []byte(`---
+- inputs:
+    - name: my-app
+      default: web
+  tasks:
+    - dokku_app:
+        app: "{{ .my-app }}"
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "invalid_input_name")
+	if p == nil {
+		t.Fatalf("expected invalid_input_name problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, `"my-app"`) {
+		t.Errorf("unexpected message: %q", p.Message)
+	}
+	if p.Line == 0 {
+		t.Errorf("expected a source line, got 0")
+	}
+	// The clearer name diagnostic must win over the render error it prevents.
+	if n := countProblems(problems, "template_render"); n != 0 {
+		t.Errorf("invalid_input_name should suppress the template_render error, got %d", n)
+	}
+}
+
+func TestValidateRejectsInvalidInputNameEvenWhenUnreferenced(t *testing.T) {
+	// The name is rejected at declaration, regardless of whether a template
+	// ever references it (#370).
+	data := []byte(`---
+- inputs:
+    - name: my-app
+      default: web
+  tasks:
+    - dokku_app:
+        app: static
+`)
+	problems := Validate(data, ValidateOptions{})
+	if p := findProblem(problems, "invalid_input_name"); p == nil {
+		t.Fatalf("expected invalid_input_name problem, got: %+v", problems)
+	}
+}
+
+func TestValidateAllowsValidInputNames(t *testing.T) {
+	// Letters, digits, and underscores are valid template variable names and
+	// must not be flagged (#370).
+	for _, name := range []string{"app", "db_host", "app2", "_private", "App"} {
+		data := []byte(`---
+- inputs:
+    - name: ` + name + `
+      default: web
+  tasks:
+    - dokku_app:
+        app: "{{ .` + name + ` }}"
+`)
+		problems := Validate(data, ValidateOptions{})
+		if p := findProblem(problems, "invalid_input_name"); p != nil {
+			t.Errorf("input name %q should be valid, got: %+v", name, *p)
+		}
+	}
+}
+
+func TestValidateReservedNameNotReportedAsInvalidInputName(t *testing.T) {
+	// A reserved name is also hyphenated, but it must surface as the more
+	// specific reserved_input_name, not invalid_input_name (#370).
+	data := []byte(`---
+- inputs:
+    - name: no-color
+      default: x
+  tasks:
+    - dokku_app:
+        app: web
+`)
+	problems := Validate(data, ValidateOptions{})
+	if p := findProblem(problems, "invalid_input_name"); p != nil {
+		t.Errorf("reserved name should not be invalid_input_name, got: %+v", *p)
+	}
+	if p := findProblem(problems, "reserved_input_name"); p == nil {
+		t.Fatalf("expected reserved_input_name problem, got: %+v", problems)
+	}
+}
+
 func TestValidateRejectsDuplicateTaskNames(t *testing.T) {
 	// validate flags duplicate task names offline so a recipe that would
 	// silently drop a task fails the CI lint (#307).

--- a/tests/bats/validate.bats
+++ b/tests/bats/validate.bats
@@ -147,6 +147,56 @@ EOF
   assert_output --partial "reserved for a built-in flag"
 }
 
+@test "docket validate exits 1 on a hyphenated input name" {
+  write_tasks_file <<EOF
+---
+- inputs:
+    - name: my-app
+      default: web
+  tasks:
+    - dokku_app:
+        app: "{{ .my-app }}"
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "not a valid template variable name"
+  refute_output --partial "bad character"
+}
+
+@test "docket validate --json emits invalid_input_name for a hyphenated input name" {
+  write_tasks_file <<EOF
+---
+- inputs:
+    - name: my-app
+      default: web
+  tasks:
+    - dokku_app:
+        app: "{{ .my-app }}"
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE" --json
+  assert_failure
+  assert_output --partial '"code":"invalid_input_name"'
+}
+
+@test "docket apply rejects a hyphenated input name offline" {
+  # A hyphenated input name breaks `{{ .name }}` rendering; the loader must
+  # reject it up front with the same clear message validate reports, not a
+  # cryptic render error (#370).
+  write_tasks_file <<EOF
+---
+- inputs:
+    - name: my-app
+      default: web
+  tasks:
+    - dokku_app:
+        app: "{{ .my-app }}"
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_failure
+  assert_output --partial "not a valid template variable name"
+  refute_output --partial "bad character"
+}
+
 @test "docket apply does not panic on an input named after a built-in flag" {
   # An input named after a built-in flag used to make pflag panic before
   # flag parsing began (#302). apply must now fail cleanly instead.


### PR DESCRIPTION
An input name containing a hyphen could not be referenced with the documented `{{ .name }}` syntax and failed with a cryptic `bad character` template error from `validate`, `plan`, and `apply`. Such a name is now rejected up front as `invalid_input_name` with a hint to rename it using letters, digits, and underscores.

Fixes #370.
