### PR TITLE
fix: mark in-place storage mount drift as a modify

### DIFF
--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -188,6 +188,10 @@ func (t StorageMountTask) Plan() PlanResult {
 			}
 			var args []string
 			reason := "mount missing"
+			// A brand-new attachment is a create; drift on an existing one
+			// is an in-place modify, matching the create-vs-modify split in
+			// sibling tasks such as service_expose.
+			status := PlanStatusCreate
 			if existing == nil {
 				args = t.mountArgs()
 			} else {
@@ -197,11 +201,12 @@ func (t StorageMountTask) Plan() PlanResult {
 				// exists." (dokku/dokku#8713 kept that contract).
 				args = t.namedMountArgs(existing.EntryName)
 				reason = fmt.Sprintf("volume_options drift (have %q, want %q)", existing.VolumeOptions, t.VolumeOptions)
+				status = PlanStatusModify
 			}
 			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
 			return PlanResult{
 				InSync:    false,
-				Status:    PlanStatusCreate,
+				Status:    status,
 				Reason:    reason,
 				Mutations: []string{fmt.Sprintf("mount %s on %s", t.describeMount(), t.App)},
 				Commands:  resolveCommands(inputs),

--- a/tasks/storage_mount_task_integration_test.go
+++ b/tasks/storage_mount_task_integration_test.go
@@ -179,12 +179,16 @@ func TestIntegrationStorageMountVolumeOptions(t *testing.T) {
 		t.Error("expected changed=false for unchanged legacy mount with options")
 	}
 
-	// dropping volume_options should surface as drift
+	// dropping volume_options should surface as drift on the existing mount,
+	// which the plan must render as an in-place modify (~), not a create (+).
 	withoutOpts := StorageMountTask{
 		App:          appName,
 		HostDir:      hostDir,
 		ContainerDir: containerDir,
 		State:        StatePresent,
+	}
+	if plan := withoutOpts.Plan(); plan.Status != PlanStatusModify {
+		t.Errorf("expected Modify status for volume_options drift on an existing mount, got %q (reason %q)", plan.Status, plan.Reason)
 	}
 	result = withoutOpts.Execute()
 	if result.Error != nil {

--- a/tasks/storage_mount_task_test.go
+++ b/tasks/storage_mount_task_test.go
@@ -392,6 +392,69 @@ func TestStorageMountPlanFindsRunOnlyMount(t *testing.T) {
 	}
 }
 
+func TestStorageMountPlanVolumeOptionsDriftReportsModify(t *testing.T) {
+	// An attachment already exists and only volume_options drifted: the plan
+	// remediates it in place, so it must render the modify marker (~), not the
+	// create marker (+). Regression guard for the hardcoded PlanStatusCreate.
+	report := `{
+		"attachment.1.entry-name": "data",
+		"attachment.1.host-path": "/h/data",
+		"attachment.1.container-path": "/app/storage",
+		"attachment.1.phases": "deploy,run",
+		"attachment.1.volume-options": "Z",
+		"attachment.1.readonly": "false"
+	}`
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet storage:report node-js-app --format json": report,
+	}))()
+
+	task := StorageMountTask{
+		App:           "node-js-app",
+		EntryName:     "data",
+		ContainerDir:  "/app/storage",
+		VolumeOptions: "noexec,nosuid",
+		State:         StatePresent,
+	}
+	plan := task.Plan()
+	if plan.Error != nil {
+		t.Fatalf("Plan returned error: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Fatal("expected drift when volume_options differ on an existing mount")
+	}
+	if plan.Status != PlanStatusModify {
+		t.Errorf("expected Modify status for in-place volume_options drift, got %q", plan.Status)
+	}
+	if !strings.Contains(plan.Reason, "volume_options drift") {
+		t.Errorf("expected reason to mention volume_options drift, got %q", plan.Reason)
+	}
+}
+
+func TestStorageMountPlanMissingReportsCreate(t *testing.T) {
+	// No attachment matches the recipe, so the mount is brand new and must
+	// render the create marker (+). Pins the default create branch.
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet storage:report node-js-app --format json": "{}",
+	}))()
+
+	task := StorageMountTask{
+		App:          "node-js-app",
+		EntryName:    "data",
+		ContainerDir: "/app/storage",
+		State:        StatePresent,
+	}
+	plan := task.Plan()
+	if plan.Error != nil {
+		t.Fatalf("Plan returned error: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Fatal("expected drift when no attachment exists")
+	}
+	if plan.Status != PlanStatusCreate {
+		t.Errorf("expected Create status for a brand-new mount, got %q", plan.Status)
+	}
+}
+
 func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
The present-state planner hardcoded `PlanStatusCreate` even when an existing attachment was found and only `volume_options` drifted, so `docket plan` rendered the in-place remediation with the `+` create marker instead of the `~` modify marker. It now reports `PlanStatusModify` on the existing-attachment branch, matching sibling tasks such as `service_expose`. This affects only plan rendering; `apply` runs the same command and is unchanged.

Fixes #343.
