### PR TITLE
fix: fail rescue-less groups when a block child fails

### DIFF
--- a/commands/apply.go
+++ b/commands/apply.go
@@ -664,11 +664,20 @@ func (c *ApplyCommand) executeGroup(env *tasks.TaskEnvelope, name string, ac *ap
 		groupState.Error = rescueErr
 		groupState.State = ""
 	case blockFailedState != nil && len(env.Rescue) == 0:
-		// Block errored and there is no rescue clause; the original
-		// error propagates as the group's verdict.
+		// Block failed and there is no rescue clause; the failing
+		// child's verdict becomes the group's. A child can fail three
+		// ways: with an error, via a state mismatch (nil error), or via
+		// a zero-value failed state (a runtime-erroring when/failed_when
+		// predicate). Propagate the error and/or state mismatch as-is.
 		groupState.Error = blockFailedState.Error
 		groupState.State = blockFailedState.State
 		groupState.DesiredState = blockFailedState.DesiredState
+		if groupState.Error == nil && groupState.State == groupState.DesiredState {
+			// The child failed with neither an error nor a state
+			// mismatch; synthesize an error so the failure is not
+			// silently classified as ok/changed.
+			groupState.Error = errors.New("block child failed")
+		}
 	}
 
 	postState, overrideErr := applyEnvelopeOverrides(env, groupState, ac.playExprCtx, ac.registered, failedTask)
@@ -705,6 +714,23 @@ func (c *ApplyCommand) executeGroup(env *tasks.TaskEnvelope, name string, ac *ap
 			Ignored:   ignored,
 			Duration:  time.Since(taskStart),
 			Timestamp: time.Now().UTC(),
+		})
+		return applyTaskOutcome{state: groupState, failed: !ignored, abort: c.failFast && !ignored}
+	case groupState.State != groupState.DesiredState:
+		ignored := env.IgnoreErrors
+		if !ignored {
+			ac.counts.Errors++
+		}
+		ac.emitter.ApplyTask(ApplyTaskEvent{
+			Play:         ac.play.Name,
+			Name:         name,
+			Phase:        phase,
+			Group:        true,
+			State:        groupState,
+			InvalidState: true,
+			Ignored:      ignored,
+			Duration:     time.Since(taskStart),
+			Timestamp:    time.Now().UTC(),
 		})
 		return applyTaskOutcome{state: groupState, failed: !ignored, abort: c.failFast && !ignored}
 	case groupState.Changed:

--- a/commands/apply_envelope_test.go
+++ b/commands/apply_envelope_test.go
@@ -187,6 +187,28 @@ func TestApplyFailedWhenTrueMarksSuccessAsError(t *testing.T) {
 	}
 }
 
+// TestApplyLeafStateMismatchFailsRun: a top-level task that fails via a
+// bare state mismatch (State != DesiredState, nil error) renders [error]
+// and aborts the run with a non-zero exit. This is the baseline the
+// group path is expected to match (see TestApplyGroupBlockStateMismatchFailsGroup).
+func TestApplyLeafStateMismatchFailsRun(t *testing.T) {
+	defer stubReset()
+	stubSet("a", StubFixture{MismatchState: true})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: drifted
+      dokku_stub: { key: a }
+`)
+	stdout, stderr, exit := runApply(t, path)
+	if exit == 0 {
+		t.Fatalf("exit = 0, want non-zero (a bare state mismatch should fail the run); stdout=%s stderr=%s", stdout, stderr)
+	}
+	if !strings.Contains(stderr, "[error]") {
+		t.Errorf("expected [error] marker in stderr; got:\n%s", stderr)
+	}
+}
+
 // TestApplyFailedWhenFalseClearsStateMismatch: a falsy failed_when
 // also normalizes State to DesiredState so the state-mismatch branch
 // does not re-flag the task.

--- a/commands/group_test.go
+++ b/commands/group_test.go
@@ -282,3 +282,63 @@ func TestApplyGroupNestedFailureReachesOuterRescue(t *testing.T) {
 		t.Errorf("outer rescue should fire; got:\n%s", stdout)
 	}
 }
+
+// TestApplyGroupBlockStateMismatchFailsGroup: a block child that fails
+// via a state mismatch (State != DesiredState, nil error) inside a
+// rescue-less group must mark the group failed, render [error]  (group),
+// abort the rest of the play, and exit non-zero -- matching the verdict
+// the identical task gets at the top level.
+func TestApplyGroupBlockStateMismatchFailsGroup(t *testing.T) {
+	defer stubReset()
+	stubSet("mismatch", StubFixture{MismatchState: true})
+	stubSet("after", StubFixture{Changed: true})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: deploy
+      block:
+        - name: mismatched
+          dokku_stub: { key: mismatch }
+    - name: after-group
+      dokku_stub: { key: after }
+`)
+	stdout, stderr, exit := runApply(t, path)
+	if exit == 0 {
+		t.Fatalf("expected non-zero exit when a block child fails via state mismatch; stdout=%s stderr=%s", stdout, stderr)
+	}
+	combined := stdout + stderr
+	if !strings.Contains(stderr, "[error]") {
+		t.Errorf("expected [error] marker in stderr; combined=\n%s", combined)
+	}
+	if !strings.Contains(combined, "deploy  (group)") {
+		t.Errorf("expected the group summary line to render; combined=\n%s", combined)
+	}
+	if strings.Contains(combined, "after-group") {
+		t.Errorf("follow-up task must not run after the failed group; combined=\n%s", combined)
+	}
+}
+
+// TestApplyGroupBlockRuntimeFailedWhenErrorFailsGroup: a block child
+// whose failed_when predicate errors at run time returns failed with a
+// zero-value state (nil error, empty State/DesiredState). A rescue-less
+// group must still surface that as a failure rather than swallowing it.
+func TestApplyGroupBlockRuntimeFailedWhenErrorFailsGroup(t *testing.T) {
+	defer stubReset()
+	stubSet("ok", StubFixture{})
+
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: deploy
+      block:
+        - name: boom
+          failed_when: 'result.Commands[0] == ""'
+          dokku_stub: { key: ok }
+`)
+	stdout, stderr, exit := runApply(t, path)
+	if exit == 0 {
+		t.Fatalf("expected non-zero exit when a block child's failed_when errors at run time; stdout=%s stderr=%s", stdout, stderr)
+	}
+	if !strings.Contains(stderr, "[error]") {
+		t.Errorf("expected [error] marker in stderr; stdout=%s stderr=%s", stdout, stderr)
+	}
+}

--- a/docs/task-envelope.md
+++ b/docs/task-envelope.md
@@ -236,7 +236,8 @@ tasks. Use it when a sequence of steps needs a cleanup or rollback path. The out
 The rules:
 
 - `block:` children run in order. The first one that fails (and whose own `ignore_errors` is false)
-  stops the block.
+  stops the block. "Fails" means the same thing it does for any task: a hard error, a state mismatch
+  (`State != DesiredState`), or a `when:` / `failed_when:` predicate that errors at runtime.
 - `rescue:` children run, in order, only when a block child failed. They run with the failing
   child's result bound to `.failed_task`, so a rescue can branch on the cause:
   `when: 'failed_task.Stderr contains "..."'`.
@@ -244,6 +245,10 @@ The rules:
 - The group's own envelope applies to the combined outcome: `register:` saves the post-rescue,
   post-always result, and `ignore_errors: true` on the group swallows any error that remains after
   rescue and always.
+- With no `rescue:`, an uncaught block failure becomes the group's verdict: the group line renders
+  `[error]  (group)`, `apply` aborts the rest of the play and exits non-zero, exactly as the same
+  failing task would at the top level. A falsy `failed_when:` or `ignore_errors: true` on the group
+  clears it.
 - `ignore_errors: true` on a *child* of `block:` swallows that child's error and continues; it does
   not trigger `rescue:`. Rescue is the "handle it" path; `ignore_errors` is the "swallow it" path.
 - `loop:` on a group runs the whole group once per item, with `.item` / `.index` shared by every

--- a/tests/bats/block.bats
+++ b/tests/bats/block.bats
@@ -127,6 +127,29 @@ EOF
   done
 }
 
+@test "uncaught block failure fails the run and marks the group" {
+  require_dokku
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: deploy
+      block:
+        - dokku_ports:
+            app: nonexistent-block-target-zzz
+            port_mappings: [{ scheme: http, host: 80, container: 5000 }]
+            state: present
+    - name: after-group
+      dokku_app: { app: docket-test-block-1 }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "[error]"
+  assert_output --partial "(group)"
+  refute_output --partial "after-group"
+  run dokku apps:exists docket-test-block-1
+  assert_failure
+}
+
 @test "validate flags empty block" {
   write_tasks_file <<EOF
 ---


### PR DESCRIPTION
Fixes #303.

A block child that failed via a state mismatch or a runtime-erroring `when:`/`failed_when:` predicate inside a group with no `rescue:` was swallowed: the group reported `[ok]`/`[changed]`, the play continued to the next task, and `apply` exited 0 even though the deploy had failed. The group now reports the uncaught failure as its own verdict, aborting the play and exiting non-zero, matching how the identical task behaves at the top level.