### PR TITLE
Fix for code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/tasks/json5_dup.go
+++ b/tasks/json5_dup.go
@@ -240,7 +240,7 @@ func (s *json5Scanner) readString() string {
 				// line continuation: the newline is elided
 			case 'u':
 				if s.pos+4 <= len(s.data) {
-					if r, err := strconv.ParseUint(string(s.data[s.pos:s.pos+4]), 16, 32); err == nil {
+					if r, err := strconv.ParseInt(string(s.data[s.pos:s.pos+4]), 16, 32); err == nil {
 						for i := 0; i < 4; i++ {
 							s.advance()
 						}


### PR DESCRIPTION
Potential fix for [https://github.com/dokku/docket/security/code-scanning/2](https://github.com/dokku/docket/security/code-scanning/2)

The safest no-functional-change fix is to parse directly into a signed 32-bit integer and convert that to `rune`, instead of parsing unsigned then narrowing.  
Specifically in `tasks/json5_dup.go`, inside `readString()` at the `case 'u':` block:

- Replace `strconv.ParseUint(..., 16, 32)` with `strconv.ParseInt(..., 16, 32)`.
- Keep the existing `if err == nil` flow and character consumption logic unchanged.
- Convert using `rune(r)` where `r` is now `int64`, which is a signed-to-signed narrowing to `int32` under a 32-bit parse bound and satisfies the CodeQL concern raised for unsigned-to-int32 conversion.

No new imports or helper methods are needed; `strconv` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
