### PR TITLE
feat: add create-time options to dokku_service_create

### DIFF
--- a/docs/ansible-dokku.md
+++ b/docs/ansible-dokku.md
@@ -241,7 +241,7 @@ dokku plugin the row needs; blank means dokku core.
 | `dokku_registry` | `dokku_registry_auth` and `dokku_registry_property` | | Credentials go to `dokku_registry_auth` (`registry:login`); `image` and `server` go to `dokku_registry_property` as `image-repo` and `server`. The module still declares the old third-party `dokku-registry` plugin; docket treats `registry` as core. |
 | `dokku_resource_limit` | `dokku_resource_limit` | | Direct. |
 | `dokku_resource_reserve` | `dokku_resource_reserve` | | Direct. |
-| `dokku_service_create` | `dokku_service_create` | datastore plugin | docket adds `state: absent`. |
+| `dokku_service_create` | `dokku_service_create` | datastore plugin | docket adds `state: absent`, and exposes the create-time options as task fields (`image`, `image_version`, `custom_env`, and the rest) rather than through the environment. |
 | `dokku_service_link` | `dokku_service_link` | datastore plugin | Direct. |
 | `dokku_storage` | `dokku_storage_mount`, `dokku_storage_entry`, `dokku_storage_ensure` | | One `dokku_storage_mount` per entry in `mounts`. Host-directory creation is only partly covered. |
 
@@ -250,6 +250,16 @@ while `dokku_registry_auth` drives `registry:login`, and `dokku_proxy` reads its
 `config:get <app> DOKKU_DISABLE_PROXY` while docket reads the proxy plugin's report. In both cases
 the intent matches even though the wire calls differ, which is the point of delegating - docket's
 side is the one that stays current with dokku.
+
+One mapping is not a field at all on the module side. `dokku_service_create` pins a service's image
+by reading `POSTGRES_IMAGE` and friends out of Ansible's `environment:` keyword; docket sends the
+same overrides as flags on `<service>:create`, so a wrapper translates them into task fields:
+`<SERVICE>_IMAGE` becomes `image`, `<SERVICE>_IMAGE_VERSION` becomes `image_version`,
+`<SERVICE>_CUSTOM_ENV` becomes the `custom_env` map, and `<SERVICE>_CONFIG_OPTIONS` becomes
+`config_options`. Flags rather than environment variables because docket may be driving the server
+over SSH, where variables put in front of the local process never reach the remote shell. The
+remaining create-time options (`memory`, `shm_size`, the three network fields, `password`, and
+`root_password`) have no module counterpart.
 
 ## Required and optional fields disagree
 
@@ -284,7 +294,7 @@ the same two defaults outright, so the behavior matches.
 
 ## What cannot be delegated yet
 
-Three things. Each is tracked, so a wrapper can keep the module implementation for now and drop it when
+Two things. Each is tracked, so a wrapper can keep the module implementation for now and drop it when
 the task lands.
 
 - **The `dokku_git_sync` module**
@@ -300,10 +310,6 @@ the task lands.
   no chmod and no host-directory removal. The module gets away with raw filesystem calls because
   Ansible is already running on the dokku host; docket may be driving it over SSH, so anything it does
   here has to go through a `dokku` subcommand.
-- **Custom service images**
-  ([#417](https://github.com/dokku/docket/issues/417)). `dokku_service_create` in the module reads
-  image overrides from Ansible's `environment:` (`POSTGRES_IMAGE` and friends) rather than from a
-  module argument. docket does not forward those.
 
 ## docket tasks with no ansible-dokku module
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -87,7 +87,10 @@ code onto the new server with whichever deploy source your recipe uses:
 
 ## Step 4: Move service data (outside docket)
 
-[`dokku_service_create`](tasks/dokku_service_create.md) makes an *empty* service, and
+[`dokku_service_create`](tasks/dokku_service_create.md) makes an *empty* service - on the same image
+the old one was running, which export reads off the container so the new server does not silently
+pick up a different major version its plugin happens to default to. The other create-time options
+(`custom_env`, `memory`, the networks, and the passwords) cannot be read back and must be re-supplied.
 [`dokku_service_backup`](tasks/dokku_service_backup.md) only configures the S3 backup schedule and
 auth - there is no restore task. Export carries the schedule, bucket, and `use_iam` flag but not the
 AWS credentials or encryption passphrase (they cannot be read back), so re-add those before the

--- a/docs/tasks/dokku_service_create.md
+++ b/docs/tasks/dokku_service_create.md
@@ -10,7 +10,7 @@ Creates or destroys a dokku service
 
 ## Export support
 
-Supported.
+Partial - the service and the image it is running are exported; the remaining create-time options (config_options, custom_env, memory, shm_size, the networks, and the passwords) have no read command and must be re-supplied.
 
 ## Parameters
 
@@ -18,6 +18,17 @@ Supported.
 | --- | --- | --- | --- | --- | --- |
 | `service` | string | yes |  |  | Type of service to create (e.g. redis, postgres, mysql) |
 | `name` | string | yes |  |  | Name of the service instance |
+| `image` | string | no |  |  | Image to start the service with, e.g. postgis/postgis. Applied only when the service is created. |
+| `image_version` | string | no |  |  | Image tag to start the service with. Applied only when the service is created. |
+| `config_options` | string | no |  |  | Extra arguments to pass to the container create command. Applied only when the service is created. |
+| `custom_env` | dict | no |  |  | Map of environment variables to start the service with. Applied only when the service is created. (sensitive) |
+| `memory` | int | no |  |  | Container memory limit in megabytes. Applied only when the service is created. |
+| `shm_size` | string | no |  |  | Shared memory size for the service container. Applied only when the service is created. |
+| `initial_network` | string | no |  |  | Network to attach the service to initially. Applied only when the service is created. |
+| `post_create_network` | list | no |  |  | Networks to attach the service container to after creation. Applied only when the service is created. |
+| `post_start_network` | list | no |  |  | Networks to attach the service container to after start. Applied only when the service is created. |
+| `password` | string | no |  |  | Override the user-level service password. Applied only when the service is created. (sensitive) |
+| `root_password` | string | no |  |  | Override the root-level service password. Applied only when the service is created. (sensitive) |
 | `state` | string | no | present | present, absent | Desired state of the service |
 
 ## Examples
@@ -36,6 +47,16 @@ dokku_service_create:
 dokku_service_create:
     service: postgres
     name: my-db
+```
+
+### Create a redis service on a pinned image
+
+```yaml
+dokku_service_create:
+    service: redis
+    name: my-pinned-redis
+    image: redis
+    image_version: 7.2.5
 ```
 
 ### Destroy a redis service named my-redis

--- a/subprocess/exec.go
+++ b/subprocess/exec.go
@@ -27,7 +27,15 @@ type ExecCommandInput struct {
 	// DisableStdioBuffer disables the stdio buffer
 	DisableStdioBuffer bool
 
-	// Env is the environment variables to pass to the command
+	// Env is the environment variables to pass to the command.
+	//
+	// These reach the local process only. On the SSH path they decorate the
+	// local `ssh` client, which does not forward them (no SendEnv here, and
+	// the server would have to opt in with AcceptEnv anyway), so the remote
+	// `dokku` never sees them. A task that needs to influence a remote
+	// command must put it on the argv - see ServiceCreateTask, which renders
+	// its create-time options as `<service>:create` flags for this reason.
+	// Whether to make this work remotely or drop it is tracked in #436.
 	Env map[string]string
 
 	// Stdin is the stdin of the command

--- a/subprocess/ssh_test.go
+++ b/subprocess/ssh_test.go
@@ -269,6 +269,42 @@ func TestBuildSshArgvQuotesInjection(t *testing.T) {
 	}
 }
 
+// TestBuildSshArgvQuotesServiceCreateFlags covers the create-time options
+// dokku_service_create renders onto `<service>:create`. They are argv entries
+// rather than environment assignments precisely so the remote path works:
+// ExecCommandInput.Env only decorates the local ssh process. The semicolon
+// delimiters inside a --custom-env token are the sharp edge - unquoted they
+// would be command separators on the remote login shell.
+func TestBuildSshArgvQuotesServiceCreateFlags(t *testing.T) {
+	t.Setenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS", "")
+	t.Setenv("DOKKU_SUDO", "")
+
+	target := sshTarget{User: "alice", Host: "host", Port: "22"}
+	argv, err := buildSshArgv(target, []string{
+		"dokku", "--quiet", "postgres:create", "my-db",
+		"--image", "postgis/postgis",
+		"--image-version", "13-master",
+		"--custom-env", "GREETING=hello there;TZ=UTC",
+	})
+	if err != nil {
+		t.Fatalf("buildSshArgv returned error: %v", err)
+	}
+	dashIdx := indexOf(argv, "--")
+	if dashIdx < 0 {
+		t.Fatalf("argv missing -- separator: %v", argv)
+	}
+	post := argv[dashIdx+1:]
+	want := []string{
+		"dokku", "--quiet", "postgres:create", "my-db",
+		"--image", "postgis/postgis",
+		"--image-version", "13-master",
+		"--custom-env", "'GREETING=hello there;TZ=UTC'",
+	}
+	if !equalStrings(post, want) {
+		t.Errorf("post-`--` argv = %v, want %v", post, want)
+	}
+}
+
 func TestBuildSshArgvRejectsUnquotable(t *testing.T) {
 	t.Setenv("DOKKU_SSH_ACCEPT_NEW_HOST_KEYS", "")
 	t.Setenv("DOKKU_SUDO", "")

--- a/tasks/example_integration_test.go
+++ b/tasks/example_integration_test.go
@@ -44,6 +44,11 @@ type exampleReq struct {
 	// cleanupApps are extra apps the task creates (e.g. a clone target) that
 	// must be destroyed afterward.
 	cleanupApps []string
+	// cleanupServices are `<type>:<name>` datastore services the task's own
+	// examples create and do not destroy. ensureExampleService skips
+	// dokku_service_create, so its examples are the one place a service is
+	// left standing unless it is named here.
+	cleanupServices []string
 	// freshAppPerExample destroys and recreates the referenced app before each
 	// example, so a task whose examples are independent full deploys of the
 	// same app (git_from_archive) does not fail the second on unchanged content.
@@ -88,6 +93,10 @@ var exampleIntegrationPolicy = map[string]exampleReq{
 		setup:      setupMaintenanceCustomPageExample,
 	},
 	"dokku_letsencrypt_property": {plugins: []string{"letsencrypt"}},
+
+	// service_create's examples create three services and destroy only one,
+	// so the survivors are torn down here.
+	"dokku_service_create": {cleanupServices: []string{"postgres:my-db", "redis:my-pinned-redis"}},
 
 	// Deploy-dependent tasks.
 	"dokku_app_clone":    {deployApps: []string{"node-js-app"}, cleanupApps: []string{"node-js-app-staging"}},
@@ -160,6 +169,11 @@ func TestIntegrationTaskExamples(t *testing.T) {
 				}
 				for _, app := range policy.cleanupApps {
 					destroyApp(app)
+				}
+				for _, svc := range policy.cleanupServices {
+					if parts := strings.SplitN(svc, ":", 2); len(parts) == 2 {
+						destroyService(parts[0], parts[1])
+					}
 				}
 			})
 			for _, app := range policy.ensureApps {

--- a/tasks/service_create_task.go
+++ b/tasks/service_create_task.go
@@ -2,16 +2,67 @@ package tasks
 
 import (
 	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
 	"github.com/dokku/docket/subprocess"
 )
 
-// ServiceCreateTask creates or destroys a dokku service
+// ServiceCreateTask creates or destroys a dokku service.
+//
+// Every field below `Name` is a create-time option: the datastore plugins
+// accept them as flags on `<service>:create` (the same set ansible-dokku's
+// module reaches through Ansible's `environment:` keyword, e.g.
+// POSTGRES_IMAGE). They are rendered onto the argv rather than passed as
+// environment variables so they behave identically locally and over SSH -
+// subprocess.ExecCommandInput.Env only decorates the local process and never
+// reaches the remote shell.
+//
+// They apply only when the service is created. The task probes
+// `<service>:exists`, so a service that already exists is in sync whatever
+// image it is running; changing that needs `<service>:upgrade`, which
+// recreates the container and is not something docket does implicitly
+// (tracked in #435).
 type ServiceCreateTask struct {
 	// Service is the type of service to create (e.g. redis, postgres, mysql)
 	Service string `required:"true" yaml:"service" description:"Type of service to create (e.g. redis, postgres, mysql)"`
 
 	// Name is the name of the service instance
 	Name string `required:"true" yaml:"name" description:"Name of the service instance"`
+
+	// Image is the image the service container is started from.
+	Image string `required:"false" yaml:"image,omitempty" description:"Image to start the service with, e.g. postgis/postgis. Applied only when the service is created."`
+
+	// ImageVersion is the tag of the image the service container is started from.
+	ImageVersion string `required:"false" yaml:"image_version,omitempty" description:"Image tag to start the service with. Applied only when the service is created."`
+
+	// ConfigOptions are extra arguments passed to the container create command.
+	ConfigOptions string `required:"false" yaml:"config_options,omitempty" description:"Extra arguments to pass to the container create command. Applied only when the service is created."`
+
+	// CustomEnv is the environment the service container is started with.
+	CustomEnv map[string]string `required:"false" sensitive:"true" yaml:"custom_env,omitempty" description:"Map of environment variables to start the service with. Applied only when the service is created."`
+
+	// Memory is the container memory limit in megabytes.
+	Memory int `required:"false" yaml:"memory,omitempty" description:"Container memory limit in megabytes. Applied only when the service is created."`
+
+	// ShmSize is the shared memory size of the service container.
+	ShmSize string `required:"false" yaml:"shm_size,omitempty" description:"Shared memory size for the service container. Applied only when the service is created."`
+
+	// InitialNetwork is the network the service is attached to on creation.
+	InitialNetwork string `required:"false" yaml:"initial_network,omitempty" description:"Network to attach the service to initially. Applied only when the service is created."`
+
+	// PostCreateNetwork are the networks attached after service creation.
+	PostCreateNetwork []string `required:"false" yaml:"post_create_network,omitempty" description:"Networks to attach the service container to after creation. Applied only when the service is created."`
+
+	// PostStartNetwork are the networks attached after service start.
+	PostStartNetwork []string `required:"false" yaml:"post_start_network,omitempty" description:"Networks to attach the service container to after start. Applied only when the service is created."`
+
+	// Password overrides the user-level service password.
+	Password string `required:"false" sensitive:"true" yaml:"password,omitempty" description:"Override the user-level service password. Applied only when the service is created."`
+
+	// RootPassword overrides the root-level service password.
+	RootPassword string `required:"false" sensitive:"true" yaml:"root_password,omitempty" description:"Override the root-level service password. Applied only when the service is created."`
 
 	// State is the desired state of the service
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the service"`
@@ -38,13 +89,15 @@ func (t ServiceCreateTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t ServiceCreateTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportSupported}
+	return ExportSupport{Status: ExportPartial, Caveat: "the service and the image it is running are exported; the remaining create-time options (config_options, custom_env, memory, shm_size, the networks, and the passwords) have no read command and must be re-supplied"}
 }
 
 // ExportGlobal reconstructs every datastore service instance on the server as a
 // dokku_service_create task. Discovery is via listServices (the `service-list`
-// plugin trigger); like dokku_storage_mount, only the resource's existence is
-// exported - the service's data is migrated separately.
+// plugin trigger). Like dokku_storage_mount, the service's data is migrated
+// separately - but the image it runs is exported, so a service recreated on
+// another server comes up on the same version rather than whatever that
+// server's plugin defaults to, which is what its `:import` counterpart needs.
 func (t ServiceCreateTask) ExportGlobal() ([]interface{}, error) {
 	services, err := listServices()
 	if err != nil {
@@ -52,7 +105,17 @@ func (t ServiceCreateTask) ExportGlobal() ([]interface{}, error) {
 	}
 	var out []interface{}
 	for _, s := range services {
-		out = append(out, ServiceCreateTask{Service: s.Type, Name: s.Name, State: StatePresent})
+		image, version, err := serviceImage(s.Type, s.Name)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, ServiceCreateTask{
+			Service:      s.Type,
+			Name:         s.Name,
+			Image:        image,
+			ImageVersion: version,
+			State:        StatePresent,
+		})
 	}
 	return out, nil
 }
@@ -80,6 +143,15 @@ func (t ServiceCreateTask) Examples() ([]Doc, error) {
 			},
 		},
 		{
+			Name: "Create a redis service on a pinned image",
+			ServiceCreateTask: ServiceCreateTask{
+				Service:      "redis",
+				Name:         "my-pinned-redis",
+				Image:        "redis",
+				ImageVersion: "7.2.5",
+			},
+		},
+		{
 			Name: "Destroy a redis service named my-redis",
 			ServiceCreateTask: ServiceCreateTask{
 				Service: "redis",
@@ -95,8 +167,166 @@ func (t ServiceCreateTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// setCreateOptions returns the recipe keys of every create-time option the
+// task supplied, in field order. Keep it in step with createFlags: an option
+// that renders a flag but is missing here would be silently accepted under
+// state 'absent', where dokku has nowhere to put it.
+func (t ServiceCreateTask) setCreateOptions() []string {
+	var set []string
+	for _, opt := range []struct {
+		name string
+		used bool
+	}{
+		{"image", t.Image != ""},
+		{"image_version", t.ImageVersion != ""},
+		{"config_options", t.ConfigOptions != ""},
+		{"custom_env", len(t.CustomEnv) > 0},
+		{"memory", t.Memory != 0},
+		{"shm_size", t.ShmSize != ""},
+		{"initial_network", t.InitialNetwork != ""},
+		{"post_create_network", len(t.PostCreateNetwork) > 0},
+		{"post_start_network", len(t.PostStartNetwork) > 0},
+		{"password", t.Password != ""},
+		{"root_password", t.RootPassword != ""},
+	} {
+		if opt.used {
+			set = append(set, opt.name)
+		}
+	}
+	return set
+}
+
+// createFlags renders the create-time options as the flags every datastore
+// plugin accepts on `<service>:create`. The order is fixed so plan and apply
+// build byte-identical argv across runs.
+func (t ServiceCreateTask) createFlags() []string {
+	var args []string
+	if t.Image != "" {
+		args = append(args, "--image", t.Image)
+	}
+	if t.ImageVersion != "" {
+		args = append(args, "--image-version", t.ImageVersion)
+	}
+	if t.ConfigOptions != "" {
+		args = append(args, "--config-options", t.ConfigOptions)
+	}
+	if env := formatCustomEnv(t.CustomEnv); env != "" {
+		args = append(args, "--custom-env", env)
+	}
+	if t.Memory != 0 {
+		args = append(args, "--memory", strconv.Itoa(t.Memory))
+	}
+	if t.ShmSize != "" {
+		args = append(args, "--shm-size", t.ShmSize)
+	}
+	if t.InitialNetwork != "" {
+		args = append(args, "--initial-network", t.InitialNetwork)
+	}
+	if len(t.PostCreateNetwork) > 0 {
+		args = append(args, "--post-create-network", strings.Join(t.PostCreateNetwork, ","))
+	}
+	if len(t.PostStartNetwork) > 0 {
+		args = append(args, "--post-start-network", strings.Join(t.PostStartNetwork, ","))
+	}
+	if t.Password != "" {
+		args = append(args, "--password", t.Password)
+	}
+	if t.RootPassword != "" {
+		args = append(args, "--root-password", t.RootPassword)
+	}
+	return args
+}
+
+// formatCustomEnv renders the custom_env map as the single semicolon-delimited
+// `KEY=value` token `--custom-env` expects. Keys are sorted so the rendered
+// command is stable across runs.
+func formatCustomEnv(env map[string]string) string {
+	if len(env) == 0 {
+		return ""
+	}
+	keys := mapKeys(env)
+	sort.Strings(keys)
+	pairs := make([]string, 0, len(keys))
+	for _, k := range keys {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", k, env[k]))
+	}
+	return strings.Join(pairs, ";")
+}
+
+// imageSuffix renders the pinned image for the mutation line. Text `docket
+// plan` prints Mutations and never Commands, so without this the pin a recipe
+// asked for would not show up in a plan at all. The remaining create-time
+// options stay out: two of them are secrets, and the resolved Commands already
+// carry the full argv with sensitive values masked.
+func (t ServiceCreateTask) imageSuffix() string {
+	switch {
+	case t.Image != "" && t.ImageVersion != "":
+		return fmt.Sprintf(" (image %s:%s)", t.Image, t.ImageVersion)
+	case t.Image != "":
+		return fmt.Sprintf(" (image %s)", t.Image)
+	case t.ImageVersion != "":
+		return fmt.Sprintf(" (image version %s)", t.ImageVersion)
+	}
+	return ""
+}
+
+// Validate checks the ServiceCreateTask's inputs without contacting the server.
+func (t ServiceCreateTask) Validate() error {
+	// `<service>:destroy` takes none of the create-time options, so any
+	// supplied alongside state 'absent' would be silently discarded rather
+	// than applied. Every other state consumes them.
+	if t.State == StateAbsent {
+		if set := t.setCreateOptions(); len(set) > 0 {
+			return fmt.Errorf("'%s' must not be set for state 'absent'", strings.Join(set, "', '"))
+		}
+		return nil
+	}
+
+	if t.Memory < 0 {
+		return fmt.Errorf("'memory' must not be negative")
+	}
+
+	// dokku receives custom_env as one `KEY=value;KEY=value` token, so a key
+	// or value carrying a delimiter would silently restructure the map.
+	keys := mapKeys(t.CustomEnv)
+	sort.Strings(keys)
+	for _, k := range keys {
+		if k == "" {
+			return fmt.Errorf("'custom_env' keys must not be empty")
+		}
+		if strings.ContainsAny(k, "=;") {
+			return fmt.Errorf("'custom_env' key %q must not contain '=' or ';'", k)
+		}
+		if strings.Contains(t.CustomEnv[k], ";") {
+			return fmt.Errorf("'custom_env' value for %q must not contain ';'", k)
+		}
+	}
+
+	// The network lists are joined with commas for the same reason.
+	for _, list := range []struct {
+		name     string
+		networks []string
+	}{
+		{"post_create_network", t.PostCreateNetwork},
+		{"post_start_network", t.PostStartNetwork},
+	} {
+		for _, network := range list.networks {
+			if network == "" {
+				return fmt.Errorf("'%s' entries must not be empty", list.name)
+			}
+			if strings.Contains(network, ",") {
+				return fmt.Errorf("'%s' entry %q must not contain ','", list.name, network)
+			}
+		}
+	}
+	return nil
+}
+
 // Plan reports the drift the ServiceCreateTask would produce.
 func (t ServiceCreateTask) Plan() PlanResult {
+	if err := t.Validate(); err != nil {
+		return planErr(err)
+	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
 			exists, err := serviceExists(t.Service, t.Name)
@@ -106,15 +336,16 @@ func (t ServiceCreateTask) Plan() PlanResult {
 			if exists {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			args := append([]string{"--quiet", fmt.Sprintf("%s:create", t.Service), t.Name}, t.createFlags()...)
 			inputs := []subprocess.ExecCommandInput{{
 				Command: "dokku",
-				Args:    []string{"--quiet", fmt.Sprintf("%s:create", t.Service), t.Name},
+				Args:    args,
 			}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusCreate,
 				Reason:    fmt.Sprintf("%s service %s missing", t.Service, t.Name),
-				Mutations: []string{fmt.Sprintf("%s:create %s", t.Service, t.Name)},
+				Mutations: []string{fmt.Sprintf("%s:create %s%s", t.Service, t.Name, t.imageSuffix())},
 				Commands:  resolveCommands(inputs),
 				apply: func() TaskOutputState {
 					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)

--- a/tasks/service_create_task_integration_test.go
+++ b/tasks/service_create_task_integration_test.go
@@ -64,3 +64,48 @@ func TestIntegrationServiceCreateAndDestroy(t *testing.T) {
 		t.Errorf("expected state 'absent', got '%s'", result.State)
 	}
 }
+
+// TestIntegrationServiceCreatePinnedImage proves the create-time options reach
+// dokku: it pins an image and tag, then reads the running container back with
+// `<service>:info --version` - the same command docket export uses, so this
+// covers the round trip in both directions. A second apply must stay in sync,
+// since the image fields are create-time only and must not manufacture drift.
+func TestIntegrationServiceCreatePinnedImage(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "redis")
+
+	serviceName := "docket-test-pinned"
+	serviceType := "redis"
+	image := "redis"
+	imageVersion := "7.2.5"
+
+	destroyService(serviceType, serviceName)
+	t.Cleanup(func() { destroyService(serviceType, serviceName) })
+
+	task := ServiceCreateTask{
+		Service:      serviceType,
+		Name:         serviceName,
+		Image:        image,
+		ImageVersion: imageVersion,
+		State:        StatePresent,
+	}
+	result := task.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to create pinned service: %v\n  commands: %v\n  stderr: %s", result.Error, result.Commands, result.Stderr)
+	}
+	if !result.Changed || result.State != StatePresent {
+		t.Fatalf("expected a changed, present service, got changed=%v state=%q", result.Changed, result.State)
+	}
+
+	gotImage, gotVersion, err := serviceImage(serviceType, serviceName)
+	if err != nil {
+		t.Fatalf("serviceImage: %v", err)
+	}
+	if gotImage != image || gotVersion != imageVersion {
+		t.Errorf("service is running %q:%q, want %q:%q", gotImage, gotVersion, image, imageVersion)
+	}
+
+	if plan := task.Plan(); !plan.InSync {
+		t.Errorf("expected the pinned service to be in sync on re-plan, got %+v", plan)
+	}
+}

--- a/tasks/service_create_task_test.go
+++ b/tasks/service_create_task_test.go
@@ -1,10 +1,38 @@
 package tasks
 
 import (
+	"context"
+	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/dokku/docket/subprocess"
 	_ "github.com/gliderlabs/sigil/builtin"
 )
+
+// serviceMissing stubs every dokku call as a clean non-zero exit, which is how
+// subprocess.Probe reports `<service>:exists` saying "absent". The shared
+// fakeDokku always reports exit 0, so it cannot express a missing service and
+// any test that needs Plan() to build a create command needs this instead.
+func serviceMissing() func(context.Context, subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+	return func(_ context.Context, _ subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		return subprocess.ExecCommandResponse{ExitCode: 1}, nil
+	}
+}
+
+// planCreateCommand returns the single command Plan() would run to create the
+// task's service, failing the test if the plan did not reach a create.
+func planCreateCommand(t *testing.T, task ServiceCreateTask) string {
+	t.Helper()
+	plan := task.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if len(plan.Commands) != 1 {
+		t.Fatalf("expected 1 command, got %d (plan=%#v)", len(plan.Commands), plan)
+	}
+	return plan.Commands[0]
+}
 
 func TestServiceCreateTaskInvalidState(t *testing.T) {
 	task := ServiceCreateTask{Service: "redis", Name: "test-service", State: "invalid"}
@@ -91,5 +119,265 @@ func TestGetTasksServiceCreateWithTemplateContext(t *testing.T) {
 	}
 	if scTask.Name != "my-db" {
 		t.Errorf("Name = %q, want %q", scTask.Name, "my-db")
+	}
+}
+
+// TestServiceCreateTaskCreateFlags pins each create-time option to the
+// `<service>:create` flag it renders as. These are the flags every datastore
+// plugin accepts (verified identical in dokku-postgres and dokku-redis), and
+// they are what lets a recipe pin an image without depending on environment
+// variables that would not survive the trip to a remote shell.
+func TestServiceCreateTaskCreateFlags(t *testing.T) {
+	cases := []struct {
+		name string
+		task ServiceCreateTask
+		want string
+	}{
+		{
+			name: "no options renders a bare create",
+			task: ServiceCreateTask{Service: "redis", Name: "cache"},
+			want: "dokku --quiet redis:create cache",
+		},
+		{
+			name: "image and version",
+			task: ServiceCreateTask{Service: "postgres", Name: "db", Image: "postgis/postgis", ImageVersion: "13-master"},
+			want: "dokku --quiet postgres:create db --image postgis/postgis --image-version 13-master",
+		},
+		{
+			name: "image alone",
+			task: ServiceCreateTask{Service: "postgres", Name: "db", Image: "postgis/postgis"},
+			want: "dokku --quiet postgres:create db --image postgis/postgis",
+		},
+		{
+			name: "version alone pins the tag on the default image",
+			task: ServiceCreateTask{Service: "postgres", Name: "db", ImageVersion: "13"},
+			want: "dokku --quiet postgres:create db --image-version 13",
+		},
+		{
+			name: "custom env is sorted and semicolon joined",
+			task: ServiceCreateTask{Service: "postgres", Name: "db", CustomEnv: map[string]string{"USER": "alpha", "HOST": "beta"}},
+			want: "dokku --quiet postgres:create db --custom-env HOST=beta;USER=alpha",
+		},
+		{
+			name: "networks are comma joined",
+			task: ServiceCreateTask{
+				Service:           "redis",
+				Name:              "cache",
+				InitialNetwork:    "initial",
+				PostCreateNetwork: []string{"created-a", "created-b"},
+				PostStartNetwork:  []string{"started"},
+			},
+			want: "dokku --quiet redis:create cache --initial-network initial --post-create-network created-a,created-b --post-start-network started",
+		},
+		{
+			name: "every remaining option",
+			task: ServiceCreateTask{
+				Service:       "postgres",
+				Name:          "db",
+				ConfigOptions: "--shm-size 128m",
+				Memory:        512,
+				ShmSize:       "128m",
+				Password:      "user-pw",
+				RootPassword:  "root-pw",
+			},
+			want: "dokku --quiet postgres:create db --config-options --shm-size 128m --memory 512 --shm-size 128m --password user-pw --root-password root-pw",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer subprocess.SetExecRunner(serviceMissing())()
+			// The recipe default, applied by SetDefaults on the parse path;
+			// a struct built in Go has to state it for DispatchPlan.
+			task := tc.task
+			task.State = StatePresent
+			if got := planCreateCommand(t, task); got != tc.want {
+				t.Errorf("command = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestServiceCreateTaskMutationNamesPinnedImage keeps the pinned image visible
+// in the plan. Text `docket plan` renders Mutations and never Commands, so a
+// pin that only reached the argv would not show up in a plan at all.
+func TestServiceCreateTaskMutationNamesPinnedImage(t *testing.T) {
+	cases := []struct {
+		name string
+		task ServiceCreateTask
+		want string
+	}{
+		{"unpinned", ServiceCreateTask{Service: "redis", Name: "cache"}, "redis:create cache"},
+		{"image and version", ServiceCreateTask{Service: "postgres", Name: "db", Image: "postgis/postgis", ImageVersion: "13-master"}, "postgres:create db (image postgis/postgis:13-master)"},
+		{"image alone", ServiceCreateTask{Service: "postgres", Name: "db", Image: "postgis/postgis"}, "postgres:create db (image postgis/postgis)"},
+		{"version alone", ServiceCreateTask{Service: "postgres", Name: "db", ImageVersion: "13"}, "postgres:create db (image version 13)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer subprocess.SetExecRunner(serviceMissing())()
+			task := tc.task
+			task.State = StatePresent
+			plan := task.Plan()
+			if plan.Error != nil {
+				t.Fatalf("unexpected plan error: %v", plan.Error)
+			}
+			if len(plan.Mutations) != 1 || plan.Mutations[0] != tc.want {
+				t.Errorf("mutations = %v, want [%s]", plan.Mutations, tc.want)
+			}
+		})
+	}
+}
+
+// TestServiceCreateTaskMasksSecretsInCommands asserts the two password flags
+// and every custom_env value are registered as sensitive, so they never reach
+// the JSON `commands` stream or `apply --verbose` in the clear.
+func TestServiceCreateTaskMasksSecretsInCommands(t *testing.T) {
+	task := ServiceCreateTask{
+		Service:      "postgres",
+		Name:         "db",
+		CustomEnv:    map[string]string{"POSTGRES_PASSWORD": "env-secret"},
+		Password:     "user-secret",
+		RootPassword: "root-secret",
+		State:        StatePresent,
+	}
+
+	subprocess.SetGlobalSensitive(sensitiveValuesFromTask(&task))
+	defer subprocess.SetGlobalSensitive(nil)
+	defer subprocess.SetExecRunner(serviceMissing())()
+
+	got := planCreateCommand(t, task)
+	for _, secret := range []string{"env-secret", "user-secret", "root-secret"} {
+		if strings.Contains(got, secret) {
+			t.Errorf("command %q leaks %q", got, secret)
+		}
+	}
+	// The custom_env key is not a secret and must stay legible.
+	if !strings.Contains(got, "POSTGRES_PASSWORD=***") {
+		t.Errorf("command %q should mask the value but keep the key", got)
+	}
+}
+
+func TestServiceCreateTaskValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		task    ServiceCreateTask
+		wantErr string
+	}{
+		{
+			name:    "create options rejected under absent",
+			task:    ServiceCreateTask{Service: "redis", Name: "cache", Image: "redis", Memory: 512, State: StateAbsent},
+			wantErr: "'image', 'memory' must not be set for state 'absent'",
+		},
+		{
+			name:    "negative memory",
+			task:    ServiceCreateTask{Service: "redis", Name: "cache", Memory: -1},
+			wantErr: "'memory' must not be negative",
+		},
+		{
+			name:    "empty custom env key",
+			task:    ServiceCreateTask{Service: "redis", Name: "cache", CustomEnv: map[string]string{"": "v"}},
+			wantErr: "'custom_env' keys must not be empty",
+		},
+		{
+			name:    "custom env key with a delimiter",
+			task:    ServiceCreateTask{Service: "redis", Name: "cache", CustomEnv: map[string]string{"A=B": "v"}},
+			wantErr: `'custom_env' key "A=B" must not contain '=' or ';'`,
+		},
+		{
+			name:    "custom env value with a delimiter",
+			task:    ServiceCreateTask{Service: "redis", Name: "cache", CustomEnv: map[string]string{"A": "one;two"}},
+			wantErr: `'custom_env' value for "A" must not contain ';'`,
+		},
+		{
+			name:    "empty network entry",
+			task:    ServiceCreateTask{Service: "redis", Name: "cache", PostCreateNetwork: []string{""}},
+			wantErr: "'post_create_network' entries must not be empty",
+		},
+		{
+			name:    "network entry with a delimiter",
+			task:    ServiceCreateTask{Service: "redis", Name: "cache", PostStartNetwork: []string{"a,b"}},
+			wantErr: `'post_start_network' entry "a,b" must not contain ','`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.task.Validate()
+			if err == nil {
+				t.Fatalf("expected an error, got none")
+			}
+			if err.Error() != tc.wantErr {
+				t.Errorf("error = %q, want %q", err.Error(), tc.wantErr)
+			}
+			// Plan() must report the same message, so plan, apply, and
+			// validate all read alike.
+			if plan := tc.task.Plan(); plan.Error == nil || plan.Error.Error() != tc.wantErr {
+				t.Errorf("Plan error = %v, want %q", plan.Error, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestServiceCreateTaskValidateAcceptsDestroyWithoutOptions(t *testing.T) {
+	task := ServiceCreateTask{Service: "redis", Name: "cache", State: StateAbsent}
+	if err := task.Validate(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestGetTasksServiceCreateCreateOptionsParsed(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - name: create postgres service
+      dokku_service_create:
+        service: postgres
+        name: my-db
+        image: postgis/postgis
+        image_version: "13-master"
+        config_options: "--restart always"
+        custom_env:
+          POSTGRES_INITDB_ARGS: "--data-checksums"
+        memory: 512
+        shm_size: 128m
+        initial_network: my-network
+        post_create_network:
+          - created-a
+          - created-b
+        post_start_network:
+          - started
+        password: user-pw
+        root_password: root-pw
+`)
+
+	tasks, err := GetTasks(data, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("GetTasks failed: %v", err)
+	}
+
+	task := tasks.Get("create postgres service")
+	if task == nil {
+		t.Fatal("task 'create postgres service' not found")
+	}
+	scTask, ok := task.(*ServiceCreateTask)
+	if !ok {
+		t.Fatalf("task is not a *ServiceCreateTask (type is %T)", task)
+	}
+
+	want := ServiceCreateTask{
+		Service:           "postgres",
+		Name:              "my-db",
+		Image:             "postgis/postgis",
+		ImageVersion:      "13-master",
+		ConfigOptions:     "--restart always",
+		CustomEnv:         map[string]string{"POSTGRES_INITDB_ARGS": "--data-checksums"},
+		Memory:            512,
+		ShmSize:           "128m",
+		InitialNetwork:    "my-network",
+		PostCreateNetwork: []string{"created-a", "created-b"},
+		PostStartNetwork:  []string{"started"},
+		Password:          "user-pw",
+		RootPassword:      "root-pw",
+		State:             StatePresent,
+	}
+	if !reflect.DeepEqual(*scTask, want) {
+		t.Errorf("parsed task = %#v, want %#v", *scTask, want)
 	}
 }

--- a/tasks/service_export.go
+++ b/tasks/service_export.go
@@ -104,6 +104,41 @@ func serviceDSN(service, name string) (string, error) {
 	return result.StdoutContents(), nil
 }
 
+// serviceImage returns the image a datastore service instance is running, split
+// into the image name and its version, read from `<service>:info <name>
+// --version`. dokku reports the container's `Config.Image` there (e.g.
+// `postgres:17.2`), which is exactly what `<service>:create`'s `--image` and
+// `--image-version` reconstruct on another server. A transport-level failure
+// (`*subprocess.SSHError`) is propagated; any other failure yields no image, as
+// does a service whose container is gone - dokku prints nothing in that case.
+func serviceImage(service, name string) (string, string, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args:    []string{"--quiet", fmt.Sprintf("%s:info", service), name, "--version"},
+	})
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return "", "", err
+		}
+		return "", "", nil
+	}
+	image, version := splitImageRef(result.StdoutContents())
+	return image, version, nil
+}
+
+// splitImageRef splits a docker image reference into its name and tag. The
+// separator is the last colon, but only when it falls after the last slash:
+// in `registry.example.com:5000/postgres` that colon is a registry port, not a
+// tag. A reference carrying no tag yields an empty version.
+func splitImageRef(ref string) (string, string) {
+	colon := strings.LastIndex(ref, ":")
+	if colon < 0 || colon < strings.LastIndex(ref, "/") {
+		return ref, ""
+	}
+	return ref[:colon], ref[colon+1:]
+}
+
 // linkedServiceDSNs returns the set of datastore DSNs that service links have
 // injected into an app's config, so the config exporter can omit them: the
 // dokku_service_link task recreates those `<ALIAS>_URL` vars on apply (with the

--- a/tasks/service_export_test.go
+++ b/tasks/service_export_test.go
@@ -32,7 +32,9 @@ func TestListServicesParsesTypeAndName(t *testing.T) {
 
 func TestExportServiceCreateEnumeratesInstances(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
-		"--quiet plugin:trigger service-list": "postgres:my-db\nredis:cache",
+		"--quiet plugin:trigger service-list":   "postgres:my-db\nredis:cache",
+		"--quiet postgres:info my-db --version": "postgis/postgis:13-master",
+		"--quiet redis:info cache --version":    "redis:7.2.5",
 	}))()
 
 	bodies, err := ServiceCreateTask{}.ExportGlobal()
@@ -42,16 +44,69 @@ func TestExportServiceCreateEnumeratesInstances(t *testing.T) {
 	if len(bodies) != 2 {
 		t.Fatalf("expected 2 create tasks, got %d", len(bodies))
 	}
-	got := map[string]string{}
+	got := map[string]ServiceCreateTask{}
 	for _, b := range bodies {
 		c := b.(ServiceCreateTask)
-		got[c.Name] = c.Service
+		got[c.Name] = c
 		if c.State != StatePresent {
 			t.Errorf("expected present state, got %q", c.State)
 		}
 	}
-	if got["my-db"] != "postgres" || got["cache"] != "redis" {
+	if got["my-db"].Service != "postgres" || got["cache"].Service != "redis" {
 		t.Errorf("unexpected create tasks: %+v", got)
+	}
+	// The image a service is actually running is pinned, so recreating it on
+	// another server does not silently pick up that server's plugin default.
+	if got["my-db"].Image != "postgis/postgis" || got["my-db"].ImageVersion != "13-master" {
+		t.Errorf("postgres image = %q:%q, want postgis/postgis:13-master", got["my-db"].Image, got["my-db"].ImageVersion)
+	}
+	if got["cache"].Image != "redis" || got["cache"].ImageVersion != "7.2.5" {
+		t.Errorf("redis image = %q:%q, want redis:7.2.5", got["cache"].Image, got["cache"].ImageVersion)
+	}
+}
+
+// TestExportServiceCreateOmitsUnreadableImage covers a service whose container
+// is gone: dokku prints nothing for --version, and the export must leave both
+// image fields empty rather than emitting a half-formed pin.
+func TestExportServiceCreateOmitsUnreadableImage(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet plugin:trigger service-list": "redis:cache",
+	}))()
+
+	bodies, err := ServiceCreateTask{}.ExportGlobal()
+	if err != nil {
+		t.Fatalf("ExportGlobal: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 create task, got %d", len(bodies))
+	}
+	c := bodies[0].(ServiceCreateTask)
+	if c.Image != "" || c.ImageVersion != "" {
+		t.Errorf("expected no image, got %q:%q", c.Image, c.ImageVersion)
+	}
+}
+
+func TestSplitImageRef(t *testing.T) {
+	cases := []struct {
+		ref         string
+		wantImage   string
+		wantVersion string
+	}{
+		{"postgres:17.2", "postgres", "17.2"},
+		{"postgis/postgis:13-master", "postgis/postgis", "13-master"},
+		// The colon here is a registry port, not a tag.
+		{"registry.example.com:5000/postgres", "registry.example.com:5000/postgres", ""},
+		{"registry.example.com:5000/postgres:17.2", "registry.example.com:5000/postgres", "17.2"},
+		{"postgres", "postgres", ""},
+		{"", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.ref, func(t *testing.T) {
+			image, version := splitImageRef(tc.ref)
+			if image != tc.wantImage || version != tc.wantVersion {
+				t.Errorf("splitImageRef(%q) = %q, %q; want %q, %q", tc.ref, image, version, tc.wantImage, tc.wantVersion)
+			}
+		})
 	}
 }
 
@@ -256,6 +311,7 @@ func TestExportRecipeIncludesServiceTasks(t *testing.T) {
 		"--quiet postgres:info my-db --exposed-ports": "5432->5432",
 		"--quiet postgres:links my-db":                "web",
 		"--quiet postgres:info my-db --dsn":           "postgres://postgres:pw@dokku-postgres-my-db:5432/my_db",
+		"--quiet postgres:info my-db --version":       "postgres:17.2",
 	}))()
 
 	res, err := ExportRecipe(ExportOptions{})
@@ -272,6 +328,9 @@ func TestExportRecipeIncludesServiceTasks(t *testing.T) {
 		"dokku_service_create",
 		"dokku_service_expose",
 		"dokku_service_link",
+		// The exported create carries the image the service is running.
+		"image: postgres",
+		"image_version: \"17.2\"",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("recipe missing %q:\n%s", want, out)

--- a/tests/bats/validate.bats
+++ b/tests/bats/validate.bats
@@ -171,6 +171,36 @@ EOF
   assert_output --partial "'aws_signature_version' is required when 'endpoint_url' is set"
 }
 
+@test "docket validate exits 1 on service_create options under state absent" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_service_create:
+        service: postgres
+        name: my-db
+        image: postgis/postgis
+        state: absent
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "'image' must not be set for state 'absent'"
+}
+
+@test "docket validate exits 1 on a service_create custom_env delimiter" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - dokku_service_create:
+        service: postgres
+        name: my-db
+        custom_env:
+          GREETING: "one;two"
+EOF
+  run "$(docket_bin)" validate --tasks "$TASKS_FILE"
+  assert_failure
+  assert_output --partial "'custom_env' value for \"GREETING\" must not contain ';'"
+}
+
 @test "docket validate exits 1 on a conditional input error" {
   write_tasks_file <<EOF
 ---


### PR DESCRIPTION
The task ran a bare `<service>:create`, so a recipe could only ever create a service on the datastore plugin's default image - one of the gaps that stopped ansible-dokku from delegating to docket, since its module pins an image through Ansible's `environment:` keyword. Every datastore plugin already accepts those overrides as flags on `:create`, so `image`, `image_version`, `config_options`, `custom_env`, `memory`, `shm_size`, `initial_network`, `post_create_network`, `post_start_network`, `password`, and `root_password` render onto the argv rather than into the environment, which is what makes them behave the same locally and over SSH - `ExecCommandInput.Env` only ever reaches the local process. They are create-time only, and supplying one alongside `state: absent` is rejected rather than silently dropped. `docket export` now reads the image a service is running off `<service>:info --version` and pins it, so a migrated service comes up on the same version instead of whatever the new server's plugin defaults to; the options that have no read command make the task a partial export.

Reconciling a pin that changes after the service exists needs `<service>:upgrade` and is tracked separately in #435, as is the half-working `ExecCommandInput.Env` field in #436.

Closes #417
