### PR TITLE
refactor: drop transport-divergent ExecCommandInput fields

### DIFF
--- a/docs/remote-execution.md
+++ b/docs/remote-execution.md
@@ -44,6 +44,18 @@ as they would when running locally. An argument that cannot be represented for a
 containing a tab, newline, or null byte) is rejected with an `ssh:` error rather than sent in a
 corrupted form.
 
+## Environment variables stay local
+
+Only the command line crosses to the server. Variables you set around docket - `FOO=bar docket
+apply --host ...`, or anything exported in your shell - decorate the local `ssh` process, and
+docket configures no `SendEnv`, so they reach the remote `dokku` only if your own `ssh` config
+forwards them and the server opts in with `AcceptEnv`. Do not rely on that.
+
+Values meant for the server belong in the recipe, where they become arguments docket sends
+explicitly: [`dokku_config`](tasks/dokku_config.md) for an app's config, and
+[`dokku_service_create`](tasks/dokku_service_create.md)'s `custom_env` for the environment a service
+container starts with.
+
 ## Reading errors
 
 Errors are categorized so you can tell which side failed. SSH-level failures (refused connection,

--- a/subprocess/exec.go
+++ b/subprocess/exec.go
@@ -2,7 +2,6 @@ package subprocess
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"log"
 	"os"
@@ -23,20 +22,6 @@ type ExecCommandInput struct {
 
 	// Args are the arguments to pass to the command
 	Args []string
-
-	// DisableStdioBuffer disables the stdio buffer
-	DisableStdioBuffer bool
-
-	// Env is the environment variables to pass to the command.
-	//
-	// These reach the local process only. On the SSH path they decorate the
-	// local `ssh` client, which does not forward them (no SendEnv here, and
-	// the server would have to opt in with AcceptEnv anyway), so the remote
-	// `dokku` never sees them. A task that needs to influence a remote
-	// command must put it on the argv - see ServiceCreateTask, which renders
-	// its create-time options as `<service>:create` flags for this reason.
-	// Whether to make this work remotely or drop it is tracked in #436.
-	Env map[string]string
 
 	// Stdin is the stdin of the command
 	Stdin io.Reader
@@ -59,9 +44,6 @@ type ExecCommandInput struct {
 
 	// Sudo runs the command with sudo -n -u root
 	Sudo bool
-
-	// WorkingDirectory is the working directory to run the command in
-	WorkingDirectory string
 
 	// Host, when non-empty, routes the command through an `ssh` subprocess
 	// against [user@]host[:port] instead of executing locally. Only used
@@ -263,19 +245,9 @@ func defaultExecRunner(ctx context.Context, input ExecCommandInput) (ExecCommand
 		cancel()
 	}()
 
-	// hack: colors do not work natively with io.MultiWriter
-	// as it isn't detected as a tty. If the output isn't
-	// being captured, then color output can be forced.
+	// isatty reports whether our own stdout is a terminal, which is the
+	// signal used below to decide whether the child may read the terminal.
 	isatty := !color.NoColor
-	env := os.Environ()
-	if isatty && input.DisableStdioBuffer {
-		env = append(env, "FORCE_TTY=1")
-	}
-	if input.Env != nil {
-		for k, v := range input.Env {
-			env = append(env, fmt.Sprintf("%s=%s", k, v))
-		}
-	}
 
 	command := input.Command
 	commandArgs := input.Args
@@ -284,15 +256,14 @@ func defaultExecRunner(ctx context.Context, input ExecCommandInput) (ExecCommand
 		command = "sudo"
 	}
 
+	// Env and Cwd are deliberately left unset: go-execute only overrides the
+	// child's environment and directory when they are non-empty, so the child
+	// inherits docket's own. Nothing is layered on top, because anything that
+	// must influence a dokku invocation has to be on the argv - the only form
+	// that survives the SSH transport.
 	cmd := execute.ExecTask{
-		Command:            command,
-		Args:               commandArgs,
-		Env:                env,
-		DisableStdioBuffer: input.DisableStdioBuffer,
-	}
-
-	if input.WorkingDirectory != "" {
-		cmd.Cwd = input.WorkingDirectory
+		Command: command,
+		Args:    commandArgs,
 	}
 
 	if os.Getenv("DOKKU_TRACE") == "1" {

--- a/subprocess/exec_test.go
+++ b/subprocess/exec_test.go
@@ -201,11 +201,15 @@ func TestCallExecCommandNotFound(t *testing.T) {
 	}
 }
 
-func TestCallExecCommandWithEnv(t *testing.T) {
-	resp, err := CallExecCommand(ExecCommandInput{
-		Command: "env",
-		Env:     map[string]string{"DOCKET_TEST_VAR": "test123"},
-	})
+// TestCallExecCommandInheritsProcessEnv locks the environment contract that
+// remains now that ExecCommandInput has no Env field: the child gets docket's
+// own environment, and nothing is layered on top. The inheritance itself is
+// implicit - go-execute leaves cmd.Env nil when ExecTask.Env is empty - so it
+// is worth asserting rather than assuming.
+func TestCallExecCommandInheritsProcessEnv(t *testing.T) {
+	t.Setenv("DOCKET_TEST_VAR", "test123")
+
+	resp, err := CallExecCommand(ExecCommandInput{Command: "env"})
 	if err != nil {
 		t.Fatalf("CallExecCommand failed: %v", err)
 	}

--- a/subprocess/ssh.go
+++ b/subprocess/ssh.go
@@ -292,8 +292,8 @@ func CallSshCommand(host string, input ExecCommandInput) (ExecCommandResponse, e
 
 // CallSshCommandWithContext executes a remote command over ssh against
 // host. The execution pipeline mirrors CallExecCommandWithContext (same
-// signal handling, env propagation, DOKKU_TRACE logging, masking, stdio
-// wiring) so callers see identical behavior aside from the transport.
+// signal handling, DOKKU_TRACE logging, masking, stdio wiring) so callers
+// see identical behavior aside from the transport.
 //
 // On exit code 255 (OpenSSH's transport-failure code), the returned
 // error is `*SSHError`. On any other non-zero exit, the returned error
@@ -319,16 +319,9 @@ func CallSshCommandWithContext(ctx context.Context, host string, input ExecComma
 		cancel()
 	}()
 
+	// isatty reports whether our own stdout is a terminal, which is the
+	// signal used below to decide whether the child may read the terminal.
 	isatty := !color.NoColor
-	env := os.Environ()
-	if isatty && input.DisableStdioBuffer {
-		env = append(env, "FORCE_TTY=1")
-	}
-	if input.Env != nil {
-		for k, v := range input.Env {
-			env = append(env, fmt.Sprintf("%s=%s", k, v))
-		}
-	}
 
 	remote := append([]string{input.Command}, input.Args...)
 	argv, err := buildSshArgv(target, remote)
@@ -336,14 +329,12 @@ func CallSshCommandWithContext(ctx context.Context, host string, input ExecComma
 		return ExecCommandResponse{}, &SSHError{Host: target.UserHost(), Command: remote, Err: err}
 	}
 
+	// The `ssh` client inherits docket's environment and directory; nothing is
+	// layered on top. Decorating this process would be pointless anyway, since
+	// only the argv assembled above crosses to the remote shell.
 	cmd := execute.ExecTask{
-		Command:            "ssh",
-		Args:               argv,
-		Env:                env,
-		DisableStdioBuffer: input.DisableStdioBuffer,
-	}
-	if input.WorkingDirectory != "" {
-		cmd.Cwd = input.WorkingDirectory
+		Command: "ssh",
+		Args:    argv,
 	}
 
 	if os.Getenv("DOKKU_TRACE") == "1" {

--- a/subprocess/ssh_test.go
+++ b/subprocess/ssh_test.go
@@ -271,8 +271,8 @@ func TestBuildSshArgvQuotesInjection(t *testing.T) {
 
 // TestBuildSshArgvQuotesServiceCreateFlags covers the create-time options
 // dokku_service_create renders onto `<service>:create`. They are argv entries
-// rather than environment assignments precisely so the remote path works:
-// ExecCommandInput.Env only decorates the local ssh process. The semicolon
+// rather than environment assignments precisely so the remote path works: only
+// the argv assembled here crosses to the remote shell. The semicolon
 // delimiters inside a --custom-env token are the sharp edge - unquoted they
 // would be command separators on the remote login shell.
 func TestBuildSshArgvQuotesServiceCreateFlags(t *testing.T) {

--- a/tasks/config_task.go
+++ b/tasks/config_task.go
@@ -261,7 +261,6 @@ func getConfig(t ConfigTask) (map[string]string, error) {
 			"json",
 			t.App,
 		},
-		WorkingDirectory: "/tmp",
 	})
 	if err != nil {
 		return config, err

--- a/tasks/service_create_task.go
+++ b/tasks/service_create_task.go
@@ -15,9 +15,9 @@ import (
 // accept them as flags on `<service>:create` (the same set ansible-dokku's
 // module reaches through Ansible's `environment:` keyword, e.g.
 // POSTGRES_IMAGE). They are rendered onto the argv rather than passed as
-// environment variables so they behave identically locally and over SSH -
-// subprocess.ExecCommandInput.Env only decorates the local process and never
-// reaches the remote shell.
+// environment variables so they behave identically locally and over SSH - a
+// variable put in front of the local process never reaches the remote shell,
+// so the argv is the only carrier both transports share.
 //
 // They apply only when the service is created. The task probes
 // `<service>:exists`, so a service that already exists is in sync whatever


### PR DESCRIPTION
`Env`, `WorkingDirectory` and `DisableStdioBuffer` arrived as part of a helper copied from dokku's `plugins/common/exec.go` and each behaved differently depending on transport: over SSH they decorated the local `ssh` client rather than the remote `dokku`, and `ResolveCommandString` never rendered them, so an assignment would have been invisible to `plan`, `apply --verbose` and the JSON command stream, and unmasked if it held a secret. Nothing set any of them apart from the config probe pinning its cwd to `/tmp`, which had no traceable rationale, and the `FORCE_TTY=1` append they gated is read only by dokku commands docket never issues. Every dokku invocation now maps to a bare command line, the only form that behaves the same locally and over SSH.

Closes #436
