### PR TITLE
fix: guard make() capacity against integer overflow

### DIFF
--- a/commands/capacity.go
+++ b/commands/capacity.go
@@ -1,0 +1,18 @@
+package commands
+
+import "math"
+
+// safeCap returns base+extra for use as a make() capacity hint while guarding
+// the addition against signed-integer overflow. Callers pass lengths of
+// in-memory collections, which are non-negative and far below math.MaxInt, so
+// the guard never trips at runtime; it exists so the capacity arithmetic is
+// provably non-overflowing (resolving CodeQL go/allocation-size-overflow) and
+// degrades to a valid hint instead of wrapping negative on pathological input.
+// On the unreachable overflow it returns base, itself a valid length, so
+// make() still receives a sane hint and grows as needed.
+func safeCap(base, extra int) int {
+	if extra < 0 || base > math.MaxInt-extra {
+		return base
+	}
+	return base + extra
+}

--- a/commands/capacity_test.go
+++ b/commands/capacity_test.go
@@ -1,0 +1,29 @@
+package commands
+
+import (
+	"math"
+	"testing"
+)
+
+func TestSafeCap(t *testing.T) {
+	cases := []struct {
+		name  string
+		base  int
+		extra int
+		want  int
+	}{
+		{"both zero", 0, 0, 0},
+		{"small sum", 3, 4, 7},
+		{"zero extra", 5, 0, 5},
+		{"boundary sum", math.MaxInt - 1, 1, math.MaxInt},
+		{"overflow returns base", math.MaxInt, 4, math.MaxInt},
+		{"negative extra returns base", 5, -1, 5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := safeCap(tc.base, tc.extra); got != tc.want {
+				t.Errorf("safeCap(%d, %d) = %d, want %d", tc.base, tc.extra, got, tc.want)
+			}
+		})
+	}
+}

--- a/commands/envelope_context.go
+++ b/commands/envelope_context.go
@@ -45,7 +45,7 @@ func envelopeExprContext(
 	if !hasLoopVars && !hasResult && !hasRegistered && !hasFailedTask {
 		return base
 	}
-	out := make(map[string]interface{}, len(base)+4)
+	out := make(map[string]interface{}, safeCap(len(base), 4))
 	for k, v := range base {
 		out[k] = v
 	}

--- a/tasks/capacity.go
+++ b/tasks/capacity.go
@@ -1,0 +1,18 @@
+package tasks
+
+import "math"
+
+// safeCap returns base+extra for use as a make() capacity hint while guarding
+// the addition against signed-integer overflow. Callers pass lengths of
+// in-memory collections, which are non-negative and far below math.MaxInt, so
+// the guard never trips at runtime; it exists so the capacity arithmetic is
+// provably non-overflowing (resolving CodeQL go/allocation-size-overflow) and
+// degrades to a valid hint instead of wrapping negative on pathological input.
+// On the unreachable overflow it returns base, itself a valid length, so
+// make() still receives a sane hint and grows as needed.
+func safeCap(base, extra int) int {
+	if extra < 0 || base > math.MaxInt-extra {
+		return base
+	}
+	return base + extra
+}

--- a/tasks/capacity_test.go
+++ b/tasks/capacity_test.go
@@ -1,0 +1,50 @@
+package tasks
+
+import (
+	"math"
+	"testing"
+)
+
+func TestSafeCap(t *testing.T) {
+	cases := []struct {
+		name  string
+		base  int
+		extra int
+		want  int
+	}{
+		{"both zero", 0, 0, 0},
+		{"small sum", 3, 4, 7},
+		{"zero extra", 5, 0, 5},
+		{"doubling shape", 6, 6, 12},
+		{"boundary sum", math.MaxInt - 1, 1, math.MaxInt},
+		{"overflow returns base", math.MaxInt, 1, math.MaxInt},
+		{"huge extra returns base", 10, math.MaxInt, 10},
+		{"negative extra returns base", 5, -1, 5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := safeCap(tc.base, tc.extra); got != tc.want {
+				t.Errorf("safeCap(%d, %d) = %d, want %d", tc.base, tc.extra, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSafeCapAllocates ensures the returned hint is a legal make() capacity
+// for realistic and boundary inputs.
+func TestSafeCapAllocates(t *testing.T) {
+	for _, base := range []int{0, 8, 1024} {
+		s := make([]int, 0, safeCap(base, 2))
+		if cap(s) < base {
+			t.Errorf("cap(make with safeCap(%d, 2)) = %d, want >= %d", base, cap(s), base)
+		}
+	}
+	// The unreachable-overflow branch must still yield an allocatable hint.
+	if got := safeCap(math.MaxInt, 4); got != math.MaxInt {
+		t.Fatalf("safeCap(MaxInt, 4) = %d, want MaxInt", got)
+	}
+	m := make(map[string]int, safeCap(0, 4))
+	if len(m) != 0 {
+		t.Errorf("new map should be empty, got len %d", len(m))
+	}
+}

--- a/tasks/format.go
+++ b/tasks/format.go
@@ -150,7 +150,7 @@ func reorderMapping(node *yaml.Node, priority []string) {
 		return
 	}
 	pairs := mappingPairs(node)
-	out := make([]*yaml.Node, 0, len(pairs)*2)
+	out := make([]*yaml.Node, 0, safeCap(len(pairs), len(pairs)))
 	used := make(map[int]bool, len(pairs))
 
 	for _, key := range priority {
@@ -182,7 +182,7 @@ func reorderTaskEnvelope(node *yaml.Node) {
 		return
 	}
 	pairs := mappingPairs(node)
-	out := make([]*yaml.Node, 0, len(pairs)*2)
+	out := make([]*yaml.Node, 0, safeCap(len(pairs), len(pairs)))
 	used := make(map[int]bool, len(pairs))
 
 	for _, key := range canonicalEnvelopeKeys {
@@ -345,7 +345,7 @@ func spliceSeparatorBlank(out []string, dashIndent int) []string {
 	for at > 0 && isCommentAtColumn(out[at-1], dashIndent) {
 		at--
 	}
-	res := make([]string, 0, len(out)+1)
+	res := make([]string, 0, safeCap(len(out), 1))
 	res = append(res, out[:at]...)
 	res = append(res, "")
 	res = append(res, out[at:]...)

--- a/tasks/loop.go
+++ b/tasks/loop.go
@@ -41,7 +41,7 @@ func expandLoop(base *TaskEnvelope, bodyBytes []byte, typeKey string, sigilConte
 	names := loopExpansionNames(base.Name, items)
 	out := make([]*TaskEnvelope, 0, len(items))
 	for i, item := range items {
-		iterCtx := make(map[string]interface{}, len(sigilContext)+2)
+		iterCtx := make(map[string]interface{}, safeCap(len(sigilContext), 2))
 		for k, v := range sigilContext {
 			iterCtx[k] = v
 		}
@@ -114,7 +114,7 @@ func expandLoopGroup(base *TaskEnvelope, blockNode, rescueNode, alwaysNode *yaml
 	names := loopExpansionNames(base.Name, items)
 	out := make([]*TaskEnvelope, 0, len(items))
 	for i, item := range items {
-		iterCtx := make(map[string]interface{}, len(sigilContext)+2)
+		iterCtx := make(map[string]interface{}, safeCap(len(sigilContext), 2))
 		for k, v := range sigilContext {
 			iterCtx[k] = v
 		}

--- a/tasks/main.go
+++ b/tasks/main.go
@@ -749,7 +749,7 @@ func renderRecipeBytes(data []byte, context map[string]interface{}) ([]byte, err
 // per-play context the loader used so per-task `when:` predicates see
 // the same values as the rendered task bodies.
 func BuildPerPlayContext(base map[string]interface{}, playInputs []Input, userSet map[string]bool) map[string]interface{} {
-	out := make(map[string]interface{}, len(base)+len(playInputs))
+	out := make(map[string]interface{}, safeCap(len(base), len(playInputs)))
 	for k, v := range base {
 		out[k] = v
 	}


### PR DESCRIPTION
CodeQL's `go/allocation-size-overflow` query opened five high-severity alerts (3-7) against `make()` calls whose capacity hint adds a small constant to, or doubles, the length of an in-memory collection - patterns like `len(base)+4` and `len(pairs)*2`. Because those lengths are bounded by available memory they cannot approach `math.MaxInt`, so the overflow is unreachable in practice, but CodeQL cannot prove that and the warnings recur on every scan.

Each capacity computation now goes through a small `safeCap` helper that returns the sum unless it would overflow, in which case it falls back to the base length, so the hint is unchanged for every realistic input while the arithmetic is provably non-overflowing. The same idiom in `tasks/format.go` that CodeQL had not yet flagged is folded in so the treatment stays consistent.

Resolves code scanning alerts 3-7.