### PR TITLE
fix: suggest recipe files in shell completion

### DIFF
--- a/commands/apply.go
+++ b/commands/apply.go
@@ -115,7 +115,7 @@ func (c *ApplyCommand) AutocompleteFlags() complete.Flags {
 	return command.MergeAutocompleteFlags(
 		c.Meta.AutocompleteFlags(command.FlagSetClient),
 		complete.Flags{
-			"--tasks":                complete.PredictFiles(taskFileAutocompleteGlob),
+			"--tasks":                taskFileAutocomplete(),
 			"--verbose":              complete.PredictNothing,
 			"--json":                 complete.PredictNothing,
 			"--host":                 complete.PredictAnything,

--- a/commands/export.go
+++ b/commands/export.go
@@ -86,8 +86,8 @@ func (c *ExportCommand) AutocompleteFlags() complete.Flags {
 	return command.MergeAutocompleteFlags(
 		c.Meta.AutocompleteFlags(command.FlagSetClient),
 		complete.Flags{
-			"--output":               complete.PredictFiles(taskFileAutocompleteGlob),
-			"--vars-output":          complete.PredictFiles(taskFileAutocompleteGlob),
+			"--output":               taskFileAutocomplete(),
+			"--vars-output":          taskFileAutocomplete(),
 			"--overwrite":            complete.PredictNothing,
 			"--redact":               complete.PredictNothing,
 			"--app":                  complete.PredictNothing,

--- a/commands/fmt.go
+++ b/commands/fmt.go
@@ -65,7 +65,7 @@ func (c *FmtCommand) Arguments() []command.Argument {
 }
 
 func (c *FmtCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictFiles(taskFileAutocompleteGlob)
+	return taskFileAutocomplete()
 }
 
 func (c *FmtCommand) ParsedArguments(args []string) (map[string]command.Argument, error) {

--- a/commands/init.go
+++ b/commands/init.go
@@ -86,7 +86,7 @@ func (c *InitCommand) AutocompleteFlags() complete.Flags {
 	return command.MergeAutocompleteFlags(
 		c.Meta.AutocompleteFlags(command.FlagSetClient),
 		complete.Flags{
-			"--output":  complete.PredictFiles(taskFileAutocompleteGlob),
+			"--output":  taskFileAutocomplete(),
 			"--force":   complete.PredictNothing,
 			"--minimal": complete.PredictNothing,
 			"--name":    complete.PredictNothing,

--- a/commands/plan.go
+++ b/commands/plan.go
@@ -112,7 +112,7 @@ func (c *PlanCommand) AutocompleteFlags() complete.Flags {
 	return command.MergeAutocompleteFlags(
 		c.Meta.AutocompleteFlags(command.FlagSetClient),
 		complete.Flags{
-			"--tasks":                complete.PredictFiles(taskFileAutocompleteGlob),
+			"--tasks":                taskFileAutocomplete(),
 			"--json":                 complete.PredictNothing,
 			"--detailed-exitcode":    complete.PredictNothing,
 			"--host":                 complete.PredictAnything,

--- a/commands/task_file.go
+++ b/commands/task_file.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/posener/complete"
 )
 
 // Task file format identifiers used throughout the commands package and
@@ -102,16 +104,21 @@ func fetchTaskFileURL(rawURL string) ([]byte, error) {
 	return data, nil
 }
 
+// taskFileExtensions lists the recipe file extensions docket recognises,
+// the single source of truth for hasTaskFileExtension and taskFileAutocomplete.
+var taskFileExtensions = []string{"yml", "yaml", "json", "json5"}
+
 // hasTaskFileExtension reports whether path carries one of the recipe
 // file extensions. Used to spot a positional recipe path in an argv the
 // flag parser has not yet processed.
 func hasTaskFileExtension(path string) bool {
-	switch strings.ToLower(filepath.Ext(path)) {
-	case ".yml", ".yaml", ".json", ".json5":
-		return true
-	default:
-		return false
+	ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(path), "."))
+	for _, candidate := range taskFileExtensions {
+		if ext == candidate {
+			return true
+		}
 	}
+	return false
 }
 
 // resolveTaskFilePath returns the path to use as the task file plus its
@@ -156,6 +163,40 @@ func resolveTaskFileArg(explicit string, positional []string) (string, error) {
 	return positional[0], nil
 }
 
-// taskFileAutocompleteGlob is the shared file glob for the --tasks flag
-// completion across apply / plan / validate / fmt / init.
-const taskFileAutocompleteGlob = "*.{yml,yaml,json,json5}"
+// predictFilesByExtension returns a completion predictor offering files whose
+// name ends in one of the given extensions (each without a leading dot, e.g.
+// "yml"), plus directories for navigation, each offered exactly once.
+//
+// complete.PredictFiles feeds its pattern to filepath.Glob, whose
+// filepath.Match engine has no brace expansion, so a single "*.{yml,yaml}"
+// glob matches nothing (#340). Unioning one PredictFiles per extension
+// restores per-extension matching; the dedupe stops a directory (which every
+// sub-predictor lists) from being offered once per extension -- the library
+// prints every option without deduping (posener/complete complete.go output).
+func predictFilesByExtension(extensions []string) complete.Predictor {
+	predictors := make([]complete.Predictor, 0, len(extensions))
+	for _, ext := range extensions {
+		predictors = append(predictors, complete.PredictFiles("*."+ext))
+	}
+	return complete.PredictFunc(func(a complete.Args) []string {
+		seen := make(map[string]bool)
+		var matches []string
+		for _, p := range predictors {
+			for _, match := range p.Predict(a) {
+				if seen[match] {
+					continue
+				}
+				seen[match] = true
+				matches = append(matches, match)
+			}
+		}
+		return matches
+	})
+}
+
+// taskFileAutocomplete is the file-completion predictor shared by the
+// --tasks / --output / --vars-output flags and `docket fmt`'s positional
+// argument across apply / plan / validate / fmt / init / export.
+func taskFileAutocomplete() complete.Predictor {
+	return predictFilesByExtension(taskFileExtensions)
+}

--- a/commands/task_file_test.go
+++ b/commands/task_file_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/posener/complete"
 )
 
 func TestDetectTaskFileFormat(t *testing.T) {
@@ -171,6 +173,87 @@ func TestResolveTaskFileFromArgsUsesExplicitFlag(t *testing.T) {
 	}
 	if format != taskFileFormatYAML {
 		t.Errorf("format = %q, want yaml", format)
+	}
+}
+
+// TestTaskFileAutocompleteMatchesRecipeExtensions guards #340: the previous
+// brace glob "*.{yml,yaml,json,json5}" matched no file through filepath.Glob,
+// so completion only ever offered directories. Every recipe extension must now
+// be offered, a non-recipe file must not, and a directory must appear once
+// (the dedupe, since each per-extension sub-predictor lists it).
+func TestTaskFileAutocompleteMatchesRecipeExtensions(t *testing.T) {
+	dir := t.TempDir()
+	recipes := []string{"tasks.yml", "config.yaml", "data.json", "recipe.json5"}
+	for _, name := range recipes {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("---\n"), 0o644); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed notes.txt: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+
+	withCwd(t, dir, func() {
+		counts := map[string]int{}
+		for _, match := range taskFileAutocomplete().Predict(complete.Args{Last: ""}) {
+			counts[match]++
+		}
+		for _, name := range recipes {
+			if counts[name] == 0 {
+				t.Errorf("expected %q to be offered, got %v", name, counts)
+			}
+		}
+		if counts["notes.txt"] != 0 {
+			t.Errorf("non-recipe notes.txt must not be offered, got %v", counts)
+		}
+		if counts["sub/"] != 1 {
+			t.Errorf("directory sub/ should be offered exactly once, got %d (%v)", counts["sub/"], counts)
+		}
+	})
+}
+
+// TestPredictFilesByExtension proves the completion mechanism is generic and
+// not hard-wired to the recipe extensions.
+func TestPredictFilesByExtension(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"readme.md", "todo.txt", "ignore.yml"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+
+	withCwd(t, dir, func() {
+		got := map[string]bool{}
+		for _, match := range predictFilesByExtension([]string{"md", "txt"}).Predict(complete.Args{Last: ""}) {
+			got[match] = true
+		}
+		if !got["readme.md"] {
+			t.Errorf("expected readme.md to be offered, got %v", got)
+		}
+		if !got["todo.txt"] {
+			t.Errorf("expected todo.txt to be offered, got %v", got)
+		}
+		if got["ignore.yml"] {
+			t.Errorf("ignore.yml must not be offered for extensions {md,txt}, got %v", got)
+		}
+	})
+}
+
+func TestHasTaskFileExtension(t *testing.T) {
+	yes := []string{"tasks.yml", "tasks.YAML", "path/to/c.json", "x.json5"}
+	no := []string{"notes.txt", "tasks", "archive.tar.gz", ""}
+	for _, p := range yes {
+		if !hasTaskFileExtension(p) {
+			t.Errorf("hasTaskFileExtension(%q) = false, want true", p)
+		}
+	}
+	for _, p := range no {
+		if hasTaskFileExtension(p) {
+			t.Errorf("hasTaskFileExtension(%q) = true, want false", p)
+		}
 	}
 }
 

--- a/commands/validate.go
+++ b/commands/validate.go
@@ -93,7 +93,7 @@ func (c *ValidateCommand) AutocompleteFlags() complete.Flags {
 	return command.MergeAutocompleteFlags(
 		c.Meta.AutocompleteFlags(command.FlagSetClient),
 		complete.Flags{
-			"--tasks":         complete.PredictFiles(taskFileAutocompleteGlob),
+			"--tasks":         taskFileAutocomplete(),
 			"--json":          complete.PredictNothing,
 			"--strict":        complete.PredictNothing,
 			"--vars-file":     complete.PredictFiles("*"),

--- a/tests/bats/completion.bats
+++ b/tests/bats/completion.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+#
+# Shell-completion regression tests for #340. docket enables autocompletion by
+# default (mitchellh/cli NewCLI sets Autocomplete: true) and satisfies the shell
+# completion protocol when COMP_LINE is set, so completing a recipe-file flag or
+# argument runs the real predictor. The previous brace glob
+# "*.{yml,yaml,json,json5}" matched no file through Go's filepath.Glob, so only
+# directories were ever offered; these tests assert real recipe files come back.
+#
+# COMP_POINT is intentionally omitted: posener/complete falls back to the end of
+# COMP_LINE, so the trailing space makes the word being completed empty and every
+# candidate file matches.
+
+load test_helper
+
+setup() {
+  docket_build
+}
+
+@test "docket apply --tasks completes recipe files but not other files (#340)" {
+  cd "$BATS_TEST_TMPDIR"
+  : >tasks.yml
+  : >config.yaml
+  : >data.json
+  : >recipe.json5
+  : >notes.txt
+  export COMP_LINE='docket apply --tasks '
+  run "$(docket_bin)" apply --tasks
+  assert_success
+  assert_output --partial 'tasks.yml'
+  assert_output --partial 'config.yaml'
+  assert_output --partial 'data.json'
+  assert_output --partial 'recipe.json5'
+  refute_output --partial 'notes.txt'
+}
+
+@test "docket fmt completes recipe files positionally (#340)" {
+  cd "$BATS_TEST_TMPDIR"
+  : >tasks.yml
+  : >notes.txt
+  export COMP_LINE='docket fmt '
+  run "$(docket_bin)" fmt
+  assert_success
+  assert_output --partial 'tasks.yml'
+  refute_output --partial 'notes.txt'
+}


### PR DESCRIPTION
The shared file-completion glob used brace syntax that Go's `filepath.Glob` does not expand, so `--tasks`, `--output`, `--vars-output`, and `docket fmt` completion matched no recipe file and offered only directories.

Fixes #340.