### PR TITLE
fix: correct toggle task global and ssh-probe bugs

### DIFF
--- a/docs/tasks/dokku_checks_toggle.md
+++ b/docs/tasks/dokku_checks_toggle.md
@@ -13,7 +13,6 @@ Supported.
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | yes |  |  | Name of the app |
-| `global` | bool | no |  |  | Flag indicating if the checks plugin should be applied globally |
 | `state` | string | no | present | present, absent | Desired state of the checks plugin |
 
 ## Examples

--- a/docs/tasks/dokku_domains_toggle.md
+++ b/docs/tasks/dokku_domains_toggle.md
@@ -13,7 +13,6 @@ Supported.
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | yes |  |  | Name of the app |
-| `global` | bool | no |  |  | Flag indicating if the domains plugin should be applied globally |
 | `state` | string | no | present | present, absent | Desired state of the domains plugin |
 
 ## Examples

--- a/docs/tasks/dokku_proxy_toggle.md
+++ b/docs/tasks/dokku_proxy_toggle.md
@@ -13,7 +13,6 @@ Supported.
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | yes |  |  | Name of the app |
-| `global` | bool | no |  |  | Flag indicating if the proxy should be applied globally |
 | `state` | string | no | present | present, absent | Desired state of the proxy |
 
 ## Examples

--- a/tasks/checks_toggle_task.go
+++ b/tasks/checks_toggle_task.go
@@ -8,26 +8,15 @@ import (
 )
 
 // checksEnabled probes whether checks are enabled for an app by reading the
-// `disabled-list` key from `checks:report --format json` (the global scope
-// reads `global-disabled-list`). The dokku-checks plugin lists disabled
-// process types there; an empty list or "none" means every process has checks
-// enabled. The JSON report is used because dokku 0.38.21 renamed the
-// flag-based `--checks-disabled` probe to `--checks-disabled-list`; the report
-// key is stable across those versions.
+// `disabled-list` key from `checks:report <app> --format json`. The
+// dokku-checks plugin lists disabled process types there; an empty list or
+// "none" means every process has checks enabled. The JSON report is used
+// because dokku 0.38.21 renamed the flag-based `--checks-disabled` probe to
+// `--checks-disabled-list`; the report key is stable across those versions.
 func checksEnabled(ctx ToggleContext) (bool, error) {
-	args := []string{"checks:report"}
-	key := "disabled-list"
-	if ctx.AllowGlobal && ctx.Global {
-		args = append(args, "--global")
-		key = "global-disabled-list"
-	} else {
-		args = append(args, ctx.App)
-	}
-	args = append(args, "--format", "json")
-
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
-		Args:    args,
+		Args:    []string{"checks:report", ctx.App, "--format", "json"},
 	})
 	if err != nil {
 		return false, err
@@ -37,7 +26,7 @@ func checksEnabled(ctx ToggleContext) (bool, error) {
 	if err := json.Unmarshal(result.StdoutBytes(), &report); err != nil {
 		return false, err
 	}
-	disabled := strings.TrimSpace(report[key])
+	disabled := strings.TrimSpace(report["disabled-list"])
 	return disabled == "" || disabled == "none", nil
 }
 
@@ -58,9 +47,6 @@ func (t ChecksToggleTask) ExportApp(app string) ([]interface{}, error) {
 type ChecksToggleTask struct {
 	// App is the name of the app
 	App string `required:"true" yaml:"app" description:"Name of the app"`
-
-	// Global is a flag indicating if the checks plugin should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the checks plugin should be applied globally"`
 
 	// State is the desired state of the checks plugin
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the checks plugin"`
@@ -115,14 +101,9 @@ func (t ChecksToggleTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// Validate checks the ChecksToggleTask's inputs without contacting the server.
-func (t ChecksToggleTask) Validate() error {
-	return validateToggleInput(t.App, t.Global, false)
-}
-
 // Plan reports the drift the ChecksToggleTask would produce.
 func (t ChecksToggleTask) Plan() PlanResult {
-	return planToggle(t.State, t.App, t.Global, false, "checks:enable", "checks:disable", checksEnabled)
+	return planToggle(t.State, t.App, "checks:enable", "checks:disable", checksEnabled)
 }
 
 // init registers the ChecksToggleTask with the task registry

--- a/tasks/checks_toggle_task_test.go
+++ b/tasks/checks_toggle_task_test.go
@@ -1,7 +1,11 @@
 package tasks
 
 import (
+	"context"
+	"errors"
 	"testing"
+
+	"github.com/dokku/docket/subprocess"
 )
 
 func TestChecksToggleTaskInvalidState(t *testing.T) {
@@ -9,5 +13,29 @@ func TestChecksToggleTaskInvalidState(t *testing.T) {
 	result := task.Execute()
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+// TestChecksToggleTaskPlanSurfacesSSHError proves the checksEnabled probe
+// forwards an SSH transport failure so planToggle reports it as a plan error
+// rather than spurious drift (#357).
+func TestChecksToggleTaskPlanSurfacesSSHError(t *testing.T) {
+	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		return subprocess.ExecCommandResponse{ExitCode: 255}, &subprocess.SSHError{
+			Host:   "dokku@unreachable",
+			Stderr: "ssh: connect to host unreachable port 22: Connection refused",
+		}
+	})()
+
+	plan := ChecksToggleTask{App: "web", State: StatePresent}.Plan()
+	if plan.Status != PlanStatusError {
+		t.Errorf("Status = %q, want %q", plan.Status, PlanStatusError)
+	}
+	if plan.InSync {
+		t.Error("expected InSync=false on transport failure")
+	}
+	var sshErr *subprocess.SSHError
+	if !errors.As(plan.Error, &sshErr) {
+		t.Errorf("Error = %v, want *subprocess.SSHError", plan.Error)
 	}
 }

--- a/tasks/domains_toggle_task.go
+++ b/tasks/domains_toggle_task.go
@@ -7,18 +7,11 @@ import (
 )
 
 // domainsEnabled probes whether the domains plugin is enabled for an app
-// via `dokku --quiet domains:report <app> --domains-app-enabled`, or for
-// the global scope via `--domains-global-enabled`.
+// via `dokku --quiet domains:report <app> --domains-app-enabled`.
 func domainsEnabled(ctx ToggleContext) (bool, error) {
-	args := []string{"--quiet", "domains:report"}
-	if ctx.AllowGlobal && ctx.Global {
-		args = append(args, "--global", "--domains-global-enabled")
-	} else {
-		args = append(args, ctx.App, "--domains-app-enabled")
-	}
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
-		Args:    args,
+		Args:    []string{"--quiet", "domains:report", ctx.App, "--domains-app-enabled"},
 	})
 	if err != nil {
 		return false, err
@@ -43,9 +36,6 @@ func (t DomainsToggleTask) ExportApp(app string) ([]interface{}, error) {
 type DomainsToggleTask struct {
 	// App is the name of the app
 	App string `required:"true" yaml:"app" description:"Name of the app"`
-
-	// Global is a flag indicating if the domains plugin should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the domains plugin should be applied globally"`
 
 	// State is the desired state of the domains plugin
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the domains plugin"`
@@ -99,14 +89,9 @@ func (t DomainsToggleTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// Validate checks the DomainsToggleTask's inputs without contacting the server.
-func (t DomainsToggleTask) Validate() error {
-	return validateToggleInput(t.App, t.Global, false)
-}
-
 // Plan reports the drift the DomainsToggleTask would produce.
 func (t DomainsToggleTask) Plan() PlanResult {
-	return planToggle(t.State, t.App, t.Global, false, "domains:enable", "domains:disable", domainsEnabled)
+	return planToggle(t.State, t.App, "domains:enable", "domains:disable", domainsEnabled)
 }
 
 // init registers the DomainsToggleTask with the task registry

--- a/tasks/domains_toggle_task_test.go
+++ b/tasks/domains_toggle_task_test.go
@@ -1,7 +1,11 @@
 package tasks
 
 import (
+	"context"
+	"errors"
 	"testing"
+
+	"github.com/dokku/docket/subprocess"
 )
 
 func TestDomainsToggleTaskInvalidState(t *testing.T) {
@@ -9,5 +13,29 @@ func TestDomainsToggleTaskInvalidState(t *testing.T) {
 	result := task.Execute()
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+// TestDomainsToggleTaskPlanSurfacesSSHError proves the domainsEnabled probe
+// forwards an SSH transport failure so planToggle reports it as a plan error
+// rather than spurious drift (#357).
+func TestDomainsToggleTaskPlanSurfacesSSHError(t *testing.T) {
+	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		return subprocess.ExecCommandResponse{ExitCode: 255}, &subprocess.SSHError{
+			Host:   "dokku@unreachable",
+			Stderr: "ssh: connect to host unreachable port 22: Connection refused",
+		}
+	})()
+
+	plan := DomainsToggleTask{App: "web", State: StatePresent}.Plan()
+	if plan.Status != PlanStatusError {
+		t.Errorf("Status = %q, want %q", plan.Status, PlanStatusError)
+	}
+	if plan.InSync {
+		t.Error("expected InSync=false on transport failure")
+	}
+	var sshErr *subprocess.SSHError
+	if !errors.As(plan.Error, &sshErr) {
+		t.Errorf("Error = %v, want *subprocess.SSHError", plan.Error)
 	}
 }

--- a/tasks/maintenance_task.go
+++ b/tasks/maintenance_task.go
@@ -9,7 +9,8 @@ import (
 // maintenanceEnabled probes whether maintenance mode is enabled for an app by
 // reading the `enabled` key from `maintenance:report --format json` (the plugin
 // strips the `maintenance-` prefix from JSON report keys). A probe failure
-// returns an error, which planToggle treats as drift.
+// returns an error, which planToggle treats as drift unless it is an SSH
+// transport failure, which surfaces as a plan error.
 func maintenanceEnabled(ctx ToggleContext) (bool, error) {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
@@ -102,14 +103,9 @@ func (t MaintenanceTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// Validate checks the MaintenanceTask's inputs without contacting the server.
-func (t MaintenanceTask) Validate() error {
-	return validateToggleInput(t.App, false, false)
-}
-
 // Plan reports the drift the MaintenanceTask would produce.
 func (t MaintenanceTask) Plan() PlanResult {
-	return planToggle(t.State, t.App, false, false, "maintenance:enable", "maintenance:disable", maintenanceEnabled)
+	return planToggle(t.State, t.App, "maintenance:enable", "maintenance:disable", maintenanceEnabled)
 }
 
 // init registers the MaintenanceTask with the task registry

--- a/tasks/maintenance_task_test.go
+++ b/tasks/maintenance_task_test.go
@@ -1,7 +1,11 @@
 package tasks
 
 import (
+	"context"
+	"errors"
 	"testing"
+
+	"github.com/dokku/docket/subprocess"
 )
 
 func TestMaintenanceTaskInvalidState(t *testing.T) {
@@ -9,5 +13,29 @@ func TestMaintenanceTaskInvalidState(t *testing.T) {
 	result := task.Execute()
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+// TestMaintenanceTaskPlanSurfacesSSHError proves the maintenanceEnabled probe
+// forwards an SSH transport failure so planToggle reports it as a plan error
+// rather than spurious drift (#357).
+func TestMaintenanceTaskPlanSurfacesSSHError(t *testing.T) {
+	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		return subprocess.ExecCommandResponse{ExitCode: 255}, &subprocess.SSHError{
+			Host:   "dokku@unreachable",
+			Stderr: "ssh: connect to host unreachable port 22: Connection refused",
+		}
+	})()
+
+	plan := MaintenanceTask{App: "web", State: StatePresent}.Plan()
+	if plan.Status != PlanStatusError {
+		t.Errorf("Status = %q, want %q", plan.Status, PlanStatusError)
+	}
+	if plan.InSync {
+		t.Error("expected InSync=false on transport failure")
+	}
+	var sshErr *subprocess.SSHError
+	if !errors.As(plan.Error, &sshErr) {
+		t.Errorf("Error = %v, want *subprocess.SSHError", plan.Error)
 	}
 }

--- a/tasks/proxy_toggle_task.go
+++ b/tasks/proxy_toggle_task.go
@@ -9,15 +9,9 @@ import (
 // proxyEnabled probes whether the proxy is enabled for an app via
 // `dokku --quiet proxy:report <app> --proxy-enabled`. Output is "true"/"false".
 func proxyEnabled(ctx ToggleContext) (bool, error) {
-	args := []string{"--quiet", "proxy:report"}
-	if ctx.AllowGlobal && ctx.Global {
-		args = append(args, "--global", "--proxy-enabled")
-	} else {
-		args = append(args, ctx.App, "--proxy-enabled")
-	}
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
-		Args:    args,
+		Args:    []string{"--quiet", "proxy:report", ctx.App, "--proxy-enabled"},
 	})
 	if err != nil {
 		return false, err
@@ -42,9 +36,6 @@ func (t ProxyToggleTask) ExportApp(app string) ([]interface{}, error) {
 type ProxyToggleTask struct {
 	// App is the name of the app
 	App string `required:"true" yaml:"app" description:"Name of the app"`
-
-	// Global is a flag indicating if the proxy should be applied globally
-	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the proxy should be applied globally"`
 
 	// State is the desired state of the proxy
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the proxy"`
@@ -98,14 +89,9 @@ func (t ProxyToggleTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
-// Validate checks the ProxyToggleTask's inputs without contacting the server.
-func (t ProxyToggleTask) Validate() error {
-	return validateToggleInput(t.App, t.Global, false)
-}
-
 // Plan reports the drift the ProxyToggleTask would produce.
 func (t ProxyToggleTask) Plan() PlanResult {
-	return planToggle(t.State, t.App, t.Global, false, "proxy:enable", "proxy:disable", proxyEnabled)
+	return planToggle(t.State, t.App, "proxy:enable", "proxy:disable", proxyEnabled)
 }
 
 // init registers the ProxyToggleTask with the task registry

--- a/tasks/proxy_toggle_task_test.go
+++ b/tasks/proxy_toggle_task_test.go
@@ -1,7 +1,11 @@
 package tasks
 
 import (
+	"context"
+	"errors"
 	"testing"
+
+	"github.com/dokku/docket/subprocess"
 )
 
 func TestProxyToggleTaskInvalidState(t *testing.T) {
@@ -9,5 +13,29 @@ func TestProxyToggleTaskInvalidState(t *testing.T) {
 	result := task.Execute()
 	if result.Error == nil {
 		t.Fatal("Execute with invalid state should return an error")
+	}
+}
+
+// TestProxyToggleTaskPlanSurfacesSSHError proves the proxyEnabled probe
+// forwards an SSH transport failure so planToggle reports it as a plan error
+// rather than spurious drift (#357).
+func TestProxyToggleTaskPlanSurfacesSSHError(t *testing.T) {
+	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		return subprocess.ExecCommandResponse{ExitCode: 255}, &subprocess.SSHError{
+			Host:   "dokku@unreachable",
+			Stderr: "ssh: connect to host unreachable port 22: Connection refused",
+		}
+	})()
+
+	plan := ProxyToggleTask{App: "web", State: StateAbsent}.Plan()
+	if plan.Status != PlanStatusError {
+		t.Errorf("Status = %q, want %q", plan.Status, PlanStatusError)
+	}
+	if plan.InSync {
+		t.Error("expected InSync=false on transport failure")
+	}
+	var sshErr *subprocess.SSHError
+	if !errors.As(plan.Error, &sshErr) {
+		t.Errorf("Error = %v, want *subprocess.SSHError", plan.Error)
 	}
 }

--- a/tasks/toggle.go
+++ b/tasks/toggle.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/dokku/docket/subprocess"
@@ -9,81 +10,70 @@ import (
 // ToggleContext represents the context for a toggle operation
 type ToggleContext struct {
 	// App is the name of the app
-	App string `required:"true" yaml:"app"`
-
-	// Global is a flag indicating if the toggle should be applied globally
-	Global bool `required:"false" yaml:"global"`
-
-	// AllowGlobal is a flag indicating if the toggle should be applied globally
-	AllowGlobal bool `required:"false" yaml:"allow_global"`
+	App string
 }
 
 // ToggleProbe returns whether the toggle is currently in the "enabled"
 // (state: present) position. nil from a probe (or a non-nil error) is
-// treated as "drift, must mutate" so we still run the underlying command.
+// treated as "drift, must mutate" so we still run the underlying command,
+// except an SSH transport failure, which is surfaced as a plan error.
 type ToggleProbe func(ctx ToggleContext) (enabled bool, err error)
 
 // planToggle is the shared Plan() implementation for toggle tasks. The
 // probe reports whether the underlying plugin is currently in the
-// "enabled" position; when probe is nil or fails, planToggle reports drift
-// and the apply closure runs the underlying enable/disable command.
-// validateToggleInput checks a toggle task's inputs without probing the
-// server. planToggle and each toggle task's Validate() call it so plan and
-// validate report the same error.
-func validateToggleInput(app string, global, allowGlobal bool) error {
-	if allowGlobal && global && app != "" {
-		return fmt.Errorf("'app' must not be set when 'global' is set to true")
-	}
-	return nil
-}
-
-func planToggle(state State, app string, global bool, allowGlobal bool, enableCmd, disableCmd string, probe ToggleProbe) PlanResult {
-	if err := validateToggleInput(app, global, allowGlobal); err != nil {
-		return planErr(err)
-	}
-
-	target := app
-	if allowGlobal && global {
-		target = "--global"
-	}
-
-	ctx := ToggleContext{
-		AllowGlobal: allowGlobal,
-		App:         app,
-		Global:      global,
-	}
+// "enabled" position; when probe is nil or fails with a non-transport
+// error, planToggle reports drift and the apply closure runs the
+// underlying enable/disable command. An SSH transport failure short-
+// circuits to a plan error so an unreachable host is not mistaken for
+// drift.
+func planToggle(state State, app string, enableCmd, disableCmd string, probe ToggleProbe) PlanResult {
+	ctx := ToggleContext{App: app}
 
 	return DispatchPlan(state, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
 			if probe != nil {
-				if enabled, err := probe(ctx); err == nil && enabled {
+				enabled, err := probe(ctx)
+				if err != nil {
+					var sshErr *subprocess.SSHError
+					if errors.As(err, &sshErr) {
+						return PlanResult{Status: PlanStatusError, Error: err}
+					}
+					// non-SSH probe error: treat as drift, must mutate
+				} else if enabled {
 					return PlanResult{InSync: true, Status: PlanStatusOK}
 				}
 			}
-			inputs := toggleInputs(enableCmd, target)
+			inputs := toggleInputs(enableCmd, app)
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
-				Reason:    fmt.Sprintf("would run %s on %s", enableCmd, target),
-				Mutations: []string{fmt.Sprintf("%s %s", enableCmd, target)},
+				Reason:    fmt.Sprintf("would run %s on %s", enableCmd, app),
+				Mutations: []string{fmt.Sprintf("%s %s", enableCmd, app)},
 				Commands:  resolveCommands(inputs),
-				apply:     applyToggle(enableCmd, target, StatePresent),
+				apply:     applyToggle(enableCmd, app, StatePresent),
 			}
 		},
 		StateAbsent: func() PlanResult {
 			if probe != nil {
-				if enabled, err := probe(ctx); err == nil && !enabled {
+				enabled, err := probe(ctx)
+				if err != nil {
+					var sshErr *subprocess.SSHError
+					if errors.As(err, &sshErr) {
+						return PlanResult{Status: PlanStatusError, Error: err}
+					}
+					// non-SSH probe error: treat as drift, must mutate
+				} else if !enabled {
 					return PlanResult{InSync: true, Status: PlanStatusOK}
 				}
 			}
-			inputs := toggleInputs(disableCmd, target)
+			inputs := toggleInputs(disableCmd, app)
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusModify,
-				Reason:    fmt.Sprintf("would run %s on %s", disableCmd, target),
-				Mutations: []string{fmt.Sprintf("%s %s", disableCmd, target)},
+				Reason:    fmt.Sprintf("would run %s on %s", disableCmd, app),
+				Mutations: []string{fmt.Sprintf("%s %s", disableCmd, app)},
 				Commands:  resolveCommands(inputs),
-				apply:     applyToggle(disableCmd, target, StateAbsent),
+				apply:     applyToggle(disableCmd, app, StateAbsent),
 			}
 		},
 	})

--- a/tasks/toggle_test.go
+++ b/tasks/toggle_test.go
@@ -1,0 +1,105 @@
+package tasks
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dokku/docket/subprocess"
+)
+
+// TestPlanToggleSurfacesSSHTransportError locks the #357 fix: an SSH transport
+// failure from the probe must surface as a plan error (so an unreachable host
+// is not mistaken for drift), for both the present and absent states.
+func TestPlanToggleSurfacesSSHTransportError(t *testing.T) {
+	sshErr := &subprocess.SSHError{
+		Host:   "dokku@unreachable",
+		Stderr: "ssh: connect to host unreachable port 22: Connection refused",
+	}
+	probe := func(ToggleContext) (bool, error) { return false, sshErr }
+
+	for _, state := range []State{StatePresent, StateAbsent} {
+		plan := planToggle(state, "web", "checks:enable", "checks:disable", probe)
+		if plan.Status != PlanStatusError {
+			t.Errorf("state %s: Status = %q, want %q", state, plan.Status, PlanStatusError)
+		}
+		if plan.InSync {
+			t.Errorf("state %s: expected InSync=false on transport failure", state)
+		}
+		var got *subprocess.SSHError
+		if !errors.As(plan.Error, &got) {
+			t.Errorf("state %s: Error = %v, want *subprocess.SSHError", state, plan.Error)
+		}
+	}
+}
+
+// TestPlanToggleTreatsNonSSHProbeErrorAsDrift preserves the deliberate
+// "nil/failed probe = drift, must mutate" behavior for non-transport errors
+// (e.g. a plugin that does not support the report command).
+func TestPlanToggleTreatsNonSSHProbeErrorAsDrift(t *testing.T) {
+	probe := func(ToggleContext) (bool, error) { return false, fmt.Errorf("dokku: no such app") }
+
+	for _, tc := range []struct {
+		state State
+		cmd   string
+	}{
+		{StatePresent, "checks:enable"},
+		{StateAbsent, "checks:disable"},
+	} {
+		plan := planToggle(tc.state, "web", "checks:enable", "checks:disable", probe)
+		if plan.Error != nil {
+			t.Errorf("state %s: non-SSH probe error should not surface as a plan error, got %v", tc.state, plan.Error)
+		}
+		if plan.Status != PlanStatusModify {
+			t.Errorf("state %s: Status = %q, want %q", tc.state, plan.Status, PlanStatusModify)
+		}
+		if plan.InSync {
+			t.Errorf("state %s: expected drift (InSync=false)", tc.state)
+		}
+		if len(plan.Commands) == 0 || !strings.Contains(plan.Commands[0], tc.cmd+" web") {
+			t.Errorf("state %s: Commands = %v, want one containing %q", tc.state, plan.Commands, tc.cmd+" web")
+		}
+	}
+}
+
+// TestPlanTogglePresentInSyncWhenEnabled covers the happy path: present desired
+// and the probe reports enabled means no change.
+func TestPlanTogglePresentInSyncWhenEnabled(t *testing.T) {
+	probe := func(ToggleContext) (bool, error) { return true, nil }
+	plan := planToggle(StatePresent, "web", "checks:enable", "checks:disable", probe)
+	if !plan.InSync || plan.Status != PlanStatusOK {
+		t.Errorf("present+enabled: InSync=%v Status=%q, want InSync=true Status=%q", plan.InSync, plan.Status, PlanStatusOK)
+	}
+}
+
+// TestPlanToggleAbsentInSyncWhenDisabled covers the happy path: absent desired
+// and the probe reports disabled means no change.
+func TestPlanToggleAbsentInSyncWhenDisabled(t *testing.T) {
+	probe := func(ToggleContext) (bool, error) { return false, nil }
+	plan := planToggle(StateAbsent, "web", "checks:enable", "checks:disable", probe)
+	if !plan.InSync || plan.Status != PlanStatusOK {
+		t.Errorf("absent+disabled: InSync=%v Status=%q, want InSync=true Status=%q", plan.InSync, plan.Status, PlanStatusOK)
+	}
+}
+
+// TestPlanTogglePresentDriftTargetsApp locks the #322 fix: with the global
+// machinery removed, a drift always targets the app and never a --global scope.
+func TestPlanTogglePresentDriftTargetsApp(t *testing.T) {
+	probe := func(ToggleContext) (bool, error) { return false, nil }
+	plan := planToggle(StatePresent, "web", "checks:enable", "checks:disable", probe)
+	if plan.InSync {
+		t.Fatal("expected drift when probe reports disabled and present is desired")
+	}
+	if plan.Status != PlanStatusModify {
+		t.Errorf("Status = %q, want %q", plan.Status, PlanStatusModify)
+	}
+	if len(plan.Commands) == 0 || !strings.Contains(plan.Commands[0], "checks:enable web") {
+		t.Errorf("Commands = %v, want one containing %q", plan.Commands, "checks:enable web")
+	}
+	for _, cmd := range plan.Commands {
+		if strings.Contains(cmd, "--global") {
+			t.Errorf("command must target the app, not --global, got %q", cmd)
+		}
+	}
+}

--- a/tests/bats/ssh.bats
+++ b/tests/bats/ssh.bats
@@ -82,6 +82,22 @@ EOF
   assert_output --partial "ssh:"
 }
 
+@test "ssh transport failure on a toggle task surfaces as a plan error" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: enable the proxy
+      dokku_proxy_toggle:
+        app: docket-test-ssh
+EOF
+  # A toggle task's probe also propagates *subprocess.SSHError, so an
+  # unreachable host is a plan error (exit 1) rather than spurious drift
+  # that would exit 0.
+  DOKKU_HOST="$USER@127.0.0.1:1" run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "ssh:"
+}
+
 @test "--host flag overrides DOKKU_HOST env var" {
   write_tasks_file <<EOF
 ---


### PR DESCRIPTION
Resolves the two bugs tracked by #376 in the shared toggle task machinery used by `dokku_checks_toggle`, `dokku_domains_toggle`, `dokku_proxy_toggle`, and `dokku_maintenance`.

The documented `global` parameter on the checks, domains, and proxy toggle tasks never worked because enable and disable for these plugins is app-only, so setting it silently targeted the app while the docs implied a global change. The parameter and its dead machinery are removed, and all four toggle tasks are now app-only. Toggle tasks also now surface an SSH transport failure during plan as a plan error instead of reporting a spurious pending change and exiting 0, matching how property, domains, and certs tasks already behave against an unreachable host.

Closes #322
Closes #357