### PR TITLE
docs: add state: absent to property clearing examples

### DIFF
--- a/docs/tasks/dokku_app_json_property.md
+++ b/docs/tasks/dokku_app_json_property.md
@@ -45,6 +45,7 @@ dokku_app_json_property:
 dokku_app_json_property:
     app: node-js-app
     property: appjson-path
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_builder_dockerfile_property.md
+++ b/docs/tasks/dokku_builder_dockerfile_property.md
@@ -45,6 +45,7 @@ dokku_builder_dockerfile_property:
 dokku_builder_dockerfile_property:
     app: node-js-app
     property: dockerfile-path
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_builder_herokuish_property.md
+++ b/docs/tasks/dokku_builder_herokuish_property.md
@@ -45,6 +45,7 @@ dokku_builder_herokuish_property:
 dokku_builder_herokuish_property:
     app: node-js-app
     property: allowed
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_builder_lambda_property.md
+++ b/docs/tasks/dokku_builder_lambda_property.md
@@ -45,6 +45,7 @@ dokku_builder_lambda_property:
 dokku_builder_lambda_property:
     app: node-js-app
     property: lambdayml-path
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_builder_nixpacks_property.md
+++ b/docs/tasks/dokku_builder_nixpacks_property.md
@@ -45,6 +45,7 @@ dokku_builder_nixpacks_property:
 dokku_builder_nixpacks_property:
     app: node-js-app
     property: nixpackstoml-path
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_builder_pack_property.md
+++ b/docs/tasks/dokku_builder_pack_property.md
@@ -45,6 +45,7 @@ dokku_builder_pack_property:
 dokku_builder_pack_property:
     app: node-js-app
     property: projecttoml-path
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_builder_property.md
+++ b/docs/tasks/dokku_builder_property.md
@@ -35,6 +35,7 @@ dokku_builder_property:
 dokku_builder_property:
     app: node-js-app
     property: selected
+    state: absent
 ```
 
 ### Changing the build build directory

--- a/docs/tasks/dokku_builder_railpack_property.md
+++ b/docs/tasks/dokku_builder_railpack_property.md
@@ -45,6 +45,7 @@ dokku_builder_railpack_property:
 dokku_builder_railpack_property:
     app: node-js-app
     property: railpackjson-path
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_buildpacks_property.md
+++ b/docs/tasks/dokku_buildpacks_property.md
@@ -45,6 +45,7 @@ dokku_buildpacks_property:
 dokku_buildpacks_property:
     app: node-js-app
     property: stack
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_builds_property.md
+++ b/docs/tasks/dokku_builds_property.md
@@ -45,6 +45,7 @@ dokku_builds_property:
 dokku_builds_property:
     app: node-js-app
     property: retention
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_caddy_property.md
+++ b/docs/tasks/dokku_caddy_property.md
@@ -45,6 +45,7 @@ dokku_caddy_property:
 dokku_caddy_property:
     app: node-js-app
     property: tls-internal
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_checks_property.md
+++ b/docs/tasks/dokku_checks_property.md
@@ -45,6 +45,7 @@ dokku_checks_property:
 dokku_checks_property:
     app: node-js-app
     property: wait-to-retire
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_cron_property.md
+++ b/docs/tasks/dokku_cron_property.md
@@ -45,6 +45,7 @@ dokku_cron_property:
 dokku_cron_property:
     app: node-js-app
     property: maintenance
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_git_property.md
+++ b/docs/tasks/dokku_git_property.md
@@ -54,6 +54,7 @@ dokku_git_property:
 dokku_git_property:
     app: node-js-app
     property: deploy-branch
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_haproxy_property.md
+++ b/docs/tasks/dokku_haproxy_property.md
@@ -45,6 +45,7 @@ dokku_haproxy_property:
 dokku_haproxy_property:
     app: node-js-app
     property: letsencrypt-email
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_letsencrypt_property.md
+++ b/docs/tasks/dokku_letsencrypt_property.md
@@ -58,6 +58,7 @@ dokku_letsencrypt_property:
 dokku_letsencrypt_property:
     app: node-js-app
     property: email
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_logs_property.md
+++ b/docs/tasks/dokku_logs_property.md
@@ -45,6 +45,7 @@ dokku_logs_property:
 dokku_logs_property:
     app: node-js-app
     property: max-size
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_network_property.md
+++ b/docs/tasks/dokku_network_property.md
@@ -54,6 +54,7 @@ dokku_network_property:
 dokku_network_property:
     app: hello-world
     property: attach-post-create
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_nginx_property.md
+++ b/docs/tasks/dokku_nginx_property.md
@@ -54,6 +54,7 @@ dokku_nginx_property:
 dokku_nginx_property:
     app: node-js-app
     property: proxy-read-timeout
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_openresty_property.md
+++ b/docs/tasks/dokku_openresty_property.md
@@ -54,6 +54,7 @@ dokku_openresty_property:
 dokku_openresty_property:
     app: node-js-app
     property: proxy-read-timeout
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_proxy_property.md
+++ b/docs/tasks/dokku_proxy_property.md
@@ -54,6 +54,7 @@ dokku_proxy_property:
 dokku_proxy_property:
     app: node-js-app
     property: type
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_ps_property.md
+++ b/docs/tasks/dokku_ps_property.md
@@ -45,6 +45,7 @@ dokku_ps_property:
 dokku_ps_property:
     app: node-js-app
     property: restart-policy
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_registry_property.md
+++ b/docs/tasks/dokku_registry_property.md
@@ -54,6 +54,7 @@ dokku_registry_property:
 dokku_registry_property:
     app: node-js-app
     property: image-repo
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_scheduler_docker_local_property.md
+++ b/docs/tasks/dokku_scheduler_docker_local_property.md
@@ -43,6 +43,7 @@ dokku_scheduler_docker_local_property:
 dokku_scheduler_docker_local_property:
     app: node-js-app
     property: init-process
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_scheduler_k3s_property.md
+++ b/docs/tasks/dokku_scheduler_k3s_property.md
@@ -54,6 +54,7 @@ dokku_scheduler_k3s_property:
 dokku_scheduler_k3s_property:
     app: node-js-app
     property: namespace
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_scheduler_property.md
+++ b/docs/tasks/dokku_scheduler_property.md
@@ -45,6 +45,7 @@ dokku_scheduler_property:
 dokku_scheduler_property:
     app: node-js-app
     property: selected
+    state: absent
 ```
 
 ## Return Values

--- a/docs/tasks/dokku_traefik_property.md
+++ b/docs/tasks/dokku_traefik_property.md
@@ -45,6 +45,7 @@ dokku_traefik_property:
 dokku_traefik_property:
     app: node-js-app
     property: letsencrypt-email
+    state: absent
 ```
 
 ## Return Values

--- a/tasks/app_json_property_task.go
+++ b/tasks/app_json_property_task.go
@@ -66,6 +66,7 @@ func (t AppJsonPropertyTask) Examples() ([]Doc, error) {
 			AppJsonPropertyTask: AppJsonPropertyTask{
 				App:      "node-js-app",
 				Property: "appjson-path",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/builder_dockerfile_property_task.go
+++ b/tasks/builder_dockerfile_property_task.go
@@ -66,6 +66,7 @@ func (t BuilderDockerfilePropertyTask) Examples() ([]Doc, error) {
 			BuilderDockerfilePropertyTask: BuilderDockerfilePropertyTask{
 				App:      "node-js-app",
 				Property: "dockerfile-path",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/builder_herokuish_property_task.go
+++ b/tasks/builder_herokuish_property_task.go
@@ -66,6 +66,7 @@ func (t BuilderHerokuishPropertyTask) Examples() ([]Doc, error) {
 			BuilderHerokuishPropertyTask: BuilderHerokuishPropertyTask{
 				App:      "node-js-app",
 				Property: "allowed",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/builder_lambda_property_task.go
+++ b/tasks/builder_lambda_property_task.go
@@ -66,6 +66,7 @@ func (t BuilderLambdaPropertyTask) Examples() ([]Doc, error) {
 			BuilderLambdaPropertyTask: BuilderLambdaPropertyTask{
 				App:      "node-js-app",
 				Property: "lambdayml-path",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/builder_nixpacks_property_task.go
+++ b/tasks/builder_nixpacks_property_task.go
@@ -66,6 +66,7 @@ func (t BuilderNixpacksPropertyTask) Examples() ([]Doc, error) {
 			BuilderNixpacksPropertyTask: BuilderNixpacksPropertyTask{
 				App:      "node-js-app",
 				Property: "nixpackstoml-path",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/builder_pack_property_task.go
+++ b/tasks/builder_pack_property_task.go
@@ -66,6 +66,7 @@ func (t BuilderPackPropertyTask) Examples() ([]Doc, error) {
 			BuilderPackPropertyTask: BuilderPackPropertyTask{
 				App:      "node-js-app",
 				Property: "projecttoml-path",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/builder_property_task.go
+++ b/tasks/builder_property_task.go
@@ -58,6 +58,7 @@ func (t BuilderPropertyTask) Examples() ([]Doc, error) {
 			BuilderPropertyTask: BuilderPropertyTask{
 				App:      "node-js-app",
 				Property: "selected",
+				State:    StateAbsent,
 			},
 		},
 		{

--- a/tasks/builder_railpack_property_task.go
+++ b/tasks/builder_railpack_property_task.go
@@ -66,6 +66,7 @@ func (t BuilderRailpackPropertyTask) Examples() ([]Doc, error) {
 			BuilderRailpackPropertyTask: BuilderRailpackPropertyTask{
 				App:      "node-js-app",
 				Property: "railpackjson-path",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/buildpacks_property_task.go
+++ b/tasks/buildpacks_property_task.go
@@ -66,6 +66,7 @@ func (t BuildpacksPropertyTask) Examples() ([]Doc, error) {
 			BuildpacksPropertyTask: BuildpacksPropertyTask{
 				App:      "node-js-app",
 				Property: "stack",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/builds_property_task.go
+++ b/tasks/builds_property_task.go
@@ -66,6 +66,7 @@ func (t BuildsPropertyTask) Examples() ([]Doc, error) {
 			BuildsPropertyTask: BuildsPropertyTask{
 				App:      "node-js-app",
 				Property: "retention",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/caddy_property_task.go
+++ b/tasks/caddy_property_task.go
@@ -66,6 +66,7 @@ func (t CaddyPropertyTask) Examples() ([]Doc, error) {
 			CaddyPropertyTask: CaddyPropertyTask{
 				App:      "node-js-app",
 				Property: "tls-internal",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/checks_property_task.go
+++ b/tasks/checks_property_task.go
@@ -66,6 +66,7 @@ func (t ChecksPropertyTask) Examples() ([]Doc, error) {
 			ChecksPropertyTask: ChecksPropertyTask{
 				App:      "node-js-app",
 				Property: "wait-to-retire",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/cron_property_task.go
+++ b/tasks/cron_property_task.go
@@ -66,6 +66,7 @@ func (t CronPropertyTask) Examples() ([]Doc, error) {
 			CronPropertyTask: CronPropertyTask{
 				App:      "node-js-app",
 				Property: "maintenance",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/git_property_task.go
+++ b/tasks/git_property_task.go
@@ -74,6 +74,7 @@ func (t GitPropertyTask) Examples() ([]Doc, error) {
 			GitPropertyTask: GitPropertyTask{
 				App:      "node-js-app",
 				Property: "deploy-branch",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/haproxy_property_task.go
+++ b/tasks/haproxy_property_task.go
@@ -66,6 +66,7 @@ func (t HaproxyPropertyTask) Examples() ([]Doc, error) {
 			HaproxyPropertyTask: HaproxyPropertyTask{
 				App:      "node-js-app",
 				Property: "letsencrypt-email",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/letsencrypt_property_task.go
+++ b/tasks/letsencrypt_property_task.go
@@ -81,6 +81,7 @@ func (t LetsencryptPropertyTask) Examples() ([]Doc, error) {
 			LetsencryptPropertyTask: LetsencryptPropertyTask{
 				App:      "node-js-app",
 				Property: "email",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/logs_property_task.go
+++ b/tasks/logs_property_task.go
@@ -66,6 +66,7 @@ func (t LogsPropertyTask) Examples() ([]Doc, error) {
 			LogsPropertyTask: LogsPropertyTask{
 				App:      "node-js-app",
 				Property: "max-size",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/network_property_task.go
+++ b/tasks/network_property_task.go
@@ -74,6 +74,7 @@ func (t NetworkPropertyTask) Examples() ([]Doc, error) {
 			NetworkPropertyTask: NetworkPropertyTask{
 				App:      "hello-world",
 				Property: "attach-post-create",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/nginx_property_task.go
+++ b/tasks/nginx_property_task.go
@@ -74,6 +74,7 @@ func (t NginxPropertyTask) Examples() ([]Doc, error) {
 			NginxPropertyTask: NginxPropertyTask{
 				App:      "node-js-app",
 				Property: "proxy-read-timeout",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/openresty_property_task.go
+++ b/tasks/openresty_property_task.go
@@ -74,6 +74,7 @@ func (t OpenrestyPropertyTask) Examples() ([]Doc, error) {
 			OpenrestyPropertyTask: OpenrestyPropertyTask{
 				App:      "node-js-app",
 				Property: "proxy-read-timeout",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/proxy_property_task.go
+++ b/tasks/proxy_property_task.go
@@ -74,6 +74,7 @@ func (t ProxyPropertyTask) Examples() ([]Doc, error) {
 			ProxyPropertyTask: ProxyPropertyTask{
 				App:      "node-js-app",
 				Property: "type",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/ps_property_task.go
+++ b/tasks/ps_property_task.go
@@ -66,6 +66,7 @@ func (t PsPropertyTask) Examples() ([]Doc, error) {
 			PsPropertyTask: PsPropertyTask{
 				App:      "node-js-app",
 				Property: "restart-policy",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/registry_property_task.go
+++ b/tasks/registry_property_task.go
@@ -74,6 +74,7 @@ func (t RegistryPropertyTask) Examples() ([]Doc, error) {
 			RegistryPropertyTask: RegistryPropertyTask{
 				App:      "node-js-app",
 				Property: "image-repo",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/scheduler_docker_local_property_task.go
+++ b/tasks/scheduler_docker_local_property_task.go
@@ -63,6 +63,7 @@ func (t SchedulerDockerLocalPropertyTask) Examples() ([]Doc, error) {
 			SchedulerDockerLocalPropertyTask: SchedulerDockerLocalPropertyTask{
 				App:      "node-js-app",
 				Property: "init-process",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/scheduler_k3s_property_task.go
+++ b/tasks/scheduler_k3s_property_task.go
@@ -79,6 +79,7 @@ func (t SchedulerK3sPropertyTask) Examples() ([]Doc, error) {
 			SchedulerK3sPropertyTask: SchedulerK3sPropertyTask{
 				App:      "node-js-app",
 				Property: "namespace",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/scheduler_property_task.go
+++ b/tasks/scheduler_property_task.go
@@ -66,6 +66,7 @@ func (t SchedulerPropertyTask) Examples() ([]Doc, error) {
 			SchedulerPropertyTask: SchedulerPropertyTask{
 				App:      "node-js-app",
 				Property: "selected",
+				State:    StateAbsent,
 			},
 		},
 	})

--- a/tasks/traefik_property_task.go
+++ b/tasks/traefik_property_task.go
@@ -66,6 +66,7 @@ func (t TraefikPropertyTask) Examples() ([]Doc, error) {
 			TraefikPropertyTask: TraefikPropertyTask{
 				App:      "node-js-app",
 				Property: "letsencrypt-email",
+				State:    StateAbsent,
 			},
 		},
 	})


### PR DESCRIPTION
The generated "Clearing the <property>" examples omitted `state: absent`, so copying them into a recipe defaulted the state to `present` with an empty value and failed validation with `setting a state of 'present' is invalid without a value for 'value'`. Setting `State: StateAbsent` on each clearing example makes the generated docs emit `state: absent` so the snippets validate and apply as written.

Test coverage that would exercise every documented example, both offline validation and end-to-end integration, is tracked separately in #388.

Closes #323.
