### PR TITLE
feat: add set and clear states to dokku_ports

### DIFF
--- a/docs/ansible-dokku.md
+++ b/docs/ansible-dokku.md
@@ -235,7 +235,7 @@ dokku plugin the row needs; blank means dokku core.
 | `dokku_letsencrypt` | `dokku_letsencrypt` | dokku-letsencrypt | Direct. |
 | `dokku_network` | `dokku_network` | | Direct. |
 | `dokku_network_property` | `dokku_network_property` | | docket adds `state`. |
-| `dokku_ports` | `dokku_ports` | | `mappings` strings become structured `port_mappings`; `state: clear` has no equivalent. |
+| `dokku_ports` | `dokku_ports` | | `mappings` strings become structured `port_mappings`. |
 | `dokku_proxy` | `dokku_proxy_toggle` | | `proxy:enable` / `proxy:disable`. |
 | `dokku_ps_scale` | `dokku_ps_scale` | | Direct. |
 | `dokku_registry` | `dokku_registry_auth` and `dokku_registry_property` | | Credentials go to `dokku_registry_auth` (`registry:login`); `image` and `server` go to `dokku_registry_property` as `image-repo` and `server`. The module still declares the old third-party `dokku-registry` plugin; docket treats `registry` as core. |
@@ -270,7 +270,7 @@ same file, and it is the spec that Ansible enforces. Those modules are `dokku_bu
 | `app` on `dokku_certs` | Required | Optional, but exactly one of `app` or `global` must be set | Nothing for the app case; the global case goes through the same task. |
 | `cert` / `key` | Optional in the spec | Optional, but `state: present` requires `cert` + `key` or `cert_content` + `key_content` | A `state: present` call with no material passes Ansible's arg spec and fails `docket validate`. Validate before applying. |
 | `phase` on `dokku_docker_options` | Required in the spec, optional in the docs | Required | Nothing; docket agrees with the spec. |
-| `mappings` / `port_mappings` | Optional list of `"http:80:5000"` strings | **Required** list of `{scheme, host, container}` objects | Parse each string and restructure it. An empty list is rejected too (`no port mappings provided`), so a module call that relied on omitting `mappings` has nothing to send. |
+| `mappings` / `port_mappings` | Optional list of `"http:80:5000"` strings | Optional list of `{scheme, host, container}` objects, but required and non-empty for `state: present`, `absent`, and `set` | Parse each string and restructure it. Omit the field entirely for `state: clear`, which rejects a list rather than ignoring one. |
 | `username` / `password` on `dokku_registry` | Both required, even for `state: absent` | Only `server` is required; credentials are required when `state: present` | A `state: absent` call carries credentials docket does not need. Drop them. |
 | `app` on `dokku_builder`, `dokku_network_property` | Required in the docs, optional in the spec | Optional, paired with `global` | Nothing. |
 | `app` on `dokku_storage` | Required | `dokku_storage_mount` requires `app` and `container_dir` | Split `mounts` into one task per entry, and split each `host:container` string. |
@@ -284,7 +284,7 @@ the same two defaults outright, so the behavior matches.
 
 ## What cannot be delegated yet
 
-Four things. Each is tracked, so a wrapper can keep the module implementation for now and drop it when
+Three things. Each is tracked, so a wrapper can keep the module implementation for now and drop it when
 the task lands.
 
 - **The `dokku_git_sync` module**
@@ -292,10 +292,6 @@ the task lands.
   plugin (`git-sync:set <app> remote`), which docket has no task for. Mind the name collision:
   docket's `dokku_git_sync` is core `git:sync`, which is what the `dokku_clone` module does. The two
   are unrelated.
-- **`dokku_ports` with `state: clear`**
-  ([#415](https://github.com/dokku/docket/issues/415)). `dokku_ports` handles `present` and `absent`
-  only, and rejects an empty `port_mappings` list, so clearing every mapping has to stay in the module
-  for now.
 - **Host-directory management in `dokku_storage`**
   ([#416](https://github.com/dokku/docket/issues/416)). With `create_host_dir`, the module does
   host-side `os.makedirs`, `chmod 0777`, and `chown` using the `user` / `group` options;

--- a/docs/tasks/dokku_domains.md
+++ b/docs/tasks/dokku_domains.md
@@ -14,7 +14,7 @@ Supported.
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | no |  |  | Name of the app |
 | `global` | bool | no |  |  | Flag indicating if the domains should be applied globally |
-| `domains` | list | no |  |  | List of domain names |
+| `domains` | list | no |  |  | List of domain names; omit for state 'clear' |
 | `state` | string | no | present | present, absent, set, clear | Desired state of the domains |
 
 ## Examples
@@ -56,7 +56,6 @@ dokku_domains:
 ```yaml
 dokku_domains:
     app: example-app
-    domains: []
     state: clear
 ```
 

--- a/docs/tasks/dokku_http_auth_domain.md
+++ b/docs/tasks/dokku_http_auth_domain.md
@@ -17,7 +17,7 @@ Supported.
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | yes |  |  | Name of the app |
-| `domains` | list | no |  |  | List of domains to restrict HTTP auth to |
+| `domains` | list | no |  |  | List of domains to restrict HTTP auth to; omit for state 'clear' |
 | `state` | string | no | present | present, absent, set, clear | Desired state of the HTTP auth domain entries |
 
 ## Examples
@@ -57,7 +57,6 @@ dokku_http_auth_domain:
 ```yaml
 dokku_http_auth_domain:
     app: hello-world
-    domains: []
     state: clear
 ```
 

--- a/docs/tasks/dokku_ports.md
+++ b/docs/tasks/dokku_ports.md
@@ -13,8 +13,8 @@ Supported.
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | yes |  |  | Name of the app |
-| `port_mappings` | list | yes |  |  | Port mappings to set. Each item has: scheme, host, container. |
-| `state` | string | no | present | present, absent | Desired state of the ports |
+| `port_mappings` | list | no |  |  | Port mappings to set; omit for state 'clear'. Each item has: scheme, host, container. |
+| `state` | string | no | present | present, absent, set, clear | Desired state of the ports |
 
 ## Examples
 
@@ -53,6 +53,26 @@ dokku_ports:
           host: 80
           container: 5000
     state: absent
+```
+
+### Replace every port mapping on an app
+
+```yaml
+dokku_ports:
+    app: node-js-app
+    port_mappings:
+        - scheme: https
+          host: 443
+          container: 5000
+    state: set
+```
+
+### Clear all port mappings from an app
+
+```yaml
+dokku_ports:
+    app: node-js-app
+    state: clear
 ```
 
 ## Return Values

--- a/tasks/domains_task.go
+++ b/tasks/domains_task.go
@@ -16,7 +16,7 @@ type DomainsTask struct {
 	Global bool `required:"false" yaml:"global,omitempty" description:"Flag indicating if the domains should be applied globally"`
 
 	// Domains is the list of domain names
-	Domains []string `required:"false" yaml:"domains" description:"List of domain names"`
+	Domains []string `required:"false" yaml:"domains,omitempty" description:"List of domain names; omit for state 'clear'"`
 
 	// State is the desired state of the domains
 	State State `required:"false" yaml:"state" default:"present" options:"present,absent,set,clear" description:"Desired state of the domains"`
@@ -284,6 +284,11 @@ func validateDomainsTask(t DomainsTask, requireDomains bool) error {
 	}
 	if requireDomains && len(t.Domains) == 0 {
 		return fmt.Errorf("'domains' must not be empty for state '%s'", t.State)
+	}
+	// domains:clear takes no domains, so a list supplied alongside it would be
+	// silently discarded rather than removed.
+	if !requireDomains && len(t.Domains) > 0 {
+		return fmt.Errorf("'domains' must not be set for state '%s'", t.State)
 	}
 	return nil
 }

--- a/tasks/domains_task_test.go
+++ b/tasks/domains_task_test.go
@@ -46,6 +46,19 @@ func TestDomainsTaskEmptyDomains(t *testing.T) {
 	}
 }
 
+func TestDomainsTaskClearRejectsDomains(t *testing.T) {
+	// domains:clear takes no domains, so a list here would be silently
+	// discarded rather than removed.
+	task := DomainsTask{App: "test-app", Domains: []string{"example.com"}, State: StateClear}
+	err := task.Validate()
+	if err == nil {
+		t.Fatal("expected an error when domains are supplied with state 'clear'")
+	}
+	if !strings.Contains(err.Error(), "'domains' must not be set for state 'clear'") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestDomainsTaskClearNoDomains(t *testing.T) {
 	task := DomainsTask{App: "test-app", State: StateClear}
 	result := task.Execute()

--- a/tasks/export_test.go
+++ b/tasks/export_test.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -681,5 +682,51 @@ func TestExportGlobalCertDisabledEmitsNoTask(t *testing.T) {
 	recipe, _ := res.MarshalRecipe("yaml")
 	if strings.Contains(string(recipe), "dokku_certs") {
 		t.Errorf("recipe should not contain a certs task when the global cert is disabled:\n%s", recipe)
+	}
+}
+
+func TestExportPortsUsesStateSet(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet ports:report web --ports-map": "https:443:5000 http:80:5000",
+	}))()
+
+	// state:set replaces the whole mapping list, so re-applying an export
+	// converges an app that has extra mappings rather than adding to them.
+	bodies, err := PortsTask{}.ExportApp("web")
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 exported task, got %d", len(bodies))
+	}
+	ports := bodies[0].(PortsTask)
+	if ports.State != StateSet {
+		t.Errorf("State = %q, want %q", ports.State, StateSet)
+	}
+	// The probe hands back a map, so the export sorts for a stable recipe.
+	want := []string{"http:80:5000", "https:443:5000"}
+	got := []string{}
+	for _, pm := range ports.PortMappings {
+		got = append(got, pm.String())
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("PortMappings = %v, want %v", got, want)
+	}
+	if err := ports.Validate(); err != nil {
+		t.Errorf("exported ports task must be valid, got: %v", err)
+	}
+}
+
+func TestExportPortsEmitsNoTaskWithoutMappings(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet ports:report web --ports-map": "",
+	}))()
+
+	bodies, err := PortsTask{}.ExportApp("web")
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+	if len(bodies) != 0 {
+		t.Errorf("expected no exported task when the app has no mappings, got %v", bodies)
 	}
 }

--- a/tasks/http_auth_domain_task.go
+++ b/tasks/http_auth_domain_task.go
@@ -17,7 +17,7 @@ type HttpAuthDomainTask struct {
 	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// Domains is the list of domains to restrict HTTP auth to
-	Domains []string `required:"false" yaml:"domains" description:"List of domains to restrict HTTP auth to"`
+	Domains []string `required:"false" yaml:"domains,omitempty" description:"List of domains to restrict HTTP auth to; omit for state 'clear'"`
 
 	// State is the desired state of the HTTP auth domain entries
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent,set,clear" description:"Desired state of the HTTP auth domain entries"`
@@ -106,6 +106,11 @@ func (t HttpAuthDomainTask) Validate() error {
 	}
 	if t.State == StateSet && len(t.Domains) == 0 {
 		return fmt.Errorf("'domains' must not be empty for state 'set'")
+	}
+	// http-auth:set-domains is called with no domains to clear, so a list
+	// supplied alongside it would be silently discarded rather than removed.
+	if t.State == StateClear && len(t.Domains) > 0 {
+		return fmt.Errorf("'domains' must not be set for state 'clear'")
 	}
 	return nil
 }

--- a/tasks/http_auth_domain_task_test.go
+++ b/tasks/http_auth_domain_task_test.go
@@ -79,6 +79,19 @@ func TestHttpAuthDomainTaskSetEmptyDomains(t *testing.T) {
 	}
 }
 
+func TestHttpAuthDomainTaskClearRejectsDomains(t *testing.T) {
+	// The clear path calls http-auth:set-domains with no domains, so a list
+	// here would be silently discarded rather than removed.
+	task := HttpAuthDomainTask{App: "test-app", Domains: []string{"app.example.com"}, State: StateClear}
+	err := task.Validate()
+	if err == nil {
+		t.Fatal("expected an error when domains are supplied with state 'clear'")
+	}
+	if !strings.Contains(err.Error(), "'domains' must not be set for state 'clear'") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestGetTasksHttpAuthDomainTaskParsedCorrectly(t *testing.T) {
 	data := []byte(`---
 - tasks:

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -15,10 +15,10 @@ type PortsTask struct {
 	App string `required:"true" yaml:"app" description:"Name of the app"`
 
 	// PortMappings are the port mappings to set
-	PortMappings []PortMapping `required:"true" yaml:"port_mappings" description:"Port mappings to set"`
+	PortMappings []PortMapping `required:"false" yaml:"port_mappings,omitempty" description:"Port mappings to set; omit for state 'clear'"`
 
 	// State is the desired state of the ports
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the ports"`
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent,set,clear" description:"Desired state of the ports"`
 }
 
 // PortsTaskExample contains an example of a PortsTask
@@ -94,10 +94,27 @@ func (t PortsTask) Examples() ([]Doc, error) {
 				State: StateAbsent,
 			},
 		},
+		{
+			Name: "Replace every port mapping on an app",
+			PortsTask: PortsTask{
+				App: "node-js-app",
+				PortMappings: []PortMapping{
+					{Scheme: "https", Host: 443, Container: 5000},
+				},
+				State: StateSet,
+			},
+		},
+		{
+			Name: "Clear all port mappings from an app",
+			PortsTask: PortsTask{
+				App:   "node-js-app",
+				State: StateClear,
+			},
+		},
 	})
 }
 
-// Execute sets or unsets the ports
+// Execute manages the app's port mappings
 func (t PortsTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
@@ -107,8 +124,16 @@ func (t PortsTask) Validate() error {
 	if t.App == "" {
 		return errors.New("'app' is required")
 	}
+	// ports:clear takes no mappings, so a list supplied alongside it would be
+	// silently discarded rather than removed. Every other state consumes one.
+	if t.State == StateClear {
+		if len(t.PortMappings) > 0 {
+			return errors.New("'port_mappings' must not be set for state 'clear'")
+		}
+		return nil
+	}
 	if len(t.PortMappings) == 0 {
-		return errors.New("no port mappings provided")
+		return fmt.Errorf("'port_mappings' must not be empty for state '%s'", t.State)
 	}
 	// Each mapping renders as scheme:host:container, so an unknown or
 	// misspelled key (silently ignored by the YAML decode) or a missing
@@ -134,79 +159,164 @@ func (t PortsTask) Plan() PlanResult {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		StatePresent: func() PlanResult {
-			currentPorts, err := getPorts(t.App)
-			if err != nil {
-				return PlanResult{Status: PlanStatusError, Error: err}
-			}
-			toAdd := []PortMapping{}
-			mutations := []string{}
-			for _, pm := range t.PortMappings {
-				if _, ok := currentPorts[pm.String()]; !ok {
-					toAdd = append(toAdd, pm)
-					mutations = append(mutations, fmt.Sprintf("add %s", pm.String()))
-				}
-			}
-			if len(toAdd) == 0 {
-				return PlanResult{InSync: true, Status: PlanStatusOK}
-			}
-			status := PlanStatusModify
-			if len(currentPorts) == 0 {
-				status = PlanStatusCreate
-			}
-			args := []string{"--quiet", "ports:add", t.App}
-			for _, pm := range toAdd {
-				args = append(args, pm.String())
-			}
-			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
-			return PlanResult{
-				InSync:    false,
-				Status:    status,
-				Reason:    fmt.Sprintf("%d port mapping(s) to add", len(toAdd)),
-				Mutations: mutations,
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
-				},
-			}
-		},
-		StateAbsent: func() PlanResult {
-			currentPorts, err := getPorts(t.App)
-			if err != nil {
-				return PlanResult{Status: PlanStatusError, Error: err}
-			}
-			toRemove := []PortMapping{}
-			mutations := []string{}
-			for _, pm := range t.PortMappings {
-				if _, ok := currentPorts[pm.String()]; ok {
-					toRemove = append(toRemove, pm)
-					mutations = append(mutations, fmt.Sprintf("remove %s", pm.String()))
-				}
-			}
-			if len(toRemove) == 0 {
-				return PlanResult{InSync: true, Status: PlanStatusOK}
-			}
-			args := []string{"--quiet", "ports:remove", t.App}
-			for _, pm := range toRemove {
-				args = append(args, pm.String())
-			}
-			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
-			return PlanResult{
-				InSync:    false,
-				Status:    PlanStatusDestroy,
-				Reason:    fmt.Sprintf("%d port mapping(s) to remove", len(toRemove)),
-				Mutations: mutations,
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StatePresent}, StateAbsent, inputs)
-				},
-			}
-		},
+		StatePresent: func() PlanResult { return planPortsPresent(t) },
+		StateAbsent:  func() PlanResult { return planPortsAbsent(t) },
+		StateSet:     func() PlanResult { return planPortsSet(t) },
+		StateClear:   func() PlanResult { return planPortsClear(t) },
 	})
+}
+
+// planPortsPresent reports drift for the present-state mapping add.
+func planPortsPresent(t PortsTask) PlanResult {
+	currentPorts, err := getPorts(t.App)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	toAdd := []string{}
+	mutations := []string{}
+	for _, pm := range t.PortMappings {
+		if _, ok := currentPorts[pm.String()]; !ok {
+			toAdd = append(toAdd, pm.String())
+			mutations = append(mutations, fmt.Sprintf("add %s", pm.String()))
+		}
+	}
+	if len(toAdd) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	status := PlanStatusModify
+	if len(currentPorts) == 0 {
+		status = PlanStatusCreate
+	}
+	inputs := dokkuArgsInputs("ports:add", t.App, toAdd)
+	return PlanResult{
+		InSync:    false,
+		Status:    status,
+		Reason:    fmt.Sprintf("%d port mapping(s) to add", len(toAdd)),
+		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
+		apply:     applyDokkuArgs("ports:add", t.App, toAdd, StatePresent, StateAbsent),
+	}
+}
+
+// planPortsAbsent reports drift for the absent-state mapping remove.
+func planPortsAbsent(t PortsTask) PlanResult {
+	currentPorts, err := getPorts(t.App)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	toRemove := []string{}
+	mutations := []string{}
+	for _, pm := range t.PortMappings {
+		if _, ok := currentPorts[pm.String()]; ok {
+			toRemove = append(toRemove, pm.String())
+			mutations = append(mutations, fmt.Sprintf("remove %s", pm.String()))
+		}
+	}
+	if len(toRemove) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	inputs := dokkuArgsInputs("ports:remove", t.App, toRemove)
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    fmt.Sprintf("%d port mapping(s) to remove", len(toRemove)),
+		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
+		apply:     applyDokkuArgs("ports:remove", t.App, toRemove, StateAbsent, StatePresent),
+	}
+}
+
+// planPortsSet reports drift for the set-state full replacement. The itemized
+// mutations are the adds and removes the replacement works out to; the command
+// itself always carries the complete desired list.
+func planPortsSet(t PortsTask) PlanResult {
+	currentPorts, err := getPorts(t.App)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	desired := map[string]bool{}
+	for _, pm := range t.PortMappings {
+		desired[pm.String()] = true
+	}
+	mutations := []string{}
+	for _, pm := range t.PortMappings {
+		if _, ok := currentPorts[pm.String()]; !ok {
+			mutations = append(mutations, fmt.Sprintf("add %s", pm.String()))
+		}
+	}
+	for _, mapping := range sortedPortMappings(currentPorts) {
+		if !desired[mapping] {
+			mutations = append(mutations, fmt.Sprintf("remove %s", mapping))
+		}
+	}
+	if len(mutations) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	status := PlanStatusModify
+	if len(currentPorts) == 0 {
+		status = PlanStatusCreate
+	}
+	args := portMappingArgs(t.PortMappings)
+	inputs := dokkuArgsInputs("ports:set", t.App, args)
+	return PlanResult{
+		InSync:    false,
+		Status:    status,
+		Reason:    fmt.Sprintf("%d port mapping change(s)", len(mutations)),
+		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
+		apply:     applyDokkuArgs("ports:set", t.App, args, StateSet, StateAbsent),
+	}
+}
+
+// planPortsClear reports drift for the clear-state operation.
+func planPortsClear(t PortsTask) PlanResult {
+	currentPorts, err := getPorts(t.App)
+	if err != nil {
+		return PlanResult{Status: PlanStatusError, Error: err}
+	}
+	if len(currentPorts) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+	mappings := sortedPortMappings(currentPorts)
+	mutations := make([]string, 0, len(mappings))
+	for _, mapping := range mappings {
+		mutations = append(mutations, fmt.Sprintf("remove %s", mapping))
+	}
+	inputs := dokkuArgsInputs("ports:clear", t.App, nil)
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusDestroy,
+		Reason:    fmt.Sprintf("clear %d port mapping(s)", len(currentPorts)),
+		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
+		apply:     applyDokkuArgs("ports:clear", t.App, nil, StateClear, StatePresent),
+	}
+}
+
+// portMappingArgs renders mappings as the scheme:host:container arguments the
+// ports subcommands take.
+func portMappingArgs(mappings []PortMapping) []string {
+	args := make([]string, 0, len(mappings))
+	for _, pm := range mappings {
+		args = append(args, pm.String())
+	}
+	return args
+}
+
+// sortedPortMappings returns the mapping strings of a getPorts result in a
+// stable order, since the probe hands back a map.
+func sortedPortMappings(mappings map[string]PortMapping) []string {
+	keys := make([]string, 0, len(mappings))
+	for k := range mappings {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // ExportApp reads the app's port mappings and returns a dokku_ports task, or
 // nil when none are configured. Mappings are sorted for deterministic output.
+// state:set replaces the whole mapping list for an exact match.
 func (t PortsTask) ExportApp(app string) ([]interface{}, error) {
 	mappings, err := getPorts(app)
 	if err != nil {
@@ -215,23 +325,19 @@ func (t PortsTask) ExportApp(app string) ([]interface{}, error) {
 	if len(mappings) == 0 {
 		return nil, nil
 	}
-	keys := make([]string, 0, len(mappings))
-	for k := range mappings {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	list := make([]PortMapping, 0, len(keys))
-	for _, k := range keys {
+	list := make([]PortMapping, 0, len(mappings))
+	for _, k := range sortedPortMappings(mappings) {
 		list = append(list, mappings[k])
 	}
-	return []interface{}{PortsTask{App: app, PortMappings: list}}, nil
+	return []interface{}{PortsTask{App: app, PortMappings: list, State: StateSet}}, nil
 }
 
 // getPorts gets the ports for a given app. A transport-level failure
 // (`*subprocess.SSHError`) is propagated; a dokku-level non-zero exit
 // (e.g. app does not exist) is treated as "no ports configured."
 func getPorts(appName string) (map[string]PortMapping, error) {
-	// todo: update dokku to add proper json output for this
+	// dokku master has a --ports-map-json that would replace this text parse,
+	// but it is not in a release yet; see #431.
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args: []string{

--- a/tasks/ports_task_integration_test.go
+++ b/tasks/ports_task_integration_test.go
@@ -1,8 +1,28 @@
 package tasks
 
 import (
+	"sort"
+	"strings"
 	"testing"
+
+	"github.com/dokku/docket/subprocess"
 )
+
+// getReportedPorts queries dokku ports:report to get the current mappings for
+// an app, so assertions do not lean on the task's own probe.
+func getReportedPorts(appName string) []string {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", "ports:report", appName, "--ports-map"},
+	})
+	if err != nil {
+		return nil
+	}
+
+	mappings := strings.Fields(result.StdoutContents())
+	sort.Strings(mappings)
+	return mappings
+}
 
 func TestIntegrationPortsAddAndRemove(t *testing.T) {
 	skipIfNoDokkuT(t)
@@ -59,5 +79,85 @@ func TestIntegrationPortsAddAndRemove(t *testing.T) {
 	}
 	if result.Changed {
 		t.Error("expected changed=false for nonexistent port")
+	}
+}
+
+func TestIntegrationPortsSetAndClear(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	appName := "docket-test-ports-set-clear"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	// seed two mappings so set has something to replace
+	seedTask := PortsTask{
+		App: appName,
+		PortMappings: []PortMapping{
+			{Scheme: "http", Host: 8080, Container: 5000},
+			{Scheme: "http", Host: 8081, Container: 5000},
+		},
+		State: StatePresent,
+	}
+	if result := seedTask.Execute(); result.Error != nil {
+		t.Fatalf("failed to seed ports: %v", result.Error)
+	}
+
+	// set replaces the whole list rather than adding to it
+	setTask := PortsTask{
+		App:          appName,
+		PortMappings: []PortMapping{{Scheme: "http", Host: 8082, Container: 5000}},
+		State:        StateSet,
+	}
+	result := setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set ports: %v", result.Error)
+	}
+	if result.State != StateSet {
+		t.Errorf("expected state 'set', got '%s'", result.State)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for set ports")
+	}
+
+	mappings := getReportedPorts(appName)
+	if len(mappings) != 1 || mappings[0] != "http:8082:5000" {
+		t.Fatalf("expected exactly [http:8082:5000] after set, got %v", mappings)
+	}
+
+	// set again (idempotent)
+	result = setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent set failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false when the mappings already match")
+	}
+
+	// clear drops every mapping in one call
+	clearTask := PortsTask{App: appName, State: StateClear}
+	result = clearTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to clear ports: %v", result.Error)
+	}
+	if result.State != StateClear {
+		t.Errorf("expected state 'clear', got '%s'", result.State)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for clear ports")
+	}
+
+	if mappings := getReportedPorts(appName); len(mappings) != 0 {
+		t.Errorf("expected 0 mappings after clear, got %d: %v", len(mappings), mappings)
+	}
+
+	// clear again (idempotent)
+	result = clearTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("idempotent clear failed: %v", result.Error)
+	}
+	if result.Changed {
+		t.Error("expected changed=false when there is nothing to clear")
 	}
 }

--- a/tasks/ports_task_test.go
+++ b/tasks/ports_task_test.go
@@ -1,9 +1,11 @@
 package tasks
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/dokku/docket/subprocess"
 	_ "github.com/gliderlabs/sigil/builtin"
 )
 
@@ -57,6 +59,34 @@ func TestPortsTaskValidatePerItem(t *testing.T) {
 			task:    PortsTask{PortMappings: []PortMapping{{Scheme: "http", Host: 80, Container: 5000}}},
 			wantErr: "'app' is required",
 		},
+		{
+			name:    "empty list is rejected for present",
+			task:    PortsTask{App: "web", PortMappings: []PortMapping{}, State: StatePresent},
+			wantErr: "'port_mappings' must not be empty for state 'present'",
+		},
+		{
+			name:    "empty list is rejected for absent",
+			task:    PortsTask{App: "web", PortMappings: []PortMapping{}, State: StateAbsent},
+			wantErr: "'port_mappings' must not be empty for state 'absent'",
+		},
+		{
+			name:    "empty list is rejected for set",
+			task:    PortsTask{App: "web", PortMappings: []PortMapping{}, State: StateSet},
+			wantErr: "'port_mappings' must not be empty for state 'set'",
+		},
+		{
+			name: "clear does not require a list",
+			task: PortsTask{App: "web", State: StateClear},
+		},
+		{
+			name: "clear accepts an explicitly empty list",
+			task: PortsTask{App: "web", PortMappings: []PortMapping{}, State: StateClear},
+		},
+		{
+			name:    "clear rejects a list",
+			task:    PortsTask{App: "web", PortMappings: []PortMapping{{Scheme: "http", Host: 80, Container: 5000}}, State: StateClear},
+			wantErr: "'port_mappings' must not be set for state 'clear'",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -71,6 +101,186 @@ func TestPortsTaskValidatePerItem(t *testing.T) {
 				t.Fatalf("expected error %q, got: %v", tt.wantErr, err)
 			}
 		})
+	}
+}
+
+// portsReportKey is the fakeDokku key for the probe getPorts runs.
+const portsReportKey = "--quiet ports:report web --ports-map"
+
+func TestPortsSetPlansFullReplacement(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		portsReportKey: "http:80:5000 https:443:5000",
+	}))()
+
+	plan := PortsTask{
+		App:          "web",
+		PortMappings: []PortMapping{{Scheme: "http", Host: 8080, Container: 5000}},
+		State:        StateSet,
+	}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Fatal("expected drift when the desired mappings differ from the report")
+	}
+	if plan.Status != PlanStatusModify {
+		t.Errorf("Status = %q, want %q", plan.Status, PlanStatusModify)
+	}
+	if len(plan.Commands) != 1 {
+		t.Fatalf("expected exactly one planned command, got %v", plan.Commands)
+	}
+	// The command carries the complete desired list, not the per-mapping delta.
+	if !strings.HasSuffix(plan.Commands[0], "ports:set web http:8080:5000") {
+		t.Errorf("expected ports:set with the full desired list, got %q", plan.Commands[0])
+	}
+	want := []string{"add http:8080:5000", "remove http:80:5000", "remove https:443:5000"}
+	if !reflect.DeepEqual(plan.Mutations, want) {
+		t.Errorf("Mutations = %v, want %v", plan.Mutations, want)
+	}
+}
+
+func TestPortsSetOnAppWithNoMappingsIsACreate(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		portsReportKey: "",
+	}))()
+
+	plan := PortsTask{
+		App:          "web",
+		PortMappings: []PortMapping{{Scheme: "http", Host: 80, Container: 5000}},
+		State:        StateSet,
+	}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.Status != PlanStatusCreate {
+		t.Errorf("Status = %q, want %q", plan.Status, PlanStatusCreate)
+	}
+}
+
+func TestPortsSetConvergesWhenReportMatches(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		portsReportKey: "https:443:5000 http:80:5000",
+	}))()
+
+	plan := PortsTask{
+		App: "web",
+		PortMappings: []PortMapping{
+			{Scheme: "http", Host: 80, Container: 5000},
+			{Scheme: "https", Host: 443, Container: 5000},
+		},
+		State: StateSet,
+	}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if !plan.InSync {
+		t.Fatalf("expected in-sync once the report matches the desired set, got %#v", plan)
+	}
+	if len(plan.Commands) != 0 {
+		t.Errorf("expected no planned commands when in sync, got %v", plan.Commands)
+	}
+}
+
+func TestPortsClearPlansEveryMapping(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		portsReportKey: "http:80:5000 https:443:5000",
+	}))()
+
+	plan := PortsTask{App: "web", State: StateClear}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Fatal("expected drift when the app has mappings to clear")
+	}
+	if plan.Status != PlanStatusDestroy {
+		t.Errorf("Status = %q, want %q", plan.Status, PlanStatusDestroy)
+	}
+	if len(plan.Commands) != 1 {
+		t.Fatalf("expected exactly one planned command, got %v", plan.Commands)
+	}
+	// ports:clear takes the app and nothing else.
+	if !strings.HasSuffix(plan.Commands[0], "ports:clear web") {
+		t.Errorf("expected a bare ports:clear command, got %q", plan.Commands[0])
+	}
+	want := []string{"remove http:80:5000", "remove https:443:5000"}
+	if !reflect.DeepEqual(plan.Mutations, want) {
+		t.Errorf("Mutations = %v, want %v", plan.Mutations, want)
+	}
+}
+
+func TestPortsClearIsInSyncWithoutMappings(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		portsReportKey: "",
+	}))()
+
+	plan := PortsTask{App: "web", State: StateClear}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if !plan.InSync {
+		t.Fatalf("expected in-sync when the app has no mappings, got %#v", plan)
+	}
+	if len(plan.Commands) != 0 {
+		t.Errorf("expected no planned commands when in sync, got %v", plan.Commands)
+	}
+}
+
+func TestPortsPresentPlansOnlyTheMissingMappings(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		portsReportKey: "http:80:5000",
+	}))()
+
+	plan := PortsTask{
+		App: "web",
+		PortMappings: []PortMapping{
+			{Scheme: "http", Host: 80, Container: 5000},
+			{Scheme: "https", Host: 443, Container: 5000},
+		},
+		State: StatePresent,
+	}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.Status != PlanStatusModify {
+		t.Errorf("Status = %q, want %q", plan.Status, PlanStatusModify)
+	}
+	if len(plan.Commands) != 1 {
+		t.Fatalf("expected exactly one planned command, got %v", plan.Commands)
+	}
+	if !strings.HasSuffix(plan.Commands[0], "ports:add web https:443:5000") {
+		t.Errorf("expected ports:add with only the missing mapping, got %q", plan.Commands[0])
+	}
+	want := []string{"add https:443:5000"}
+	if !reflect.DeepEqual(plan.Mutations, want) {
+		t.Errorf("Mutations = %v, want %v", plan.Mutations, want)
+	}
+}
+
+func TestPortsAbsentPlansOnlyThePresentMappings(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		portsReportKey: "http:80:5000",
+	}))()
+
+	plan := PortsTask{
+		App: "web",
+		PortMappings: []PortMapping{
+			{Scheme: "http", Host: 80, Container: 5000},
+			{Scheme: "https", Host: 443, Container: 5000},
+		},
+		State: StateAbsent,
+	}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.Status != PlanStatusDestroy {
+		t.Errorf("Status = %q, want %q", plan.Status, PlanStatusDestroy)
+	}
+	if len(plan.Commands) != 1 {
+		t.Fatalf("expected exactly one planned command, got %v", plan.Commands)
+	}
+	if !strings.HasSuffix(plan.Commands[0], "ports:remove web http:80:5000") {
+		t.Errorf("expected ports:remove with only the configured mapping, got %q", plan.Commands[0])
 	}
 }
 
@@ -147,5 +357,45 @@ func TestGetTasksPortsTaskWithMappings(t *testing.T) {
 	}
 	if portsTask.PortMappings[1].String() != "https:443:5000" {
 		t.Errorf("mapping[1] = %q, want %q", portsTask.PortMappings[1].String(), "https:443:5000")
+	}
+}
+
+func TestGetTasksPortsTaskClearWithoutMappings(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: clear ports
+      dokku_ports:
+        app: test-app
+        state: clear
+`)
+	context := map[string]interface{}{}
+
+	tasks, err := GetTasks(data, context)
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("clear ports")
+	if task == nil {
+		t.Fatal("task 'clear ports' not found")
+	}
+
+	portsTask, ok := task.(*PortsTask)
+	if !ok {
+		pt, ok2 := task.(PortsTask)
+		if !ok2 {
+			t.Fatalf("task is not a PortsTask (type is %T)", task)
+		}
+		portsTask = &pt
+	}
+
+	if portsTask.State != StateClear {
+		t.Errorf("expected state 'clear', got %q", portsTask.State)
+	}
+	if len(portsTask.PortMappings) != 0 {
+		t.Errorf("expected no port mappings, got %d", len(portsTask.PortMappings))
+	}
+	if err := portsTask.Validate(); err != nil {
+		t.Errorf("clear without port_mappings should validate, got: %v", err)
 	}
 }

--- a/tests/bats/validate.bats
+++ b/tests/bats/validate.bats
@@ -58,6 +58,50 @@ EOF
   assert_output --partial "'scheme' is required"
 }
 
+@test "docket validate exits 0 on ports state clear without port_mappings (#415)" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_ports:
+        app: web
+        state: clear
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_success
+  assert_output --partial "is valid"
+}
+
+@test "docket validate exits 1 on ports state clear carrying port_mappings" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_ports:
+        app: web
+        state: clear
+        port_mappings:
+          - scheme: http
+            host: 80
+            container: 5000
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "'port_mappings' must not be set for state 'clear'"
+}
+
+@test "docket validate exits 1 on ports state set with an empty port_mappings" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_ports:
+        app: web
+        state: set
+        port_mappings: []
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "'port_mappings' must not be empty for state 'set'"
+}
+
 @test "docket validate exits 1 on git_from_image email without username" {
   write_tasks_file <<EOF
 ---


### PR DESCRIPTION
docket could only add and remove individual port mappings, so clearing them all meant reading the server and enumerating every mapping as `absent`, which is exactly the work a generated recipe cannot do. `state: clear` and `state: set` cover that, `port_mappings` is now optional, and supplying a list alongside `state: clear` is rejected rather than silently ignored - a rule `dokku_domains` and `dokku_http_auth_domain` now share. `docket export` emits port mappings as `state: set` so an exported recipe reproduces the exact set rather than appending to whatever is already on the target.

Two things surfaced while working on this and are tracked separately rather than folded in: dokku master has a `ports:report --ports-map-json` that would replace docket's text parse but is not in a release yet (#431), and dokku rejects two mappings sharing a scheme and host port while `docket validate` does not (#432).

Closes #415
