### PR TITLE
Assert play scoping without a Dokku server

### DIFF
--- a/commands/play_when_test.go
+++ b/commands/play_when_test.go
@@ -232,6 +232,90 @@ func TestPlayWhenCannotSeeSiblingPlayInputs(t *testing.T) {
 	}
 }
 
+// playLines returns the `==> Play:` lines of out, in order. Task lines
+// are dropped because the two renderers describe tasks differently by
+// design (`[0] <name>` under --list-tasks, `[ok]` / `[changed]` under
+// plan); only play selection is being compared.
+func playLines(out string) []string {
+	var lines []string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "==> Play:") {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+// TestPlayWhenListTasksMatchesPlan pins that `plan` and
+// `plan --list-tasks` reach the same play-selection verdict. The two
+// resolve play `when:` in separate code paths - the plan loop in
+// plan.go against Formatter.PlaySkipped, and renderListTasks against
+// its own format strings in list_tasks.go - which agree today only by
+// convention. tests/bats/plays.bats asserts play scoping through
+// --list-tasks (it is the offline surface, #412), so a divergence there
+// would silently stop covering what plan actually does.
+//
+// Task bodies are dokku_stub, whose Plan() reads a fixture instead of
+// shelling out, so the plan side runs a play to completion without a
+// server. The recipe carries no sensitive values: the plan side masks
+// play names and --list-tasks does not, so a sensitive name would make
+// the two differ by design rather than by drift.
+func TestPlayWhenListTasksMatchesPlan(t *testing.T) {
+	defer stubReset()
+	path := writePlayTasks(t, `---
+- inputs:
+    - name: env
+      default: prod
+- name: api
+  inputs:
+    - name: app
+      default: api
+  when: 'env == "prod"'
+  tasks:
+    - dokku_stub: { key: a }
+- name: worker
+  when: 'env == "staging"'
+  tasks:
+    - dokku_stub: { key: b }
+- name: sibling
+  when: 'app == "api"'
+  tasks:
+    - dokku_stub: { key: c }
+`)
+
+	planOut, planErr, planExit := playOutput(t, path)
+	if planExit != 0 {
+		t.Fatalf("plan exit = %d, want 0; stdout=%s stderr=%s", planExit, planOut, planErr)
+	}
+	listOut, listErr, listExit := playOutput(t, path, "--list-tasks")
+	if listExit != 0 {
+		t.Fatalf("plan --list-tasks exit = %d, want 0; stdout=%s stderr=%s", listExit, listOut, listErr)
+	}
+
+	got := playLines(listOut)
+	want := playLines(planOut)
+	if len(want) != 3 {
+		t.Fatalf("expected 3 play lines from plan, got %d:\n%s", len(want), planOut)
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("--list-tasks and plan disagree on play selection\nplan:\n%s\n--list-tasks:\n%s",
+			strings.Join(want, "\n"), strings.Join(got, "\n"))
+	}
+
+	// Guard the comparison itself: two empty line sets would compare
+	// equal, so assert the three verdicts the recipe was built to
+	// produce actually appear.
+	if !strings.Contains(listOut, "==> Play: api") || strings.Contains(listOut, "==> Play: api  (skipped") {
+		t.Errorf("api should run (file-level default satisfies when:); got:\n%s", listOut)
+	}
+	if !strings.Contains(listOut, `==> Play: worker  (skipped: when "env == \"staging\"")`) {
+		t.Errorf("worker should be skipped by its false predicate; got:\n%s", listOut)
+	}
+	if !strings.Contains(listOut, `==> Play: sibling  (skipped: when "app == \"api\"")`) {
+		t.Errorf("sibling should be skipped (api's play-local input must not leak); got:\n%s", listOut)
+	}
+}
+
 // TestPlayWhenCannotSeeLoopVars: `.item` is a loop-iteration value;
 // it must not be available to a play-level `when:`. With `==` the
 // undefined identifier resolves to nil → comparison false → skipped.

--- a/tests/bats/README.md
+++ b/tests/bats/README.md
@@ -36,6 +36,26 @@ bats tests/bats/
 Tests skip themselves when `dokku` is not available, so the suite is safe
 to run on a developer laptop without a local Dokku.
 
+## Gating on a server
+
+A test that reaches the server calls `require_dokku` as the first line of
+its body (or of `setup()`, when every test in the file needs one). Without
+it the test fails rather than skips on a machine with no `dokku` on
+`$PATH`, which is what happened in #412.
+
+Reach for the gate only when the assertion genuinely needs a server.
+Anything resolved before server contact should be asserted offline
+instead, so the coverage stays available to contributors without Dokku:
+
+- `validate` and `fmt` never contact a server.
+- `apply --list-tasks` / `plan --list-tasks` render the resolved plan -
+  play selection, `when:` evaluation, loop expansion, tag filtering,
+  interpolated task bodies - and return before any task is planned.
+
+`plan` is not itself offline: it probes the server for every play that
+runs, so a `plan` test asserting that a play ran needs either the gate or
+`--list-tasks`.
+
 ## CI
 
 `.github/workflows/test.yml` defines a `bats-test` job that installs Dokku

--- a/tests/bats/plays.bats
+++ b/tests/bats/plays.bats
@@ -7,8 +7,9 @@ load test_helper
 # play in order, --play <name> filters to one play, --fail-fast reverts
 # to the abort-entire-run semantics, and a play-level when: predicate
 # skips the entire play. Variable-visibility scoping for play-level
-# when: is exercised against the plan path so tests do not require a
-# Dokku server.
+# when: is exercised through plan --list-tasks, which resolves play
+# selection and returns before any server contact, so those tests need
+# no Dokku server.
 
 setup() {
   docket_build
@@ -255,8 +256,13 @@ EOF
   assert_output --partial 'unexpected play key "invalidkey"'
 }
 
-# Variable-visibility tests for play-level when: drive the plan path so
-# they do not require a Dokku server. The pattern is:
+# Variable-visibility tests for play-level when: drive plan --list-tasks
+# so they do not require a Dokku server. Plain `plan` probes the server
+# for every play that actually runs, so a test asserting a play ran would
+# fail without dokku rather than skip (#412). --list-tasks resolves the
+# play when: against the same merged context and prints the same
+# `==> Play:` header and `(skipped: when ...)` marker, then returns
+# before any task is planned. The pattern is:
 #  - file-level input default is visible to play when: (truthy makes the
 #    play run; falsy makes it skip).
 #  - CLI / vars-file overrides win.
@@ -275,7 +281,7 @@ EOF
     - dokku_app:
         app: docket-test-noop
 EOF
-  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --list-tasks
   assert_success
   assert_output --partial "==> Play: api"
   refute_output --partial "==> Play: api  (skipped"
@@ -293,7 +299,7 @@ EOF
     - dokku_app:
         app: docket-test-noop
 EOF
-  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --list-tasks
   assert_success
   assert_output --partial '==> Play: api  (skipped: when "env == \"prod\"")'
 }
@@ -310,7 +316,7 @@ EOF
     - dokku_app:
         app: docket-test-noop
 EOF
-  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --env prod
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --list-tasks --env prod
   assert_success
   assert_output --partial "==> Play: api"
   refute_output --partial "==> Play: api  (skipped"
@@ -331,7 +337,7 @@ EOF
   cat >"$BATS_TEST_TMPDIR/vars.yml" <<EOF
 env: prod
 EOF
-  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --vars-file "$BATS_TEST_TMPDIR/vars.yml"
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --list-tasks --vars-file "$BATS_TEST_TMPDIR/vars.yml"
   assert_success
   assert_output --partial "==> Play: api"
   refute_output --partial "==> Play: api  (skipped"
@@ -349,7 +355,7 @@ EOF
     - dokku_app:
         app: docket-test-noop
 EOF
-  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --list-tasks
   assert_success
   assert_output --partial '(skipped:'
 }
@@ -372,12 +378,17 @@ EOF
       dokku_app:
         app: docket-test-noop-worker
 EOF
-  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --list-tasks
   assert_success
   assert_output --partial "==> Play: api"
   assert_output --partial '==> Play: worker  (skipped'
 }
 
+# The tasks here are deliberately unnamed: --list-tasks prints a
+# user-supplied name: verbatim, so a named task would render as `noop`
+# in both plays and hide the value under test. Unnamed, the listing
+# falls back to `<type>: <body identifier>` and shows the app each play
+# rendered from its own input.
 @test "plays: per-play inputs scope to their own play in task body" {
   write_tasks_file <<EOF
 ---
@@ -386,19 +397,17 @@ EOF
     - name: app
       default: docket-test-noop-api
   tasks:
-    - name: noop
-      dokku_app:
+    - dokku_app:
         app: "{{ .app }}"
 - name: worker
   inputs:
     - name: app
       default: docket-test-noop-worker
   tasks:
-    - name: noop
-      dokku_app:
+    - dokku_app:
         app: "{{ .app }}"
 EOF
-  run "$(docket_bin)" plan --tasks "$TASKS_FILE"
+  run "$(docket_bin)" plan --tasks "$TASKS_FILE" --list-tasks
   assert_success
   assert_output --partial "docket-test-noop-api"
   assert_output --partial "docket-test-noop-worker"


### PR DESCRIPTION
The seven play-scoping tests in `plays.bats` drove plain `plan`, which probes the server for every play that actually runs, so five of them failed rather than skipped on a machine without dokku. They now drive `plan --list-tasks`, which resolves play selection against the same merged context and returns before any task is planned, so the coverage stays available to contributors without Dokku instead of being gated away behind `require_dokku`. A new Go test pins that `plan` and `plan --list-tasks` agree on play selection, since the two resolve play `when:` in separate code paths.

The full bats suite now runs clean with no `dokku` on `$PATH`: 216 pass, 0 fail. `tests/bats/README.md` gains the gating convention that was previously only implied, so the next server-touching test does not repeat this.

The dead `playWhenSkipped` variable noticed in `renderListTasks` while working on this is left for #429.

Fixes #412
