### PR TITLE
fix: export global-scope plugin properties

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -52,8 +52,10 @@ git-installed third-party plugins into [`dokku_plugin`](tasks/dokku_plugin.md) t
 global play; core plugins and plugins installed from a tarball or local path are omitted. Datastore
 services are reconstructed into that same global play - the service itself, its exposed ports, its
 backup schedule, and its dokku-acl access list - with each app's service links emitted into the
-app's own play. Sensitive values (config and other secrets) are lifted into `tasks.vars.yml`; the
-recipe references them through inputs, so the pair is applied together with `--vars-file`. If you
+app's own play. Globally-set plugin properties are reconstructed into that global play too - for
+example the scheduler-k3s bootstrap keys such as the cluster token, ingress class, and letsencrypt
+emails. Sensitive values (config, the k3s token, and other secrets) are lifted into `tasks.vars.yml`;
+the recipe references them through inputs, so the pair is applied together with `--vars-file`. If you
 already maintain a recipe as the source of truth for the old server, skip this and use it directly.
 
 Some state cannot be read back and is left out with a warning - notably write-only credentials

--- a/tasks/app_json_property_task.go
+++ b/tasks/app_json_property_task.go
@@ -99,6 +99,13 @@ func (t AppJsonPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t AppJsonPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("app-json:set", appJsonPropertyKeys, func(property, value string) interface{} {
+		return AppJsonPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the AppJsonPropertyTask with the task registry
 func init() {
 	RegisterTask(&AppJsonPropertyTask{})

--- a/tasks/apps_property_task.go
+++ b/tasks/apps_property_task.go
@@ -116,6 +116,13 @@ func (t AppsPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t AppsPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("apps:set", appsPropertyKeys, func(property, value string) interface{} {
+		return AppsPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the AppsPropertyTask with the task registry
 func init() {
 	RegisterTask(&AppsPropertyTask{})

--- a/tasks/builder_dockerfile_property_task.go
+++ b/tasks/builder_dockerfile_property_task.go
@@ -100,6 +100,13 @@ func (t BuilderDockerfilePropertyTask) ExportApp(app string) ([]interface{}, err
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t BuilderDockerfilePropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("builder-dockerfile:set", builderDockerfilePropertyKeys, func(property, value string) interface{} {
+		return BuilderDockerfilePropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the BuilderDockerfilePropertyTask with the task registry
 func init() {
 	RegisterTask(&BuilderDockerfilePropertyTask{})

--- a/tasks/builder_herokuish_property_task.go
+++ b/tasks/builder_herokuish_property_task.go
@@ -100,6 +100,13 @@ func (t BuilderHerokuishPropertyTask) ExportApp(app string) ([]interface{}, erro
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t BuilderHerokuishPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("builder-herokuish:set", builderHerokuishPropertyKeys, func(property, value string) interface{} {
+		return BuilderHerokuishPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the BuilderHerokuishPropertyTask with the task registry
 func init() {
 	RegisterTask(&BuilderHerokuishPropertyTask{})

--- a/tasks/builder_lambda_property_task.go
+++ b/tasks/builder_lambda_property_task.go
@@ -100,6 +100,13 @@ func (t BuilderLambdaPropertyTask) ExportApp(app string) ([]interface{}, error) 
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t BuilderLambdaPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("builder-lambda:set", builderLambdaPropertyKeys, func(property, value string) interface{} {
+		return BuilderLambdaPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the BuilderLambdaPropertyTask with the task registry
 func init() {
 	RegisterTask(&BuilderLambdaPropertyTask{})

--- a/tasks/builder_nixpacks_property_task.go
+++ b/tasks/builder_nixpacks_property_task.go
@@ -100,6 +100,13 @@ func (t BuilderNixpacksPropertyTask) ExportApp(app string) ([]interface{}, error
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t BuilderNixpacksPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("builder-nixpacks:set", builderNixpacksPropertyKeys, func(property, value string) interface{} {
+		return BuilderNixpacksPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the BuilderNixpacksPropertyTask with the task registry
 func init() {
 	RegisterTask(&BuilderNixpacksPropertyTask{})

--- a/tasks/builder_pack_property_task.go
+++ b/tasks/builder_pack_property_task.go
@@ -99,6 +99,13 @@ func (t BuilderPackPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t BuilderPackPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("builder-pack:set", builderPackPropertyKeys, func(property, value string) interface{} {
+		return BuilderPackPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the BuilderPackPropertyTask with the task registry
 func init() {
 	RegisterTask(&BuilderPackPropertyTask{})

--- a/tasks/builder_property_task.go
+++ b/tasks/builder_property_task.go
@@ -109,6 +109,13 @@ func (t BuilderPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t BuilderPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("builder:set", builderPropertyKeys, func(property, value string) interface{} {
+		return BuilderPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the BuilderTask with the task registry
 func init() {
 	RegisterTask(&BuilderPropertyTask{})

--- a/tasks/builder_railpack_property_task.go
+++ b/tasks/builder_railpack_property_task.go
@@ -100,6 +100,13 @@ func (t BuilderRailpackPropertyTask) ExportApp(app string) ([]interface{}, error
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t BuilderRailpackPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("builder-railpack:set", builderRailpackPropertyKeys, func(property, value string) interface{} {
+		return BuilderRailpackPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the BuilderRailpackPropertyTask with the task registry
 func init() {
 	RegisterTask(&BuilderRailpackPropertyTask{})

--- a/tasks/buildpacks_property_task.go
+++ b/tasks/buildpacks_property_task.go
@@ -101,6 +101,13 @@ func (t BuildpacksPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t BuildpacksPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("buildpacks:set-property", buildpacksPropertyKeys, func(property, value string) interface{} {
+		return BuildpacksPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the BuildpacksPropertyTask with the task registry
 func init() {
 	RegisterTask(&BuildpacksPropertyTask{})

--- a/tasks/builds_property_task.go
+++ b/tasks/builds_property_task.go
@@ -99,6 +99,13 @@ func (t BuildsPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t BuildsPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("builds:set", buildsPropertyKeys, func(property, value string) interface{} {
+		return BuildsPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the BuildsPropertyTask with the task registry
 func init() {
 	RegisterTask(&BuildsPropertyTask{})

--- a/tasks/caddy_property_task.go
+++ b/tasks/caddy_property_task.go
@@ -105,6 +105,13 @@ func (t CaddyPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t CaddyPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("caddy:set", caddyPropertyKeys, func(property, value string) interface{} {
+		return CaddyPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the CaddyPropertyTask with the task registry
 func init() {
 	RegisterTask(&CaddyPropertyTask{})

--- a/tasks/checks_property_task.go
+++ b/tasks/checks_property_task.go
@@ -99,6 +99,13 @@ func (t ChecksPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t ChecksPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("checks:set", checksPropertyKeys, func(property, value string) interface{} {
+		return ChecksPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the ChecksPropertyTask with the task registry
 func init() {
 	RegisterTask(&ChecksPropertyTask{})

--- a/tasks/cron_property_task.go
+++ b/tasks/cron_property_task.go
@@ -102,6 +102,13 @@ func (t CronPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t CronPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("cron:set", cronPropertyKeys, func(property, value string) interface{} {
+		return CronPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the CronPropertyTask with the task registry
 func init() {
 	RegisterTask(&CronPropertyTask{})

--- a/tasks/export.go
+++ b/tasks/export.go
@@ -51,6 +51,37 @@ var globalExportOrder = []string{
 	"dokku_scheduler_k3s_annotations",
 	"dokku_scheduler_k3s_labels",
 	"dokku_scheduler_k3s_autoscaling_auth",
+	// property-plugin global scope: globally-set (global: true) properties of each
+	// property plugin. These also appear in appExportOrder for the per-app scope;
+	// here they emit the global scope (for example scheduler-k3s bootstrap keys
+	// like token and ingress-class). Ordered as in appExportOrder.
+	"dokku_app_json_property",
+	"dokku_apps_property",
+	"dokku_builder_property",
+	"dokku_builder_dockerfile_property",
+	"dokku_builder_herokuish_property",
+	"dokku_builder_lambda_property",
+	"dokku_builder_nixpacks_property",
+	"dokku_builder_pack_property",
+	"dokku_builder_railpack_property",
+	"dokku_buildpacks_property",
+	"dokku_builds_property",
+	"dokku_caddy_property",
+	"dokku_checks_property",
+	"dokku_cron_property",
+	"dokku_git_property",
+	"dokku_haproxy_property",
+	"dokku_letsencrypt_property",
+	"dokku_logs_property",
+	"dokku_network_property",
+	"dokku_nginx_property",
+	"dokku_openresty_property",
+	"dokku_proxy_property",
+	"dokku_ps_property",
+	"dokku_registry_property",
+	"dokku_scheduler_property",
+	"dokku_scheduler_k3s_property",
+	"dokku_traefik_property",
 	// datastore services: create must precede expose/backup/acl, which all
 	// operate on an existing service instance. The datastore plugins they rely
 	// on are installed by the dokku_plugin tasks emitted first.
@@ -293,9 +324,49 @@ func (res *ExportResult) processBody(app string, body interface{}, opts ExportOp
 		return res.processMaintenanceCustomPage(app, b, opts)
 	case SchedulerK3sAutoscalingAuthTask:
 		return res.processSchedulerK3sAutoscalingAuth(app, b, opts)
+	case SchedulerK3sPropertyTask:
+		return res.processPropertyValue(app, b, b.Property, b.Value, schedulerK3sPropertyKeys[b.Property].Sensitive, opts, func(v string) interface{} {
+			b.Value = v
+			return b
+		})
+	case TraefikPropertyTask:
+		return res.processPropertyValue(app, b, b.Property, b.Value, traefikPropertyKeys[b.Property].Sensitive, opts, func(v string) interface{} {
+			b.Value = v
+			return b
+		})
 	default:
 		return res.processSensitiveScalars(app, body, opts)
 	}
+}
+
+// processPropertyValue lifts a sensitive property value (for example the
+// scheduler-k3s cluster token or a traefik basic-auth password) into a required
+// sensitive input in file mode, blanks it under inline+redact, and otherwise
+// keeps it inline (like a config value). A non-sensitive property value is
+// returned unchanged, so only secret-flagged properties are ever lifted (#327).
+func (res *ExportResult) processPropertyValue(app string, body interface{}, property, value string, sensitive bool, opts ExportOptions, rebuild func(string) interface{}) (interface{}, []map[string]interface{}) {
+	if !sensitive || value == "" {
+		return body, nil
+	}
+	if opts.Inline {
+		if opts.Redact {
+			return rebuild(""), nil
+		}
+		return body, nil
+	}
+	name := res.uniqueVarName(app, property)
+	out := rebuild("{{ ." + name + " }}")
+	if opts.Redact {
+		res.Vars[name] = ""
+	} else {
+		res.Vars[name] = value
+	}
+	inputs := []map[string]interface{}{{
+		"name":      name,
+		"required":  true,
+		"sensitive": true,
+	}}
+	return out, inputs
 }
 
 // processSensitiveScalars lifts every non-empty string field tagged

--- a/tasks/export_integration_test.go
+++ b/tasks/export_integration_test.go
@@ -165,6 +165,55 @@ func TestIntegrationExportGlobalCerts(t *testing.T) {
 	}
 }
 
+// TestIntegrationExportGitPropertyGlobal verifies the global property exporter
+// (#327) against a real dokku: a globally-set property is read back through
+// git:report --global and reconstructed as a global: true task that round-trips
+// with no drift. archive-max-files is a global-only key, so it exercises the
+// scope the per-app exporter cannot reach. git is a core plugin, so only dokku
+// itself is required.
+func TestIntegrationExportGitPropertyGlobal(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	cleanup := GitPropertyTask{Global: true, Property: "archive-max-files", State: StateAbsent}
+	cleanup.Execute()
+	defer cleanup.Execute()
+
+	set := GitPropertyTask{Global: true, Property: "archive-max-files", Value: "4242", State: StatePresent}
+	if r := set.Execute(); r.Error != nil {
+		t.Fatalf("set global git property: %v", r.Error)
+	}
+
+	bodies, err := GitPropertyTask{}.ExportGlobal()
+	if err != nil {
+		t.Fatalf("ExportGlobal: %v", err)
+	}
+	var found *GitPropertyTask
+	for i := range bodies {
+		if p, ok := bodies[i].(GitPropertyTask); ok && p.Property == "archive-max-files" {
+			found = &p
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("exported global git properties do not include archive-max-files: %+v", bodies)
+	}
+	if !found.Global {
+		t.Errorf("exported property should set global: true, got %+v", *found)
+	}
+	if found.App != "" {
+		t.Errorf("exported global property should not set app, got %q", found.App)
+	}
+	if found.Value != "4242" {
+		t.Errorf("exported value = %q, want 4242", found.Value)
+	}
+
+	// The exporter omits state; set it as the recipe loader would before planning.
+	found.State = StatePresent
+	if plan := found.Plan(); !plan.InSync {
+		t.Errorf("exported global property should report no drift, got status %v reason %q", plan.Status, plan.Reason)
+	}
+}
+
 // TestIntegrationExportSchedulerK3sProfile verifies the global profile exporter
 // against a real dokku. scheduler-k3s is a core plugin and profiles are stored
 // on disk (no cluster or deploy needed), so only dokku itself is required.

--- a/tasks/export_test.go
+++ b/tasks/export_test.go
@@ -566,6 +566,104 @@ func TestExportMissingAppsRecorded(t *testing.T) {
 	}
 }
 
+func TestExportGlobalPropertiesReadsGlobalScope(t *testing.T) {
+	// #327: exportGlobalProperties reads the --global report and emits the global
+	// form of each set property (both global-only and dual-scope keys), skipping
+	// empty values and per-app-only keys.
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet git:report --global --format json": `{"global-deploy-branch":"main","global-archive-max-files":"100","global-keep-git-dir":""}`,
+	}))()
+
+	bodies, err := exportGlobalProperties("git:set", gitPropertyKeys, func(property, value string) interface{} {
+		return GitPropertyTask{Global: true, Property: property, Value: value}
+	})
+	if err != nil {
+		t.Fatalf("exportGlobalProperties: %v", err)
+	}
+	got := map[string]string{}
+	for _, b := range bodies {
+		p := b.(GitPropertyTask)
+		if !p.Global {
+			t.Errorf("expected Global:true for %q", p.Property)
+		}
+		got[p.Property] = p.Value
+	}
+	if got["deploy-branch"] != "main" {
+		t.Errorf("deploy-branch = %q, want main", got["deploy-branch"])
+	}
+	if got["archive-max-files"] != "100" {
+		t.Errorf("archive-max-files = %q, want 100", got["archive-max-files"])
+	}
+	if _, ok := got["keep-git-dir"]; ok {
+		t.Errorf("keep-git-dir has an empty value and must be skipped")
+	}
+}
+
+func TestExportGlobalK3sTokenLiftedAsSensitiveInput(t *testing.T) {
+	// #327: the scheduler-k3s global token is core bootstrap state and must be
+	// exported - but as a secret, lifted into a sensitive input, never inline.
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list": "",
+		"--quiet scheduler-k3s:report --global --format json": `{"global-token":"s3cr3ttoken","global-ingress-class":"nginx-ingress"}`,
+	}))()
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	if got := res.Vars["global_token"]; got != "s3cr3ttoken" {
+		t.Errorf("vars[global_token] = %q, want the token lifted", got)
+	}
+	recipe, _ := res.MarshalRecipe("yaml")
+	out := string(recipe)
+	if strings.Contains(out, "s3cr3ttoken") {
+		t.Errorf("recipe leaked the k3s cluster token:\n%s", out)
+	}
+	for _, want := range []string{
+		"dokku_scheduler_k3s_property",
+		"global: true",
+		"{{ .global_token }}",
+		"name: global_token",
+		"sensitive: true",
+		"nginx-ingress", // a non-sensitive global stays inline
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("recipe missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestExportGlobalTraefikPasswordLiftedAsSensitiveInput(t *testing.T) {
+	// #327: the traefik global basic-auth password is also a secret and must be
+	// lifted rather than emitted in cleartext.
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list": "",
+		"--quiet traefik:report --global --format json": `{"global-basic-auth-password":"hunter2"}`,
+	}))()
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	if got := res.Vars["global_basic_auth_password"]; got != "hunter2" {
+		t.Errorf("vars[global_basic_auth_password] = %q, want the password lifted", got)
+	}
+	recipe, _ := res.MarshalRecipe("yaml")
+	out := string(recipe)
+	if strings.Contains(out, "hunter2") {
+		t.Errorf("recipe leaked the traefik basic-auth password:\n%s", out)
+	}
+	for _, want := range []string{
+		"dokku_traefik_property",
+		"{{ .global_basic_auth_password }}",
+		"sensitive: true",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("recipe missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestExportGlobalCertDisabledEmitsNoTask(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
 		"--quiet apps:list": "",

--- a/tasks/git_property_task.go
+++ b/tasks/git_property_task.go
@@ -114,6 +114,13 @@ func (t GitPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t GitPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("git:set", gitPropertyKeys, func(property, value string) interface{} {
+		return GitPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the GitPropertyTask with the task registry
 func init() {
 	RegisterTask(&GitPropertyTask{})

--- a/tasks/haproxy_property_task.go
+++ b/tasks/haproxy_property_task.go
@@ -104,6 +104,13 @@ func (t HaproxyPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t HaproxyPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("haproxy:set", haproxyPropertyKeys, func(property, value string) interface{} {
+		return HaproxyPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the HaproxyPropertyTask with the task registry
 func init() {
 	RegisterTask(&HaproxyPropertyTask{})

--- a/tasks/letsencrypt_property_task.go
+++ b/tasks/letsencrypt_property_task.go
@@ -121,6 +121,13 @@ func (t LetsencryptPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t LetsencryptPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("letsencrypt:set", letsencryptPropertyKeys, func(property, value string) interface{} {
+		return LetsencryptPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the LetsencryptPropertyTask with the task registry
 func init() {
 	RegisterTask(&LetsencryptPropertyTask{})

--- a/tasks/logs_property_task.go
+++ b/tasks/logs_property_task.go
@@ -104,6 +104,13 @@ func (t LogsPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t LogsPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("logs:set", logsPropertyKeys, func(property, value string) interface{} {
+		return LogsPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the LogsPropertyTask with the task registry
 func init() {
 	RegisterTask(&LogsPropertyTask{})

--- a/tasks/network_property_task.go
+++ b/tasks/network_property_task.go
@@ -113,6 +113,13 @@ func (t NetworkPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t NetworkPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("network:set", networkPropertyKeys, func(property, value string) interface{} {
+		return NetworkPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the NetworkPropertyTask with the task registry
 func init() {
 	RegisterTask(&NetworkPropertyTask{})

--- a/tasks/nginx_property_task.go
+++ b/tasks/nginx_property_task.go
@@ -128,6 +128,13 @@ func (t NginxPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t NginxPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("nginx:set", nginxPropertyKeys, func(property, value string) interface{} {
+		return NginxPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // Validate checks the NginxPropertyTask's inputs without contacting the server.
 func (t NginxPropertyTask) Validate() error {
 	return validatePropertyInput(t.State, t.App, t.Global, t.Property, t.Value, "nginx:set", nginxPropertyKeys)

--- a/tasks/openresty_property_task.go
+++ b/tasks/openresty_property_task.go
@@ -141,6 +141,13 @@ func (t OpenrestyPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t OpenrestyPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("openresty:set", openrestyPropertyKeys, func(property, value string) interface{} {
+		return OpenrestyPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the OpenrestyPropertyTask with the task registry
 func init() {
 	RegisterTask(&OpenrestyPropertyTask{})

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -139,6 +139,44 @@ func exportProperties(app, subcommand string, keys map[string]PropertyKeys, fact
 	return out, nil
 }
 
+// exportGlobalProperties reconstructs the explicitly-set global properties of a
+// property plugin, mirroring exportProperties for the --global scope: it reads
+// `<plugin>:report --global --format json` once and, for each property whose
+// Global key is present and non-empty, emits a task body (built by factory). A
+// property with no global form (an empty Global key) is skipped, so
+// globally-scoped state (for example scheduler-k3s bootstrap keys) is captured
+// instead of silently dropped (#327).
+func exportGlobalProperties(subcommand string, keys map[string]PropertyKeys, factory func(property, value string) interface{}) ([]interface{}, error) {
+	plugin := pluginFromSubcommand(subcommand)
+	payload, err := readPropertyReport(plugin, "", true)
+	if err != nil {
+		return nil, err
+	}
+	if payload == nil {
+		return nil, nil
+	}
+
+	props := make([]string, 0, len(keys))
+	for prop := range keys {
+		props = append(props, prop)
+	}
+	sort.Strings(props)
+
+	var out []interface{}
+	for _, prop := range props {
+		key := keys[prop].Global
+		if key == "" {
+			continue
+		}
+		value, ok := payload[key]
+		if !ok || value == "" {
+			continue
+		}
+		out = append(out, factory(prop, value))
+	}
+	return out, nil
+}
+
 // readPropertyReport runs `dokku <plugin>:report [<app>|--global] --format json`
 // and returns the decoded payload, distinguishing a plugin that is not installed
 // (returns nil, nil - a quiet skip) from one that is installed but whose report

--- a/tasks/proxy_property_task.go
+++ b/tasks/proxy_property_task.go
@@ -110,6 +110,13 @@ func (t ProxyPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t ProxyPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("proxy:set", proxyPropertyKeys, func(property, value string) interface{} {
+		return ProxyPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the ProxyPropertyTask with the task registry
 func init() {
 	RegisterTask(&ProxyPropertyTask{})

--- a/tasks/ps_property_task.go
+++ b/tasks/ps_property_task.go
@@ -106,6 +106,13 @@ func (t PsPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t PsPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("ps:set", psPropertyKeys, func(property, value string) interface{} {
+		return PsPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the PsPropertyTask with the task registry
 func init() {
 	RegisterTask(&PsPropertyTask{})

--- a/tasks/registry_property_task.go
+++ b/tasks/registry_property_task.go
@@ -112,6 +112,13 @@ func (t RegistryPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t RegistryPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("registry:set", registryPropertyKeys, func(property, value string) interface{} {
+		return RegistryPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the RegistryPropertyTask with the task registry
 func init() {
 	RegisterTask(&RegistryPropertyTask{})

--- a/tasks/scheduler_k3s_property_task.go
+++ b/tasks/scheduler_k3s_property_task.go
@@ -135,6 +135,13 @@ func (t SchedulerK3sPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t SchedulerK3sPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("scheduler-k3s:set", schedulerK3sPropertyKeys, func(property, value string) interface{} {
+		return SchedulerK3sPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the SchedulerK3sPropertyTask with the task registry
 func init() {
 	RegisterTask(&SchedulerK3sPropertyTask{})

--- a/tasks/scheduler_property_task.go
+++ b/tasks/scheduler_property_task.go
@@ -100,6 +100,13 @@ func (t SchedulerPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t SchedulerPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("scheduler:set", schedulerPropertyKeys, func(property, value string) interface{} {
+		return SchedulerPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the SchedulerPropertyTask with the task registry
 func init() {
 	RegisterTask(&SchedulerPropertyTask{})

--- a/tasks/traefik_property_task.go
+++ b/tasks/traefik_property_task.go
@@ -115,6 +115,13 @@ func (t TraefikPropertyTask) ExportApp(app string) ([]interface{}, error) {
 	})
 }
 
+// ExportGlobal reconstructs the globally-set properties.
+func (t TraefikPropertyTask) ExportGlobal() ([]interface{}, error) {
+	return exportGlobalProperties("traefik:set", traefikPropertyKeys, func(property, value string) interface{} {
+		return TraefikPropertyTask{Global: true, Property: property, Value: value}
+	})
+}
+
 // init registers the TraefikPropertyTask with the task registry
 func init() {
 	RegisterTask(&TraefikPropertyTask{})


### PR DESCRIPTION
`docket export` read only the per-app property report, so every globally-set plugin property (`global: true`) was silently dropped, most damagingly the scheduler-k3s bootstrap keys such as the cluster token and ingress class. Each property task now reconstructs its global scope into the leading global play, with secret global values such as the k3s token and the traefik basic-auth password lifted into the vars-file rather than written in cleartext.

Stacked on #377; retarget to `main` once that merges.

Closes #327.