### PR TITLE
docs: add plan/apply and idempotency comparison pages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,3 +21,7 @@ Complete documentation for docket, a declarative way to pre-package and ship app
 - [JSON output](json-output.md) -- the `--json` event schema for `apply` and `plan`
 - [Writing tasks](writing-tasks.md) -- contribute a new task type
 - [Roadmap](roadmap.md) -- ideas for where docket could go next
+
+## Comparisons
+
+- [Comparisons](comparisons/README.md) -- how docket's plan/apply and idempotency compare to Terraform/OpenTofu, Ansible, Kubernetes, and other tools

--- a/docs/comparisons/README.md
+++ b/docs/comparisons/README.md
@@ -1,0 +1,29 @@
+# Comparisons
+
+Neutral, reference-backed comparisons of how docket handles plan/apply and idempotency next to other
+infrastructure-as-code and configuration-management tools. Each page states what each tool does and the
+trade-off - not which is better - cites primary sources inline, and traces every docket claim back to
+the reference docs.
+
+The pages are ordered from the tools closest to docket to the ones furthest from it:
+
+- [docket vs the dokku CLI](dokku-cli.md) -- a declarative front-end over the same `dokku`
+  commands docket already runs, adding a recipe, a plan, and idempotency.
+- [docket vs Ansible](ansible.md) -- docket's direct ancestor; idempotency enforced by
+  construction and a guaranteed-consistent plan/apply instead of per-module check mode.
+- [docket vs Chef, Puppet, and SaltStack](config-management.md) -- the rest of the
+  configuration-management idempotency family, agentless single binary versus server-plus-agent systems.
+- [docket vs Terraform / OpenTofu](terraform.md) -- a stateless live probe versus a persisted
+  state file, and everything that follows from that one decision.
+- [docket vs Kamal](kamal.md) -- desired-state convergence versus an imperative deploy
+  pipeline, both agentless over SSH.
+- [docket vs Docker Compose](docker-compose.md) -- a per-task probe versus recreate-on-diff,
+  and where Compose's project-scoped pruning sits between docket and Terraform.
+- [docket vs Kubernetes (kubectl apply and GitOps)](kubernetes.md) -- a one-shot converge
+  versus continuous reconciliation with Argo CD or Flux.
+
+## See also
+
+- [Getting started](../getting-started.md) -- why docket, and the plan/apply model these pages build on
+- [Command reference](../command-reference.md) -- `plan`, `apply`, and `--detailed-exitcode`
+- [Writing tasks](../writing-tasks.md) -- the `Plan()` / `Execute()` model that makes docket idempotent

--- a/docs/comparisons/ansible.md
+++ b/docs/comparisons/ansible.md
@@ -1,0 +1,165 @@
+# plan/apply and idempotency: docket vs Ansible
+
+docket and Ansible are close relatives, so this comparison reads differently from the one against
+Terraform/OpenTofu. docket grew out of [`ansible-dokku`](https://github.com/dokku/ansible-dokku) and
+exposes the same modules, so its task names look familiar and existing `ansible-dokku` task lists
+migrate with minimal changes [^6][^10]. The task envelope - `when`, `loop`, `register`, `changed_when`,
+`failed_when`, `ignore_errors`, `block`/`rescue`/`always`, `tags` - is taken almost verbatim from
+Ansible [^5][^13], as is the `--start-at-task` flag [^11]. On the axes where docket looks unusual next
+to Terraform (no state file, assertion-based deletion, ordered execution), it simply agrees with
+Ansible.
+
+Ansible and docket also share the same definition of the property in question. Ansible's glossary:
+"an operation is idempotent if the result of performing it once is exactly the same as the result of
+performing it repeatedly without any intervening actions" [^1]. And they share the same mechanism for
+achieving it - each unit of work reads the live target and only acts if the state does not already
+match. Neither keeps a persisted state file.
+
+So the interesting question is not *whether* docket and Ansible differ on idempotency but *where docket
+tightens the Ansible model*. Three places stand out: idempotency is enforced by construction rather than
+left to module discipline; `plan` and `apply` are one guaranteed-consistent pair rather than a
+per-module check mode; and the whole thing ships as a single Go binary scoped to Dokku instead of a
+general-purpose Python control node. This document is neutral - Ansible's generality and docket's focus
+serve different jobs - and it treats the two together where they agree.
+
+## At a glance
+
+| Dimension | docket | Ansible |
+|-----------|--------|---------|
+| Idempotency check | equality of desired vs current, per task [^14] | equality of desired vs current, per module [^1][^2] |
+| Who guarantees it | the framework: every task is a probe-then-maybe-apply `Plan()` [^14] | the module author; "not all ... modules behave this way" [^2] |
+| Persistent state | none [^14] | none [^2] |
+| Source of "current state" | live per-task probe, every run [^14] | live per-module check, every run [^2] |
+| Dry run | `plan` and `apply` share one `Plan()`; universal [^14] | check mode, per-module; unsupported modules "report nothing and do nothing" [^3] |
+| Deleting a resource removed from the file | not deleted; explicit `state: absent` [^14] | not deleted; explicit `state: absent` |
+| Execution model | ordered plays then tasks, single target [^12] | ordered plays then tasks, across an inventory [^2] |
+| Task envelope | `when`/`loop`/`register`/`changed_when`/`failed_when`/`ignore_errors`/`block`/`rescue`/`always` [^13] | the same keys; docket's source [^5][^13] |
+| Templating | sigil `{{ .app }}` bodies, expr predicates [^13] | Jinja2 `{{ }}` throughout [^8] |
+| Runtime and scope | single Go binary, Dokku only [^10] | Python control node + inventory, general purpose |
+
+## Idempotency mechanism
+
+Ansible and docket both converge by having each unit of work check the live target and skip when it
+already matches. Ansible states it plainly: "most Ansible modules check whether the desired final state
+has already been achieved and exit without performing any actions if that state has been achieved ...
+modules that behave this way are 'idempotent'" [^2]. The important qualifier is the next sentence:
+"whether you run a playbook once or multiple times, the outcome should be the same. However, not all
+playbooks and not all modules behave this way" [^2]. Idempotency in Ansible is a per-module convention,
+not a framework guarantee. The classic exception is the `command` module (and `shell`), which runs its
+command on every pass unless you guard it - with `creates`/`removes` so a matching file means "this
+step will not be run", or with `changed_when`/`when` [^4].
+
+docket removes the discretion. Every task implements a `Plan()` that probes the live server once,
+computes current versus desired, and either reports it is in sync (and does nothing) or returns a
+closure that performs the mutation; `apply` is defined as executing that plan [^14]. Idempotency is a
+property of the task model itself rather than of how carefully each task was written. There is no
+general "run this arbitrary command" task acting as an unguarded escape hatch. The escape hatches that
+remain are narrow and documented: a few tasks cannot read their own state (notably `dokku_git_auth`,
+`dokku_registry_auth`, and `dokku_storage_ensure`) and so always apply [^11], and some dynamic property
+families skip probing [^14] - the same "this module cannot honestly dry-run" situation Ansible has, but
+enumerated rather than open-ended.
+
+The practical difference: in Ansible "is this task idempotent?" is a question you ask per module and per
+author; in docket it is answered by the type of thing a task is.
+
+## Statelessness
+
+Both tools are stateless in the sense that matters here: neither keeps a persisted record of what it
+manages. Ansible determines what to do by having each module check the live target's current state [^2];
+docket does the same through each task's `Plan()` probe [^14]. This is the axis where docket looks
+nothing like Terraform/OpenTofu, whose state file exists precisely to "map real world resources to your
+configuration" [^9] - and exactly like Ansible.
+
+The shared consequences are the same ones the Ansible ecosystem lives with: no state file to store,
+lock, back up, or reconcile, and no way for a stored record to drift from reality; but also no built-in
+inventory of managed resources, and the cost of reading live state on every run. docket's `export` -
+reading a live server and writing a recipe that reapplies with no drift [^11] - is the nearest thing to
+a snapshot, and it is a command you invoke rather than a file the tool maintains.
+
+## plan/apply versus check mode
+
+This is where docket most clearly tightens the Ansible model. Ansible's dry run is check mode:
+"in check mode, Ansible runs without making any changes on remote systems" [^3]. But check mode inherits
+the same per-module discretion as idempotency: "modules that support check mode report the changes they
+would have made. Modules that do not support check mode report nothing and do nothing" [^3]. `--diff`
+similarly only reports for "any module that supports diff mode" [^3]. So an Ansible dry run is as complete
+as the modules in the play, and a play that leans on `command`/`shell` can dry-run as a no-op that tells
+you little.
+
+docket makes dry run structural. `plan` and `apply` call the *same* `Plan()` method - `apply` re-probes
+within its own run and reuses that read to decide whether to mutate - so the two cannot disagree and
+every task can be planned [^14]. The command strings `plan` says it *would* run and `apply` says it
+*did* run are rendered by identical code and are byte-identical [^15]. `plan` reports drift with `[ok]`,
+`[+]`, `[~]`, `[-]`, and `[!]` (probe error), and `docket plan --detailed-exitcode` returns 0 for no
+drift, 2 for drift, and 1 on error [^11]. Where Ansible offers a per-module preview, docket offers a
+whole-recipe one with a matching exit-code contract for CI.
+
+## Deletion and assertion semantics
+
+Here docket and Ansible agree, and both differ from Terraform. In neither tool is the file a complete
+inventory whose members get pruned. Each task or module is an *assertion* about one resource, and
+removing it from the file does nothing to the target. Deletion is requested explicitly, with the same
+idiom in both: `state: absent` [^14]. The upside is that you cannot destroy something by deleting or
+forgetting a block; the downside is that neither tool cleans up orphans for you - anything you want gone
+must be named with `state: absent`.
+
+## Execution model
+
+Both run in source order with no dependency graph. Ansible: "a playbook runs in order from top to
+bottom. Within each play, tasks also run in order from top to bottom" [^2]. docket keeps the same play
+then task ordering it inherited, with `loop:` expanding a task over a list and `register:` passing one
+task's result to a later task's condition [^13]. Neither derives an order from resource references the
+way Terraform's graph does; you write the order.
+
+The difference is the target axis. An Ansible play targets an inventory of managed nodes and runs each
+task across all of them, using forks as its concurrency model, so one task fans out over many hosts
+[^7]. docket drives a single Dokku target - the local CLI or one host over SSH - so its ordering is
+purely the task sequence, with no host fan-out [^16]. Ansible's parallelism is across hosts; docket has
+none to speak of.
+
+## The task envelope and templating
+
+docket's error handling and flow control are Ansible's, deliberately. Ansible defines `ignore_errors` to
+"continue despite of the failure", `failed_when` to "define what 'failure' means in each task",
+`changed_when` to "define when a particular task has 'changed' a remote node", and blocks to "define
+responses to task errors" via `rescue`/`always` [^5]. docket carries the same keys with the same meanings:
+`failed_when` as the "this exit code is fine" idiom that makes an imperative call idempotent,
+`changed_when` to rewrite the changed verdict, `ignore_errors` to continue past an error, and
+`block`/`rescue`/`always` as try/catch/finally over a group [^13], plus `--start-at-task` to resume and
+`--fail-fast` to widen the abort scope [^11]. If you know Ansible's envelope, you know docket's.
+
+Templating is the one surface that looks similar but is engineered differently. Ansible uses Jinja2 for
+both interpolation and conditionals [^8]. docket splits the two: task bodies use sigil templates
+(`{{ .app }}`) and envelope predicates use the expr language (`app == "api"`), kept in separate places
+so they are not confused [^13]. The `{{ }}` shape is familiar from Ansible, but the engines and the
+split are docket's own, and docket pairs them with offline typed validation (`docket validate`) and a
+canonical formatter (`docket fmt`) - checks that in the Ansible world live in separate tools like
+`ansible-lint` rather than in the core run [^11].
+
+## Runtime and scope
+
+The last difference is operational rather than conceptual. Ansible is a general-purpose automation
+engine: a Python control node, an inventory, connection plumbing, and a large module ecosystem that can
+manage almost any host. docket is a single Go binary with no Ansible installation required [^10], scoped
+to one job - declaring the state of a Dokku app - driving the local `dokku` CLI or one server over SSH
+[^16]. It trades Ansible's breadth for a focused tool with typed tasks, a real plan/apply, and offline
+validation, while keeping the parts of Ansible - the envelope, statelessness, assertion semantics,
+ordered execution - that already fit the job [^13][^14]. For an existing `ansible-dokku` user, that is
+the migration story: the same task vocabulary, minus the Ansible runtime, plus a plan.
+
+[^1]: Ansible, "Glossary" (idempotency definition) - https://docs.ansible.com/projects/ansible/latest/reference_appendices/glossary.html
+[^2]: Ansible, "Ansible playbooks" (ordered execution, idempotency as a module property) - https://docs.ansible.com/projects/ansible/latest/playbook_guide/playbooks_intro.html
+[^3]: Ansible, "Validating tasks: check mode and diff mode" - https://docs.ansible.com/projects/ansible/latest/playbook_guide/playbooks_checkmode.html
+[^4]: Ansible, "ansible.builtin.command module" (`creates`/`removes` guards) - https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/command_module.html
+[^5]: Ansible, "Error handling in playbooks" - https://docs.ansible.com/projects/ansible/latest/playbook_guide/playbooks_error_handling.html
+[^6]: `ansible-dokku` (docket's direct ancestor) - https://github.com/dokku/ansible-dokku
+[^7]: Ansible, "Controlling playbook execution: strategies and more" (forks, per-task host fan-out) - https://docs.ansible.com/projects/ansible/latest/playbook_guide/playbooks_strategies.html
+[^8]: Ansible, "Templating (Jinja2)" - https://docs.ansible.com/projects/ansible/latest/playbook_guide/playbooks_templating.html
+[^9]: HashiCorp, "State" - https://developer.hashicorp.com/terraform/language/state
+[^10]: docket, "Getting started" (`ansible-dokku` lineage, single binary) - [docs/getting-started.md](../getting-started.md)
+[^11]: docket, "Command reference" (`plan`, `apply`, drift markers, `--detailed-exitcode`, `validate`, `fmt`, `export`) - [docs/command-reference.md](../command-reference.md)
+[^12]: docket, "Recipes" (plays, tasks, and ordering) - [docs/recipes.md](../recipes.md)
+[^13]: docket, "Task envelope" (`when`, `loop`, `register`, error handling, templating split) - [docs/task-envelope.md](../task-envelope.md)
+[^14]: docket, "Writing tasks" (the `Plan()` / probe model) - [docs/writing-tasks.md](../writing-tasks.md)
+[^15]: docket, "JSON output" (the `commands` arrays and their shared rendering) - [docs/json-output.md](../json-output.md)
+[^16]: docket, "Remote execution" (one host over SSH) - [docs/remote-execution.md](../remote-execution.md)

--- a/docs/comparisons/config-management.md
+++ b/docs/comparisons/config-management.md
@@ -1,0 +1,173 @@
+# plan/apply and idempotency: docket vs Chef, Puppet, and SaltStack
+
+Chef, Puppet, and SaltStack are the general-purpose configuration-management systems in the same
+idempotency lineage as Ansible - and therefore as docket, which grew out of `ansible-dokku`. Ansible
+gets its own comparison in [`ansible.md`](ansible.md); this document covers the
+other three together, because they share a model and differ from docket in the same ways. All three
+converge by resource-level idempotency: a manifest, recipe, or state file declares resources, each
+resource type checks the node's current state, and it acts only when current and desired differ [^2][^6].
+docket rests on the same idea, one task at a time [^12].
+
+Because the shared premise is identical, the interesting question is again *where docket tightens the
+model* rather than whether it disagrees. Three differences stand out, and they are the same three that
+set docket apart from Ansible. First, idempotency is enforced by construction: every docket task is a
+probe-then-maybe-apply `Plan()`, rather than a convention each resource-type author must uphold [^12].
+Second, dry run is a guaranteed-consistent `plan`/`apply` pair built from that same `Plan()` [^12],
+rather than a tool-specific preview mode - Puppet `--noop` [^2], Salt `test=True` [^6], Chef
+`--why-run` [^4] - whose fidelity varies by resource, most sharply in Chef, where the vendor itself
+calls why-run "by definition incomplete" [^5]. Third, docket is an agentless single Go binary scoped to
+Dokku [^16], rather than a server-plus-agent system (Puppet primary/agent, Chef server/client, Salt
+master/minion) with masterless fallbacks [^4][^9][^10][^11].
+
+This is a neutral comparison. These three are broad systems that manage almost any resource on almost
+any host; docket manages one thing, a Dokku app, and trades breadth for a focused tool with typed
+tasks, a real plan, and offline validation. Where they behave alike - resource idempotency, reconverge
+from live state each run, explicit deletion - the document says so.
+
+## At a glance
+
+| Dimension | docket | Chef / Puppet / Salt |
+|-----------|--------|----------------------|
+| Idempotency check | equality of desired vs current, per task [^12] | resource-level convergence: each resource/state type checks current vs desired [^2][^6] |
+| Who guarantees it | the framework: every task is a probe-then-maybe-apply `Plan()` [^12] | the resource-type author, per type; fidelity varies |
+| Persistent prior-state file | none [^12] | none in the Terraform sense; each run reconverges from live state [^2][^6] |
+| Dry run | `plan` and `apply` share one `Plan()`; universal, byte-identical [^12][^17] | Puppet `--noop` [^2], Salt `test=True` [^6], Chef `--why-run` - "by definition incomplete" [^4][^5] |
+| Deleting a resource removed from the file | not deleted; explicit `state: absent` [^12] | explicit `ensure => absent` per resource; Puppet adds optional `purge` to prune unmanaged [^3] |
+| Execution model | ordered plays then tasks [^14] | Puppet relationship graph (manifest order + relationships/autorequire) [^1]; Salt deterministic SLS order + requisites [^7]; Chef recipe order [^8] |
+| Architecture | agentless single binary, one target [^16][^18] | typically server + agent pull (Puppet primary/agent, Chef server/client, Salt master/minion); masterless variants exist [^4][^9][^10][^11] |
+| Authoring | YAML/JSON5 recipes, sigil `{{ }}` + expr [^14][^15] | Puppet DSL; Chef Ruby recipes; Salt YAML + Jinja |
+| Scope and runtime | Dokku only, Go binary [^16] | general-purpose configuration management |
+
+## Idempotency mechanism
+
+All three systems converge the same way docket does: each unit of desired state carries the logic to
+inspect the node and skip when it already matches. In Puppet a resource is applied only when it is not
+already in sync - the `noop` metaparameter makes this explicit: Puppet "checks whether the resource is
+in the desired state as declared in the catalog" and, if it is not, "takes no action, but reports the
+changes it would have made" [^2]. Salt reports a state as changed or already-satisfied per state
+function, and its test mode surfaces exactly the states "that will be applied" [^6]. Chef's model is a
+two-phase compile-then-converge over a resource collection, where each resource's provider decides
+whether action is needed [^8]. In every case idempotency is a property each resource type must
+implement correctly, and its quality varies across the ecosystem - the same per-unit convention Ansible
+has.
+
+docket removes the discretion in the same way it does versus Ansible: every task implements a `Plan()`
+that probes the live server once, computes current versus desired, and either reports it is in sync (and
+does nothing) or returns a closure that performs the mutation, with `apply` defined as executing that
+plan [^12]. Idempotency is a property of the task model, not of how carefully each task was written, and
+the exceptions are narrow and documented - a few tasks that cannot read their own state and so always
+apply [^13]. The practical difference is the one that recurs throughout this family: in Chef, Puppet, and
+Salt "is this resource idempotent, and does it dry-run faithfully?" is asked per resource type; in
+docket it is answered by the task model itself.
+
+## Dry run: plan versus noop, test, and why-run
+
+Each of the three ships a dry-run mode, and this is where they diverge from docket most visibly. Puppet
+runs in noop mode, where it checks whether each resource is in the desired state and, for anything out
+of state, "takes no action, but reports the changes it would have made" [^2]. Salt adds `test=True` to
+any state run: "the return information will show states that will be applied ... and the result is
+reported as `None`" [^6]. Chef offers why-run mode via `-W` / `--why-run`, "a way to see what Chef
+Infra Client would have configured, had an actual Chef Infra Client run occurred" [^4].
+
+The catch is fidelity, and it is not uniform. Puppet's and Salt's previews reuse the same in-sync checks
+the real run performs, so they are generally faithful [^2][^6]. Chef's is not: Chef's own guidance - a
+post titled "Why 'Why-Run' Mode Is Considered Harmful" - calls why-run "by definition incomplete", warns
+that it "in many non-trivial situations will give incorrect results, thereby creating a false sense of
+security", and steers users to Test Kitchen and InSpec instead [^5]. So across this family a dry run is
+only as trustworthy as each resource type's support for it - the same per-resource discretion seen in
+idempotency.
+
+docket makes dry run structural rather than a mode. `plan` and `apply` call the *same* `Plan()`, and
+`apply` reuses the probe within its own run, so the two cannot disagree and every task is plannable
+[^12]. The command strings `plan` says it *would* run and `apply` says it *did* run are rendered by
+identical code and are byte-identical [^17]. `plan` reports drift with `[ok]`, `[+]`, `[~]`, `[-]`, and
+`[!]` (probe error), and `docket plan --detailed-exitcode` returns 0 for no drift, 2 for drift, and 1 on
+error [^13]. There is no separate preview engine that can drift from the real run.
+
+## Statelessness and architecture
+
+Like Ansible and docket, none of the three keep a Terraform-style persisted file of prior values that
+must be reconciled and locked; each run reads the node's live state and reconverges from it [^2][^6].
+What they add is a control plane. Puppet, Chef, and Salt are typically server-plus-agent systems: a
+Puppet agent pulls a compiled catalog from a primary server, a chef-client pulls run-lists and cookbooks
+from a Chef Infra Server, and Salt minions take instructions from a Salt master. Each also offers a
+masterless mode for local runs - `puppet apply` [^9], `chef-solo` or local-mode `chef-client` [^4][^10],
+and `salt-call --local` [^11] - but the server model is the common deployment.
+
+docket has no control plane at all. It is a single Go binary that drives one Dokku target, the local
+`dokku` CLI or one host over SSH [^16][^18], with nothing installed on the target beyond Dokku itself.
+The trade-off is the usual one: docket gives up fleet management, node inventories, and scheduled pull
+runs across many machines, in exchange for no agents to install, no server to run, and no catalog
+compilation step. `docket export` - reading a live server and writing a recipe that reapplies with no
+drift - is the nearest thing to a stored snapshot, and it is a command you invoke, not state a server
+maintains [^13].
+
+## Deletion and pruning
+
+Deletion is explicit in all four tools by the same idiom: a resource declared `ensure => absent` (Puppet
+and Salt spellings vary; docket uses `state: absent`) is removed, and simply *deleting* a resource from
+the manifest does not remove it from the node [^12]. On its own, that matches docket and Ansible - the
+file is a set of assertions, not a complete inventory that gets pruned.
+
+Puppet is the exception worth naming, because it offers optional set-pruning that docket does not. The
+`resources` metatype's `purge` attribute will "delete any resource that is not specified in your
+configuration and is not autorequired by any managed resources" [^3], which brings the Terraform-style
+"remove it from config and it gets destroyed" behavior to a whole resource type when you opt in. docket
+has no equivalent: it acts only on resources you name, and anything you want gone must be named with
+`state: absent` [^12]. The trade-off is the same as everywhere else in this axis - Puppet's purge can
+keep a node clean of drift automatically but can also delete something you simply forgot to declare,
+while docket cannot prune for you but also cannot surprise you.
+
+## Execution and ordering
+
+Within this family, ordering models split, and Puppet is the one that looks like Terraform. Puppet
+applies "resources ... in the order they are defined in their manifest, but only if the resource has no
+implicit relationship with another resource"; explicit relationships via metaparameters (`before`,
+`require`, `notify`, `subscribe`) and chaining arrows (`->`, `~>`), plus automatic ones through
+`autorequire` and friends, build an ordering that is "not limited by evaluation-order" [^1]. That is a
+dependency graph, much like Terraform's. Salt "always executes states in a deterministic manner", in the
+order defined in the SLS unless requisites (`require`, `watch`) or the `order` option intervene [^7].
+Chef evaluates resources in the order they appear in a recipe and converges them in that order [^8].
+
+docket runs in source order: ordered plays, then ordered tasks [^14], with `loop:` expanding a task over
+a list and `register:` passing one task's result to a later task's condition [^15]. It has no dependency
+graph and no autorequire; you write the order, as you do in Chef and in un-related Puppet resources. So
+on ordering docket sits with Chef and default-Salt on the explicit-order side, and Puppet's relationship
+graph is the outlier that most resembles the Terraform comparison.
+
+## Authoring and scope
+
+The three systems each have their own authoring surface: Puppet a purpose-built declarative DSL, Chef
+Ruby recipes backed by a resource DSL, and Salt YAML templated with Jinja. docket recipes are YAML or
+JSON5 [^14], with task bodies interpolated by sigil templates (`{{ .app }}`) and envelope predicates
+written in the expr language (`app == "api"`), kept separate so the two are not confused [^15]. docket
+also pairs authoring with offline typed validation (`docket validate`) and a canonical formatter
+(`docket fmt`), catching a malformed recipe before any server is touched [^13] - checks that in this
+ecosystem tend to live in adjacent tools (`puppet parser validate`, cookbook linting, Salt's render
+checks) rather than in one built-in command.
+
+The last difference is scope, and it frames all the others. Chef, Puppet, and Salt are general-purpose
+engines that manage packages, files, services, users, and much more across large fleets. docket manages
+one thing - the declarative state of a Dokku app - and keeps only the parts of the configuration-
+management model that fit that job: resource idempotency, reconverge-from-live-state, explicit deletion,
+and ordered execution [^12][^14]. It adds a guaranteed plan/apply and offline validation on top, and
+leaves the control plane out.
+
+[^1]: Puppet, "Relationships and ordering" - https://www.puppet.com/docs/puppet/7/lang_relationships.html
+[^2]: Puppet, "Metaparameters" (the `noop` metaparameter) - https://www.puppet.com/docs/puppet/7/metaparameter.html
+[^3]: Puppet, "Resource type: resources" (the `purge` attribute) - https://www.puppet.com/docs/puppet/7/types/resources.html
+[^4]: Chef, "Chef Infra Client (executable)" (why-run mode, `-W` / `--why-run`, local mode) - https://docs.chef.io/client/19/reference/ctl_chef_client/
+[^5]: Chef, "Why 'Why-Run' Mode Is Considered Harmful" - https://www.chef.io/blog/why-why-run-mode-is-considered-harmful
+[^6]: Salt Project, "State Testing" (`test=True`) - https://docs.saltproject.io/en/latest/ref/states/testing.html
+[^7]: Salt Project, "Ordering States" - https://docs.saltproject.io/en/latest/ref/states/ordering.html
+[^8]: Chef, "Chef Infra overview" (compile then converge over a resource collection) - https://docs.chef.io/client/19/overview/chef_overview/
+[^9]: Puppet, "puppet apply man page" (standalone, serverless runs) - https://www.puppet.com/docs/puppet/7/man/apply.html
+[^10]: Chef, "chef-solo" (running without a Chef Infra Server) - https://docs.chef.io/client/19/features/chef_solo/
+[^11]: Salt Project, "Standalone Minion" (`salt-call --local`) - https://docs.saltproject.io/en/latest/topics/tutorials/standalone_minion.html
+[^12]: docket, "Writing tasks" (the `Plan()` / probe model, `state` fields) - [docs/writing-tasks.md](../writing-tasks.md)
+[^13]: docket, "Command reference" (`plan`, `apply`, drift markers, `--detailed-exitcode`, `validate`, `fmt`, `export`) - [docs/command-reference.md](../command-reference.md)
+[^14]: docket, "Recipes" (plays, tasks, ordering, YAML/JSON5) - [docs/recipes.md](../recipes.md)
+[^15]: docket, "Task envelope" (`loop`, `register`, templating split) - [docs/task-envelope.md](../task-envelope.md)
+[^16]: docket, "Getting started" (single binary, scope) - [docs/getting-started.md](../getting-started.md)
+[^17]: docket, "JSON output" (the `commands` arrays and their shared rendering) - [docs/json-output.md](../json-output.md)
+[^18]: docket, "Remote execution" (one host over SSH) - [docs/remote-execution.md](../remote-execution.md)

--- a/docs/comparisons/docker-compose.md
+++ b/docs/comparisons/docker-compose.md
@@ -1,0 +1,141 @@
+# plan/apply and idempotency: docket vs Docker Compose
+
+Docker Compose is the declarative tool most Dokku users have already met: a compose file describes a
+set of services, and `docker compose up` converges the running containers to match it [^1][^2]. That
+"one file plus one converge command" shape is close enough to docket's that the two invite comparison,
+but they operate on different units and reach idempotency by different mechanisms.
+
+The unit is the first difference. Compose declares services - containers, with their networks and
+volumes [^1]. docket declares the state of a Dokku app, which is broader than its containers: app
+existence, config, domains, TLS, persistent storage, and plugins [^12]. Compose orchestrates the
+container runtime directly; docket declares Dokku state, and Dokku is what wraps Docker, buildpacks,
+nginx, and TLS underneath.
+
+The idempotency mechanism is the second. Compose converges by recreation: "if there are existing
+containers for a service, and the service's configuration or image was changed after the container's
+creation, `docker compose up` picks up the changes by stopping and recreating the containers" [^2]. Run
+`up` twice with no change and the second run recreates nothing - idempotent, but by comparing a
+service's current container against the file and recreating on a diff. docket instead has each task
+probe the live server and skip when already in sync [^6].
+
+There is one axis where Compose sits between docket and Terraform rather than beside either: it groups
+a project's resources under a project name and can prune the ones no longer declared, with
+`--remove-orphans` removing "containers for services not defined in the Compose file" [^2][^3]. docket
+tracks no such set. This document is neutral - Compose's direct runtime control and docket's broader
+Dokku-state model serve different jobs - and it notes where each fits.
+
+## At a glance
+
+| Dimension | docket | Docker Compose |
+|-----------|--------|----------------|
+| Unit of declaration | Dokku app state: apps, config, domains, TLS, storage, plugins [^12] | services (containers), networks, volumes [^1] |
+| Idempotency check | per-task live probe; in-sync tasks no-op [^6] | per-service: recreate only if config or image changed since creation [^2] |
+| Source of "current state" | live per-task probe, every run [^6] | the running containers compared to the file [^2] |
+| Persistent state | none [^6] | no state file; resources grouped under a project name [^3] |
+| Tracks a managed set / prunes removed | no; deletion is explicit `state: absent` [^6] | yes, opt-in: `--remove-orphans` removes services no longer in the file [^2] |
+| Dry run / plan | `plan` and `apply` share one `Plan()`; `--detailed-exitcode` 0/2/1 [^7] | global `--dry-run` "Execute command in dry run mode" [^3] |
+| Execution order | ordered tasks you write; `loop`/`register` [^8][^9] | dependency order from `depends_on` [^4] |
+| Scope | declares Dokku state (which wraps Docker, buildpacks, nginx, TLS) [^12] | orchestrates the container runtime directly [^1] |
+| Runtime | single Go binary; local or one SSH host [^10][^11] | Docker CLI plugin; local Docker or a remote context |
+
+## Idempotency mechanism
+
+Both tools make a second run safe, but they compare different things. Compose's mechanism is
+recreate-on-diff at the container level: "if there are existing containers for a service, and the
+service's configuration or image was changed after the container's creation, `docker compose up` picks
+up the changes by stopping and recreating the containers (preserving mounted volumes)" [^2]. If nothing
+changed, `up` leaves the containers as they are; `--force-recreate` overrides that to "recreate
+containers even if their configuration and image haven't changed", and `--no-recreate` suppresses
+recreation entirely [^2]. So Compose is idempotent in the sense that an unchanged file plus a second
+`up` is a no-op, decided by whether a service's declared config still matches its running container.
+
+docket's mechanism is a per-task probe. Every task implements a `Plan()` that reads the live server
+once, computes current versus desired, and either reports it is in sync (and does nothing) or returns
+a closure that performs the mutation; `apply` executes that plan [^6]. The comparison is not "did this
+container's config hash change" but "does the server's actual state for this task - the config value,
+the domain, the TLS enablement, the mount - already match the recipe". Because a Dokku app is more
+than a container, docket's equality check spans surface that has no container to recreate.
+
+The upshot: Compose reconciles the container runtime by rebuilding what drifted; docket reconciles a
+broader slice of app state by probing each piece and touching only what is off.
+
+## Statelessness and the managed set
+
+Neither tool keeps a Terraform-style state file, but they differ on whether they track a managed set.
+docket is fully stateless and keeps no inventory: each task's `Plan()` probe is the only source of
+truth, and there is no record of "everything docket manages" [^6]. Compose also has no state file, but
+it groups a run's resources under a project name - derived from `-p`, `COMPOSE_PROJECT_NAME`, the
+top-level `name:`, or the project directory's basename [^3] - and that grouping lets it reason about the
+whole set, not just the service in front of it.
+
+That is why Compose can answer a question docket cannot: "which running containers belong to this
+project but are no longer in the file?" It surfaces them as orphans and, with `--remove-orphans`, deletes
+them [^2]. docket has no equivalent because it has no managed set to diff against - it only ever acts on
+the tasks you wrote. On this axis Compose sits between docket (tracks nothing) and Terraform (tracks
+everything and destroys removed resources by default): Compose tracks the set but prunes only when you
+ask.
+
+## Dry run and plan
+
+docket makes dry run a first-class, structural feature. `plan` and `apply` call the same `Plan()`
+method, and `apply` reuses the probe within its own run, so the two cannot disagree and every task can
+be previewed [^6]. `plan` reports drift with `[ok]`, `[+]`, `[~]`, `[-]`, and `[!]` (probe error), and
+`docket plan --detailed-exitcode` returns 0 for no drift, 2 for drift, and 1 on error - an exit-code
+contract built for CI [^7].
+
+Compose offers a global `--dry-run` flag, described tersely as "Execute command in dry run mode" [^3].
+It lets you invoke a Compose command to see what it would do without executing it, which covers the
+same need at the command level. It is not, however, framed as a separate `plan` verb with a stable
+drift-marker vocabulary or a detailed exit-code contract the way docket's `plan` is; it is a mode you
+add to an existing command.
+
+## Deletion and pruning
+
+The two tools remove things differently. In docket, deletion is an explicit assertion: a task requests
+it with `state: absent`, and removing a task from the recipe does nothing to the server, because docket
+tracks no managed set to prune from [^6]. You cannot destroy a resource by deleting or forgetting a
+block, but nothing is cleaned up automatically either.
+
+Compose removes on two triggers. `docker compose down` tears down the project's containers and
+networks [^5], and `--remove-orphans` on `up` or `down` removes "containers for services not defined in
+the Compose file" [^2]. Removal is opt-in - a plain `up` leaves orphaned containers in place - so
+Compose is more aggressive than docket (it can prune a service you deleted from the file) but less
+aggressive than Terraform's default, where removing a resource block destroys it on the next apply.
+
+## Execution model
+
+Compose derives an order from the graph of service relationships: "Compose always starts and stops
+containers in dependency order, where dependencies are determined by `depends_on`, `links`,
+`volumes_from`, and `network_mode: "service:..."`", and "Compose creates services in dependency order"
+[^4]. You express dependencies and Compose schedules from them, much as Terraform does with its
+resource graph.
+
+docket runs in the order you write. A recipe is ordered plays then ordered tasks [^8], with `loop:`
+expanding a task over a list and `register:` passing one task's result to a later task's condition [^9].
+There is no dependency graph derived from references between tasks; the sequence is the source order.
+Compose's model is convenient when services genuinely depend on one another; docket's is explicit and
+predictable.
+
+## Scope and runtime
+
+Finally, the two sit at different layers. Compose is a Docker CLI plugin that orchestrates the
+container runtime directly - creating and converging services against local Docker or a remote context
+[^1]. docket declares Dokku state and lets Dokku do the orchestration; a docket recipe can create an
+app, set config, attach domains, enable TLS, and mount storage, and Dokku translates those into the
+underlying Docker, buildpack, nginx, and certificate operations [^12]. docket ships as a single Go
+binary driving the local `dokku` CLI or one host over SSH [^10][^11], whereas Compose runs wherever the
+Docker CLI does. A Dokku user reaching for Compose gets direct container control; reaching for docket
+gets the whole app's declarative state, with a real plan/apply over it.
+
+[^1]: Docker, "Docker Compose overview" - https://docs.docker.com/compose/
+[^2]: Docker, "docker compose up" (recreate-on-change, `--force-recreate` / `--no-recreate`, `--remove-orphans`) - https://docs.docker.com/reference/cli/docker/compose/up/
+[^3]: Docker, "docker compose" CLI reference (global `--dry-run`, project name) - https://docs.docker.com/reference/cli/docker/compose/
+[^4]: Docker, "Control startup and shutdown order in Compose" (`depends_on` dependency order) - https://docs.docker.com/compose/how-tos/startup-order/
+[^5]: Docker, "docker compose down" - https://docs.docker.com/reference/cli/docker/compose/down/
+[^6]: docket, "Writing tasks" (the `Plan()` / probe model, `state` fields) - [docs/writing-tasks.md](../writing-tasks.md)
+[^7]: docket, "Command reference" (`plan`, `apply`, drift markers, `--detailed-exitcode`) - [docs/command-reference.md](../command-reference.md)
+[^8]: docket, "Recipes" (plays, tasks, and ordering) - [docs/recipes.md](../recipes.md)
+[^9]: docket, "Task envelope" (`loop`, `register`) - [docs/task-envelope.md](../task-envelope.md)
+[^10]: docket, "Getting started" (single binary) - [docs/getting-started.md](../getting-started.md)
+[^11]: docket, "Remote execution" (one host over SSH) - [docs/remote-execution.md](../remote-execution.md)
+[^12]: docket, "Tasks" (the full task surface) - [docs/tasks/README.md](../tasks/README.md)

--- a/docs/comparisons/dokku-cli.md
+++ b/docs/comparisons/dokku-cli.md
@@ -1,0 +1,138 @@
+# plan/apply and idempotency: docket vs the dokku CLI
+
+The dokku CLI is imperative. Each subcommand does one thing right now: `apps:create` makes an app [^1],
+`config:set` sets environment variables [^2], `domains:add` attaches a hostname [^3], and `git:sync`
+clones or fetches a repository and can build it [^4]. You run those commands in sequence, by hand, to
+bring an app into the shape you want.
+
+docket does not replace that CLI - it drives it. Every docket task ultimately resolves to one or more
+`dokku` commands and runs them; `apply --verbose` echoes each resolved `dokku` line it invoked [^6],
+and both `plan` and `apply` render the exact command strings they would run or did run [^10]. dokku must
+still be installed - locally, or on the server docket reaches over SSH [^5][^11]. docket is a
+declarative desired-state layer over the same commands, not an alternative to them.
+
+The difference is what sits between you and those commands. With the bare CLI, ordering, re-run safety,
+and "what would this change?" are the operator's job: docket's own getting-started framing notes that
+the steps "live in your shell history or a README, they are easy to run out of order, and there is no
+safe way to ask 'what would change if I ran these again?'" [^5]. docket reads a file describing the state
+you want, compares it to the live server, and runs only the commands needed to close the gap [^5].
+
+This is a neutral comparison. The bare CLI needs no extra tool and gives direct, interactive control,
+which suits one-off and exploratory work. docket adds a layer that pays off when you want repeatability,
+review, previews, and idempotency. Both ultimately run the same `dokku`.
+
+## At a glance
+
+| Dimension | docket | dokku CLI |
+|-----------|--------|-----------|
+| What you write | a declarative recipe (desired state) [^7] | a sequence of imperative commands [^1][^2][^3][^4] |
+| Underlying execution | resolves to and runs `dokku` commands [^6] | the `dokku` commands themselves [^1][^2][^3][^4] |
+| Requires dokku installed | yes - local or over SSH [^5][^11] | yes [^1] |
+| Re-running is safe | yes; an in-sync task is a no-op [^5] | depends on the command; a create-style step can be redundant or error [^5] |
+| Dry run / preview | `docket plan`, with drift markers [^6] | none |
+| Ordering | fixed by the recipe; `loop`/`register`/`when` [^8] | whatever order you type |
+| Reviewability | a file you can diff, `fmt`, and `validate` offline [^6] | shell history or a README [^5] |
+| Error handling | `failed_when`/`block`/`rescue`/`ignore_errors`/`--start-at-task` [^8][^6] | manual, per command |
+| Remote execution | `--host` over SSH, `--sudo` [^11] | `ssh`/`dokku` by hand |
+| Capture a live server | `docket export` [^6] | read `:report` output by hand [^1][^3] |
+
+## Idempotency
+
+A dokku command does what it says each time you run it. That is exactly what you want interactively, but
+it puts re-run safety on the operator: re-running a create-style step is at best redundant and, depending
+on the command, can error rather than silently succeed. docket frames its own value against precisely this
+friction - after the first run "the second run sees the server already matches and does nothing", and
+"there is no 'already exists' error to work around" [^5].
+
+docket gets there by making every task check the live server before acting. Each task probes current
+state once, compares it to the desired state, and only runs the underlying `dokku` command when they
+differ [^9]. The observable result is that a second `apply` against an unchanged server changes nothing:
+the first run reports each task as `[changed]`, the second reports every task as `[ok]` [^5].
+
+```text
+# first run
+Summary: 2 tasks · 2 changed · 0 ok · 0 skipped · 0 errors
+
+# second run
+Summary: 2 tasks · 0 changed · 2 ok · 0 skipped · 0 errors
+```
+
+The commands are the same in both worlds; docket adds the check that decides whether to run them.
+
+## Plan and preview
+
+The dokku CLI has no dry run. To learn what a sequence of commands would do, you run them - or read each
+plugin's `:report` output by hand and reason about the difference yourself [^1][^3].
+
+docket makes that preview a first-class command. `docket plan` reads each task's current state from the
+live server and reports what `apply` would change without running any mutating command, using drift
+markers - `[ok]` in sync, `[+]` create, `[~]` modify, `[-]` remove, and `[!]` when the probe itself
+errored [^6]. Because `plan` and `apply` run the same underlying probe - `apply` re-reads the server
+within its own run - the two cannot disagree [^9], and the command strings `plan` says it would run are
+byte-identical to the ones `apply` runs [^10]. For CI, `docket plan --detailed-exitcode` returns 0 for
+no drift, 2 for drift, and 1 on error [^6].
+
+## A declarative file versus shell history
+
+With the CLI, the record of how an app was configured is whatever you kept - shell history, a README, a
+setup script [^5]. It is prose or a command log, not something a tool can check.
+
+A docket recipe is a reviewable artifact. It can be committed, diffed in a pull request, formatted
+canonically with `docket fmt`, and checked offline with `docket validate` - which parses the file,
+verifies each task's shape and required fields, and reports problems without contacting a server [^6].
+The same file that documents the desired state is the one that enforces it, so the two cannot drift apart
+the way a README and a server can.
+
+## Ordering and repeatability
+
+By hand, order is whatever you type, and reproducing a setup means re-typing or re-sourcing the same
+commands in the same order. docket fixes the order in the recipe and runs it top to bottom [^7]. Where the
+CLI would have you repeat a command per app, `loop:` expands one task over a list; `register:` saves a
+task's result so a later task's `when:` can react to it; and `when:` gates a task on inputs or an earlier
+result [^8]. The sequence is written once and reruns identically.
+
+## Error handling
+
+When a hand-run command fails, recovery is manual: read the error, decide whether it matters, fix, and
+continue from the right place. docket carries an error-handling envelope on every task [^8]. `failed_when`
+is the "this exit code is fine" idiom that turns an imperative command into an idempotent one - treating,
+say, "not mounted" as success. `changed_when` overrides the changed verdict. `ignore_errors` continues
+past a failed task. `block`/`rescue`/`always` give try/catch/finally over a group of tasks, so a deploy
+can carry its own rollback path [^8]. And `--start-at-task` resumes a partially applied recipe from a
+named task, with `--fail-fast` controlling whether an error aborts the whole run or only the current play
+[^6].
+
+## Remote execution and export
+
+Driving a remote server with the bare CLI means an SSH session or dokku's own remote invocation, run by
+hand. docket takes `--host <user@host:port>` to run the same recipe against a remote server over SSH, with
+`--sudo` to wrap the remote call in `sudo -n` and `--accept-new-host-keys` for first connect - still
+invoking `dokku` on the far side [^11].
+
+docket also inverts the flow. `docket export` reads a live server and writes a recipe describing it, so an
+existing server assembled with hand-run commands can be captured as a file rather than reconstructed from
+memory; its correctness contract is that applying the export (together with its companion vars file) back
+reports no drift [^6]. There is no CLI equivalent beyond reading each plugin's `:report` output yourself
+[^1][^3].
+
+## Scope: a front-end, not a replacement
+
+docket is a declarative front-end for the same `dokku` subcommands, not a different way to run a server.
+It requires dokku to be installed and resolves its tasks to real `dokku` commands [^5][^6], so anything
+docket does, you could do by hand with the CLI - and anything the CLI can do that no docket task covers is
+still done at the CLI. The choice is not docket or dokku; it is whether to run those dokku commands
+directly or through a layer that adds a recipe, a plan, idempotency, and structured error handling. Direct
+is simpler for a one-off; the layer earns its keep when the same setup has to be repeatable, reviewable,
+and safe to re-run.
+
+[^1]: Dokku, "Application management" (`apps:create`, `apps:destroy`, `apps:rename`, `apps:list`, `apps:report`) - https://dokku.com/docs/deployment/application-management/
+[^2]: Dokku, "Environment variables" (`config:set`, `config:unset`, `config:show`) - https://dokku.com/docs/configuration/environment-variables/
+[^3]: Dokku, "Domain configuration" (`domains:add`, `domains:set`, `domains:remove`, `domains:report`) - https://dokku.com/docs/configuration/domains/
+[^4]: Dokku, "Git deployment" (`git:sync`) - https://dokku.com/docs/deployment/methods/git/
+[^5]: docket, "Getting started" - [docs/getting-started.md](../getting-started.md)
+[^6]: docket, "Command reference" (`plan`, `apply`, drift markers, `--detailed-exitcode`, `validate`, `fmt`, `export`) - [docs/command-reference.md](../command-reference.md)
+[^7]: docket, "Recipes" (plays, tasks, and ordering) - [docs/recipes.md](../recipes.md)
+[^8]: docket, "Task envelope" (`when`, `loop`, `register`, error handling) - [docs/task-envelope.md](../task-envelope.md)
+[^9]: docket, "Writing tasks" (the `Plan()` / probe model) - [docs/writing-tasks.md](../writing-tasks.md)
+[^10]: docket, "JSON output" (the `commands` arrays and their shared rendering) - [docs/json-output.md](../json-output.md)
+[^11]: docket, "Remote execution" (`--host`, `--sudo`, `--accept-new-host-keys`) - [docs/remote-execution.md](../remote-execution.md)

--- a/docs/comparisons/kamal.md
+++ b/docs/comparisons/kamal.md
@@ -1,0 +1,155 @@
+# plan/apply and idempotency: docket vs Kamal
+
+docket and Kamal are close in operational shape and far apart in what they model, which makes for a
+sharp comparison. Both are single tools you run from your laptop against servers you own: agentless,
+SSH-driven, with no control plane and no persisted state file. Kamal calls itself "Capistrano for
+Containers, without the need to carefully prepare servers in advance" [^1], and it "works seamlessly
+across multiple servers, using SSHKit to execute commands" [^2] - plain Docker commands over SSH, not
+declarative state reconciled the way Kubernetes or Swarm do it. docket is likewise a single Go binary
+[^7] that drives a Dokku target locally or over one SSH host [^11], reading live state each run rather
+than storing it [^8].
+
+Where they diverge is the job. Kamal is a deploy *pipeline*: `kamal deploy` builds and pushes an image,
+boots new containers, health-checks them, and switches traffic through kamal-proxy [^1][^3][^5]. It is
+"intentionally designed around imperative commands, like Capistrano" [^1], and its command surface is
+rollout-shaped - `deploy`, `redeploy`, `rollback`, `setup`, `accessory`, `proxy` [^3]. docket is
+desired-state *convergence*: each task probes the live server, computes drift, and runs only the
+commands needed to close the gap, across a broad app surface - apps, config, domains, TLS, storage,
+plugins, and git sync - not just container rollout [^8][^12].
+
+That difference shows up most in idempotency and preview. Kamal makes a deploy happen; docket makes the
+server *match a description*, and can tell you what would change before it does. Neither is a substitute
+for the other's core value: Kamal owns zero-downtime container cutover [^1], and docket owns drift-aware
+declaration of a Dokku app's whole configuration [^9]. This document is neutral about which fits your
+setup and focuses on how each handles plan/apply and idempotency.
+
+## At a glance
+
+| Dimension | docket | Kamal |
+|-----------|--------|-------|
+| Core model | desired-state convergence [^8] | imperative deploy pipeline [^1][^3] |
+| Idempotency check | equality of desired vs current, per task [^8] | no per-resource drift check; each deploy runs the pipeline [^3] |
+| Dry run / plan | `plan` and `apply` share one `Plan()`; `--detailed-exitcode` 0/2/1 [^9] | no plan/diff/dry-run command among its commands [^3] |
+| Persistent state | none; live probe each run [^8] | none; commands over SSH, no control plane [^2] |
+| Transport | local `dokku` CLI or one host over SSH [^11] | SSH via SSHKit, multiple servers [^2] |
+| What it manages | full Dokku app state (config, domains, TLS, storage, plugins, git) [^12] | container rollout, accessories, proxy [^1][^3][^4] |
+| Traffic cutover | delegated to Dokku's proxy [^12] | kamal-proxy health-checks `/up`, then switches [^5] |
+| Rollback | re-apply desired state [^8] | `kamal rollback VERSION` [^3] |
+| Runtime | single Go binary, no Ansible/Ruby needed [^7] | Ruby gem, Docker-native [^1][^6] |
+| Scope | Dokku-specific (Dokku wraps Docker/buildpacks) [^7] | app-runtime-agnostic containers [^1][^2] |
+
+## Idempotency mechanism
+
+docket converges by having every task check the live server and skip when it already matches. Each task
+implements a `Plan()` that probes once, computes current versus desired, and either reports it is in
+sync (and does nothing) or returns a closure that performs the mutation; `apply` is defined as executing
+that plan, so a second `apply` against an unchanged server changes nothing [^8]. Idempotency is a
+property of the task model.
+
+Kamal's model is a deploy pipeline rather than a per-resource convergence. `kamal deploy` is documented
+as "Deploy app to servers", `kamal redeploy` as "Deploy app to servers without bootstrapping servers,
+starting kamal-proxy and pruning" [^3]; the tool boots the specified image version and cuts traffic over
+to it each time you run it. There is no per-resource equality check that decides "this is already in the
+desired state, do nothing" the way docket's probe does - the deploy runs its steps. This is a good fit
+for Kamal's purpose: shipping a new image version is the common case, and a rolling, health-checked boot
+is exactly what you want there [^1][^5]. It is a different guarantee from docket's "run it twice, the
+second run is a no-op" [^7].
+
+## Dry run and plan
+
+docket makes preview structural. `plan` and `apply` call the *same* `Plan()`, and `apply` reuses the
+probe within its own run, so the two cannot disagree and every task can be previewed [^8]. `plan`
+reports drift with `[ok]`, `[+]`, `[~]`, `[-]`, and `[!]` (probe error), and `docket plan
+--detailed-exitcode` returns 0 for no drift, 2 for drift, and 1 on error, which gives CI a gate on
+whether anything would change [^9].
+
+Kamal's documented command set does not include a plan, diff, or dry-run command that previews changes
+against desired state without applying them [^3]. It offers rich rollout controls - health checks,
+timeouts, rollback to a prior version - but the preview-before-change step that docket's `plan` provides
+is not part of the surface. If your question is "what will change if I run this?", docket answers it
+before touching the server; Kamal's answer is the deploy itself, with health checks and a rollback path
+if the new version misbehaves [^3][^5].
+
+## Statelessness
+
+Here the two agree, and both differ from state-file tools like Terraform. Kamal keeps no agent on the
+servers and no control plane of its own; it executes commands over SSH with SSHKit [^1][^2], and nothing
+about your infrastructure is recorded in a persisted state file that could drift from reality. docket is
+stateless in the same sense: the live probe is the source of truth on every run, so there is nothing to
+store, lock, or reconcile, and no stored record to fall out of sync [^8].
+
+The shared trade-offs follow: neither keeps a cheap inventory of what it manages, and both pay to read
+live state (docket on every plan/apply probe; Kamal implicitly, by running against the servers each
+deploy). docket's `export` - reading a live server and writing a recipe that reapplies with no drift -
+is the nearest thing to a snapshot, and it is a command you invoke rather than a file the tool maintains
+[^9].
+
+## What each manages
+
+The surfaces barely overlap. Kamal manages the containerized app's rollout plus its supporting pieces:
+the image build and push, the app containers, "accessories" for databases and caches ("Manage
+accessories (db/redis/search)" [^3], "Additional services to run in Docker" [^4]), and the proxy that
+fronts traffic [^1][^5]. Its configuration lives in `config/deploy.yml` with sections for service, image,
+servers, registry, env, proxy, accessories, and builder [^4].
+
+docket manages the declarative state of a Dokku app across many subsystems - the app itself, config
+variables, domains, TLS via letsencrypt, storage mounts, third-party plugins, and git sync - each as a
+task with its own idempotent probe [^8][^12]. It does not build or push images or orchestrate a container
+cutover itself; that is Dokku's job, which docket triggers through tasks like git sync [^12]. So Kamal
+owns the deploy mechanics end to end, while docket declares the configuration around and including a
+deploy and lets Dokku perform the container work.
+
+## Execution model
+
+Both are agentless and run over SSH, and both are essentially ordered rather than graph-scheduled. Kamal
+fans a deploy out across every server in the config, using SSHKit to execute commands on multiple hosts
+[^2], which suits a horizontally scaled web app on several boxes. docket drives a single Dokku target -
+the local CLI or one host over SSH [^11] - and runs its recipe as ordered plays and tasks, with no host
+fan-out [^10].
+
+The concurrency axis is therefore different: Kamal's parallelism is across servers running the same
+rollout; docket has none to speak of and instead sequences tasks against one target. Neither derives an
+execution order from a dependency graph; you get the order you wrote (docket) or the fixed pipeline steps
+of a deploy (Kamal).
+
+## Deploy pipeline versus convergence
+
+The clearest way to hold the two in mind is pipeline versus convergence. A Kamal deploy is a sequence
+with a defined shape: build and push the image, boot new containers, health-check them - "the proxy will
+by default hit `/up` once every second until we hit the deploy timeout" - and once the app is up, the
+proxy stops probing [^5]. The value is a zero-downtime, health-gated cutover to a new version [^1][^5].
+
+A docket run is not a rollout with a beginning and end so much as a reconciliation: read what the server
+currently is, compare it to the recipe, and issue only the commands that close the difference, task by
+task [^8]. Running it when nothing has changed does nothing; running it after editing one config value
+changes only that. The two answer different questions - "ship this new version safely" versus "make the
+server match this description" - which is why many setups could reasonably use a deploy tool and a
+convergence tool for different parts of the same app.
+
+## Runtime and scope
+
+Operationally both are lightweight single tools with no agent to install, but they sit at different
+layers. Kamal is Docker-native and app-runtime-agnostic: it deploys "web apps anywhere" as containers,
+"originally built for Rails apps" but working with "any type of web app that can be containerized", and
+a fresh server "will be auto-provisioned with Docker" on first use [^1]. docket is Dokku-specific, and
+Dokku itself is the layer that wraps Docker, buildpacks, and the proxy; docket declares a Dokku app's
+state and lets Dokku realize it [^7]. It ships as a single Go binary with no additional runtime required
+[^7], while Kamal is distributed as a Ruby gem [^6].
+
+Put simply, Kamal talks to Docker directly and owns the deploy; docket talks to Dokku and owns the
+declaration. If you already run Dokku, docket adds a plan/apply and idempotency layer over its whole app
+surface; if you run raw Docker on your own servers, Kamal gives you a zero-downtime container deploy
+without adopting a PaaS.
+
+[^1]: Kamal, "Deploy web apps anywhere" (homepage) - https://kamal-deploy.org/
+[^2]: Kamal, README (`basecamp/kamal`) - https://github.com/basecamp/kamal
+[^3]: Kamal, "View all commands" - https://kamal-deploy.org/docs/commands/view-all-commands/
+[^4]: Kamal, "Configuration" overview - https://kamal-deploy.org/docs/configuration/overview/
+[^5]: Kamal, "Proxy" configuration (health checks) - https://kamal-deploy.org/docs/configuration/proxy/
+[^6]: Kamal, "Installation" (`gem install kamal`) - https://kamal-deploy.org/docs/installation/
+[^7]: docket, "Getting started" (single binary, Dokku scope) - [docs/getting-started.md](../getting-started.md)
+[^8]: docket, "Writing tasks" (the `Plan()` / probe model) - [docs/writing-tasks.md](../writing-tasks.md)
+[^9]: docket, "Command reference" (`plan`, `apply`, drift markers, `--detailed-exitcode`, `export`) - [docs/command-reference.md](../command-reference.md)
+[^10]: docket, "Recipes" (plays, tasks, and ordering) - [docs/recipes.md](../recipes.md)
+[^11]: docket, "Remote execution" (one host over SSH) - [docs/remote-execution.md](../remote-execution.md)
+[^12]: docket, "Tasks" (the full task surface) - [docs/tasks/README.md](../tasks/README.md)

--- a/docs/comparisons/kubernetes.md
+++ b/docs/comparisons/kubernetes.md
@@ -1,0 +1,170 @@
+# plan/apply and idempotency: docket vs Kubernetes (kubectl apply and GitOps)
+
+docket and Kubernetes both start from declarative desired state: you write down what you want, and the
+tool works out the changes needed to get there. `kubectl apply` merges your manifest into the live
+object and changes only what differs [^1], and `kubectl diff` can show "the current online
+configuration, and the configuration as it would be if applied" before you commit to it [^3]. Applying
+the same configuration again converges to the same result [^1]. docket does the same thing per task:
+each task probes the live server once, compares current against desired, and only mutates when they
+differ [^11]. On the narrow question the blog "Idempotency in IaC" asks - is a re-run safe - the two
+agree.
+
+They part company on *when* and *for how long* that convergence happens, and this is the sharpest model
+contrast in this whole set of comparisons. Kubernetes is a **continuous reconciliation** system. Your
+applied objects are persisted in the cluster's datastore (etcd) [^8], and controllers work forever to
+drive actual state toward that stored desired state [^9]. GitOps operators layer another loop on top:
+Argo CD "has the ability to automatically sync an application when it detects differences between the
+desired manifests in Git, and the live state in the cluster" [^4], and Flux reconciles on an interval so
+that "if you make any changes to the cluster using kubectl edit/patch/delete, they will be promptly
+reverted" [^5]. Convergence is a standing background process.
+
+docket is a **one-shot converge**. It has no controller, no persisted desired state, and no background
+loop. It runs when you run it, reads the live server on that run, makes the changes, and exits [^11].
+Drift that appears an hour later is invisible until the next time you run `docket plan` or `docket
+apply`.
+
+This document is neutral. Kubernetes and docket target very different scales - a cluster of many
+workloads reconciled continuously versus a single Dokku host converged on demand - and neither model is
+"better" in the abstract; they answer different questions. The sections below map where they line up and
+where they diverge.
+
+## At a glance
+
+| Dimension | docket | Kubernetes / GitOps |
+|-----------|--------|---------------------|
+| Idempotency check | equality of desired vs current, per task [^11] | declarative merge of intent into live objects [^1][^2] |
+| Source of "current state" | live per-task probe, every run [^11] | the cluster datastore (etcd), read by kubectl or a controller [^1][^8] |
+| Persistent desired state | none [^11] | yes - applied objects stored in the cluster, tracked by `last-applied-configuration` / `managedFields` [^1][^2] |
+| When convergence happens | once, when you run `apply` [^11] | continuously - controllers reconcile forever; GitOps re-syncs on an interval [^5][^9] |
+| Dry run / preview | `plan` and `apply` share one `Plan()`; universal [^11] | `kubectl diff` (server-side dry run); Argo CD / Flux diff views [^3][^4] |
+| Drift correction | only on your next `plan` / `apply` [^12] | automatic and continuous (Argo CD self-heal, Flux revert) [^4][^5] |
+| Deleting a resource removed from the file | not deleted; explicit `state: absent` [^11] | pruned - `apply --prune`, Argo CD auto-prune, Flux garbage collection [^7][^4][^6] |
+| Execution model | ordered recipe, single Dokku target [^13] | many controllers reconciling in parallel across a cluster [^9][^5] |
+| Runtime | single Go binary [^15] | a cluster: API server, datastore, controllers (plus a GitOps operator) [^8][^5] |
+
+## Idempotency mechanism
+
+Both tools converge by comparing desired state to live state and acting only on the difference.
+`kubectl apply` merges your "fully specified intent" into the existing object and changes only what
+differs, using a recorded baseline - historically the `kubectl.kubernetes.io/last-applied-configuration`
+annotation [^1], and with Server-Side Apply a `managedFields` record where "the Kubernetes API server
+tracks managed fields for all newly created objects" and moves ownership of a field to whichever manager
+last changed it [^2]. The comparison is what makes a second apply a no-op.
+
+docket reaches the same place per task. Every task implements a `Plan()` that probes the live server
+once, computes current versus desired, and either reports it is in sync (and does nothing) or returns a
+closure that performs the mutation; `apply` is defined as executing that plan [^11]. The difference is not
+*whether* there is an equality check but *what records the desired side*: Kubernetes keeps the applied
+intent in the object itself (annotation or managed fields) so any client or controller can merge against
+it [^1][^2], while docket holds nothing between runs and recomputes intent from the recipe each time [^11].
+
+## Dry run and plan
+
+Kubernetes previews changes with `kubectl diff`, which shows "the current online configuration, and the
+configuration as it would be if applied", performing a server-side dry run without mutating anything [^3].
+It even carries an exit-code contract - `0` when there is no difference, `1` when there is, and greater
+than `1` on error [^3]. GitOps tools add their own previews: Argo CD surfaces the difference between Git
+and the cluster as an `OutOfSync` status before (or instead of) syncing [^4].
+
+docket makes preview structural rather than a separate code path. `plan` and `apply` call the *same*
+`Plan()` method, and `apply` reuses the probe within its own run, so the two cannot disagree and every
+task can be previewed [^11]. The command strings `plan` says it *would* run and `apply` says it *did* run
+are rendered by identical code and are byte-identical [^17]. `docket plan --detailed-exitcode` mirrors the
+same idea as `kubectl diff`'s exit status, returning `0` for no drift, `2` for drift, and `1` on error
+[^12]. The shapes are close; the difference is that `kubectl diff` is a distinct command that re-derives
+the apply, whereas docket's preview *is* the apply path stopped short of mutating.
+
+## State and reconciliation
+
+This is the core divergence. Kubernetes is a state store with active reconcilers. Applied objects live
+in the cluster datastore [^8], and controllers continuously drive real resources toward that stored
+desired state - the reconcile loop is the heart of the system [^9]. GitOps extends the loop to a git
+repository as the source of truth: Flux describes reconciliation as "ensuring that a given state ...
+matches a desired state declaratively defined somewhere (e.g. a Git repository)", running "every five
+minutes by default" and correcting drift as it goes [^5], with the interval configurable per
+Kustomization [^6]; Argo CD watches for divergence between Git and the cluster and can sync
+automatically [^4].
+
+docket is stateless and has no loop. Each run reads the live server as the single source of truth, makes
+the recipe true, and exits - there is nothing persisted to reconcile against and no process running
+between invocations [^11]. The trade-off is direct: docket never fights you over an intentional manual
+change and needs no control plane to keep running, but it also will not notice or repair drift on its own
+- convergence happens exactly when you invoke it. The nearest analog to a stored snapshot is `docket
+export`, which reads a live server and writes a recipe that reapplies with no drift, but that is a
+command you run, not a controller the tool maintains [^12].
+
+## Drift detection
+
+Because Kubernetes reconciles continuously, drift detection and correction are automatic. Argo CD reports
+an application as `OutOfSync` when the cluster deviates from Git and, with self-heal enabled, re-syncs
+"when the live cluster's state deviates from the state defined in Git" [^4]. Flux's controllers revert
+out-of-band changes on their next interval - manual `kubectl edit/patch/delete` "will be promptly
+reverted" [^5]. Drift is caught within a reconcile interval whether or not anyone is watching.
+
+docket detects drift only when you ask. `docket plan` reads the server and reports each task as `[ok]`,
+`[+]` create, `[~]` modify, `[-]` remove, or `[!]` when the probe itself errored [^12]. Between runs, drift
+simply accumulates unobserved. In practice teams close this gap by running `docket plan --detailed-exitcode`
+on a schedule or in CI, which turns drift into a non-zero exit an operator can act on [^12] - but that is an
+external cron or pipeline, not a controller inside the tool.
+
+## Deletion and pruning
+
+Here Kubernetes behaves like the managed-set model from the Terraform comparison, not like docket. Because
+the applied set is tracked, resources removed from the config can be pruned: `kubectl apply --prune` will
+"automatically delete resource objects, that do not appear in the configs" [^1][^7], Argo CD prunes
+resources deleted from Git when auto-prune is enabled [^4], and Flux's garbage collection removes
+"Kubernetes objects that were previously applied on the cluster but are missing from the current source
+revision" [^6]. Deleting a manifest can delete the resource.
+
+docket has no managed set to prune against. Each task is an *assertion* about one resource, so removing a
+task from a recipe does nothing to the server; deletion is requested explicitly with `state: absent` [^11].
+The upside is that you cannot destroy a workload by deleting or forgetting a block, and there is no prune
+step to arm carefully; the downside is that docket will not garbage-collect orphans for you - anything you
+want gone must be named.
+
+## Execution model
+
+Kubernetes has no single ordered script. Many controllers reconcile many object kinds concurrently, each
+watching the datastore and acting when its resources drift, with dependencies expressed through the API
+(references, ownership, readiness and health) rather than through a sequence you write [^9][^5]. GitOps
+operators add ordering primitives on top (sync waves, health gates) [^10], but the base model is a fan-out
+of independent loops across a cluster.
+
+docket runs a recipe top to bottom against a single target. Plays run in order, tasks run in order [^13],
+with `loop:` expanding a task over a list and `register:` passing one task's result to a later task's
+condition [^14]. There is no dependency graph and no host fan-out - docket drives one Dokku target, the
+local CLI or a single host over SSH [^16]. The contrast is one ordered pass over one server versus many
+perpetual loops over a cluster.
+
+## Scope and operational weight
+
+The operational footprints differ by an order of magnitude, which is really a statement about the problems
+the two tools are built for. Kubernetes is a distributed system: an API server, a datastore, a set of
+controllers, and - for GitOps - an Argo CD or Flux operator running in-cluster, all kept alive so
+reconciliation can continue [^8][^5]. That machinery is what buys continuous drift correction, pruning, and
+cluster-wide scale.
+
+docket is a single Go binary with no runtime to operate, scoped to one job - declaring the state of a
+Dokku app [^15] - and driving the local `dokku` CLI or one server over SSH [^16]. It has no control plane
+to install, secure, or upgrade, and it stops existing the moment it exits. It trades continuous
+reconciliation and cluster scale for a tool you can run from a laptop or a CI job against a single host.
+For a Dokku operator that is the point; for a fleet of services needing self-healing at scale, the
+Kubernetes model is what that requires. The two sit at opposite ends of the same declarative idea.
+
+[^1]: Kubernetes, "Declarative Management of Kubernetes Objects Using Configuration Files" (`kubectl apply`, `last-applied-configuration`, pruning) - https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/
+[^2]: Kubernetes, "Server-Side Apply" (field management, `managedFields`, fully specified intent) - https://kubernetes.io/docs/reference/using-api/server-side-apply/
+[^3]: Kubernetes, "kubectl diff" (server-side dry run, exit-code contract) - https://kubernetes.io/docs/reference/kubectl/generated/kubectl_diff/
+[^4]: Argo CD, "Automated Sync Policy" (auto-sync, self-heal, auto-prune, `OutOfSync`) - https://argo-cd.readthedocs.io/en/stable/user-guide/auto_sync/
+[^5]: Flux, "Core Concepts" (continuous reconciliation, default interval, drift revert) - https://fluxcd.io/flux/concepts/
+[^6]: Flux, "Kustomization" (garbage collection / pruning, reconciliation interval) - https://fluxcd.io/flux/components/kustomize/kustomizations/
+[^7]: Kubernetes, "kubectl apply" reference (the `--prune` flag) - https://kubernetes.io/docs/reference/kubectl/generated/kubectl_apply/
+[^8]: Kubernetes, "Kubernetes Components" (etcd as the cluster datastore) - https://kubernetes.io/docs/concepts/overview/components/
+[^9]: Kubernetes, "Controllers" (reconcile loops driving current state toward desired state) - https://kubernetes.io/docs/concepts/architecture/controller/
+[^10]: Argo CD, "Sync Phases and Waves" - https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/
+[^11]: docket, "Writing tasks" (the `Plan()` / probe model) - [docs/writing-tasks.md](../writing-tasks.md)
+[^12]: docket, "Command reference" (`plan`, `apply`, drift markers, `--detailed-exitcode`, `export`) - [docs/command-reference.md](../command-reference.md)
+[^13]: docket, "Recipes" (plays, tasks, and ordering) - [docs/recipes.md](../recipes.md)
+[^14]: docket, "Task envelope" (`loop`, `register`) - [docs/task-envelope.md](../task-envelope.md)
+[^15]: docket, "Getting started" (single binary, scope) - [docs/getting-started.md](../getting-started.md)
+[^16]: docket, "Remote execution" (one host over SSH) - [docs/remote-execution.md](../remote-execution.md)
+[^17]: docket, "JSON output" (the `commands` arrays and their shared rendering) - [docs/json-output.md](../json-output.md)

--- a/docs/comparisons/terraform.md
+++ b/docs/comparisons/terraform.md
@@ -1,0 +1,184 @@
+# plan/apply and idempotency: docket vs Terraform/OpenTofu
+
+Both docket and Terraform/OpenTofu are declarative infrastructure tools: you describe the state you
+want, the tool figures out the commands to get there, and running the same description twice is safe.
+Karim's post "Idempotency in IaC" argues that this safety reduces to something simple - idempotency
+in IaC is "just an equality check" between the state you declared and the state that already exists,
+and when the two are equal the tool does nothing [^1]. docket accepts that same premise [^8].
+
+Where the two tools diverge is in one design decision: *where the "current state" side of that
+equality check comes from*. Terraform and OpenTofu read the real world once, record it in a persisted
+**state file**, and reconcile your configuration against that file [^3][^4]. docket keeps no state file
+at all - each task reads the live server every run and compares against that fresh read [^8]. That
+single difference is the root of almost every other difference below: how deletion works, how drift
+is handled, how execution is ordered, and how failures are caught.
+
+This document treats Terraform and OpenTofu together, because they share the plan/apply/state model
+described here; the post that prompted this comparison uses OpenTofu specifically [^1]. It is a neutral
+comparison - each section states what each tool does and the trade-off, not which is better. The
+approaches fit different problems: Terraform/OpenTofu manage a closed world of cloud resources through
+provider APIs; docket converges a Dokku server through `dokku` commands.
+
+## At a glance
+
+| Dimension | docket | Terraform/OpenTofu |
+|-----------|--------|--------------------|
+| Idempotency check | equality of desired vs current [^8] | equality of desired vs current [^1] |
+| Source of "current state" | live per-task probe, every run [^8] | state file, refreshed from providers [^3][^4] |
+| Persistent state | none | `terraform.tfstate` (+ backends, locking) [^3] |
+| Deleting a resource removed from config | not deleted; delete is explicit via `state: absent` [^8] | destroyed on next apply [^3] |
+| Execution model | ordered plays then ordered tasks (Ansible lineage) [^11] | dependency graph, auto-ordered and parallelized [^5] |
+| plan and apply agreement | same `Plan()`, re-probed at apply [^8] | saved plan (`-out`) applied exactly, or re-plan [^2] |
+| Error handling | `failed_when`, `block`/`rescue`/`always`, `ignore_errors` [^12] | lifecycle rules, provider retries [^6] |
+| Drift limit | unprobeable tasks over-apply (safe, not a no-op) [^9] | dishonest providers cause permanent diffs [^1] |
+
+## Idempotency mechanism
+
+The post walks OpenTofu's decision as refresh, then merge, then decide, then apply: it reads the
+current object, merges it with your configuration into a proposed object, and compares. The comparison
+is the whole story - when `unmarkedPlannedNewVal.Equals(unmarkedPriorVal)` holds, the action becomes a
+NoOp and the provider's update method never runs [^1]. "Idempotency in IaC is just an equality check"
+is the post's way of saying the machinery around that comparison is incidental; the comparison is what
+makes a second run safe [^1].
+
+docket lands on the same equality check, but performs it per task against a live read rather than
+against a stored prior. Every task implements a `Plan()` method that probes the live server once,
+computes the difference between current and desired state, and either reports it is already in sync
+(and does nothing) or embeds a closure that performs the mutation [^8]. `apply` is defined as executing
+that same plan, so an in-sync task is a no-op for exactly the reason the post describes: the compared
+values are equal.
+
+The observable result is identical to Terraform's. The first `apply` reports each task as `[changed]`;
+a second `apply` against an unchanged server reports every task as `[ok]` and mutates nothing [^10]:
+
+```text
+# first run
+Summary: 2 tasks · 2 changed · 0 ok · 0 skipped · 0 errors
+
+# second run
+Summary: 2 tasks · 0 changed · 2 ok · 0 skipped · 0 errors
+```
+
+The difference is not *whether* there is an equality check but *what it compares against*: a value
+merged into a persisted state object [^1], versus a value read live from the server on this run [^8].
+
+## State: none versus a state file
+
+Terraform and OpenTofu need a state file. Its "primary purpose is to store bindings between objects in
+a remote system and resource instances declared in your configuration"; it exists to "map real world
+resources to your configuration, keep track of metadata, and to improve performance for large
+infrastructures" [^3][^4]. That file is real infrastructure of its own: it must be stored in a backend,
+locked so two applies do not race, refreshed to catch out-of-band changes, and edited through
+dedicated commands (`terraform import`, `terraform state`) when reality and the file diverge. Secret
+values that pass through resources are recorded in it [^7].
+
+docket has no state file. The live probe is the source of truth on every run, so there is nothing to
+store, lock, refresh, or import, and no way for a state file to drift from the server it describes [^8].
+The trade-off is the flip side of the same coin: docket has no cheap ledger of "what do I manage", it
+pays the probe cost on every plan and apply, and a resource it cannot read back cannot be reconciled at
+all. The closest analog to Terraform's state snapshot or `import` is `docket export`, which reads a live
+server and writes a recipe describing it; its correctness contract is idempotency - applying an exported
+recipe (together with its companion vars file) back to the same server reports no drift [^9].
+
+## plan and apply symmetry
+
+Terraform's `plan` refreshes state, compares the configuration to the prior state, and proposes the set
+of create/update/delete actions that would make the world match the configuration [^2]. That plan can be
+saved with `-out` and handed to `apply` so the applied changes are exactly the ones shown, or `apply`
+can compute a fresh plan itself. `terraform plan -detailed-exitcode` returns 0 for an empty diff, 2 for
+a non-empty diff, and 1 for an error [^2].
+
+docket guarantees plan/apply agreement structurally: both commands call the same `Plan()`, and `apply`
+reuses the probe that `plan` performed to decide whether to mutate [^8]. There is no saved-plan artifact -
+docket re-probes at apply time within the run rather than replaying a file. The command strings that
+`plan` says it *would* run and that `apply` says it *did* run are rendered by the same code and are
+byte-identical [^13]. `plan` reports drift with a small marker set - `[ok]` in sync, `[+]` create, `[~]`
+modify, `[-]` remove, and `[!]` when the probe itself errored - and `docket plan --detailed-exitcode`
+deliberately mirrors Terraform: 0 for no drift, 2 for drift, 1 on error, with errors winning over drift
+[^9].
+
+## Deletion and pruning semantics
+
+This is the sharpest divergence, and it follows directly from the state decision. Because Terraform's
+state file records every object it created against a resource instance, the configuration is the
+*complete* desired state of everything Terraform manages. When Terraform "creates a remote object in
+response to a change of configuration, it records the identity of that remote object ... and potentially
+updates or deletes that object in response to future configuration changes" [^3]. Remove a resource block
+from the configuration and the next apply destroys the object, because state still lists it as managed
+while the configuration no longer declares it.
+
+docket has no such managed set. Each task is an *assertion* about one resource, not membership in a
+global inventory, so removing a task from a recipe does nothing to the server - docket only ever acts on
+resources you name. Deletion is explicit: a task requests it with `state: absent` [^8]. The consequence
+cuts both ways. You cannot accidentally destroy a resource by deleting or forgetting a block, but docket
+also will not clean up orphaned resources for you; anything you want gone must be named with `state:
+absent`.
+
+## Ordered tasks versus a dependency graph
+
+Terraform builds a dependency graph from the references between resources and uses it to order
+operations and to parallelize independent ones automatically [^5]; you generally do not specify order,
+you express dependencies and Terraform derives the schedule.
+
+docket runs in source order. It grew out of `ansible-dokku` and keeps the Ansible shape: a recipe is a
+list of plays, each play a list of tasks, executed top to bottom [^11]. Ordering is whatever you write.
+`loop:` expands one task into one copy per list item, and `register:` saves a task's result so a later
+task's condition can react to it - for example, stamping a config value only on the run that first
+created an app [^12]. There is no automatic dependency graph and no automatic parallelism. The trade-off
+is explicitness and predictability against the convenience of a scheduler that orders and parallelizes
+for you.
+
+## Error handling and retries
+
+Terraform's error handling lives mostly in resource `lifecycle` rules - `create_before_destroy`,
+`prevent_destroy`, `ignore_changes` [^6] - and in provider-level retry logic; a failed apply leaves
+partial state that the next run reconciles.
+
+docket carries an Ansible-style error envelope on every task [^12]. `failed_when` is the standard "this
+exit code is fine" idiom that turns an imperative command into an idempotent one - for example, treating
+"not mounted" as success when unmounting - and a falsy predicate fully clears the failure. `changed_when`
+overrides the changed verdict. `ignore_errors: true` lets the run continue past a task that errored.
+`block` / `rescue` / `always` give a try / catch / finally over a group of tasks, so a deploy can carry
+its own rollback path. And `--start-at-task` resumes a partially applied recipe from a named task, while
+`--fail-fast` controls whether an error aborts the whole run or only the current play [^9].
+
+## Drift and "honest providers"
+
+The post names the limit of the equality-check model directly: "OpenTofu can only be as honest as its
+providers." If a provider misreports a value during refresh, the compared values never converge and you
+get a permanent diff - the tool keeps trying to "fix" state that is already correct, and idempotency
+breaks [^1].
+
+docket has the same class of limit, because its equality check is only as honest as each task's probe,
+but it degrades differently. A few tasks - notably `dokku_git_auth`, `dokku_registry_auth`, and
+`dokku_storage_ensure` - cannot read their own state without running the underlying command, so they
+always report drift with a `(... not probed)` reason and apply unconditionally [^9]. Some property
+families whose report key only appears after the value is set, such as letsencrypt's `dns-provider-*`,
+skip probing for the same reason [^8]. And `dokku_plugin` is idempotent by plugin name only, so a
+changed URL or committish on an already-installed plugin is not detected [^14]. When the probe command
+cannot run at all - the `dokku` CLI is missing, or the SSH host is unreachable - an existence probe
+renders `[!]` and `plan` exits 1 rather than optimistically predicting `[+] create` for state it never
+read [^9]; a property read that fails short of a transport error degrades the other way, reporting
+drift and re-applying the value. Either way, docket does not silently assume the server matches.
+
+The shapes of the two failure modes differ. When current state cannot be read honestly, Terraform tends
+toward a *permanent diff* - a change it proposes forever [^1] - while docket tends toward *over-applying*:
+it re-runs the command it could not prove unnecessary [^9]. docket's outcome is safe rather than a true
+no-op, so idempotency degrades to "runs again" rather than "diffs forever". Both are bounded by the same
+underlying constraint the post identifies: the equality check is only as good as the read of current
+state feeding it.
+
+[^1]: Karim, "Idempotency in IaC" - https://www.spamsbykarim.com/blog/idempotency-in-iac (primary source)
+[^2]: HashiCorp, "terraform plan command reference" - https://developer.hashicorp.com/terraform/cli/commands/plan
+[^3]: HashiCorp, "State" - https://developer.hashicorp.com/terraform/language/state
+[^4]: OpenTofu, "State" - https://opentofu.org/docs/language/state/
+[^5]: HashiCorp, "Resource graph" (dependency ordering and parallel graph walks) - https://developer.hashicorp.com/terraform/internals/graph
+[^6]: HashiCorp, "The lifecycle meta-argument" (`create_before_destroy`, `prevent_destroy`, `ignore_changes`) - https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle
+[^7]: HashiCorp, "Sensitive data in state" - https://developer.hashicorp.com/terraform/language/state/sensitive-data
+[^8]: docket, "Writing tasks" (the `Plan()` / probe model) - [docs/writing-tasks.md](../writing-tasks.md)
+[^9]: docket, "Command reference" (`plan`, `apply`, drift markers, `--detailed-exitcode`, `export`) - [docs/command-reference.md](../command-reference.md)
+[^10]: docket, "Getting started" - [docs/getting-started.md](../getting-started.md)
+[^11]: docket, "Recipes" (plays, tasks, and ordering) - [docs/recipes.md](../recipes.md)
+[^12]: docket, "Task envelope" (`when`, `loop`, `register`, error handling) - [docs/task-envelope.md](../task-envelope.md)
+[^13]: docket, "JSON output" (the `commands` arrays and their shared rendering) - [docs/json-output.md](../json-output.md)
+[^14]: docket, "dokku_plugin" - [docs/tasks/dokku_plugin.md](../tasks/dokku_plugin.md)


### PR DESCRIPTION
Adds reference-backed comparisons of docket's plan/apply and idempotency model against the dokku CLI, Ansible, Chef/Puppet/SaltStack, Terraform/OpenTofu, Kamal, Docker Compose, and Kubernetes GitOps operators. Every external quote is verified against its source, and each docket claim cites the specific reference doc that backs it via footnotes.