### PR TITLE
fix: correct task envelope semantics bugs

### DIFF
--- a/commands/envelope_overrides.go
+++ b/commands/envelope_overrides.go
@@ -80,10 +80,11 @@ func (a loopRegisterAccumulator) remember(name string, state tasks.TaskOutputSta
 }
 
 // finalize returns the RegisteredValue for name from the accumulated
-// states. For a single-iteration accumulator this is identical to the
-// non-loop register shape (Results: nil). For multi-iteration accumulators
-// the embedded TaskOutputState aggregates per the documented Ansible
-// semantics and Results carries every iteration's post-override state.
+// states. Every loop expansion - including a single-iteration one -
+// carries a Results list with one entry per iteration, so `.Results[0]`
+// is always available. The embedded TaskOutputState aggregates per the
+// documented Ansible semantics (Changed = any iteration changed, Error =
+// first error, the rest mirror the last iteration).
 func (a loopRegisterAccumulator) finalize(name string) tasks.RegisteredValue {
 	return tasks.AggregateRegistered(a[name])
 }

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -412,6 +412,7 @@ func planLeaf(env *tasks.TaskEnvelope, name string, pc *planContext, failedTask 
 
 	result.Error = synth.Error
 	result.InSync = !synth.Changed && synth.Error == nil
+	result.Status = planStatusForVerdict(result)
 
 	out := planTaskOutcome{state: synth}
 	switch {
@@ -434,6 +435,30 @@ func planLeaf(env *tasks.TaskEnvelope, name string, pc *planContext, failedTask 
 		Timestamp: time.Now().UTC(),
 	})
 	return out
+}
+
+// planStatusForVerdict recomputes the drift marker after envelope
+// overrides (changed_when / failed_when) may have flipped the InSync /
+// Error verdict, so the marker and JSON status agree with it (#313). It
+// is called with result.Error / result.InSync already set to the
+// post-override verdict but result.Status still at the value Plan()
+// returned. A probe error is `!`; an in-sync task is `ok`; otherwise the
+// task would change and keeps its original create/destroy/modify marker,
+// defaulting to modify when the pre-override marker was ok/error/empty.
+func planStatusForVerdict(r tasks.PlanResult) tasks.PlanStatus {
+	switch {
+	case r.Error != nil:
+		return tasks.PlanStatusError
+	case r.InSync:
+		return tasks.PlanStatusOK
+	default:
+		switch r.Status {
+		case tasks.PlanStatusCreate, tasks.PlanStatusDestroy, tasks.PlanStatusModify:
+			return r.Status
+		default:
+			return tasks.PlanStatusModify
+		}
+	}
 }
 
 // planGroup plans a try/catch/finally group entry (#211). Block

--- a/commands/play_executor_test.go
+++ b/commands/play_executor_test.go
@@ -238,6 +238,145 @@ func TestPlanFailedWhenClearsError(t *testing.T) {
 	}
 }
 
+// TestPlanChangedWhenTrueRecomputesStatus pins #313: changed_when: 'true'
+// on an in-sync task must flip the marker and the JSON status to a
+// would-change verdict, not leave the stale [ok] / "status":"ok" the
+// probe returned.
+func TestPlanChangedWhenTrueRecomputesStatus(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{Changed: false}) // Plan() -> InSync, PlanStatusOK
+
+	path := writeMultiPlayTasks(t, `---
+- tasks:
+    - name: forced
+      changed_when: 'true'
+      dokku_stub: { key: a }
+`)
+
+	stdout, _, exit := runPlan(t, path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	if strings.Contains(stdout, "[ok]") {
+		t.Errorf("changed_when:true must not render [ok]; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "[~]") {
+		t.Errorf("expected [~] marker for the forced change; got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "1 would change") {
+		t.Errorf("summary should count 1 would change; got:\n%s", stdout)
+	}
+
+	jsonOut, _, exit := runPlan(t, path, "--json")
+	if exit != 0 {
+		t.Fatalf("json exit = %d, want 0; out=%s", exit, jsonOut)
+	}
+	sawTask := false
+	for _, ev := range decodeLines(t, jsonOut) {
+		if ev["type"] != "task" {
+			continue
+		}
+		sawTask = true
+		if ev["status"] != "~" {
+			t.Errorf("json status = %v, want ~", ev["status"])
+		}
+		if ev["would_change"] != true {
+			t.Errorf("json would_change = %v, want true", ev["would_change"])
+		}
+	}
+	if !sawTask {
+		t.Fatalf("no task event in json output:\n%s", jsonOut)
+	}
+}
+
+// TestPlanFailedWhenClearingErrorRecomputesStatus pins the #313 inverse:
+// failed_when clearing a probe error leaves a would-change line marked
+// [~], not the stale [!] the probe returned.
+func TestPlanFailedWhenClearingErrorRecomputesStatus(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{
+		PlanError: errors.New("App nonexistent does not exist"),
+		Stderr:    "App nonexistent does not exist",
+	})
+
+	path := writeMultiPlayTasks(t, `---
+- tasks:
+    - name: tolerant
+      failed_when: 'false'
+      dokku_stub: { key: a }
+`)
+
+	jsonOut, _, exit := runPlan(t, path, "--json")
+	if exit != 0 {
+		t.Fatalf("json exit = %d, want 0; out=%s", exit, jsonOut)
+	}
+	for _, ev := range decodeLines(t, jsonOut) {
+		if ev["type"] != "task" {
+			continue
+		}
+		if ev["status"] == "error" || ev["status"] == "!" {
+			t.Errorf("failed_when:false should clear the probe error; status = %v", ev["status"])
+		}
+	}
+}
+
+// TestPlanRejectsDuplicateRegisterName pins #314: apply/plan reject a
+// register name reused across tasks at load time (the same rule validate
+// enforces) instead of silently merging results.
+func TestPlanRejectsDuplicateRegisterName(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{Changed: true})
+	stubSet("b", StubFixture{Changed: false})
+
+	path := writeMultiPlayTasks(t, `---
+- tasks:
+    - name: first
+      register: dup
+      dokku_stub: { key: a }
+    - name: second
+      register: dup
+      dokku_stub: { key: b }
+`)
+	_, stderr, exit := runPlan(t, path)
+	if exit == 0 {
+		t.Fatalf("expected non-zero exit for a reused register name")
+	}
+	if !strings.Contains(stderr, "already declared") {
+		t.Errorf("expected an 'already declared' error; got stderr:\n%s", stderr)
+	}
+}
+
+// TestPlanSingleIterationLoopRegisterResultsIndex pins #330: a loop that
+// resolves to one iteration still exposes .Results[0], so a follow-up
+// predicate that reads it plans normally instead of failing with an
+// index-out-of-range error.
+func TestPlanSingleIterationLoopRegisterResultsIndex(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{Changed: true})
+	stubSet("b", StubFixture{Changed: false})
+
+	path := writeMultiPlayTasks(t, `---
+- tasks:
+    - name: deploy
+      loop: ["only"]
+      register: deploys
+      dokku_stub: { key: a }
+    - name: follow
+      when: 'registered.deploys.Results[0].Changed'
+      dokku_stub: { key: b }
+`)
+	stdout, stderr, exit := runPlan(t, path)
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s stderr=%s", exit, stdout, stderr)
+	}
+	if strings.Contains(stdout, "index out of range") || strings.Contains(stderr, "index out of range") {
+		t.Errorf("single-iteration loop register should expose Results[0]; got:\n%s\n%s", stdout, stderr)
+	}
+	if !strings.Contains(stdout, "follow") {
+		t.Errorf("follow-up task reading Results[0] should be planned; got:\n%s", stdout)
+	}
+}
+
 // TestMultiPlayWhenSkippedShowsInSummary: skipped plays count toward
 // the new "n play skipped" summary segment.
 func TestMultiPlayWhenSkippedShowsInSummary(t *testing.T) {

--- a/tasks/loop.go
+++ b/tasks/loop.go
@@ -38,6 +38,7 @@ func expandLoop(base *TaskEnvelope, bodyBytes []byte, typeKey string, sigilConte
 		return nil, err
 	}
 
+	names := loopExpansionNames(base.Name, items)
 	out := make([]*TaskEnvelope, 0, len(items))
 	for i, item := range items {
 		iterCtx := make(map[string]interface{}, len(sigilContext)+2)
@@ -67,7 +68,7 @@ func expandLoop(base *TaskEnvelope, bodyBytes []byte, typeKey string, sigilConte
 		expanded.LoopItem = item
 		expanded.LoopIndex = i
 		expanded.IsLoopExpansion = true
-		expanded.Name = loopExpansionName(base.Name, item, i)
+		expanded.Name = names[i]
 
 		out = append(out, &expanded)
 	}
@@ -110,6 +111,7 @@ func expandLoopGroup(base *TaskEnvelope, blockNode, rescueNode, alwaysNode *yaml
 		}
 	}
 
+	names := loopExpansionNames(base.Name, items)
 	out := make([]*TaskEnvelope, 0, len(items))
 	for i, item := range items {
 		iterCtx := make(map[string]interface{}, len(sigilContext)+2)
@@ -151,7 +153,7 @@ func expandLoopGroup(base *TaskEnvelope, blockNode, rescueNode, alwaysNode *yaml
 		expanded.Block = blockChildren
 		expanded.Rescue = rescueChildren
 		expanded.Always = alwaysChildren
-		expanded.Name = loopExpansionName(base.Name, item, i)
+		expanded.Name = names[i]
 
 		out = append(out, &expanded)
 	}
@@ -226,6 +228,29 @@ func loopExpansionName(base string, item interface{}, index int) string {
 		return fmt.Sprintf("%s (item=#%d)", base, index)
 	}
 	return fmt.Sprintf("%s (item=%s)", base, rendered)
+}
+
+// loopExpansionNames derives the per-iteration task name for every item
+// in a loop, guaranteeing a unique map key per iteration. Distinct scalar
+// items keep the readable `<base> (item=<value>)` form; items that would
+// otherwise collide - duplicate scalars, or scalars equal only after
+// TrimSpace - get an ` #<index>` suffix so every iteration survives
+// instead of overwriting an earlier one or tripping the duplicate-name
+// guard (#320). Complex items already carry an index-based suffix and
+// never collide.
+func loopExpansionNames(base string, items []interface{}) []string {
+	names := make([]string, len(items))
+	counts := make(map[string]int, len(items))
+	for i, item := range items {
+		names[i] = loopExpansionName(base, item, i)
+		counts[names[i]]++
+	}
+	for i, name := range names {
+		if counts[name] > 1 {
+			names[i] = fmt.Sprintf("%s #%d", name, i)
+		}
+	}
+	return names
 }
 
 // renderItemForName returns a stringified item value safe for use in a

--- a/tasks/loop_test.go
+++ b/tasks/loop_test.go
@@ -174,6 +174,77 @@ func TestLoopVarOutsideLoopRejectedAtParse(t *testing.T) {
 	}
 }
 
+// TestLoopVarSubfieldOutsideLoopRejected pins the #321 under-match fix:
+// a sub-field (`{{ .item.name }}`) or pipelined loop-var reference from a
+// non-loop task is rejected at parse time, not passed through literally.
+func TestLoopVarSubfieldOutsideLoopRejected(t *testing.T) {
+	for _, ref := range []string{"{{ .item.name }}", "{{ .item | upper }}", "{{ .index }}-x"} {
+		data := []byte(`---
+- tasks:
+    - name: stray
+      dokku_app:
+        app: "` + ref + `"
+`)
+		_, err := GetTasks(data, map[string]interface{}{})
+		if err == nil {
+			t.Fatalf("%q: expected rejection outside a loop, got nil", ref)
+		}
+		if !strings.Contains(err.Error(), "is only available inside a loop body") {
+			t.Errorf("%q: got: %v", ref, err)
+		}
+	}
+}
+
+// TestInputNamedLikeLoopVarRenders pins the #321 over-match fix: an input
+// whose name merely starts with `item` / `index` (here `items`) is a
+// normal file-level input and must be substituted, not hidden from the
+// render as if it were a loop variable.
+func TestInputNamedLikeLoopVarRenders(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: deploy
+      dokku_app:
+        app: "{{ .items }}"
+`)
+	out, err := GetTasks(data, map[string]interface{}{"items": "resolved-app"})
+	if err != nil {
+		t.Fatalf("GetTasks: %v", err)
+	}
+	keys := out.Keys()
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(keys))
+	}
+	if got := out.GetEnvelope(keys[0]).Task.(*AppTask).App; got != "resolved-app" {
+		t.Errorf("app = %q, want resolved-app (input was not substituted)", got)
+	}
+}
+
+// TestLoopExactDuplicateItemsBothRun pins #320 with the issue's own
+// example: two identical scalar items each produce a surviving iteration.
+func TestLoopExactDuplicateItemsBothRun(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: create
+      loop: ["web", "web"]
+      dokku_app:
+        app: "app-{{ .index }}"
+`)
+	out, err := GetTasks(data, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetTasks: %v", err)
+	}
+	keys := out.Keys()
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 expansions for duplicate items, got %d (%v)", len(keys), keys)
+	}
+	if keys[0] == keys[1] {
+		t.Fatalf("expansion keys must be unique, both were %q", keys[0])
+	}
+	if a, b := out.GetEnvelope(keys[0]).Task.(*AppTask).App, out.GetEnvelope(keys[1]).Task.(*AppTask).App; a != "app-0" || b != "app-1" {
+		t.Errorf("apps = %q, %q; want app-0, app-1", a, b)
+	}
+}
+
 // TestLoopOnGroupExpandsEntireGroup pins #211: a `loop:` on a group
 // duplicates the whole group N times so each iteration's children
 // share that iteration's `.item` / `.index`.

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -368,17 +368,23 @@ const (
 	loopIndexPlaceholder = "{{ .index }}"
 )
 
-// loopVarSentinelPattern catches `{{ .item ... }}` and `{{ .index ... }}`
-// references (any whitespace, optional sub-field access, optional
-// pipelines) so they can be hidden from the file-level sigil pass and
-// restored before loop expansion runs the second pass. The sub-match
-// captures the full template token verbatim.
+// loopVarSentinelPattern catches `{{ ... .item ... }}` and
+// `{{ ... .index ... }}` references so they can be hidden from the
+// file-level sigil pass and restored before loop expansion runs the
+// second pass, and so they can be detected outside a loop and rejected.
 //
-// Sub-field access (`{{ .item.app }}`) is the motivating case: with a
-// scalar self-referencing placeholder, sigil errors when traversing a
-// field on a string. Hiding the whole `{{ ... }}` token sidesteps the
-// problem entirely.
-var loopVarSentinelPattern = regexp.MustCompile(`\{\{[^}]*?\.(item|index)([^}]*)\}\}`)
+// `.item` / `.index` must be a *root* path segment: the dot is preceded
+// by the `{{`, whitespace, or another non-identifier char (never by an
+// identifier char, so `{{ .foo.item }}` - field `item` on input `foo` -
+// is left alone), and `item` / `index` is followed by a non-identifier
+// char (so `{{ .items }}`, `{{ .item_name }}`, `{{ .index_url }}` - real
+// inputs that merely start with the same letters - are left alone).
+// Sub-field access (`{{ .item.app }}`) and pipelines (`{{ .item | f }}`)
+// still match, which is the motivating case: a scalar self-referencing
+// placeholder makes sigil error when traversing a field on a string, so
+// hiding the whole token sidesteps the problem. The sub-match captures
+// `item` / `index` so callers can name the offending variable.
+var loopVarSentinelPattern = regexp.MustCompile(`\{\{(?:[^}]*[^\p{L}\p{N}_.])?\.(item|index)(?:[^\p{L}\p{N}_}][^}]*)?\}\}`)
 
 // loopVarSentinelOpen / Close wrap escaped loop-var tokens during the
 // file-level sigil pass. The pair must be unique enough to never appear
@@ -535,6 +541,12 @@ func GetPlaysWithFormat(data []byte, format string, context map[string]interface
 
 	plays := make([]*Play, 0, len(baseAST.Plays))
 	singleUnnamed := len(baseAST.Plays) == 1 && baseAST.Plays[0].Name == ""
+	// registerSeen enforces the documented "a register name can only be
+	// registered once" rule (docs/task-envelope.md) at load time, so apply
+	// and plan reject a reused name the same way validate does instead of
+	// silently merging results across tasks (#314). The map is recipe-wide
+	// because the registered map is shared across every play in one run.
+	registerSeen := map[string]registerHit{}
 	for i, rawPlay := range baseAST.Plays {
 		if len(rawPlay.Problems) > 0 {
 			return nil, problemToError(rawPlay.Problems[0])
@@ -598,6 +610,14 @@ func GetPlaysWithFormat(data []byte, format string, context map[string]interface
 		perPlay := perAST.Plays[i]
 		if len(perPlay.Problems) > 0 {
 			return nil, problemToError(perPlay.Problems[0])
+		}
+
+		// Reject a register name reused across tasks or plays before loop
+		// expansion, so the run-wide accumulator never merges results from
+		// two distinct tasks (#314). Iterations of one loop task share a
+		// name legally because the check walks task nodes, not expansions.
+		if regProblems := validateRegisterReferences(perPlay.TasksNode, perPlay.Label, registerSeen); len(regProblems) > 0 {
+			return nil, problemToError(regProblems[0])
 		}
 
 		exprCtx := buildExprContext(playCtx)
@@ -951,21 +971,17 @@ func buildExprContext(context map[string]interface{}) map[string]interface{} {
 }
 
 // rejectLoopVarsInTask scans every string field on task for surviving
-// `{{ .item }}` / `{{ .index }}` references and returns an error when
-// it finds one. Loop expansions render those tokens to real values, so
-// any survivor implies the user referenced a loop variable from a
-// non-loop task.
+// `{{ .item ... }}` / `{{ .index ... }}` references (including sub-field
+// and pipelined forms) and returns an error when it finds one. Loop
+// expansions render those tokens to real values, so any survivor implies
+// the user referenced a loop variable from a non-loop task.
 func rejectLoopVarsInTask(index int, name string, task Task) error {
 	bytes, err := yaml.Marshal(task)
 	if err != nil {
 		return nil
 	}
-	body := string(bytes)
-	if strings.Contains(body, ".item") && (strings.Contains(body, "{{ .item }}") || strings.Contains(body, "{{.item}}")) {
-		return fmt.Errorf("task parse error: task #%d %q: .item is only available inside a loop body", index, name)
-	}
-	if strings.Contains(body, ".index") && (strings.Contains(body, "{{ .index }}") || strings.Contains(body, "{{.index}}")) {
-		return fmt.Errorf("task parse error: task #%d %q: .index is only available inside a loop body", index, name)
+	if m := loopVarSentinelPattern.FindStringSubmatch(string(bytes)); m != nil {
+		return fmt.Errorf("task parse error: task #%d %q: .%s is only available inside a loop body", index, name, m[1])
 	}
 	return nil
 }

--- a/tasks/main_test.go
+++ b/tasks/main_test.go
@@ -466,24 +466,41 @@ func TestGetTasksRejectsDuplicateTaskNames(t *testing.T) {
 	}
 }
 
-func TestGetTasksRejectsLoopSuffixCollision(t *testing.T) {
+func TestGetTasksDisambiguatesDuplicateLoopItems(t *testing.T) {
 	// Loop item names are trimmed for the (item=<value>) suffix, so two
-	// items that differ only by surrounding whitespace collapse to the
-	// same envelope name. The runtime guard rejects the collision instead
-	// of silently dropping an iteration (#307).
+	// items that are equal (or equal only after TrimSpace) would collapse
+	// to the same envelope name. Both iterations must still run, so the
+	// colliding names get an index suffix instead of dropping an iteration
+	// or erroring (#320, resolving the tension with the #307 guard).
 	data := []byte(`---
 - tasks:
     - name: dup
-      loop: ["a", " a "]
+      loop: ["a", " a ", "web"]
       dokku_app:
-        app: "app-{{ .item }}"
+        app: "app-{{ .index }}"
 `)
-	_, err := GetTasks(data, map[string]interface{}{})
-	if err == nil {
-		t.Fatal("expected error for colliding loop suffixes, got nil")
+	out, err := GetTasks(data, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetTasks: %v", err)
 	}
-	if !strings.Contains(err.Error(), "duplicate task name") {
-		t.Errorf("expected duplicate-name error, got: %v", err)
+	keys := out.Keys()
+	if len(keys) != 3 {
+		t.Fatalf("expected 3 surviving expansions, got %d (%v)", len(keys), keys)
+	}
+	seen := map[string]bool{}
+	for _, k := range keys {
+		if seen[k] {
+			t.Errorf("duplicate expansion key %q", k)
+		}
+		seen[k] = true
+	}
+	// Each iteration renders its own body via .index, proving none was
+	// overwritten by a colliding key.
+	wantApps := []string{"app-0", "app-1", "app-2"}
+	for i, k := range keys {
+		if got := out.GetEnvelope(k).Task.(*AppTask).App; got != wantApps[i] {
+			t.Errorf("expansion %d app = %q, want %q", i, got, wantApps[i])
+		}
 	}
 }
 

--- a/tasks/predicate.go
+++ b/tasks/predicate.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"fmt"
+	"reflect"
 	"sync"
 
 	"github.com/expr-lang/expr"
@@ -97,6 +98,16 @@ func truthy(v interface{}) bool {
 		return len(x) > 0
 	case map[string]interface{}:
 		return len(x) > 0
+	}
+	// Reflect fallback for typed collections (`[]string` from
+	// registered.foo.Commands, `[]TaskOutputState` from .Results, typed
+	// maps) that do not match the generic case arms above. A typed nil
+	// slice/map has Kind Slice/Map and length 0, so an empty one is
+	// correctly false rather than falling through to the default true.
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Slice, reflect.Array, reflect.Map:
+		return rv.Len() > 0
 	}
 	return true
 }

--- a/tasks/predicate_test.go
+++ b/tasks/predicate_test.go
@@ -229,6 +229,64 @@ func TestEvalBoolRegisteredResultsIndex(t *testing.T) {
 	}
 }
 
+// TestTruthyEmptyTypedSlice pins #354: an empty typed slice/array/map
+// (not just []interface{}) coerces to false, matching the documented rule
+// that empty collections are false.
+func TestTruthyEmptyTypedSlice(t *testing.T) {
+	falsy := []interface{}{
+		[]string(nil),
+		[]string{},
+		[]TaskOutputState{},
+		[]int{},
+		map[string]string{},
+	}
+	for _, v := range falsy {
+		if truthy(v) {
+			t.Errorf("truthy(%#v) = true, want false", v)
+		}
+	}
+	truthyVals := []interface{}{
+		[]string{"dokku apps:create"},
+		[]TaskOutputState{{Changed: true}},
+		map[string]string{"a": "b"},
+	}
+	for _, v := range truthyVals {
+		if !truthy(v) {
+			t.Errorf("truthy(%#v) = false, want true", v)
+		}
+	}
+}
+
+// TestEvalBoolEmptyTypedSliceFalsy exercises #354 through a predicate:
+// registered.foo.Commands is a []string, empty for a task that ran no
+// subprocess, so `when: registered.foo.Commands` is falsy and the task
+// skips instead of running.
+func TestEvalBoolEmptyTypedSliceFalsy(t *testing.T) {
+	prog, err := CompilePredicate(`registered.foo.Commands`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	registered := map[string]RegisteredValue{
+		"foo": {TaskOutputState: TaskOutputState{Commands: nil}},
+	}
+	got, err := EvalBool(prog, map[string]interface{}{"registered": registered})
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if got {
+		t.Errorf("empty Commands should be falsy; got true")
+	}
+
+	registered["foo"] = RegisteredValue{TaskOutputState: TaskOutputState{Commands: []string{"dokku apps:create api"}}}
+	got, err = EvalBool(prog, map[string]interface{}{"registered": registered})
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if !got {
+		t.Errorf("non-empty Commands should be truthy; got false")
+	}
+}
+
 // TestAggregateRegisteredAggregatesAcrossIterations pins the
 // loop-aggregation rules: Changed = any iteration changed, Error =
 // first non-nil error, last-iteration values for the rest.
@@ -262,7 +320,13 @@ func TestAggregateRegisteredEmptyAndSingle(t *testing.T) {
 	if !got.Changed || got.Stderr != "only" {
 		t.Errorf("single-element aggregate should mirror the input; got %+v", got)
 	}
-	if got.Results != nil {
-		t.Errorf("single-element aggregate should leave Results nil; got %v", got.Results)
+	// A loop that resolves to a single iteration still carries a Results
+	// list with one entry, so `.Results[0]` is available per the
+	// documented register+loop contract (#330).
+	if len(got.Results) != 1 {
+		t.Fatalf("single-element aggregate should carry one Results entry; got %d", len(got.Results))
+	}
+	if got.Results[0].Stderr != "only" || !got.Results[0].Changed {
+		t.Errorf("Results[0] should mirror the single iteration; got %+v", got.Results[0])
 	}
 }

--- a/tasks/registered.go
+++ b/tasks/registered.go
@@ -28,15 +28,14 @@ type RegisteredValue struct {
 
 // AggregateRegistered builds a RegisteredValue from one or more
 // per-iteration TaskOutputStates. Callers use it to roll a loop's
-// expansions into a single registered value. Passing a single state
-// yields a RegisteredValue whose Results is nil and whose embedded
-// fields mirror the input directly.
+// expansions into a single registered value. Every loop expansion -
+// including one that resolves to a single iteration - yields a Results
+// list with one entry per iteration, so `.Results[0]` is always
+// available for a register+loop task (the documented contract in
+// docs/task-envelope.md). The empty input is the only nil-Results case.
 func AggregateRegistered(iter []TaskOutputState) RegisteredValue {
 	if len(iter) == 0 {
 		return RegisteredValue{}
-	}
-	if len(iter) == 1 {
-		return RegisteredValue{TaskOutputState: iter[0]}
 	}
 	last := iter[len(iter)-1]
 	out := RegisteredValue{

--- a/tasks/validate.go
+++ b/tasks/validate.go
@@ -811,19 +811,17 @@ func scanForLoopVars(node *yaml.Node, playLabel, taskLabel string, skipGroupChil
 	return problems
 }
 
-// containsLoopVar reports whether s contains a `{{ .item }}` or
-// `{{ .index }}` reference (with or without surrounding whitespace).
+// containsLoopVar reports whether s contains a `{{ .item ... }}` or
+// `{{ .index ... }}` reference, including sub-field (`{{ .item.name }}`)
+// and pipelined (`{{ .item | f }}`) forms, while leaving real inputs that
+// merely start with those letters (`{{ .items }}`, `{{ .item_name }}`)
+// alone. It shares loopVarSentinelPattern with the loader so both agree
+// on what counts as a loop-variable reference.
 func containsLoopVar(s string) bool {
 	if s == "" {
 		return false
 	}
-	if strings.Contains(s, "{{ .item }}") || strings.Contains(s, "{{.item}}") {
-		return true
-	}
-	if strings.Contains(s, "{{ .index }}") || strings.Contains(s, "{{.index}}") {
-		return true
-	}
-	return false
+	return loopVarSentinelPattern.MatchString(s)
 }
 
 // inputWithNode is the validate-time projection of an Input that also carries

--- a/tests/bats/envelope.bats
+++ b/tests/bats/envelope.bats
@@ -154,3 +154,19 @@ EOF
   assert_failure
   assert_output --partial ".item / .index are only available inside a loop body"
 }
+
+@test "envelope: .item sub-field outside a loop is rejected by validate" {
+  # A sub-field reference (`{{ .item.name }}`) used to slip past the
+  # exact-token check and render to a literal; it must now be rejected
+  # the same way a bare `{{ .item }}` is (#321).
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: stray
+      dokku_app:
+        app: "{{ .item.name }}"
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial ".item / .index are only available inside a loop body"
+}

--- a/tests/bats/list_resume.bats
+++ b/tests/bats/list_resume.bats
@@ -106,6 +106,23 @@ EOF
   assert_output --partial "item=c"
 }
 
+@test "--list-tasks keeps both iterations for duplicate loop items" {
+  # Duplicate scalar items used to collide into one envelope name and
+  # trip the duplicate-name guard, dropping an iteration (#320). Both
+  # iterations must survive with disambiguated names.
+  write_tasks_file <<EOF
+---
+- tasks:
+    - loop: [web, web]
+      dokku_app: { app: "docket-test-list-dup-{{ .index }}" }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  assert_output --partial "(item=web) #0"
+  assert_output --partial "(item=web) #1"
+  refute_output --partial "duplicate task name"
+}
+
 @test "--list-tasks shows [skipped] for when:false" {
   write_tasks_file <<EOF
 ---

--- a/tests/bats/register.bats
+++ b/tests/bats/register.bats
@@ -129,3 +129,22 @@ EOF
   assert_output --partial "register"
   assert_output --partial "already declared"
 }
+
+@test "register: duplicate name is rejected on plan, not just validate" {
+  # apply and plan load through the shared loader, which now runs the
+  # same register-uniqueness check validate does (#314), so a reused name
+  # fails at parse time offline instead of silently merging results.
+  write_tasks_file <<EOF
+---
+- tasks:
+    - register: dup
+      dokku_app:
+        app: a
+    - register: dup
+      dokku_app:
+        app: b
+EOF
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "already declared"
+}


### PR DESCRIPTION
Apply and plan now reject a reused `register` name at load time the same way validate does, a loop over duplicate or single scalar items keeps every iteration instead of collapsing or erroring, loop-variable references are matched by their root path segment so a sub-field or pipelined use is rejected outside a loop while a similarly named input still renders, a register combined with a single-iteration loop exposes `.Results[0]`, empty typed collections are falsy in predicates, and the plan status is recomputed after `changed_when` and `failed_when` overrides so the marker and JSON status agree with the verdict.

Closes #366.
Closes #313
Closes #314
Closes #320
Closes #321
Closes #330
Closes #354