### PR TITLE
fix: handle input values that break a quoted task body

### DIFF
--- a/commands/init.go
+++ b/commands/init.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -18,7 +17,6 @@ import (
 	"github.com/josegonzalez/cli-skeleton/command"
 	"github.com/posener/complete"
 	flag "github.com/spf13/pflag"
-	yaml "gopkg.in/yaml.v3"
 )
 
 // InitCommand scaffolds a starter tasks.yml from an embedded template.
@@ -214,8 +212,8 @@ func renderInit(opts initOptions) ([]byte, error) {
 	// a broken one. yamlStr leaves simple names unquoted, matching the
 	// previous output for ordinary names.
 	tmpl, err := template.New(templateName).Delims("<<", ">>").Funcs(template.FuncMap{
-		"yamlStr": yamlScalar,
-		"jsonStr": jsonScalar,
+		"yamlStr": tasks.YAMLScalar,
+		"jsonStr": tasks.JSONScalar,
 	}).Parse(string(raw))
 	if err != nil {
 		return nil, fmt.Errorf("parse template %s: %w", templateName, err)
@@ -235,28 +233,6 @@ func renderInit(opts initOptions) ([]byte, error) {
 	}
 	out.Write(body.Bytes())
 	return out.Bytes(), nil
-}
-
-// yamlScalar renders s as a YAML scalar, quoting and escaping only when
-// necessary so ordinary names stay unquoted. Used by the YAML init
-// templates so a name with YAML-special characters cannot break the
-// scaffold.
-func yamlScalar(s string) (string, error) {
-	b, err := yaml.Marshal(s)
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimRight(string(b), "\n"), nil
-}
-
-// jsonScalar renders s as a JSON string literal (valid JSON5), used by the
-// JSON5 init templates so an embedded quote or backslash is escaped.
-func jsonScalar(s string) (string, error) {
-	b, err := json.Marshal(s)
-	if err != nil {
-		return "", err
-	}
-	return string(b), nil
 }
 
 // selectInitTemplate returns the embedded template name for (format,

--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -288,8 +288,10 @@ func TestInitSpecialCharacterNamesParse(t *testing.T) {
 func TestInitYAMLSpecialNamesFullyValidate(t *testing.T) {
 	// The names the issue calls out (@web, a `: `-containing name) also
 	// round-trip through full validate, including the sigil render that
-	// substitutes the name into the task bodies (#355).
-	names := []string{"@web", "foo: bar", "*star", "- dash"}
+	// substitutes the name into the task bodies (#355). A name with a double
+	// quote (`has"quote`) used to break the rendered body; the scaffold now
+	// pipes each interpolation through `dq`, so it validates too (#371).
+	names := []string{"@web", "foo: bar", "*star", "- dash", `has"quote`}
 	for _, name := range names {
 		out, err := renderInit(initOptions{Name: name})
 		if err != nil {

--- a/commands/templates/default.json5.tmpl
+++ b/commands/templates/default.json5.tmpl
@@ -16,7 +16,7 @@
       {
         name: "create app",
         dokku_app: {
-          app: "{{ .app }}",
+          app: "{{ .app | dq }}",
           state: "present",
         },
       },
@@ -24,7 +24,7 @@
       {
         name: "configure env vars",
         dokku_config: {
-          app: "{{ .app }}",
+          app: "{{ .app | dq }}",
           config: {
             APP_ENV: "production",
             LOG_LEVEL: "info",
@@ -35,8 +35,8 @@
       {
         name: "configure domains",
         dokku_domains: {
-          app: "{{ .app }}",
-          domains: ["{{ .app }}.example.com"],
+          app: "{{ .app | dq }}",
+          domains: ["{{ .app | dq }}.example.com"],
           state: "set",
         },
       },
@@ -44,8 +44,8 @@
       {
         name: "sync git repository",
         dokku_git_sync: {
-          app: "{{ .app }}",
-          remote: "{{ .repo }}",
+          app: "{{ .app | dq }}",
+          remote: "{{ .repo | dq }}",
         },
       },
     ],

--- a/commands/templates/default.yml.tmpl
+++ b/commands/templates/default.yml.tmpl
@@ -8,23 +8,23 @@
   tasks:
     - name: create app
       dokku_app:
-        app: "{{ .app }}"
+        app: "{{ .app | dq }}"
         state: present
 
     - name: configure env vars
       dokku_config:
-        app: "{{ .app }}"
+        app: "{{ .app | dq }}"
         config:
           APP_ENV: production
           LOG_LEVEL: info
 
     - name: configure domains
       dokku_domains:
-        app: "{{ .app }}"
-        domains: ["{{ .app }}.example.com"]
+        app: "{{ .app | dq }}"
+        domains: ["{{ .app | dq }}.example.com"]
         state: set
 
     - name: sync git repository
       dokku_git_sync:
-        app: "{{ .app }}"
-        remote: "{{ .repo }}"
+        app: "{{ .app | dq }}"
+        remote: "{{ .repo | dq }}"

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -60,8 +60,10 @@ mean" for typos); required fields decode; a task's conditional/semantic input ru
 example a list that must be non-empty when `state: present`, or mutually-exclusive fields) - the same
 checks `plan` and `apply` run, surfaced offline as `invalid_task_input`; each input name is a valid
 `{{ .name }}` template variable (a hyphenated name is rejected as `invalid_input_name`); sigil
-templates render against the input defaults; expr predicates parse; and `.item` / `.index` are only
-used inside a `loop:`.
+templates render against the input defaults, and an input value that would break the scalar it is
+substituted into is reported as `unsafe_input_value` (naming the input) rather than a cryptic YAML
+error - see [special characters in values](inputs.md#special-characters-in-values); expr predicates
+parse; and `.item` / `.index` are only used inside a `loop:`.
 
 ```bash
 docket validate --tasks path/to/tasks.yml

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -58,6 +58,49 @@ the input to use underscores, for example `my_app`:
         app: "{{ .my_app }}"
 ```
 
+## Special characters in values
+
+An input value is substituted into the task body as raw text before the recipe is parsed. That
+means a value with a character that collides with the surrounding quotes breaks the scalar. Given
+the scaffolded shape `app: "{{ .app }}"`, a value containing a double quote renders the invalid
+`app: "ab"cd"`, and `docket validate` (as well as `plan` / `apply`) reports it as
+`unsafe_input_value`, naming the offending input, instead of a cryptic YAML error.
+
+The robust fix is the `dq` filter, which escapes a value for a double-quoted scalar. Use it **inside
+the quotes** so it handles any value - double quotes, both quote types, even a newline - while the
+recipe stays valid YAML/JSON5 for `docket validate` and `docket fmt`. The `docket init` scaffold uses
+it for exactly this reason:
+
+```yaml
+---
+- inputs:
+    - name: motd
+      default: 'say "hi"'
+  tasks:
+    - dokku_config:
+        app: web
+        config:
+          MOTD: "{{ .motd | dq }}"          # -> MOTD: "say \"hi\""
+    - dokku_domains:
+        app: web
+        domains: ["{{ .motd | dq }}.example.com"]   # works mid-string too
+```
+
+For a value that only contains one kind of quote, choosing a compatible quote style also works and
+needs no filter: a single-quoted body tolerates a double quote, and a double-quoted body tolerates a
+single quote.
+
+```yaml
+    - dokku_config:
+        app: web
+        config:
+          MOTD: '{{ .motd }}'               # single quotes tolerate a " in the value
+```
+
+Note that `dq` must sit inside a double-quoted scalar. Do not leave the reference unquoted
+(`app: {{ .app | dq }}`): an unquoted `{{` is not valid YAML, so `docket validate` and `docket fmt`,
+which read the recipe before it is rendered, would reject the file.
+
 ## Overriding inputs
 
 Override an input on the command line by passing its name as a flag. Omit it to use the default:

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -520,6 +520,12 @@ func GetPlaysWithFormat(data []byte, format string, context map[string]interface
 
 	baseAST, err := parseRecipeForLoader(baseRendered, format)
 	if err != nil {
+		// A parse failure here may be an input value that broke its
+		// surrounding scalar (#371); attribute it to the input so plan/apply
+		// fail with the same clear message validate reports.
+		if diag := diagnoseUnsafeInputValue(data, format, context); diag != nil {
+			return nil, problemToError(*diag)
+		}
 		return nil, err
 	}
 
@@ -579,6 +585,11 @@ func GetPlaysWithFormat(data []byte, format string, context map[string]interface
 		}
 		perAST, err := parseRecipeForLoader(perRendered, format)
 		if err != nil {
+			// As above, but against the play-local context so a play-scoped
+			// input value is attributed too.
+			if diag := diagnoseUnsafeInputValue(data, format, playCtx); diag != nil {
+				return nil, problemToError(*diag)
+			}
 			return nil, err
 		}
 		if i >= len(perAST.Plays) {

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -423,6 +423,28 @@ func TestGetPlaysRejectsInvalidInputName(t *testing.T) {
 	}
 }
 
+func TestGetPlaysRejectsUnsafeInputValue(t *testing.T) {
+	// A value containing a double quote breaks the double-quoted body it lands
+	// in; the loader rejects it offline with the same input-named message
+	// validate reports, so plan and apply do not fail with a cryptic YAML
+	// error (#371).
+	data := []byte(`---
+- inputs:
+    - name: app
+      default: 'ab"cd'
+  tasks:
+    - dokku_app:
+        app: "{{ .app }}"
+`)
+	_, err := GetPlays(data, map[string]interface{}{"app": `ab"cd`}, nil)
+	if err == nil {
+		t.Fatal("expected error for unsafe input value, got nil")
+	}
+	if !strings.Contains(err.Error(), `input "app"`) || !strings.Contains(err.Error(), "breaks the surrounding scalar") {
+		t.Errorf("expected unsafe-input-value error, got: %v", err)
+	}
+}
+
 func TestGetTasksRejectsDuplicateTaskNames(t *testing.T) {
 	// Two tasks sharing a name used to silently drop all but the last
 	// when keyed into the ordered map; the loader now rejects them (#307).

--- a/tasks/render_funcs.go
+++ b/tasks/render_funcs.go
@@ -1,0 +1,109 @@
+package tasks
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"text/template"
+
+	sigil "github.com/gliderlabs/sigil"
+	yaml "gopkg.in/yaml.v3"
+)
+
+// render_funcs.go registers the `dq` template filter with sigil so a recipe can
+// interpolate an input value that contains YAML-special characters without
+// breaking the surrounding scalar. Because docket renders the whole file as
+// text before parsing it (see renderRecipeBytes), an input value like `ab"cd`
+// substituted into `app: "{{ .app }}"` produces the invalid `app: "ab"cd"`.
+//
+// `dq` escapes the value for a double-quoted scalar and is used INSIDE the
+// existing double quotes, so the value stays safe even alongside other text:
+//
+//	app:     "{{ .app | dq }}"                 // -> app: "ab\"cd"
+//	domains: ["{{ .app | dq }}.example.com"]   // -> ["ab\"cd.example.com"]
+//
+// Keeping the quotes means the raw recipe is still valid YAML/JSON5, so
+// `docket validate` and `docket fmt` (which parse the file before it is
+// rendered) keep working - unlike a self-quoting unquoted filter would.
+//
+// The name differs from sigil's `tojson` built-in, which emits a value WITH its
+// surrounding quotes and so cannot be used inside an existing quoted scalar.
+func init() {
+	sigil.Register(template.FuncMap{
+		"dq": DoubleQuoteEscape,
+	})
+}
+
+// DoubleQuoteEscape escapes v for interpolation inside a double-quoted YAML (or
+// JSON5) scalar, returning the escaped body WITHOUT the surrounding quotes so
+// the caller keeps its own. JSON string escaping is a subset of YAML's
+// double-quoted escaping, so json.Marshal produces a body that both parsers
+// accept; HTML escaping is disabled so `<`, `>`, and `&` stay readable.
+func DoubleQuoteEscape(v interface{}) (string, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(scalarArg(v)); err != nil {
+		return "", err
+	}
+	s := strings.TrimRight(buf.String(), "\n")
+	return strings.TrimSuffix(strings.TrimPrefix(s, `"`), `"`), nil
+}
+
+// YAMLScalar renders s as a complete YAML scalar, quoting and escaping only
+// when necessary so ordinary values stay unquoted. Used by commands/init.go to
+// emit an input's `default:` in the scaffold; it is not a recipe-render filter
+// because its output carries its own quoting and so cannot sit inside an
+// existing quoted scalar.
+func YAMLScalar(v interface{}) (string, error) {
+	b, err := yaml.Marshal(scalarArg(v))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(b), "\n"), nil
+}
+
+// JSONScalar renders s as a JSON string literal (also valid JSON5), used by the
+// JSON5 init scaffold so an embedded quote or backslash is escaped.
+func JSONScalar(v interface{}) (string, error) {
+	b, err := json.Marshal(scalarArg(v))
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// scalarArg coerces a template argument to a string.
+//
+// A missing template key arrives as nil (text/template's zero value), which
+// must render as an empty string rather than error so a filter survives the
+// empty-context render used for input discovery and the validate syntax check.
+//
+// The apply/plan context stores input values as typed pointers (*string, *int,
+// ...) because pflag hands back pointers. text/template auto-dereferences a
+// pointer for a bare `{{ .x }}`, but passes it verbatim to a filter argument
+// (`{{ .x | dq }}`), so the pointer must be dereferenced here or the address,
+// not the value, would be escaped.
+func scalarArg(v interface{}) string {
+	if v == nil {
+		return ""
+	}
+	rv := reflect.ValueOf(v)
+	for rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return ""
+		}
+		rv = rv.Elem()
+	}
+	v = rv.Interface()
+	switch t := v.(type) {
+	case string:
+		return t
+	case fmt.Stringer:
+		return t.String()
+	default:
+		return fmt.Sprintf("%v", t)
+	}
+}

--- a/tasks/render_funcs_test.go
+++ b/tasks/render_funcs_test.go
@@ -1,0 +1,170 @@
+package tasks
+
+import (
+	"testing"
+
+	_ "github.com/gliderlabs/sigil/builtin"
+)
+
+func TestYAMLScalar(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"billing", "billing"},
+		// A quote or apostrophe mid-value is a valid plain scalar, so it
+		// stays unquoted; yaml.Marshal quotes only when it must.
+		{`ab"cd`, `ab"cd`},
+		{"has'apostrophe", "has'apostrophe"},
+		{"foo: bar", "'foo: bar'"},
+		{"@web", "'@web'"},
+		{"true", `"true"`},
+		{"", `""`},
+	}
+	for _, tc := range cases {
+		got, err := YAMLScalar(tc.in)
+		if err != nil {
+			t.Fatalf("YAMLScalar(%q): %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Errorf("YAMLScalar(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestJSONScalar(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"billing", `"billing"`},
+		{`say "hi"`, `"say \"hi\""`},
+		{"line1\nline2", `"line1\nline2"`},
+	}
+	for _, tc := range cases {
+		got, err := JSONScalar(tc.in)
+		if err != nil {
+			t.Fatalf("JSONScalar(%q): %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Errorf("JSONScalar(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestDoubleQuoteEscape(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"plain", "plain"},
+		{`ab"cd`, `ab\"cd`},
+		{`say "hi"`, `say \"hi\"`},
+		{"line1\nline2", `line1\nline2`},
+		{`back\slash`, `back\\slash`},
+		{"a<b>&c", "a<b>&c"},
+	}
+	for _, tc := range cases {
+		got, err := DoubleQuoteEscape(tc.in)
+		if err != nil {
+			t.Fatalf("DoubleQuoteEscape(%q): %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Errorf("DoubleQuoteEscape(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+	// A missing key arrives as nil and must render as empty, not error, so the
+	// filter survives the empty-context render used for input discovery.
+	if got, err := DoubleQuoteEscape(nil); err != nil || got != "" {
+		t.Errorf("DoubleQuoteEscape(nil) = %q, %v; want \"\", nil", got, err)
+	}
+	// The apply/plan context stores input values as *string, and sigil passes
+	// that pointer to the filter verbatim; it must be dereferenced, not
+	// formatted as an address.
+	s := `say "hi"`
+	if got, err := DoubleQuoteEscape(&s); err != nil || got != `say \"hi\"` {
+		t.Errorf("DoubleQuoteEscape(*string) = %q, %v; want %q", got, err, `say \"hi\"`)
+	}
+	var nilPtr *string
+	if got, err := DoubleQuoteEscape(nilPtr); err != nil || got != "" {
+		t.Errorf("DoubleQuoteEscape((*string)(nil)) = %q, %v; want \"\", nil", got, err)
+	}
+}
+
+// TestGetTasksDoubleQuoteEscapePointerValue guards the #371 apply path: the
+// real apply/plan context holds *string values (pflag hands back pointers), and
+// the dq filter must dereference them rather than render the pointer address.
+func TestGetTasksDoubleQuoteEscapePointerValue(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: configure
+      dokku_config:
+        app: test-app
+        config:
+          MOTD: "{{ .motd | dq }}"
+`)
+	motd := `say "hi"`
+	context := map[string]interface{}{"motd": &motd}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks with *string context failed: %v", err)
+	}
+	task := tasks.Get("configure")
+	if task == nil {
+		t.Fatal("task 'configure' not found")
+	}
+	configTask, ok := task.(*ConfigTask)
+	if !ok {
+		ct, ok2 := task.(ConfigTask)
+		if !ok2 {
+			t.Fatalf("task is not a ConfigTask (type is %T)", task)
+		}
+		configTask = &ct
+	}
+	if got := configTask.Config["MOTD"]; got != motd {
+		t.Errorf("Config[MOTD] = %q, want %q", got, motd)
+	}
+}
+
+// TestGetTasksDoubleQuoteEscapeSpecialValue is the #371 regression: an input
+// value containing characters that would break the surrounding double-quoted
+// scalar must render into a task body correctly when piped through `dq`. A
+// config value is used because it (unlike an app name) legitimately holds
+// arbitrary characters.
+func TestGetTasksDoubleQuoteEscapeSpecialValue(t *testing.T) {
+	for _, value := range []string{`say "hi"`, `he said "don't"`, "line1\nline2"} {
+		t.Run(value, func(t *testing.T) {
+			data := []byte(`---
+- tasks:
+    - name: configure
+      dokku_config:
+        app: test-app
+        config:
+          MOTD: "{{ .motd | dq }}"
+`)
+			context := map[string]interface{}{"motd": value}
+
+			tasks, err := GetTasks(data, context)
+			if err != nil {
+				t.Fatalf("GetTasks with dq filter failed for %q: %v", value, err)
+			}
+
+			task := tasks.Get("configure")
+			if task == nil {
+				t.Fatal("task 'configure' not found")
+			}
+			configTask, ok := task.(*ConfigTask)
+			if !ok {
+				ct, ok2 := task.(ConfigTask)
+				if !ok2 {
+					t.Fatalf("task is not a ConfigTask (type is %T)", task)
+				}
+				configTask = &ct
+			}
+			if got := configTask.Config["MOTD"]; got != value {
+				t.Errorf("Config[MOTD] = %q, want %q", got, value)
+			}
+		})
+	}
+}

--- a/tasks/validate.go
+++ b/tasks/validate.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -134,6 +135,10 @@ func Validate(data []byte, opts ValidateOptions) []Problem {
 		opts.InputOverrides = map[string]bool{}
 	}
 
+	// Retained before normalization so a post-render parse failure can be
+	// re-diagnosed against the original recipe (see diagnoseUnsafeInputValue).
+	rawData := data
+
 	// An input name that is not a valid template variable (e.g. a hyphen)
 	// would otherwise make the render below fail with a cryptic "bad
 	// character" error. Check names first so the clearer invalid_input_name
@@ -215,6 +220,18 @@ func Validate(data []byte, opts ValidateOptions) []Problem {
 	// below this point are validate-only: they need placeholder-aware body
 	// decoding or offline-only cross-reference auditing.
 	ast := parseRecipe(rendered)
+	// A yaml_parse problem after rendering with real input values may be an
+	// input value that broke its surrounding scalar (#371). Re-diagnose so the
+	// operator gets an input-named message instead of a cryptic YAML error;
+	// parseRecipe short-circuits on yaml_parse, so ast carries nothing else.
+	for _, p := range ast.Problems {
+		if p.Code == "yaml_parse" {
+			if diag := diagnoseUnsafeInputValue(rawData, opts.Format, context); diag != nil {
+				return []Problem{*diag}
+			}
+			break
+		}
+	}
 	problems := append([]Problem(nil), ast.Problems...)
 
 	// registerSeen tracks register names across the whole recipe so a
@@ -937,6 +954,126 @@ func checkInputNames(data []byte, format string) []Problem {
 		}
 	}
 	return problems
+}
+
+// diagnoseUnsafeInputValue attributes a post-render YAML parse failure to an
+// input whose resolved value breaks its surrounding scalar once substituted as
+// raw text (#371). It is called only on the parse-failure path and returns nil
+// when the failure is not caused by an input value, so the caller keeps its
+// original yaml_parse diagnostic.
+//
+// The culprit is isolated by re-rendering: first with every input replaced by a
+// known-safe placeholder (which must then parse), then with one input at a time
+// restored to its real value; the inputs that reintroduce the failure are the
+// culprits. data is the raw recipe bytes, format its surface syntax, and
+// context maps input name -> resolved value.
+//
+// The message never echoes an input's value: an input may be marked sensitive,
+// and the value is not needed to act on the problem.
+func diagnoseUnsafeInputValue(data []byte, format string, context map[string]interface{}) *Problem {
+	if len(context) == 0 {
+		return nil
+	}
+
+	parses := func(ctx map[string]interface{}) bool {
+		rendered, err := renderRecipeBytes(data, ctx)
+		if err != nil {
+			return false
+		}
+		normalized, probs := normalizeRecipeBytes(rendered, format)
+		if len(probs) > 0 {
+			return false
+		}
+		var node yaml.Node
+		return yaml.Unmarshal(normalized, &node) == nil
+	}
+
+	safeContext := func(real string) map[string]interface{} {
+		ctx := make(map[string]interface{}, len(context))
+		for k := range context {
+			ctx[k] = validatePlaceholder
+		}
+		if real != "" {
+			ctx[real] = context[real]
+		}
+		return ctx
+	}
+
+	// The real context must fail and the all-safe context must parse, or the
+	// failure is structural rather than a value-injection problem.
+	if parses(context) || !parses(safeContext("")) {
+		return nil
+	}
+
+	var culprits []string
+	for name := range context {
+		if !parses(safeContext(name)) {
+			culprits = append(culprits, name)
+		}
+	}
+	if len(culprits) == 0 {
+		// The values break the render only in combination; name them all so
+		// the operator still gets an actionable, non-cryptic message.
+		for name := range context {
+			culprits = append(culprits, name)
+		}
+	}
+	sort.Strings(culprits)
+
+	line, column := unsafeInputPosition(data, format, culprits[0])
+	return &Problem{
+		Code:    "unsafe_input_value",
+		Line:    line,
+		Column:  column,
+		Message: unsafeInputMessage(culprits),
+		Hint:    unsafeInputHint(culprits[0]),
+	}
+}
+
+// unsafeInputPosition returns the source position of an input's declaration so
+// the diagnostic anchors at the right line. Input declarations are
+// template-free, so the raw recipe parses even when its rendered form does not.
+// Returns 0, 0 when the position cannot be derived.
+func unsafeInputPosition(data []byte, format, name string) (int, int) {
+	normalized, probs := normalizeRecipeBytes(data, format)
+	if len(probs) > 0 {
+		return 0, 0
+	}
+	var root yaml.Node
+	if err := yaml.Unmarshal(normalized, &root); err != nil {
+		return 0, 0
+	}
+	doc := documentBody(&root)
+	if doc == nil || doc.Kind != yaml.SequenceNode {
+		return 0, 0
+	}
+	for _, inputs := range extractPlayInputs(doc) {
+		for _, in := range inputs {
+			if in.Name == name {
+				return in.Line, in.Column
+			}
+		}
+	}
+	return 0, 0
+}
+
+// unsafeInputMessage renders the unsafe_input_value message for one or more
+// culprit input names, without echoing any value.
+func unsafeInputMessage(names []string) string {
+	if len(names) == 1 {
+		return fmt.Sprintf("input %q has a value that breaks the surrounding scalar after template substitution", names[0])
+	}
+	quoted := make([]string, len(names))
+	for i, n := range names {
+		quoted[i] = fmt.Sprintf("%q", n)
+	}
+	return fmt.Sprintf("inputs %s have values that break the surrounding scalar after template substitution", strings.Join(quoted, ", "))
+}
+
+// unsafeInputHint points at the safe interpolation patterns, using name as the
+// example.
+func unsafeInputHint(name string) string {
+	return fmt.Sprintf("escape it inside the quotes with `\"{{ .%s | dq }}\"`, or use a quote style that does not clash with the value (a single-quoted `'{{ .%s }}'` tolerates a double quote)", name, name)
 }
 
 // documentBody returns the inner content node when root is a DocumentNode,

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -257,6 +257,77 @@ func TestValidateAllowsValidInputNames(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsUnsafeInputValue(t *testing.T) {
+	// The issue #371 repro: a value containing a double quote breaks the
+	// double-quoted body it is substituted into. validate names the offending
+	// input instead of reporting a cryptic YAML parse error.
+	data := []byte(`---
+- inputs:
+    - name: app
+      default: 'ab"cd'
+  tasks:
+    - dokku_app:
+        app: "{{ .app }}"
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "unsafe_input_value")
+	if p == nil {
+		t.Fatalf("expected unsafe_input_value problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, `"app"`) {
+		t.Errorf("unexpected message: %q", p.Message)
+	}
+	if p.Line == 0 {
+		t.Errorf("expected a source line, got 0")
+	}
+	// The clearer diagnostic must win over the raw YAML parse error.
+	if n := countProblems(problems, "yaml_parse"); n != 0 {
+		t.Errorf("unsafe_input_value should suppress the yaml_parse error, got %d", n)
+	}
+	// The value must not be echoed, so a sensitive input cannot leak.
+	if strings.Contains(p.Message+p.Hint, `ab"cd`) {
+		t.Errorf("message must not echo the input value: %q / %q", p.Message, p.Hint)
+	}
+}
+
+func TestValidateAllowsDoubleQuoteEscapedValue(t *testing.T) {
+	// Piping a special-character value through `dq` inside the quotes keeps the
+	// rendered scalar valid, so validate passes.
+	data := []byte(`---
+- inputs:
+    - name: motd
+      default: 'say "hi"'
+  tasks:
+    - dokku_config:
+        app: web
+        config:
+          MOTD: "{{ .motd | dq }}"
+`)
+	problems := Validate(data, ValidateOptions{})
+	if len(problems) != 0 {
+		t.Errorf("dq-escaped value should validate cleanly, got: %+v", problems)
+	}
+}
+
+func TestValidateAllowsSingleQuotedSpecialValue(t *testing.T) {
+	// A single-quoted body tolerates a double quote in the value without any
+	// filter, and stays valid YAML for validate.
+	data := []byte(`---
+- inputs:
+    - name: app
+      default: 'ab"cd'
+  tasks:
+    - dokku_config:
+        app: web
+        config:
+          MOTD: '{{ .app }}'
+`)
+	problems := Validate(data, ValidateOptions{})
+	if len(problems) != 0 {
+		t.Errorf("single-quoted body should validate cleanly, got: %+v", problems)
+	}
+}
+
 func TestValidateReservedNameNotReportedAsInvalidInputName(t *testing.T) {
 	// A reserved name is also hyphenated, but it must surface as the more
 	// specific reserved_input_name, not invalid_input_name (#370).

--- a/tests/bats/validate.bats
+++ b/tests/bats/validate.bats
@@ -216,6 +216,76 @@ EOF
   refute_output --partial "flag redefined"
 }
 
+@test "docket validate exits 1 on an input value that breaks its scalar" {
+  # A value containing a double quote breaks the double-quoted body it is
+  # substituted into; validate names the input instead of a cryptic YAML error
+  # (#371).
+  write_tasks_file <<EOF
+---
+- inputs:
+    - name: app
+      default: 'ab"cd'
+  tasks:
+    - dokku_app:
+        app: "{{ .app }}"
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial 'input "app"'
+  assert_output --partial "breaks the surrounding scalar"
+  refute_output --partial "did not find expected"
+}
+
+@test "docket validate --json emits unsafe_input_value for a breaking value" {
+  write_tasks_file <<EOF
+---
+- inputs:
+    - name: app
+      default: 'ab"cd'
+  tasks:
+    - dokku_app:
+        app: "{{ .app }}"
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE" --json
+  assert_failure
+  assert_output --partial '"code":"unsafe_input_value"'
+}
+
+@test "docket validate passes when a breaking value is escaped with dq" {
+  # Piping the value through dq inside the quotes keeps the rendered scalar
+  # valid, and the quoted recipe still parses for validate (#371).
+  write_tasks_file <<EOF
+---
+- inputs:
+    - name: motd
+      default: 'say "hi"'
+  tasks:
+    - dokku_config:
+        app: web
+        config:
+          MOTD: "{{ .motd | dq }}"
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "is valid"
+}
+
+@test "docket apply rejects an unsafe input value offline" {
+  write_tasks_file <<EOF
+---
+- inputs:
+    - name: app
+      default: 'ab"cd'
+  tasks:
+    - dokku_app:
+        app: "{{ .app }}"
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_failure
+  assert_output --partial "breaks the surrounding scalar"
+  refute_output --partial "did not find expected"
+}
+
 @test "docket validate exits 1 on duplicate task names" {
   write_tasks_file <<EOF
 ---

--- a/tests/bats/vars_file.bats
+++ b/tests/bats/vars_file.bats
@@ -205,3 +205,36 @@ EOF
   assert_success
   dokku_clean_app docket-test-vars-apply
 }
+
+@test "docket apply escapes a config value containing a quote with dq" {
+  # A config value legitimately holds arbitrary characters (an app name does
+  # not), so this proves the dq escaping end to end: a value with an embedded
+  # double quote survives the render into a double-quoted body and is stored
+  # verbatim (#371). The quote is kept mid-value because dokku's config:get
+  # renders a trailing quote inconsistently across versions.
+  require_dokku
+  dokku_clean_app docket-test-dq
+  write_tasks_file <<'EOF'
+---
+- inputs:
+    - { name: motd, required: true }
+  tasks:
+    - name: ensure docket-test-dq
+      dokku_app:
+        app: docket-test-dq
+    - name: set the motd
+      dokku_config:
+        app: docket-test-dq
+        config:
+          MOTD: "{{ .motd | dq }}"
+EOF
+  cat >"$BATS_TEST_TMPDIR/vars.yml" <<'EOF'
+motd: 'he said "hi" loudly'
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --vars-file "$BATS_TEST_TMPDIR/vars.yml"
+  assert_success
+  run dokku config:get docket-test-dq MOTD
+  assert_success
+  assert_output --partial 'he said "hi" loudly'
+  dokku_clean_app docket-test-dq
+}


### PR DESCRIPTION
An input value containing a character such as a double quote used to break the double-quoted body it was substituted into and fail with a cryptic YAML parse error. docket now reports it as `unsafe_input_value`, naming the offending input, across `validate`, `plan`, and `apply`, and a new `dq` template filter used inside the quotes as `"{{ .app | dq }}"` escapes any value safely while keeping the recipe valid for `docket validate` and `docket fmt`. The `docket init` scaffold uses `dq` so a generated recipe stays valid for any input value.

Fixes #371
