### PR TITLE
fix: accept a numeric chown uid in dokku_storage_ensure

### DIFF
--- a/docs/tasks/dokku_storage_ensure.md
+++ b/docs/tasks/dokku_storage_ensure.md
@@ -15,7 +15,7 @@ Not supported - deprecated; storage state is exported via dokku_storage_mount.
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | yes |  |  | Name of the app |
-| `chown` | string | no |  | heroku, herokuish, paketo, root, false | Chown value to set |
+| `chown` | string | no |  | heroku, herokuish, paketo, root, false | Chown value to set: an ownership preset or a numeric uid (0-65535) |
 | `state` | string | no | present | present, absent | Desired state of the storage |
 
 ## Examples

--- a/tasks/storage_ensure_task.go
+++ b/tasks/storage_ensure_task.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 
 	"github.com/dokku/docket/subprocess"
@@ -13,7 +14,7 @@ type StorageEnsureTask struct {
 	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// Chown is the chown value to set
-	Chown string `required:"false" yaml:"chown,omitempty" options:"heroku,herokuish,paketo,root,false" description:"Chown value to set"`
+	Chown string `required:"false" yaml:"chown,omitempty" options:"heroku,herokuish,paketo,root,false" description:"Chown value to set: an ownership preset or a numeric uid (0-65535)"`
 
 	// State is the desired state of the storage
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the storage"`
@@ -78,21 +79,35 @@ func (t StorageEnsureTask) Execute() TaskOutputState {
 
 // Validate checks the StorageEnsureTask's inputs without contacting the server.
 // chown is optional: an omitted value lets dokku apply its default (herokuish)
-// ownership. A non-empty value must name one of the ownership presets dokku's
-// storage:ensure-directory understands so a typo is caught before dispatch.
+// ownership. A non-empty value must be one dokku's storage:ensure-directory
+// accepts - a named ownership preset or a numeric uid in 0-65535 (see
+// validChown) - so a typo or out-of-range value is caught before dispatch.
 func (t StorageEnsureTask) Validate() error {
-	if t.State == StatePresent && t.Chown != "" {
-		chownValues := map[string]bool{
-			"heroku": true, "herokuish": true, "paketo": true, "root": true, "false": true,
-		}
-		if !chownValues[t.Chown] {
-			return errors.New("'chown' must be one of heroku, herokuish, paketo, root, false")
-		}
+	if t.State == StatePresent && t.Chown != "" && !validChown(t.Chown) {
+		return errors.New("'chown' must be one of heroku, herokuish, paketo, root, false or a numeric uid (0-65535)")
 	}
 	if t.State == StateAbsent {
 		return errors.New("the absent state is not supported for storage:ensure")
 	}
 	return nil
+}
+
+// validChown reports whether a chown value is one dokku's
+// storage:ensure-directory accepts: a named ownership preset or a raw
+// numeric uid. dokku's ResolveChownID maps the presets to uids and parses
+// a numeric value with strconv.ParseUint(value, 10, 16), so docket mirrors
+// that here - accepting a uid in 0-65535 - while still catching typos in
+// non-numeric values before dispatch. dokku's deprecated 'packeto' alias is
+// intentionally not accepted so the typo surfaces at validate time. The raw
+// string is validated with the same base-10 parser dokku applies to the
+// --chown argument, so docket's decision always matches dokku's runtime parse.
+func validChown(chown string) bool {
+	switch chown {
+	case "heroku", "herokuish", "paketo", "root", "false":
+		return true
+	}
+	_, err := strconv.ParseUint(chown, 10, 16)
+	return err == nil
 }
 
 // ensureArgs builds the storage:ensure-directory command arguments. The

--- a/tasks/storage_ensure_task_integration_test.go
+++ b/tasks/storage_ensure_task_integration_test.go
@@ -49,3 +49,27 @@ func TestIntegrationStorageEnsureOmittedChown(t *testing.T) {
 		t.Errorf("expected state 'present', got '%s'", result.State)
 	}
 }
+
+func TestIntegrationStorageEnsureNumericChown(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-storage-numeric-chown"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// A raw numeric uid is accepted by dokku (ownership set to <uid>:<uid>).
+	task := StorageEnsureTask{
+		App:   appName,
+		Chown: "32767",
+		State: StatePresent,
+	}
+	result := task.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to ensure storage with numeric chown: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+}

--- a/tasks/storage_ensure_task_test.go
+++ b/tasks/storage_ensure_task_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -13,23 +14,33 @@ func TestStorageEnsureTaskInvalidState(t *testing.T) {
 }
 
 func TestStorageEnsureValidChownValues(t *testing.T) {
-	validValues := []string{"heroku", "herokuish", "paketo", "root", "false"}
+	// The named ownership presets plus a raw numeric uid in dokku's supported
+	// range (0-65535) all pass validation, matching dokku's ResolveChownID.
+	validValues := []string{"heroku", "herokuish", "paketo", "root", "false", "0", "1000", "32767", "65535"}
 	for _, chown := range validValues {
 		task := StorageEnsureTask{App: "test-app", Chown: chown, State: StatePresent}
-		result := task.Execute()
-		// These will fail because dokku isn't running, but should NOT fail
-		// due to invalid chown value
-		if result.Error != nil && result.Error.Error() == "'chown' must be one of heroku, herokuish, paketo, root, false" {
-			t.Errorf("chown value %q should be valid but was rejected", chown)
+		if err := task.Validate(); err != nil {
+			t.Errorf("chown value %q should be valid but was rejected: %v", chown, err)
 		}
 	}
 }
 
 func TestStorageEnsureInvalidChownValue(t *testing.T) {
-	task := StorageEnsureTask{App: "test-app", Chown: "packeto", State: StatePresent}
-	result := task.Execute()
-	if result.Error == nil || result.Error.Error() != "'chown' must be one of heroku, herokuish, paketo, root, false" {
-		t.Errorf("chown value 'packeto' (misspelled) should be rejected as invalid")
+	// Non-preset, non-numeric values and out-of-range/malformed numbers are
+	// rejected before dispatch. 'packeto' is dokku's deprecated typo alias and
+	// is intentionally still rejected. 0x10/1_000 confirm the raw string (not a
+	// resolved integer) is validated with dokku's base-10 parser.
+	invalidValues := []string{"packeto", "65536", "70000", "-1", "+5", "1000:1000", "root:root", "0x10", "1_000", "abc"}
+	for _, chown := range invalidValues {
+		task := StorageEnsureTask{App: "test-app", Chown: chown, State: StatePresent}
+		err := task.Validate()
+		if err == nil {
+			t.Errorf("chown value %q should be rejected as invalid", chown)
+			continue
+		}
+		if !strings.Contains(err.Error(), "'chown' must be one of") {
+			t.Errorf("chown value %q: unexpected error message: %v", chown, err)
+		}
 	}
 }
 
@@ -52,6 +63,15 @@ func TestStorageEnsureChownCommandShape(t *testing.T) {
 	task := StorageEnsureTask{App: "node-js-app", Chown: "herokuish", State: StatePresent}
 	args := task.ensureArgs()
 	want := []string{"--quiet", "storage:ensure-directory", "--chown", "herokuish", "node-js-app"}
+	if !equalStrings(args, want) {
+		t.Errorf("ensureArgs mismatch:\n  got: %v\n want: %v", args, want)
+	}
+}
+
+func TestStorageEnsureNumericChownCommandShape(t *testing.T) {
+	task := StorageEnsureTask{App: "node-js-app", Chown: "1000", State: StatePresent}
+	args := task.ensureArgs()
+	want := []string{"--quiet", "storage:ensure-directory", "--chown", "1000", "node-js-app"}
 	if !equalStrings(args, want) {
 		t.Errorf("ensureArgs mismatch:\n  got: %v\n want: %v", args, want)
 	}

--- a/tasks/storage_entry_task_integration_test.go
+++ b/tasks/storage_entry_task_integration_test.go
@@ -55,3 +55,28 @@ func TestIntegrationStorageEntry(t *testing.T) {
 		t.Error("expected changed=false for already-absent entry")
 	}
 }
+
+func TestIntegrationStorageEntryNumericChown(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	name := "docket-test-entry-numeric-chown"
+
+	// Start clean, then create with a raw numeric uid. The sibling
+	// dokku_storage_entry passes chown through unrestricted, so numeric uids
+	// already work here (unlike the historically narrower dokku_storage_ensure).
+	destroy := StorageEntryTask{Name: name, State: StateAbsent}
+	destroy.Execute()
+	defer destroy.Execute()
+
+	create := StorageEntryTask{Name: name, Chown: "32767", State: StatePresent}
+	result := create.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to create entry with numeric chown: %v", result.Error)
+	}
+	if result.State != StatePresent {
+		t.Errorf("expected state 'present', got '%s'", result.State)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for new entry")
+	}
+}

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -598,6 +598,22 @@ func TestValidateStorageEnsureInvalidChown(t *testing.T) {
 	}
 }
 
+func TestValidateStorageEnsureNumericChownValid(t *testing.T) {
+	// dokku's storage:ensure-directory --chown also accepts a raw numeric uid.
+	// The value is written unquoted, so this also proves the YAML integer scalar
+	// decodes into the string chown field (as the raw "1000") before validation.
+	data := []byte(`---
+- tasks:
+    - dokku_storage_ensure:
+        app: node-js-app
+        chown: 1000
+`)
+	problems := Validate(data, ValidateOptions{})
+	if n := countProblems(problems, "invalid_task_input"); n != 0 {
+		t.Errorf("expected no invalid_task_input for a numeric chown, got %d: %+v", n, problems)
+	}
+}
+
 func TestValidateInvalidTaskInputSkippedWhenRequiredMissing(t *testing.T) {
 	// When a required field is missing, only missing_required_field is
 	// reported; the conditional Validate() check (which depends on that


### PR DESCRIPTION
dokku's storage:ensure-directory --chown also accepts a raw numeric uid, but the task rejected anything outside the named ownership presets, making it narrower than dokku and its siblings dokku_storage_entry and dokku_storage_mount. Validation now mirrors dokku's ResolveChownID by accepting the presets or a uid in 0-65535 while still rejecting typos and out-of-range values before dispatch.

Closes #396
