### PR TITLE
fix: correct docket export migration-fidelity bugs

### DIFF
--- a/commands/export.go
+++ b/commands/export.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/dokku/docket/subprocess"
 	"github.com/dokku/docket/tasks"
 
 	"github.com/josegonzalez/cli-skeleton/command"
@@ -113,7 +114,10 @@ func (c *ExportCommand) Run(args []string) int {
 		return 1
 	}
 
-	resolveSshFlags(c.host, c.sudo, c.acceptNewHostKeys)
+	resolvedHost := resolveSshFlags(c.host, c.sudo, c.acceptNewHostKeys)
+	if resolvedHost != "" {
+		defer subprocess.CloseSshControlMaster(resolvedHost)
+	}
 
 	toStdout := c.output == "-"
 
@@ -128,6 +132,19 @@ func (c *ExportCommand) Run(args []string) int {
 	}
 	for _, w := range res.Report.Warnings {
 		c.Ui.Warn(fmt.Sprintf("warning: %s", w))
+	}
+
+	// A nonexistent --app must not silently produce an empty recipe (which the
+	// loader then rejects). When nothing was collected, abort without writing;
+	// otherwise the existing apps are exported and the missing names are reported
+	// with a non-zero exit at the end (#346).
+	if res.PlayCount() == 0 {
+		if len(res.Report.MissingApps) > 0 {
+			c.Ui.Error(fmt.Sprintf("error: %s not found on server; nothing to export", strings.Join(res.Report.MissingApps, ", ")))
+		} else {
+			c.Ui.Error("error: nothing to export")
+		}
+		return 1
 	}
 
 	recipeFormat := taskFileFormatYAML
@@ -145,7 +162,7 @@ func (c *ExportCommand) Run(args []string) int {
 			c.Ui.Error(fmt.Sprintf("write error: %v", err))
 			return 1
 		}
-		return 0
+		return c.exitForMissingApps(res)
 	}
 
 	varsOutput := c.varsOutput
@@ -198,8 +215,7 @@ func (c *ExportCommand) Run(args []string) int {
 		}
 	}
 
-	playCount := res.PlayCount()
-	c.Ui.Output(fmt.Sprintf("==> Exported %s (%s)", c.output, pluralize(playCount, "app")))
+	c.Ui.Output(fmt.Sprintf("==> Exported %s (%s)", c.output, pluralize(res.AppCount(), "app")))
 	if writeVars {
 		c.Ui.Output(fmt.Sprintf("    values written to %s", varsOutput))
 		if c.redact {
@@ -213,7 +229,18 @@ func (c *ExportCommand) Run(args []string) int {
 	} else {
 		c.Ui.Output(fmt.Sprintf("  $ %s apply --tasks %s", appName(), c.output))
 	}
-	return 0
+	return c.exitForMissingApps(res)
+}
+
+// exitForMissingApps reports any --app names that were not found on the server
+// and returns a non-zero exit code, so a typo is surfaced even though the apps
+// that do exist were still exported (#346).
+func (c *ExportCommand) exitForMissingApps(res *tasks.ExportResult) int {
+	if len(res.Report.MissingApps) == 0 {
+		return 0
+	}
+	c.Ui.Error(fmt.Sprintf("error: %s not found on server", strings.Join(res.Report.MissingApps, ", ")))
+	return 1
 }
 
 // confirmOverwrite prompts for permission to overwrite an existing file. When

--- a/commands/export_test.go
+++ b/commands/export_test.go
@@ -168,6 +168,73 @@ func TestExportOutputValidates(t *testing.T) {
 	}
 }
 
+func TestExportCommandSummaryExcludesGlobalPlay(t *testing.T) {
+	// #345: one app plus a global play must report "(1 app)", not "(2 apps)".
+	responses := exportCommandFixture()
+	responses["--quiet plugin:list --format json"] = `[{"name":"redis","core":false,"source_url":"https://github.com/dokku/dokku-redis.git","committish":"c0ffee","branch":"master"}]`
+	defer subprocess.SetExecRunner(fakeExecRunner(responses))()
+
+	dir := t.TempDir()
+	recipe := filepath.Join(dir, "tasks.yml")
+
+	c, ui := newExportCommand()
+	if code := c.Run([]string{"--output", recipe}); code != 0 {
+		t.Fatalf("Run exit = %d, want 0", code)
+	}
+	out := ui.OutputWriter.String()
+	if !strings.Contains(out, "(1 app)") {
+		t.Errorf("summary should report 1 app, got:\n%s", out)
+	}
+	if strings.Contains(out, "(2 apps)") {
+		t.Errorf("summary must not count the global play as an app:\n%s", out)
+	}
+}
+
+func TestExportCommandNonexistentAppExitsNonZero(t *testing.T) {
+	// #346: a --app typo must not write an empty recipe and exit 0.
+	defer subprocess.SetExecRunner(fakeExecRunner(exportCommandFixture()))()
+
+	dir := t.TempDir()
+	recipe := filepath.Join(dir, "tasks.yml")
+
+	c, ui := newExportCommand()
+	code := c.Run([]string{"--app", "nope", "--output", recipe})
+	if code != 1 {
+		t.Fatalf("Run exit = %d, want 1", code)
+	}
+	if _, err := os.Stat(recipe); !os.IsNotExist(err) {
+		t.Errorf("no recipe file should be written for a nonexistent app")
+	}
+	if !strings.Contains(ui.ErrorWriter.String(), "nope") {
+		t.Errorf("error output should name the missing app:\n%s", ui.ErrorWriter.String())
+	}
+}
+
+func TestExportCommandPartialMissingAppStillWrites(t *testing.T) {
+	// #346: existing apps are still exported, but a missing one forces a non-zero
+	// exit so the typo is surfaced.
+	defer subprocess.SetExecRunner(fakeExecRunner(exportCommandFixture()))()
+
+	dir := t.TempDir()
+	recipe := filepath.Join(dir, "tasks.yml")
+
+	c, ui := newExportCommand()
+	code := c.Run([]string{"--app", "web", "--app", "nope", "--output", recipe})
+	if code != 1 {
+		t.Fatalf("Run exit = %d, want 1", code)
+	}
+	body, err := os.ReadFile(recipe)
+	if err != nil {
+		t.Fatalf("web should still be exported: %v", err)
+	}
+	if !strings.Contains(string(body), "web") {
+		t.Errorf("recipe should contain the exported app web:\n%s", body)
+	}
+	if !strings.Contains(ui.ErrorWriter.String(), "nope") {
+		t.Errorf("error output should name the missing app:\n%s", ui.ErrorWriter.String())
+	}
+}
+
 func TestExportCommandDeriveVarsOutput(t *testing.T) {
 	cases := map[string]string{
 		"tasks.yml":        "tasks.vars.yml",

--- a/docs/tasks/dokku_maintenance_custom_page.md
+++ b/docs/tasks/dokku_maintenance_custom_page.md
@@ -10,7 +10,7 @@ Installs or removes a custom maintenance page for a dokku application.
 
 ## Export support
 
-Partial - maintenance:report exposes only a custom-page-sha256 checksum, not the HTML, so the page content cannot be read back; export detects that a custom page is set and lifts it into a required content input the user supplies before apply. Multi-file tarball pages collapse to that single content input, so extra assets are not captured. A faithful export awaits an upstream export command (dokku/dokku-maintenance#28).
+Partial - export reads the current page back via maintenance:custom-page-export and inlines maintenance.html as content. Multi-file tarball pages collapse to that single content field, so extra assets are not captured. On an older dokku-maintenance without the export command the content cannot be read back and is lifted into a required content input the user supplies before apply.
 
 ## Parameters
 

--- a/tasks/certs_task.go
+++ b/tasks/certs_task.go
@@ -322,6 +322,24 @@ func exportCert(t CertsTask) ([]interface{}, error) {
 		return nil, nil
 	}
 
+	// A letsencrypt-managed app reports ssl-enabled too, but its certificate is
+	// ephemeral (~90 days) and re-issued on the new host by the dokku_letsencrypt
+	// task. Pinning the current PEM would embed a stale private key and
+	// double-manage the same certificate, so skip the certs export for it (#337).
+	// A missing dokku-letsencrypt plugin (a non-SSH probe error) means the cert is
+	// not letsencrypt-managed, so fall through and export it as a manual cert.
+	if !t.Global {
+		active, lerr := letsencryptActive(t.App)
+		if lerr != nil {
+			var sshErr *subprocess.SSHError
+			if errors.As(lerr, &sshErr) {
+				return nil, lerr
+			}
+		} else if active {
+			return nil, nil
+		}
+	}
+
 	crt, err := certsShow(t, "crt")
 	if err != nil {
 		return nil, err

--- a/tasks/export.go
+++ b/tasks/export.go
@@ -147,6 +147,11 @@ type ExportOptions struct {
 // ExportReport carries non-fatal diagnostics from an export run.
 type ExportReport struct {
 	Warnings []string
+
+	// MissingApps lists app names passed via --app that do not exist on the
+	// server. The export still proceeds for the apps that do exist; the command
+	// surfaces these and exits non-zero so a typo is not silently dropped (#346).
+	MissingApps []string
 }
 
 // ExportResult is the outcome of ExportRecipe: the assembled recipe (as a list
@@ -181,6 +186,7 @@ func ExportRecipe(opts ExportOptions) (*ExportResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	res.Report.MissingApps = missingApps(apps, opts.Apps)
 	apps = filterApps(apps, opts.Apps)
 	sort.Strings(apps)
 
@@ -306,6 +312,7 @@ func (res *ExportResult) processSensitiveScalars(app string, body interface{}, o
 	out.Set(rv)
 
 	var inputs []map[string]interface{}
+	changed := false
 	for i := 0; i < rt.NumField(); i++ {
 		field := rt.Field(i)
 		if field.Tag.Get("sensitive") != "true" || field.Type.Kind() != reflect.String {
@@ -317,13 +324,19 @@ func (res *ExportResult) processSensitiveScalars(app string, body interface{}, o
 			continue
 		}
 		if opts.Inline {
+			// Inline mode keeps the value in the body, so there is no input to
+			// declare; under --redact the value is blanked in place. The blank
+			// is written to the copy, so the copy must be returned (returning
+			// the original body would leak the value; see #311).
 			if opts.Redact {
 				fv.SetString("")
+				changed = true
 			}
 			continue
 		}
 		name := res.uniqueVarName(app, yamlFieldName(field))
 		fv.SetString("{{ ." + name + " }}")
+		changed = true
 		if opts.Redact {
 			res.Vars[name] = ""
 		} else {
@@ -335,7 +348,7 @@ func (res *ExportResult) processSensitiveScalars(app string, body interface{}, o
 			"sensitive": true,
 		})
 	}
-	if len(inputs) == 0 {
+	if !changed {
 		return body, nil
 	}
 	return out.Interface(), inputs
@@ -357,9 +370,14 @@ func yamlFieldName(field reflect.StructField) string {
 // http-auth:report never exposes password material. The recipe therefore always
 // needs the passwords supplied in the vars-file before apply.
 func (res *ExportResult) processHttpAuthUser(app string, b HttpAuthUserTask, opts ExportOptions) (interface{}, []map[string]interface{}) {
-	if opts.Inline || len(b.Users) == 0 {
+	if len(b.Users) == 0 {
 		return b, nil
 	}
+	// The password is never readable (http-auth stores an htpasswd hash), so it
+	// is always lifted into a required input rather than emitted as an empty
+	// string, which would fail HttpAuthUserTask.Validate(). Inline mode has no
+	// companion vars-file, so warn that the passwords must be supplied at apply
+	// time (e.g. via a CLI --<name>=<value> input) (#334).
 	var inputs []map[string]interface{}
 	users := make([]HttpAuthUser, len(b.Users))
 	for i, u := range b.Users {
@@ -374,21 +392,30 @@ func (res *ExportResult) processHttpAuthUser(app string, b HttpAuthUserTask, opt
 		})
 	}
 	b.Users = users
+	if opts.Inline {
+		res.Report.Warnings = append(res.Report.Warnings,
+			fmt.Sprintf("%s: http-auth passwords are not readable; supply them as inputs before apply", app))
+	}
 	return b, inputs
 }
 
-// processMaintenanceCustomPage lifts the custom page HTML into a required input,
-// since maintenance:report exposes only a checksum, never the page content. The
-// recipe therefore always needs the HTML supplied in the vars-file before apply,
-// so the value is blanked unconditionally (like http-auth passwords). Unlike a
-// secret, the page is public HTML, so the input is not marked sensitive.
+// processMaintenanceCustomPage emits the custom page task. When ExportApp was
+// able to read the page back (via maintenance:custom-page-export) it carries real
+// Content (or a Tarball), which is public HTML, so it is emitted as-is in both
+// modes. When the content could not be read (an older plugin without the export
+// command), it is lifted into a required input in both modes so the emitted task
+// is valid instead of carrying an empty content that fails Validate() (#334).
 func (res *ExportResult) processMaintenanceCustomPage(app string, b MaintenanceCustomPageTask, opts ExportOptions) (interface{}, []map[string]interface{}) {
-	if opts.Inline {
+	if b.Content != "" || b.Tarball != "" {
 		return b, nil
 	}
 	name := res.uniqueVarName(app, "maintenance_custom_page")
 	b.Content = "{{ ." + name + " }}"
 	res.Vars[name] = "" // page HTML is not readable; the user fills this in
+	if opts.Inline {
+		res.Report.Warnings = append(res.Report.Warnings,
+			fmt.Sprintf("%s: maintenance custom page is not readable; supply the content as an input before apply", app))
+	}
 	inputs := []map[string]interface{}{{
 		"name":     name,
 		"required": true,
@@ -562,9 +589,23 @@ func (res *ExportResult) HasVars() bool {
 	return len(res.Vars) > 0
 }
 
-// PlayCount returns the number of plays (one per exported app) in the result.
+// PlayCount returns the total number of plays in the result, including the
+// leading global play when one was emitted. Used to detect an empty export.
 func (res *ExportResult) PlayCount() int {
 	return len(res.plays)
+}
+
+// AppCount returns the number of app plays, excluding the leading "global" play
+// (global resources are not an app), so the export summary reports the app count
+// accurately.
+func (res *ExportResult) AppCount() int {
+	n := len(res.plays)
+	if n > 0 {
+		if name, _ := res.plays[0]["name"].(string); name == "global" {
+			n--
+		}
+	}
+	return n
 }
 
 // listApps returns every app on the server via `dokku apps:list`.
@@ -583,6 +624,26 @@ func listApps() ([]string, error) {
 		}
 	}
 	return apps, nil
+}
+
+// missingApps returns the names in want that do not appear in apps (the live
+// server list), in sorted order. Empty when want is empty or every name exists.
+func missingApps(apps, want []string) []string {
+	if len(want) == 0 {
+		return nil
+	}
+	have := map[string]bool{}
+	for _, a := range apps {
+		have[a] = true
+	}
+	var missing []string
+	for _, a := range want {
+		if !have[a] {
+			missing = append(missing, a)
+		}
+	}
+	sort.Strings(missing)
+	return missing
 }
 
 // filterApps keeps only the apps named in want, or all apps when want is empty.

--- a/tasks/export_test.go
+++ b/tasks/export_test.go
@@ -364,6 +364,208 @@ func TestExportGlobalCertBecomesGlobalTask(t *testing.T) {
 	}
 }
 
+func TestExportInlineRedactBlanksSensitiveScalar(t *testing.T) {
+	// Regression for #311: inline + redact must blank sensitive scalar fields
+	// (cert/key PEM here) in place, not fall back to the original unredacted body.
+	certPEM := "-----BEGIN CERTIFICATE-----\nMIIFAKECERT\n-----END CERTIFICATE-----"
+	keyPEM := "-----BEGIN PRIVATE KEY-----\nMIIFAKEKEY\n-----END PRIVATE KEY-----"
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list": "",
+		"--quiet global-cert:report --global --global-cert-enabled": "true",
+		"--quiet global-cert:show crt":                              certPEM,
+		"--quiet global-cert:show key":                              keyPEM,
+	}))()
+
+	res, err := ExportRecipe(ExportOptions{Inline: true, Redact: true})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	recipe, _ := res.MarshalRecipe("yaml")
+	out := string(recipe)
+	if strings.Contains(out, "MIIFAKECERT") || strings.Contains(out, "MIIFAKEKEY") {
+		t.Errorf("inline+redact leaked the certificate PEM:\n%s", out)
+	}
+	// The task is still present, just with blanked content.
+	if !strings.Contains(out, "dokku_certs") {
+		t.Errorf("expected the certs task to remain after redaction:\n%s", out)
+	}
+}
+
+func TestExportAppCertSkippedWhenLetsencryptActive(t *testing.T) {
+	// Regression for #337: a letsencrypt-managed app reports ssl-enabled, but its
+	// cert is ephemeral and re-issued by dokku_letsencrypt, so it must not be
+	// pinned as a static dokku_certs task.
+	certPEM := "-----BEGIN CERTIFICATE-----\nMIILEACERT\n-----END CERTIFICATE-----"
+	keyPEM := "-----BEGIN PRIVATE KEY-----\nMIILEAKEY\n-----END PRIVATE KEY-----"
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list":                      "web",
+		"--quiet certs:report web --ssl-enabled": "true",
+		"--quiet letsencrypt:active web":         "true",
+		"--quiet certs:show web crt":             certPEM,
+		"--quiet certs:show web key":             keyPEM,
+	}))()
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	recipe, _ := res.MarshalRecipe("yaml")
+	out := string(recipe)
+	if strings.Contains(out, "dokku_certs") {
+		t.Errorf("letsencrypt-managed cert must not be exported as dokku_certs:\n%s", out)
+	}
+	if strings.Contains(out, "MIILEACERT") || strings.Contains(out, "MIILEAKEY") {
+		t.Errorf("recipe leaked the ephemeral letsencrypt PEM:\n%s", out)
+	}
+	if !strings.Contains(out, "dokku_letsencrypt") {
+		t.Errorf("expected the letsencrypt task to be exported:\n%s", out)
+	}
+}
+
+func TestExportAppCertExportedWhenLetsencryptInactive(t *testing.T) {
+	// A manual (non-letsencrypt) cert is still exported as dokku_certs.
+	certPEM := "-----BEGIN CERTIFICATE-----\nMIIMANUAL\n-----END CERTIFICATE-----"
+	keyPEM := "-----BEGIN PRIVATE KEY-----\nMIIMANUALKEY\n-----END PRIVATE KEY-----"
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list":                      "web",
+		"--quiet certs:report web --ssl-enabled": "true",
+		"--quiet letsencrypt:active web":         "false",
+		"--quiet certs:show web crt":             certPEM,
+		"--quiet certs:show web key":             keyPEM,
+	}))()
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	recipe, _ := res.MarshalRecipe("yaml")
+	out := string(recipe)
+	if !strings.Contains(out, "dokku_certs") {
+		t.Errorf("a manual cert should be exported as dokku_certs:\n%s", out)
+	}
+	if strings.Contains(out, "dokku_letsencrypt") {
+		t.Errorf("no letsencrypt task expected when inactive:\n%s", out)
+	}
+}
+
+func TestExportMaintenanceCustomPageInlinesContent(t *testing.T) {
+	// #334: with maintenance:custom-page-export available, the page HTML is read
+	// back and inlined as content instead of lifted into an input, producing a
+	// valid, self-contained task in both file and stdout modes.
+	html := "<html><body><h1>Down for maintenance</h1></body></html>\n"
+	tarBytes, err := buildMaintenancePageTarball(html)
+	if err != nil {
+		t.Fatalf("buildMaintenancePageTarball: %v", err)
+	}
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list":                          "web",
+		"maintenance:report web --format json":       `{"enabled":"false","custom-page-sha256":"abc123"}`,
+		"--quiet maintenance:custom-page-export web": string(tarBytes),
+	}))()
+
+	// The task ExportApp yields a valid task carrying the real content.
+	bodies, err := MaintenanceCustomPageTask{}.ExportApp("web")
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 exported task, got %d", len(bodies))
+	}
+	page := bodies[0].(MaintenanceCustomPageTask)
+	if page.Content != html {
+		t.Errorf("Content = %q, want the exported HTML", page.Content)
+	}
+	if err := page.Validate(); err != nil {
+		t.Errorf("exported maintenance page task must be valid, got: %v", err)
+	}
+
+	for _, inline := range []bool{false, true} {
+		res, err := ExportRecipe(ExportOptions{Inline: inline})
+		if err != nil {
+			t.Fatalf("ExportRecipe(inline=%v): %v", inline, err)
+		}
+		if _, ok := res.Vars["web_maintenance_custom_page"]; ok {
+			t.Errorf("inline=%v: content should be inlined, not lifted into a var", inline)
+		}
+		recipe, _ := res.MarshalRecipe("yaml")
+		out := string(recipe)
+		if !strings.Contains(out, "Down for maintenance") {
+			t.Errorf("inline=%v: recipe should contain the real page content:\n%s", inline, out)
+		}
+		if strings.Contains(out, "{{ .web_maintenance_custom_page }}") {
+			t.Errorf("inline=%v: content should not be an input template:\n%s", inline, out)
+		}
+	}
+}
+
+func TestExportHttpAuthUserInlineEmitsInputAndWarns(t *testing.T) {
+	// #334: stdout export can't read passwords back, so it emits an input block
+	// (a valid non-empty sigil) and warns that the passwords must be supplied.
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list":                  "web",
+		"http-auth:report web --format json": `{"enabled":"true","users":"admin","allowed-ips":"","domains":""}`,
+	}))()
+
+	res, err := ExportRecipe(ExportOptions{Inline: true})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	recipe, _ := res.MarshalRecipe("yaml")
+	out := string(recipe)
+	for _, want := range []string{
+		"{{ .web_http_auth_password_admin }}",
+		"name: web_http_auth_password_admin",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout recipe missing %q:\n%s", want, out)
+		}
+	}
+	found := false
+	for _, w := range res.Report.Warnings {
+		if strings.Contains(w, "http-auth") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a warning about http-auth passwords, got %v", res.Report.Warnings)
+	}
+}
+
+func TestAppCountExcludesGlobalPlay(t *testing.T) {
+	// #345: the leading global play is not an app, so AppCount excludes it.
+	responses := exportFixture()
+	responses["--quiet plugin:list --format json"] = `[{"name":"redis","core":false,"source_url":"https://github.com/dokku/dokku-redis.git","committish":"c0ffee","branch":"master"}]`
+	defer subprocess.SetExecRunner(fakeDokku(responses))()
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	if got := res.PlayCount(); got != 3 {
+		t.Errorf("PlayCount = %d, want 3 (global + 2 apps)", got)
+	}
+	if got := res.AppCount(); got != 2 {
+		t.Errorf("AppCount = %d, want 2 (excludes the global play)", got)
+	}
+}
+
+func TestExportMissingAppsRecorded(t *testing.T) {
+	// #346: a nonexistent --app is recorded, not silently dropped, and the
+	// existing app still exports.
+	defer subprocess.SetExecRunner(fakeDokku(exportFixture()))()
+
+	res, err := ExportRecipe(ExportOptions{Apps: []string{"app-one", "nope"}})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	if len(res.Report.MissingApps) != 1 || res.Report.MissingApps[0] != "nope" {
+		t.Errorf("MissingApps = %v, want [nope]", res.Report.MissingApps)
+	}
+	if res.AppCount() != 1 {
+		t.Errorf("AppCount = %d, want 1 (app-one still exported)", res.AppCount())
+	}
+}
+
 func TestExportGlobalCertDisabledEmitsNoTask(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
 		"--quiet apps:list": "",

--- a/tasks/maintenance_custom_page_task.go
+++ b/tasks/maintenance_custom_page_task.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"sort"
 	"strings"
@@ -57,7 +58,7 @@ func (t MaintenanceCustomPageTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t MaintenanceCustomPageTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportPartial, Caveat: "maintenance:report exposes only a custom-page-sha256 checksum, not the HTML, so the page content cannot be read back; export detects that a custom page is set and lifts it into a required content input the user supplies before apply. Multi-file tarball pages collapse to that single content input, so extra assets are not captured. A faithful export awaits an upstream export command (dokku/dokku-maintenance#28)"}
+	return ExportSupport{Status: ExportPartial, Caveat: "export reads the current page back via maintenance:custom-page-export and inlines maintenance.html as content. Multi-file tarball pages collapse to that single content field, so extra assets are not captured. On an older dokku-maintenance without the export command the content cannot be read back and is lifted into a required content input the user supplies before apply"}
 }
 
 // Requirements lists the non-core dokku plugins this task depends on.
@@ -345,13 +346,14 @@ func maintenanceCustomPageState(app string) (checksum string, reported bool, err
 }
 
 // ExportApp emits a dokku_maintenance_custom_page task when the app has a custom
-// page installed. maintenance:report exposes only the custom-page-sha256
-// checksum, never the HTML, so the content cannot be read back; the engine lifts
-// it into a required input the user supplies before applying (see
-// processMaintenanceCustomPage). A custom page is detected purely by a non-empty
-// checksum, so nothing is emitted when no page is set or when the plugin is too
-// old to report the checksum. A transport-level SSH failure propagates as a
-// warning; a dokku-level or parse failure is treated as "nothing to export".
+// page installed. A custom page is detected by a non-empty custom-page-sha256 in
+// maintenance:report, so nothing is emitted when no page is set or when the
+// plugin is too old to report the checksum. The page content is then read back
+// via maintenance:custom-page-export and inlined as Content, producing a faithful,
+// self-contained task. On an older dokku-maintenance without the export command
+// (any non-SSH failure) the content cannot be read; an empty task is returned and
+// processMaintenanceCustomPage lifts the content into a required input. A
+// transport-level SSH failure propagates as a warning.
 func (t MaintenanceCustomPageTask) ExportApp(app string) ([]interface{}, error) {
 	checksum, reported, err := maintenanceCustomPageState(app)
 	if err != nil {
@@ -364,7 +366,66 @@ func (t MaintenanceCustomPageTask) ExportApp(app string) ([]interface{}, error) 
 	if !reported || checksum == "" {
 		return nil, nil
 	}
-	return []interface{}{MaintenanceCustomPageTask{App: app}}, nil
+
+	content, extraAssets, err := maintenanceCustomPageExport(app)
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return nil, err
+		}
+		return []interface{}{MaintenanceCustomPageTask{App: app}}, nil
+	}
+	if extraAssets {
+		log.Printf("warning: dokku maintenance custom page for %q has files beyond maintenance.html; only maintenance.html is captured in the export", app)
+	}
+	return []interface{}{MaintenanceCustomPageTask{App: app, Content: content}}, nil
+}
+
+// maintenanceCustomPageExport reads the app's current custom page back via
+// `dokku maintenance:custom-page-export <app>` (the inverse of
+// maintenance:custom-page), which streams the stored tar archive to stdout. It
+// returns the contents of the root-level maintenance.html and whether the archive
+// carried any additional files (which the single-content task shape cannot
+// represent, so they are dropped - see ExportSupport).
+func maintenanceCustomPageExport(app string) (content string, extraAssets bool, err error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "maintenance:custom-page-export", app},
+	})
+	if err != nil {
+		return "", false, err
+	}
+
+	// Read the raw stdout bytes, not StdoutBytes(), which trims whitespace and
+	// would corrupt a binary tar archive.
+	found := false
+	tr := tar.NewReader(bytes.NewReader([]byte(result.Stdout)))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", false, fmt.Errorf("read custom page tarball: %w", err)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		if strings.TrimPrefix(hdr.Name, "./") == "maintenance.html" {
+			b, err := io.ReadAll(tr)
+			if err != nil {
+				return "", false, fmt.Errorf("read maintenance.html: %w", err)
+			}
+			content = string(b)
+			found = true
+			continue
+		}
+		extraAssets = true
+	}
+	if !found {
+		return "", false, fmt.Errorf("custom page tarball has no maintenance.html")
+	}
+	return content, extraAssets, nil
 }
 
 // init registers the MaintenanceCustomPageTask with the task registry

--- a/tasks/maintenance_custom_page_task_integration_test.go
+++ b/tasks/maintenance_custom_page_task_integration_test.go
@@ -217,9 +217,10 @@ func TestIntegrationExportMaintenanceCustomPageRoundTrip(t *testing.T) {
 		t.Fatalf("failed to set custom page: %v", result.Error)
 	}
 
-	// Export reconstructs the task from the reported checksum. The content is
-	// not readable, so the exported body carries an empty Content; the engine is
-	// what lifts it into a required input.
+	// Export reconstructs the task from the reported checksum and reads the page
+	// back via maintenance:custom-page-export, so the exported body carries the
+	// real Content. An older dokku-maintenance without the export command would
+	// instead carry an empty Content for the engine to lift into an input.
 	bodies, err := (MaintenanceCustomPageTask{}).ExportApp(appName)
 	if err != nil {
 		t.Fatalf("ExportApp failed: %v", err)
@@ -234,13 +235,15 @@ func TestIntegrationExportMaintenanceCustomPageRoundTrip(t *testing.T) {
 	if got.App != appName {
 		t.Errorf("exported App = %q, want %q", got.App, appName)
 	}
-	if got.Content != "" {
-		t.Errorf("exported Content = %q, want empty (content is not readable)", got.Content)
+	if got.Content != "" && got.Content != content {
+		t.Errorf("exported Content = %q, want %q", got.Content, content)
 	}
 
-	// export -> apply idempotency: once the user supplies the same HTML the
-	// input would carry, re-planning reports no drift.
-	got.Content = content
+	// export -> apply idempotency: with the content captured (or, on an older
+	// plugin, supplied by the user), re-planning reports no drift.
+	if got.Content == "" {
+		got.Content = content
+	}
 	got.State = StatePresent
 	plan := got.Plan()
 	if plan.Error != nil {

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -110,20 +110,11 @@ func getProperty(subcommand, app string, global bool, property string, keys map[
 // keys.
 func exportProperties(app, subcommand string, keys map[string]PropertyKeys, factory func(app, property, value string) interface{}) ([]interface{}, error) {
 	plugin := pluginFromSubcommand(subcommand)
-	response, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    getPropertyArgs(plugin, app, false),
-	})
+	payload, err := readPropertyReport(plugin, app, false)
 	if err != nil {
-		var sshErr *subprocess.SSHError
-		if errors.As(err, &sshErr) {
-			return nil, err
-		}
-		return nil, nil
+		return nil, err
 	}
-
-	payload := map[string]string{}
-	if err := json.Unmarshal(response.StdoutBytes(), &payload); err != nil {
+	if payload == nil {
 		return nil, nil
 	}
 
@@ -146,6 +137,38 @@ func exportProperties(app, subcommand string, keys map[string]PropertyKeys, fact
 		out = append(out, factory(app, prop, value))
 	}
 	return out, nil
+}
+
+// readPropertyReport runs `dokku <plugin>:report [<app>|--global] --format json`
+// and returns the decoded payload, distinguishing a plugin that is not installed
+// (returns nil, nil - a quiet skip) from one that is installed but whose report
+// cannot be read (returns an error the export surfaces as a warning). An SSH
+// transport failure always propagates. Any other exec failure is a quiet skip
+// only when the plugin is not installed; when it is installed, the failure is an
+// error. A JSON parse failure is always an error, since the exec succeeded so the
+// plugin responded with something unparseable (for example a deprecation line
+// printed before the JSON payload) rather than being absent (#329).
+func readPropertyReport(plugin, app string, global bool) (map[string]string, error) {
+	response, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    getPropertyArgs(plugin, app, global),
+	})
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return nil, err
+		}
+		if installed, ierr := pluginInstalled(plugin); ierr != nil || !installed {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("dokku %s:report failed: %w", plugin, err)
+	}
+
+	payload := map[string]string{}
+	if err := json.Unmarshal(response.StdoutBytes(), &payload); err != nil {
+		return nil, fmt.Errorf("parse %s:report json: %w", plugin, err)
+	}
+	return payload, nil
 }
 
 // getPropertyArgs builds the `dokku <plugin>:report ... --format json` arg list.

--- a/tasks/properties_test.go
+++ b/tasks/properties_test.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"log"
 	"reflect"
@@ -111,6 +112,60 @@ func TestSecretPropertiesAreMarkedSensitive(t *testing.T) {
 	}
 	if !schedulerK3sPropertyKeys["token"].Sensitive {
 		t.Error("scheduler-k3s token must be marked Sensitive")
+	}
+}
+
+func TestReadPropertyReportUnparseableReportErrors(t *testing.T) {
+	// #329: the exec succeeds (plugin responded) but the payload is not clean
+	// JSON - e.g. a deprecation line before the JSON. This is "installed but
+	// unreadable" and must surface an error (which export turns into a warning),
+	// not be silently dropped.
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet nginx:report web --format json": "Deprecated: use something else\n{\"x\":\"y\"}",
+	}))()
+
+	if _, err := readPropertyReport("nginx", "web", false); err == nil {
+		t.Error("expected an error for an installed-but-unreadable report")
+	}
+}
+
+func TestReadPropertyReportNotInstalledIsQuietSkip(t *testing.T) {
+	// #329: when the report exec fails and the plugin is not installed, the skip
+	// is quiet (nil, nil) - no warning.
+	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		switch strings.Join(in.Args, " ") {
+		case "--quiet plugin:list":
+			return subprocess.ExecCommandResponse{Stdout: "nginx 1.0.0 enabled nginx"}, nil
+		case "--quiet caddy:report web --format json":
+			return subprocess.ExecCommandResponse{}, errors.New("caddy:report: command not found")
+		}
+		return subprocess.ExecCommandResponse{}, nil
+	})()
+
+	payload, err := readPropertyReport("caddy", "web", false)
+	if err != nil {
+		t.Errorf("a not-installed plugin should be a quiet skip, got error: %v", err)
+	}
+	if payload != nil {
+		t.Errorf("expected nil payload for a quiet skip, got %v", payload)
+	}
+}
+
+func TestReadPropertyReportInstalledExecFailureErrors(t *testing.T) {
+	// #329: when the report exec fails but the plugin IS installed, the failure
+	// must surface an error rather than a silent drop.
+	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		switch strings.Join(in.Args, " ") {
+		case "--quiet plugin:list":
+			return subprocess.ExecCommandResponse{Stdout: "nginx 1.0.0 enabled nginx"}, nil
+		case "--quiet nginx:report web --format json":
+			return subprocess.ExecCommandResponse{}, errors.New("boom")
+		}
+		return subprocess.ExecCommandResponse{}, nil
+	})()
+
+	if _, err := readPropertyReport("nginx", "web", false); err == nil {
+		t.Error("expected an error when an installed plugin's report fails")
 	}
 }
 

--- a/tests/bats/export.bats
+++ b/tests/bats/export.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  require_dokku
+  docket_build
+  dokku_clean_app docket-test-export
+}
+
+teardown() {
+  dokku_clean_app docket-test-export
+}
+
+@test "docket export fails on a nonexistent --app and writes nothing" {
+  run "$(docket_bin)" export --app docket-nonexistent-xyz --output "$BATS_TEST_TMPDIR/tasks.yml"
+  assert_failure
+  assert_output --partial "not found on server"
+  run test -f "$BATS_TEST_TMPDIR/tasks.yml"
+  assert_failure
+}
+
+@test "docket export writes existing apps but fails when an --app is missing" {
+  dokku apps:create docket-test-export
+  run "$(docket_bin)" export --app docket-test-export --app docket-nonexistent-xyz --output "$BATS_TEST_TMPDIR/tasks.yml"
+  assert_failure
+  assert_output --partial "not found on server"
+  run cat "$BATS_TEST_TMPDIR/tasks.yml"
+  assert_success
+  assert_output --partial "docket-test-export"
+}
+
+@test "docket export --app reports the app count without the global play" {
+  dokku apps:create docket-test-export
+  run "$(docket_bin)" export --app docket-test-export --output "$BATS_TEST_TMPDIR/tasks.yml"
+  assert_success
+  assert_output --partial "(1 app)"
+}


### PR DESCRIPTION
These migration-fidelity fixes to `docket export` stop the exported recipe from leaking sensitive values in redacted stdout output, no longer pin ephemeral letsencrypt certificates as static certs, read the maintenance custom page back so http_auth_user and maintenance_custom_page tasks are emitted validly to stdout, report the app count without counting the leading global play, fail a nonexistent `--app` instead of writing an empty recipe, tear down the remote SSH ControlMaster on exit, and surface a warning when an installed property plugin's report cannot be read.

Closes #311
Closes #329
Closes #334
Closes #337
Closes #345
Closes #346
Closes #347