### PR TITLE
feat: cover storage host directories in dokku_storage_entry

### DIFF
--- a/docs/ansible-dokku.md
+++ b/docs/ansible-dokku.md
@@ -243,7 +243,7 @@ dokku plugin the row needs; blank means dokku core.
 | `dokku_resource_reserve` | `dokku_resource_reserve` | | Direct. |
 | `dokku_service_create` | `dokku_service_create` | datastore plugin | docket adds `state: absent`, and exposes the create-time options as task fields (`image`, `image_version`, `custom_env`, and the rest) rather than through the environment. |
 | `dokku_service_link` | `dokku_service_link` | datastore plugin | Direct. |
-| `dokku_storage` | `dokku_storage_mount`, `dokku_storage_entry`, `dokku_storage_ensure` | | One `dokku_storage_mount` per entry in `mounts`. Host-directory creation is only partly covered. |
+| `dokku_storage` | `dokku_storage_mount`, `dokku_storage_entry`, `dokku_storage_ensure` | | One `dokku_storage_mount` per entry in `mounts`. Host directories go to `dokku_storage_entry`; see [host directories](#host-directories). |
 
 The mapping is not always command-for-command. `dokku_registry` drives `registry:set <app> username`
 while `dokku_registry_auth` drives `registry:login`, and `dokku_proxy` reads its current state from
@@ -260,6 +260,34 @@ same overrides as flags on `<service>:create`, so a wrapper translates them into
 over SSH, where variables put in front of the local process never reach the remote shell. The
 remaining create-time options (`memory`, `shm_size`, the three network fields, `password`, and
 `root_password`) have no module counterpart.
+
+### Host directories
+
+`dokku_storage` does raw filesystem work alongside its `storage:mount` calls, which it gets
+away with because Ansible has already connected to the dokku host and is running there.
+docket may be driving that host over SSH, where a local filesystem call would touch the wrong
+machine entirely, so everything it does goes through a `dokku` subcommand. That caps it at
+what `storage:create` expresses, and `storage:create` is exactly what `dokku_storage_entry`
+wraps.
+
+| `dokku_storage` | docket | Notes |
+|-----------------|--------|-------|
+| `create_host_dir: true` | `dokku_storage_entry` | `storage:create` creates the directory. Emit one entry task per distinct host directory, ahead of the `dokku_storage_mount` tasks that reference it. |
+| the host path itself | `dokku_storage_entry.path` | Omit it to get dokku's default, `/var/lib/dokku/data/storage/<name>`. |
+| `user` and `group` | `dokku_storage_entry.chown` | One value, not two: dokku's helper runs `chown -R <id>:<id>`, so a module call whose `user` and `group` differ cannot be expressed. The module's `"32767"` default is `chown: herokuish`. |
+| `os.chmod(host_dir, 0o777)` | **stays in the wrapper** | dokku creates the directory `0755` and has no mode flag ([dokku/dokku#8913](https://github.com/dokku/dokku/issues/8913)). |
+| `destroy_host_dir: true` | **stays in the wrapper** | `storage:destroy` deregisters the entry and leaves the docker-local directory on disk; nothing in dokku removes it ([dokku/dokku#8913](https://github.com/dokku/dokku/issues/8913)). `dokku_storage_entry` with `state: absent` covers the deregistration half. |
+| `os.lexists("/home/dokku/<app>")` | nothing to forward | The module stats the filesystem to decide whether the app exists. docket asks dokku, so a wrapper drops the probe rather than translating it. |
+
+Two constraints on `chown` are worth knowing before a wrapper leans on it. dokku refuses the
+flag outright when the entry sits at a non-default `path`, and asks the operator to chown that
+path themselves. And it is applied when the entry is created, not on every run: an entry that
+already exists is left alone, so changing `chown` in a recipe is currently a no-op
+([#439](https://github.com/dokku/docket/issues/439)).
+
+Everything else `storage:create` accepts is a field on the task - `scheduler`, `size`,
+`access_mode`, `storage_class`, `namespace`, `reclaim_policy`, `annotations`, and `labels` -
+none of which the module has a counterpart for.
 
 ## Required and optional fields disagree
 
@@ -284,6 +312,7 @@ same file, and it is the spec that Ansible enforces. Those modules are `dokku_bu
 | `username` / `password` on `dokku_registry` | Both required, even for `state: absent` | Only `server` is required; credentials are required when `state: present` | A `state: absent` call carries credentials docket does not need. Drop them. |
 | `app` on `dokku_builder`, `dokku_network_property` | Required in the docs, optional in the spec | Optional, paired with `global` | Nothing. |
 | `app` on `dokku_storage` | Required | `dokku_storage_mount` requires `app` and `container_dir` | Split `mounts` into one task per entry, and split each `host:container` string. |
+| `user` / `group` on `dokku_storage` | Two options, both defaulting to `"32767"` | `dokku_storage_entry.chown` is one value, and rejects anything that is not an ownership preset or a uid in 0-65535 | Collapse the pair into one value, and fail the module call when they differ - dokku chowns the owner and the group to the same id. |
 | `build` on `dokku_clone` | Defaults to `true` | `dokku_git_sync.build` has no default, so it is off | Send `build: true` explicitly to preserve module behavior. |
 | `state` on `dokku_image`, `dokku_service_create`, `dokku_network_property` | No `state` option at all | Present on all three | Nothing; each docket default matches the module's only behavior. Note that `dokku_git_from_image.state` defaults to `deployed`, not `present`, so do not send `present`. |
 
@@ -294,22 +323,18 @@ the same two defaults outright, so the behavior matches.
 
 ## What cannot be delegated yet
 
-Two things. Each is tracked, so a wrapper can keep the module implementation for now and drop it when
-the task lands.
+One module, and it is tracked, so a wrapper can keep its implementation for now and drop it when the
+task lands.
 
 - **The `dokku_git_sync` module**
   ([#414](https://github.com/dokku/docket/issues/414)). It targets the commercial `dokku-git-sync`
   plugin (`git-sync:set <app> remote`), which docket has no task for. Mind the name collision:
   docket's `dokku_git_sync` is core `git:sync`, which is what the `dokku_clone` module does. The two
   are unrelated.
-- **Host-directory management in `dokku_storage`**
-  ([#416](https://github.com/dokku/docket/issues/416)). With `create_host_dir`, the module does
-  host-side `os.makedirs`, `chmod 0777`, and `chown` using the `user` / `group` options;
-  `destroy_host_dir` does an `os.rmdir` before unmounting. `dokku_storage_entry` creates the entry's
-  host directory and takes a `chown` preset or numeric uid, which covers the common case, but there is
-  no chmod and no host-directory removal. The module gets away with raw filesystem calls because
-  Ansible is already running on the dokku host; docket may be driving it over SSH, so anything it does
-  here has to go through a `dokku` subcommand.
+
+Separately, two pieces of `dokku_storage` stay in the wrapper permanently rather than pending a task:
+the `0o777` chmod and the `destroy_host_dir` removal, neither of which dokku exposes a command for.
+See [host directories](#host-directories).
 
 ## docket tasks with no ansible-dokku module
 

--- a/docs/tasks/dokku_storage_entry.md
+++ b/docs/tasks/dokku_storage_entry.md
@@ -13,14 +13,16 @@ Supported.
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `name` | string | yes |  |  | Name of the storage entry |
-| `path` | string | no |  |  | Host path for the entry (docker-local scheduler; defaults to the dokku storage root joined with the entry name) |
-| `scheduler` | string | no | docker-local |  | Scheduler that backs the entry |
-| `size` | string | no |  |  | Volume size (scheduler-dependent) |
-| `access_mode` | string | no |  |  | Volume access mode (scheduler-dependent) |
-| `storage_class` | string | no |  |  | Storage class name (scheduler-dependent) |
+| `path` | string | no |  |  | Host path for the entry: an absolute path, or a docker named volume on docker-local. Defaults to the dokku storage root joined with the entry name |
+| `scheduler` | string | no | docker-local | docker-local, k3s | Scheduler that backs the entry |
+| `size` | string | no |  |  | Volume size (k3s scheduler; required there and rejected on docker-local) |
+| `access_mode` | string | no |  | ReadWriteOnce, ReadOnlyMany, ReadWriteMany, ReadWriteOncePod | Volume access mode (k3s scheduler; rejected on docker-local) |
+| `storage_class` | string | no |  |  | Storage class name (k3s scheduler; rejected on docker-local, and mutually exclusive with path) |
 | `namespace` | string | no |  |  | Namespace (scheduler-dependent) |
-| `chown` | string | no |  |  | Chown value applied when the entry's host directory is created |
-| `reclaim_policy` | string | no |  |  | Reclaim policy (scheduler-dependent) |
+| `chown` | string | no |  | heroku, herokuish, paketo, root, false | Ownership applied when the entry's host directory is created: an ownership preset or a numeric uid (0-65535). dokku sets the owner and the group to the same id, and refuses the value unless the entry sits at its default host path |
+| `reclaim_policy` | string | no |  | Retain, Delete | Reclaim policy applied to the underlying volume (k3s scheduler) |
+| `annotations` | dict | no |  |  | Map of annotations set on the underlying volume (k3s scheduler) |
+| `labels` | dict | no |  |  | Map of labels set on the underlying volume (k3s scheduler) |
 | `state` | string | no | present | present, absent | Desired state of the storage entry |
 
 ## Examples

--- a/tasks/storage_ensure_task.go
+++ b/tasks/storage_ensure_task.go
@@ -92,15 +92,19 @@ func (t StorageEnsureTask) Validate() error {
 	return nil
 }
 
-// validChown reports whether a chown value is one dokku's
-// storage:ensure-directory accepts: a named ownership preset or a raw
-// numeric uid. dokku's ResolveChownID maps the presets to uids and parses
-// a numeric value with strconv.ParseUint(value, 10, 16), so docket mirrors
-// that here - accepting a uid in 0-65535 - while still catching typos in
-// non-numeric values before dispatch. dokku's deprecated 'packeto' alias is
+// validChown reports whether a chown value is one dokku accepts: a named
+// ownership preset or a raw numeric uid. dokku's ResolveChownID maps the
+// presets to uids and parses a numeric value with
+// strconv.ParseUint(value, 10, 16), so docket mirrors that here -
+// accepting a uid in 0-65535 - while still catching typos in non-numeric
+// values before dispatch. dokku's deprecated 'packeto' alias is
 // intentionally not accepted so the typo surfaces at validate time. The raw
 // string is validated with the same base-10 parser dokku applies to the
 // --chown argument, so docket's decision always matches dokku's runtime parse.
+//
+// ResolveChownID backs both --chown flags, so this is shared by
+// dokku_storage_ensure's storage:ensure-directory and
+// dokku_storage_entry's storage:create.
 func validChown(chown string) bool {
 	switch chown {
 	case "heroku", "herokuish", "paketo", "root", "false":

--- a/tasks/storage_entry_task.go
+++ b/tasks/storage_entry_task.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -19,35 +20,45 @@ import (
 // name exists, the task is in sync regardless of the other field
 // values. Attribute changes are therefore not drift-detected; to change
 // scheduler, size, or any other attribute, the recipe must destroy and
-// re-create the entry.
+// re-create the entry. Converging them in place is tracked in
+// https://github.com/dokku/docket/issues/439 - it needs a different
+// command per scheduler, since `storage:set --chown` records a new
+// ownership value without re-running the chown on a docker-local
+// directory.
 type StorageEntryTask struct {
 	// Name is the name of the storage entry
 	Name string `required:"true" yaml:"name" description:"Name of the storage entry"`
 
-	// Path is the host path for the entry (docker-local scheduler).
-	// Optional; defaults to the dokku storage root + name.
-	Path string `required:"false" yaml:"path,omitempty" description:"Host path for the entry (docker-local scheduler; defaults to the dokku storage root joined with the entry name)"`
+	// Path is the host path for the entry. Optional; on docker-local it
+	// defaults to the dokku storage root + name.
+	Path string `required:"false" yaml:"path,omitempty" description:"Host path for the entry: an absolute path, or a docker named volume on docker-local. Defaults to the dokku storage root joined with the entry name"`
 
 	// Scheduler is the scheduler that backs the entry
-	Scheduler string `required:"false" yaml:"scheduler,omitempty" default:"docker-local" description:"Scheduler that backs the entry"`
+	Scheduler string `required:"false" yaml:"scheduler,omitempty" default:"docker-local" options:"docker-local,k3s" description:"Scheduler that backs the entry"`
 
-	// Size is the volume size (scheduler-dependent)
-	Size string `required:"false" yaml:"size,omitempty" description:"Volume size (scheduler-dependent)"`
+	// Size is the volume size (k3s scheduler; required there, rejected on docker-local)
+	Size string `required:"false" yaml:"size,omitempty" description:"Volume size (k3s scheduler; required there and rejected on docker-local)"`
 
-	// AccessMode is the volume access mode (scheduler-dependent)
-	AccessMode string `required:"false" yaml:"access_mode,omitempty" description:"Volume access mode (scheduler-dependent)"`
+	// AccessMode is the volume access mode (k3s scheduler)
+	AccessMode string `required:"false" yaml:"access_mode,omitempty" options:"ReadWriteOnce,ReadOnlyMany,ReadWriteMany,ReadWriteOncePod" description:"Volume access mode (k3s scheduler; rejected on docker-local)"`
 
-	// StorageClass is the storage class name (scheduler-dependent)
-	StorageClass string `required:"false" yaml:"storage_class,omitempty" description:"Storage class name (scheduler-dependent)"`
+	// StorageClass is the storage class name (k3s scheduler)
+	StorageClass string `required:"false" yaml:"storage_class,omitempty" description:"Storage class name (k3s scheduler; rejected on docker-local, and mutually exclusive with path)"`
 
 	// Namespace is the namespace (scheduler-dependent)
 	Namespace string `required:"false" yaml:"namespace,omitempty" description:"Namespace (scheduler-dependent)"`
 
 	// Chown is the chown value applied when the entry's host directory is created
-	Chown string `required:"false" yaml:"chown,omitempty" description:"Chown value applied when the entry's host directory is created"`
+	Chown string `required:"false" yaml:"chown,omitempty" options:"heroku,herokuish,paketo,root,false" description:"Ownership applied when the entry's host directory is created: an ownership preset or a numeric uid (0-65535). dokku sets the owner and the group to the same id, and refuses the value unless the entry sits at its default host path"`
 
-	// ReclaimPolicy is the reclaim policy (scheduler-dependent)
-	ReclaimPolicy string `required:"false" yaml:"reclaim_policy,omitempty" description:"Reclaim policy (scheduler-dependent)"`
+	// ReclaimPolicy is the reclaim policy (k3s scheduler)
+	ReclaimPolicy string `required:"false" yaml:"reclaim_policy,omitempty" options:"Retain,Delete" description:"Reclaim policy applied to the underlying volume (k3s scheduler)"`
+
+	// Annotations are the volume annotations (k3s scheduler)
+	Annotations map[string]string `required:"false" yaml:"annotations,omitempty" description:"Map of annotations set on the underlying volume (k3s scheduler)"`
+
+	// Labels are the volume labels (k3s scheduler)
+	Labels map[string]string `required:"false" yaml:"labels,omitempty" description:"Map of labels set on the underlying volume (k3s scheduler)"`
 
 	// State is the desired state of the storage entry
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the storage entry"`
@@ -109,8 +120,207 @@ func (t StorageEntryTask) Execute() TaskOutputState {
 	return ExecutePlan(t.Plan())
 }
 
+// createArgs builds the storage:create command arguments. Every flag is
+// omitted when its field is empty so dokku applies its own default, and
+// the order is fixed - including the sorted map keys - so plan and apply
+// build byte-identical argv across runs.
+func (t StorageEntryTask) createArgs() []string {
+	args := []string{"--quiet", "storage:create"}
+	if t.Scheduler != "" {
+		args = append(args, "--scheduler", t.Scheduler)
+	}
+	if t.Size != "" {
+		args = append(args, "--size", t.Size)
+	}
+	if t.AccessMode != "" {
+		args = append(args, "--access-mode", t.AccessMode)
+	}
+	if t.StorageClass != "" {
+		args = append(args, "--storage-class-name", t.StorageClass)
+	}
+	if t.Namespace != "" {
+		args = append(args, "--namespace", t.Namespace)
+	}
+	if t.Chown != "" {
+		args = append(args, "--chown", t.Chown)
+	}
+	if t.ReclaimPolicy != "" {
+		args = append(args, "--reclaim-policy", t.ReclaimPolicy)
+	}
+	args = append(args, kvFlags("--annotation", t.Annotations)...)
+	args = append(args, kvFlags("--label", t.Labels)...)
+	args = append(args, t.Name)
+	if t.Path != "" {
+		args = append(args, t.Path)
+	}
+	return args
+}
+
+// kvFlags renders a string map as the repeated `--<flag> key=value` pairs
+// dokku collects into a map. Keys are sorted so the rendered command is
+// stable across runs.
+func kvFlags(flag string, values map[string]string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	keys := mapKeys(values)
+	sort.Strings(keys)
+	args := make([]string, 0, len(keys)*2)
+	for _, k := range keys {
+		args = append(args, flag, fmt.Sprintf("%s=%s", k, values[k]))
+	}
+	return args
+}
+
+// setEntryOptions returns the recipe keys of every create-time option the
+// task supplied, in field order. Keep it in step with createArgs: an option
+// that renders a flag but is missing here would be silently accepted under
+// state 'absent', where storage:destroy has nowhere to put it. 'scheduler'
+// is deliberately absent - it carries a default, so it is never empty by
+// the time Validate runs.
+func (t StorageEntryTask) setEntryOptions() []string {
+	var set []string
+	for _, opt := range []struct {
+		name string
+		used bool
+	}{
+		{"path", t.Path != ""},
+		{"size", t.Size != ""},
+		{"access_mode", t.AccessMode != ""},
+		{"storage_class", t.StorageClass != ""},
+		{"namespace", t.Namespace != ""},
+		{"chown", t.Chown != ""},
+		{"reclaim_policy", t.ReclaimPolicy != ""},
+		{"annotations", len(t.Annotations) > 0},
+		{"labels", len(t.Labels) > 0},
+	} {
+		if opt.used {
+			set = append(set, opt.name)
+		}
+	}
+	return set
+}
+
+// dockerNamedVolume matches the docker named-volume token dokku accepts in
+// place of an absolute path on a docker-local entry. Mirrors the regexp in
+// dokku's plugins/storage/entry.go.
+var dockerNamedVolume = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]+$`)
+
+// storageAccessModes lists the values dokku accepts for --access-mode.
+var storageAccessModes = map[string]bool{
+	"ReadWriteOnce":    true,
+	"ReadOnlyMany":     true,
+	"ReadWriteMany":    true,
+	"ReadWriteOncePod": true,
+}
+
+// Validate checks the StorageEntryTask's inputs without contacting the
+// server. It mirrors the rules dokku's own Entry.Validate enforces, so a
+// combination the server would refuse fails at `docket validate` time
+// instead of halfway through an apply. It deliberately goes no further:
+// dokku ignores rather than rejects namespace, reclaim_policy,
+// annotations, and labels on a docker-local entry, and a stricter docket
+// would refuse recipes the server accepts.
+func (t StorageEntryTask) Validate() error {
+	// storage:destroy takes only the entry name, so any create-time option
+	// supplied alongside state 'absent' would be silently discarded.
+	if t.State == StateAbsent {
+		if set := t.setEntryOptions(); len(set) > 0 {
+			return fmt.Errorf("'%s' must not be set for state 'absent'", strings.Join(set, "', '"))
+		}
+		return nil
+	}
+
+	// An omitted scheduler is docker-local: createArgs drops the flag so
+	// dokku applies its own default, and a task built in Go rather than
+	// parsed from a recipe never went through the `default:` tag.
+	switch t.Scheduler {
+	case "", "docker-local":
+		for _, field := range []struct {
+			name  string
+			value string
+		}{
+			{"size", t.Size},
+			{"access_mode", t.AccessMode},
+			{"storage_class", t.StorageClass},
+		} {
+			if field.value != "" {
+				return fmt.Errorf("'%s' must not be set for scheduler 'docker-local'", field.name)
+			}
+		}
+		if t.Path != "" && !strings.HasPrefix(t.Path, "/") && !dockerNamedVolume.MatchString(t.Path) {
+			return fmt.Errorf("'path' must be an absolute path or a docker named volume, got %q", t.Path)
+		}
+	case "k3s":
+		if t.Size == "" {
+			return errors.New("'size' is required for scheduler 'k3s'")
+		}
+		if t.StorageClass != "" && t.Path != "" {
+			return errors.New("'storage_class' and 'path' must not both be set: the cluster provisions class-backed volumes")
+		}
+		if t.AccessMode != "" && !storageAccessModes[t.AccessMode] {
+			return errors.New("'access_mode' must be one of ReadWriteOnce, ReadOnlyMany, ReadWriteMany, ReadWriteOncePod")
+		}
+		if t.Path != "" && !strings.HasPrefix(t.Path, "/") {
+			return fmt.Errorf("'path' must be an absolute path, got %q", t.Path)
+		}
+		if t.ReclaimPolicy != "" && t.ReclaimPolicy != "Retain" && t.ReclaimPolicy != "Delete" {
+			return errors.New("'reclaim_policy' must be one of Retain, Delete")
+		}
+	default:
+		return fmt.Errorf("'scheduler' must be one of docker-local, k3s, got %q", t.Scheduler)
+	}
+
+	if t.Chown != "" && !validChown(t.Chown) {
+		return errors.New("'chown' must be one of heroku, herokuish, paketo, root, false or a numeric uid (0-65535)")
+	}
+
+	for _, m := range []struct {
+		name   string
+		values map[string]string
+	}{
+		{"annotations", t.Annotations},
+		{"labels", t.Labels},
+	} {
+		if err := validateKVFlag(m.name, m.values); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateKVFlag rejects keys and values a repeated `--<flag> key=value`
+// argument cannot carry intact. dokku splits each pair on its first '=',
+// so a key holding one would silently restructure the map; and the flag is
+// a pflag string slice, which comma-splits its argument through a CSV
+// reader before dokku ever sees it, so a comma or a double quote on either
+// side of the pair breaks the parse rather than the value.
+func validateKVFlag(name string, values map[string]string) error {
+	keys := mapKeys(values)
+	sort.Strings(keys)
+	for _, k := range keys {
+		if k == "" {
+			return fmt.Errorf("'%s' keys must not be empty", name)
+		}
+		if strings.Contains(k, "=") {
+			return fmt.Errorf("'%s' key %q must not contain '='", name, k)
+		}
+		if strings.ContainsAny(k, `,"`) {
+			return fmt.Errorf("'%s' key %q must not contain ',' or '\"'", name, k)
+		}
+		if strings.ContainsAny(values[k], `,"`) {
+			return fmt.Errorf("'%s' value for %q must not contain ',' or '\"'", name, k)
+		}
+	}
+	return nil
+}
+
 // Plan reports the drift the StorageEntryTask would produce.
 func (t StorageEntryTask) Plan() PlanResult {
+	if err := t.Validate(); err != nil {
+		return planErr(err)
+	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
 		StatePresent: func() PlanResult {
 			exists, err := storageEntryExists(t.Name)
@@ -120,33 +330,7 @@ func (t StorageEntryTask) Plan() PlanResult {
 			if exists {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
-			args := []string{"--quiet", "storage:create"}
-			if t.Scheduler != "" {
-				args = append(args, "--scheduler", t.Scheduler)
-			}
-			if t.Size != "" {
-				args = append(args, "--size", t.Size)
-			}
-			if t.AccessMode != "" {
-				args = append(args, "--access-mode", t.AccessMode)
-			}
-			if t.StorageClass != "" {
-				args = append(args, "--storage-class-name", t.StorageClass)
-			}
-			if t.Namespace != "" {
-				args = append(args, "--namespace", t.Namespace)
-			}
-			if t.Chown != "" {
-				args = append(args, "--chown", t.Chown)
-			}
-			if t.ReclaimPolicy != "" {
-				args = append(args, "--reclaim-policy", t.ReclaimPolicy)
-			}
-			args = append(args, t.Name)
-			if t.Path != "" {
-				args = append(args, t.Path)
-			}
-			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: args}}
+			inputs := []subprocess.ExecCommandInput{{Command: "dokku", Args: t.createArgs()}}
 			return PlanResult{
 				InSync:    false,
 				Status:    PlanStatusCreate,
@@ -188,7 +372,61 @@ func (t StorageEntryTask) Plan() PlanResult {
 // dokku_storage_entry task per explicitly-created entry. Auto-generated
 // "legacy-" entries (created implicitly by legacy bind-mounts) are skipped
 // since they are reconstructed by dokku_storage_mount.
+//
+// storage:list-entries marshals the whole entry, so every field the task
+// can set comes back from the one call. Reconstructing all of them is what
+// makes the export lossless: dropping chown would lose the host
+// directory's ownership, and dropping size would produce a k3s entry the
+// task's own validation rejects.
 func (t StorageEntryTask) ExportGlobal() ([]interface{}, error) {
+	entries, err := storageEntries()
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+
+	var out []interface{}
+	for _, e := range entries {
+		if e.Name == "" || strings.HasPrefix(e.Name, "legacy-") {
+			continue
+		}
+		out = append(out, StorageEntryTask{
+			Name:          e.Name,
+			Path:          e.HostPath,
+			Scheduler:     e.Scheduler,
+			Size:          e.Size,
+			AccessMode:    e.AccessMode,
+			StorageClass:  e.StorageClass,
+			Namespace:     e.Namespace,
+			Chown:         e.Chown,
+			ReclaimPolicy: e.ReclaimPolicy,
+			Annotations:   e.Annotations,
+			Labels:        e.Labels,
+		})
+	}
+	return out, nil
+}
+
+// storageEntry mirrors the JSON dokku's storage:list-entries emits.
+type storageEntry struct {
+	Name          string            `json:"name"`
+	Scheduler     string            `json:"scheduler"`
+	HostPath      string            `json:"host_path"`
+	Size          string            `json:"size"`
+	AccessMode    string            `json:"access_mode"`
+	StorageClass  string            `json:"storage_class"`
+	Namespace     string            `json:"namespace"`
+	Chown         string            `json:"chown"`
+	ReclaimPolicy string            `json:"reclaim_policy"`
+	Annotations   map[string]string `json:"annotations"`
+	Labels        map[string]string `json:"labels"`
+}
+
+// storageEntries reads the named storage registry. A transport-level
+// failure (`*subprocess.SSHError`) is propagated; a dokku-level non-zero
+// exit or unparseable output is treated as an empty registry, since a
+// server without the entries directory has none to report.
+func storageEntries() ([]storageEntry, error) {
 	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
 		Command: "dokku",
 		Args:    []string{"--quiet", "storage:list-entries", "--format", "json"},
@@ -201,47 +439,20 @@ func (t StorageEntryTask) ExportGlobal() ([]interface{}, error) {
 		return nil, nil
 	}
 
-	var entries []struct {
-		Name      string `json:"name"`
-		Scheduler string `json:"scheduler"`
-		HostPath  string `json:"host_path"`
-	}
+	var entries []storageEntry
 	if err := json.Unmarshal(result.StdoutBytes(), &entries); err != nil {
 		return nil, nil
 	}
-	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
-
-	var out []interface{}
-	for _, e := range entries {
-		if e.Name == "" || strings.HasPrefix(e.Name, "legacy-") {
-			continue
-		}
-		out = append(out, StorageEntryTask{Name: e.Name, Path: e.HostPath, Scheduler: e.Scheduler})
-	}
-	return out, nil
+	return entries, nil
 }
 
 // storageEntryExists reports whether a named storage registry entry
 // exists. A transport-level failure (`*subprocess.SSHError`) is
 // propagated; a dokku-level non-zero exit is treated as "no entry."
 func storageEntryExists(name string) (bool, error) {
-	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
-		Command: "dokku",
-		Args:    []string{"--quiet", "storage:list-entries", "--format", "json"},
-	})
+	entries, err := storageEntries()
 	if err != nil {
-		var sshErr *subprocess.SSHError
-		if errors.As(err, &sshErr) {
-			return false, err
-		}
-		return false, nil
-	}
-
-	var entries []struct {
-		Name string `json:"name"`
-	}
-	if err := json.Unmarshal(result.StdoutBytes(), &entries); err != nil {
-		return false, nil
+		return false, err
 	}
 	for _, entry := range entries {
 		if entry.Name == name {

--- a/tasks/storage_entry_task_integration_test.go
+++ b/tasks/storage_entry_task_integration_test.go
@@ -80,3 +80,83 @@ func TestIntegrationStorageEntryNumericChown(t *testing.T) {
 		t.Error("expected changed=true for new entry")
 	}
 }
+
+func TestIntegrationStorageEntryAnnotationsAndLabels(t *testing.T) {
+	skipIfNoDokkuT(t)
+
+	name := "docket-test-entry-metadata"
+
+	// The repeated --annotation / --label flags are the last of
+	// storage:create's surface docket exposes. dokku records them on the
+	// entry whatever the scheduler, so a docker-local entry is enough to
+	// prove the pairs survive the flag round trip intact.
+	destroy := StorageEntryTask{Name: name, State: StateAbsent}
+	destroy.Execute()
+	defer destroy.Execute()
+
+	create := StorageEntryTask{
+		Name:        name,
+		Chown:       "herokuish",
+		Annotations: map[string]string{"docket.io/team": "platform", "docket.io/tier": "data"},
+		Labels:      map[string]string{"docket-managed": "true"},
+		State:       StatePresent,
+	}
+	result := create.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to create entry with annotations and labels: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for new entry")
+	}
+
+	entries, err := storageEntries()
+	if err != nil {
+		t.Fatalf("failed to read storage entries: %v", err)
+	}
+	var found *storageEntry
+	for i := range entries {
+		if entries[i].Name == name {
+			found = &entries[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected %s in storage:list-entries, got %+v", name, entries)
+	}
+	if found.Annotations["docket.io/team"] != "platform" || found.Annotations["docket.io/tier"] != "data" {
+		t.Errorf("annotations did not round-trip: %v", found.Annotations)
+	}
+	if found.Labels["docket-managed"] != "true" {
+		t.Errorf("labels did not round-trip: %v", found.Labels)
+	}
+	if found.Chown != "herokuish" {
+		t.Errorf("expected chown 'herokuish', got %q", found.Chown)
+	}
+
+	// ExportGlobal reconstructs the same values, so `docket export`
+	// reproduces the entry rather than a lossy shell of it.
+	exported, err := StorageEntryTask{}.ExportGlobal()
+	if err != nil {
+		t.Fatalf("ExportGlobal returned an error: %v", err)
+	}
+	var task *StorageEntryTask
+	for _, item := range exported {
+		entry, ok := item.(StorageEntryTask)
+		if ok && entry.Name == name {
+			task = &entry
+			break
+		}
+	}
+	if task == nil {
+		t.Fatalf("expected %s in the exported entries, got %+v", name, exported)
+	}
+	if task.Chown != "herokuish" {
+		t.Errorf("expected exported chown 'herokuish', got %q", task.Chown)
+	}
+	if task.Annotations["docket.io/team"] != "platform" {
+		t.Errorf("expected exported annotations to carry the team, got %v", task.Annotations)
+	}
+	if task.Labels["docket-managed"] != "true" {
+		t.Errorf("expected exported labels to carry docket-managed, got %v", task.Labels)
+	}
+}

--- a/tasks/storage_entry_task_test.go
+++ b/tasks/storage_entry_task_test.go
@@ -1,7 +1,10 @@
 package tasks
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/dokku/docket/subprocess"
 )
 
 func TestStorageEntryTaskInvalidState(t *testing.T) {
@@ -26,5 +29,453 @@ func TestStorageEntryAbsentStateAllowed(t *testing.T) {
 func TestStorageEntryRegistered(t *testing.T) {
 	if _, ok := RegisteredTasks["dokku_storage_entry"]; !ok {
 		t.Fatal("expected dokku_storage_entry to be registered")
+	}
+}
+
+func TestStorageEntryCreateArgsMinimal(t *testing.T) {
+	// An omitted scheduler leaves the flag off entirely so dokku applies
+	// its own default rather than docket restating it.
+	task := StorageEntryTask{Name: "app-data", State: StatePresent}
+	want := []string{"--quiet", "storage:create", "app-data"}
+	if got := task.createArgs(); !equalStrings(got, want) {
+		t.Errorf("expected args %v, got %v", want, got)
+	}
+}
+
+func TestStorageEntryCreateArgsPathIsTrailingPositional(t *testing.T) {
+	task := StorageEntryTask{
+		Name:      "app-data",
+		Path:      "/mnt/app-data",
+		Scheduler: "docker-local",
+		Chown:     "herokuish",
+		State:     StatePresent,
+	}
+	want := []string{
+		"--quiet", "storage:create",
+		"--scheduler", "docker-local",
+		"--chown", "herokuish",
+		"app-data", "/mnt/app-data",
+	}
+	if got := task.createArgs(); !equalStrings(got, want) {
+		t.Errorf("expected args %v, got %v", want, got)
+	}
+}
+
+func TestStorageEntryCreateArgsEveryFlag(t *testing.T) {
+	// The full k3s surface, asserting the fixed flag order plan and apply
+	// both build from.
+	task := StorageEntryTask{
+		Name:          "app-data",
+		Scheduler:     "k3s",
+		Size:          "2Gi",
+		AccessMode:    "ReadWriteOnce",
+		StorageClass:  "longhorn",
+		Namespace:     "apps",
+		Chown:         "32767",
+		ReclaimPolicy: "Retain",
+		Annotations:   map[string]string{"team": "platform"},
+		Labels:        map[string]string{"tier": "data"},
+		State:         StatePresent,
+	}
+	want := []string{
+		"--quiet", "storage:create",
+		"--scheduler", "k3s",
+		"--size", "2Gi",
+		"--access-mode", "ReadWriteOnce",
+		"--storage-class-name", "longhorn",
+		"--namespace", "apps",
+		"--chown", "32767",
+		"--reclaim-policy", "Retain",
+		"--annotation", "team=platform",
+		"--label", "tier=data",
+		"app-data",
+	}
+	if got := task.createArgs(); !equalStrings(got, want) {
+		t.Errorf("expected args %v, got %v", want, got)
+	}
+}
+
+func TestStorageEntryCreateArgsRepeatsMapFlagsInSortedOrder(t *testing.T) {
+	// dokku collects the flag into a map, so docket sorts the keys to keep
+	// plan and apply byte-identical across runs.
+	task := StorageEntryTask{
+		Name:        "app-data",
+		Scheduler:   "k3s",
+		Size:        "1Gi",
+		Annotations: map[string]string{"zeta": "1", "alpha": "2", "mid": "3"},
+		Labels:      map[string]string{"zulu": "a", "bravo": "b"},
+		State:       StatePresent,
+	}
+	want := []string{
+		"--quiet", "storage:create",
+		"--scheduler", "k3s",
+		"--size", "1Gi",
+		"--annotation", "alpha=2",
+		"--annotation", "mid=3",
+		"--annotation", "zeta=1",
+		"--label", "bravo=b",
+		"--label", "zulu=a",
+		"app-data",
+	}
+	if got := task.createArgs(); !equalStrings(got, want) {
+		t.Errorf("expected args %v, got %v", want, got)
+	}
+}
+
+func TestStorageEntryValidChownValues(t *testing.T) {
+	// The same value set dokku_storage_ensure accepts: the entry task now
+	// shares validChown rather than forwarding anything at all.
+	for _, chown := range []string{"heroku", "herokuish", "paketo", "root", "false", "0", "1000", "32767", "65535"} {
+		task := StorageEntryTask{Name: "app-data", Chown: chown, State: StatePresent}
+		if err := task.Validate(); err != nil {
+			t.Errorf("chown %q should be valid, got: %v", chown, err)
+		}
+	}
+}
+
+func TestStorageEntryInvalidChownValue(t *testing.T) {
+	for _, chown := range []string{"packeto", "65536", "70000", "-1", "+5", "1000:1000", "root:root", "0x10", "1_000", "abc"} {
+		task := StorageEntryTask{Name: "app-data", Chown: chown, State: StatePresent}
+		err := task.Validate()
+		if err == nil {
+			t.Errorf("chown %q should be rejected", chown)
+			continue
+		}
+		if !strings.Contains(err.Error(), "'chown' must be one of") {
+			t.Errorf("chown %q: unexpected error %v", chown, err)
+		}
+	}
+}
+
+func TestStorageEntryOmittedChownAllowed(t *testing.T) {
+	task := StorageEntryTask{Name: "app-data", State: StatePresent}
+	if err := task.Validate(); err != nil {
+		t.Errorf("an omitted chown should be valid, got: %v", err)
+	}
+}
+
+func TestStorageEntryValidateSchedulerRules(t *testing.T) {
+	tests := []struct {
+		name    string
+		task    StorageEntryTask
+		wantErr string
+	}{
+		{
+			name:    "unknown scheduler",
+			task:    StorageEntryTask{Name: "app-data", Scheduler: "nomad"},
+			wantErr: "'scheduler' must be one of docker-local, k3s",
+		},
+		{
+			name:    "docker-local rejects size",
+			task:    StorageEntryTask{Name: "app-data", Scheduler: "docker-local", Size: "2Gi"},
+			wantErr: "'size' must not be set for scheduler 'docker-local'",
+		},
+		{
+			name:    "docker-local rejects access_mode",
+			task:    StorageEntryTask{Name: "app-data", Scheduler: "docker-local", AccessMode: "ReadWriteOnce"},
+			wantErr: "'access_mode' must not be set for scheduler 'docker-local'",
+		},
+		{
+			name:    "docker-local rejects storage_class",
+			task:    StorageEntryTask{Name: "app-data", Scheduler: "docker-local", StorageClass: "longhorn"},
+			wantErr: "'storage_class' must not be set for scheduler 'docker-local'",
+		},
+		{
+			name:    "docker-local rejects a relative path",
+			task:    StorageEntryTask{Name: "app-data", Scheduler: "docker-local", Path: "./data"},
+			wantErr: "'path' must be an absolute path or a docker named volume",
+		},
+		{
+			name: "docker-local accepts a named volume",
+			task: StorageEntryTask{Name: "app-data", Scheduler: "docker-local", Path: "app-data-volume"},
+		},
+		{
+			name:    "k3s requires size",
+			task:    StorageEntryTask{Name: "app-data", Scheduler: "k3s"},
+			wantErr: "'size' is required for scheduler 'k3s'",
+		},
+		{
+			name:    "k3s rejects storage_class with a path",
+			task:    StorageEntryTask{Name: "app-data", Scheduler: "k3s", Size: "2Gi", StorageClass: "longhorn", Path: "/mnt/data"},
+			wantErr: "'storage_class' and 'path' must not both be set",
+		},
+		{
+			name:    "k3s rejects an unknown access_mode",
+			task:    StorageEntryTask{Name: "app-data", Scheduler: "k3s", Size: "2Gi", AccessMode: "ReadWriteEverything"},
+			wantErr: "'access_mode' must be one of",
+		},
+		{
+			name:    "k3s rejects a relative path",
+			task:    StorageEntryTask{Name: "app-data", Scheduler: "k3s", Size: "2Gi", Path: "data"},
+			wantErr: "'path' must be an absolute path",
+		},
+		{
+			name:    "k3s rejects an unknown reclaim_policy",
+			task:    StorageEntryTask{Name: "app-data", Scheduler: "k3s", Size: "2Gi", ReclaimPolicy: "Recycle"},
+			wantErr: "'reclaim_policy' must be one of Retain, Delete",
+		},
+		{
+			name: "k3s full surface",
+			task: StorageEntryTask{
+				Name:          "app-data",
+				Scheduler:     "k3s",
+				Size:          "2Gi",
+				AccessMode:    "ReadWriteMany",
+				Namespace:     "apps",
+				ReclaimPolicy: "Delete",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.task.State = StatePresent
+			err := test.task.Validate()
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got none", test.wantErr)
+			}
+			if !strings.Contains(err.Error(), test.wantErr) {
+				t.Errorf("expected error containing %q, got: %v", test.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestStorageEntryValidateRejectsCreateOptionsWhenAbsent(t *testing.T) {
+	// storage:destroy takes only the entry name, so a create-time option
+	// alongside state 'absent' would be silently dropped.
+	tests := []struct {
+		name    string
+		task    StorageEntryTask
+		wantErr string
+	}{
+		{"path", StorageEntryTask{Name: "app-data", Path: "/mnt/data"}, "'path' must not be set for state 'absent'"},
+		{"chown", StorageEntryTask{Name: "app-data", Chown: "herokuish"}, "'chown' must not be set for state 'absent'"},
+		{"annotations", StorageEntryTask{Name: "app-data", Annotations: map[string]string{"a": "b"}}, "'annotations' must not be set for state 'absent'"},
+		{"labels", StorageEntryTask{Name: "app-data", Labels: map[string]string{"a": "b"}}, "'labels' must not be set for state 'absent'"},
+		{
+			"several at once",
+			StorageEntryTask{Name: "app-data", Size: "2Gi", Chown: "root"},
+			"'size', 'chown' must not be set for state 'absent'",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.task.State = StateAbsent
+			err := test.task.Validate()
+			if err == nil {
+				t.Fatalf("expected error containing %q, got none", test.wantErr)
+			}
+			if !strings.Contains(err.Error(), test.wantErr) {
+				t.Errorf("expected error containing %q, got: %v", test.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestStorageEntryValidateAbsentWithOnlyNameIsValid(t *testing.T) {
+	// The scheduler default must not count as a supplied create-time
+	// option, or every destroy would fail validation.
+	task := StorageEntryTask{Name: "app-data", Scheduler: "docker-local", State: StateAbsent}
+	if err := task.Validate(); err != nil {
+		t.Errorf("expected a bare destroy to validate, got: %v", err)
+	}
+}
+
+func TestStorageEntryValidateMapKeysAndValues(t *testing.T) {
+	// dokku splits each pair on its first '=' and the flag is comma-split
+	// through a CSV reader before dokku sees it, so neither delimiter can
+	// survive inside a key or value.
+	tests := []struct {
+		name    string
+		task    StorageEntryTask
+		wantErr string
+	}{
+		{
+			name:    "empty annotation key",
+			task:    StorageEntryTask{Annotations: map[string]string{"": "value"}},
+			wantErr: "'annotations' keys must not be empty",
+		},
+		{
+			name:    "annotation key with an equals",
+			task:    StorageEntryTask{Annotations: map[string]string{"a=b": "value"}},
+			wantErr: `'annotations' key "a=b" must not contain '='`,
+		},
+		{
+			name:    "annotation key with a comma",
+			task:    StorageEntryTask{Annotations: map[string]string{"a,b": "value"}},
+			wantErr: `'annotations' key "a,b" must not contain ',' or '"'`,
+		},
+		{
+			name:    "annotation value with a comma",
+			task:    StorageEntryTask{Annotations: map[string]string{"team": "a,b"}},
+			wantErr: `'annotations' value for "team" must not contain ',' or '"'`,
+		},
+		{
+			name:    "annotation value with a double quote",
+			task:    StorageEntryTask{Annotations: map[string]string{"team": `a"b`}},
+			wantErr: `'annotations' value for "team" must not contain ',' or '"'`,
+		},
+		{
+			name:    "label key with a double quote",
+			task:    StorageEntryTask{Labels: map[string]string{`a"b`: "value"}},
+			wantErr: `'labels' key "a\"b" must not contain ',' or '"'`,
+		},
+		{
+			name:    "label value with a comma",
+			task:    StorageEntryTask{Labels: map[string]string{"tier": "a,b"}},
+			wantErr: `'labels' value for "tier" must not contain ',' or '"'`,
+		},
+		{
+			name: "an equals in a value is fine",
+			task: StorageEntryTask{Annotations: map[string]string{"team": "a=b"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.task.Name = "app-data"
+			test.task.State = StatePresent
+			err := test.task.Validate()
+			if test.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got none", test.wantErr)
+			}
+			if !strings.Contains(err.Error(), test.wantErr) {
+				t.Errorf("expected error containing %q, got: %v", test.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestStorageEntryPlanReportsValidationError(t *testing.T) {
+	// Validate runs before the probe, so an invalid input never reaches
+	// the server.
+	task := StorageEntryTask{Name: "app-data", Chown: "packeto", State: StatePresent}
+	plan := task.Plan()
+	if plan.Status != PlanStatusError {
+		t.Fatalf("expected plan status %q, got %q", PlanStatusError, plan.Status)
+	}
+	if plan.Error == nil || !strings.Contains(plan.Error.Error(), "'chown' must be one of") {
+		t.Errorf("expected a chown error, got: %v", plan.Error)
+	}
+}
+
+func TestStorageEntryPlanCreateCarriesEveryFlag(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet storage:list-entries --format json": `[]`,
+	}))()
+
+	task := StorageEntryTask{
+		Name:        "app-data",
+		Chown:       "herokuish",
+		Annotations: map[string]string{"team": "platform"},
+		State:       StatePresent,
+	}
+	plan := task.Plan()
+	if plan.Status != PlanStatusCreate {
+		t.Fatalf("expected plan status %q, got %q", PlanStatusCreate, plan.Status)
+	}
+	if len(plan.Commands) != 1 {
+		t.Fatalf("expected one command, got %v", plan.Commands)
+	}
+	for _, want := range []string{"--chown herokuish", "--annotation team=platform"} {
+		if !strings.Contains(plan.Commands[0], want) {
+			t.Errorf("expected command to contain %q, got %q", want, plan.Commands[0])
+		}
+	}
+}
+
+// storageEntriesFixture is the storage:list-entries payload the export
+// tests read: one docker-local entry carrying ownership, one k3s entry
+// carrying the cluster attributes, and one auto-generated legacy entry.
+func storageEntriesFixture() map[string]string {
+	return map[string]string{
+		"--quiet storage:list-entries --format json": `[
+			{
+				"name": "legacy-abc123",
+				"scheduler": "docker-local",
+				"host_path": "/var/lib/dokku/data/storage/legacy",
+				"schema_version": 1
+			},
+			{
+				"name": "k3s-data",
+				"scheduler": "k3s",
+				"size": "2Gi",
+				"access_mode": "ReadWriteOnce",
+				"storage_class": "longhorn",
+				"namespace": "apps",
+				"reclaim_policy": "Retain",
+				"annotations": {"team": "platform"},
+				"labels": {"tier": "data"},
+				"schema_version": 1
+			},
+			{
+				"name": "app-data",
+				"scheduler": "docker-local",
+				"host_path": "/var/lib/dokku/data/storage/app-data",
+				"chown": "herokuish",
+				"schema_version": 1
+			}
+		]`,
+	}
+}
+
+func TestStorageEntryExportGlobal(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(storageEntriesFixture()))()
+
+	exported, err := StorageEntryTask{}.ExportGlobal()
+	if err != nil {
+		t.Fatalf("ExportGlobal returned an error: %v", err)
+	}
+	if len(exported) != 2 {
+		t.Fatalf("expected 2 entries (the legacy- entry is reconstructed by dokku_storage_mount), got %d: %v", len(exported), exported)
+	}
+
+	first, ok := exported[0].(StorageEntryTask)
+	if !ok {
+		t.Fatalf("expected a StorageEntryTask, got %T", exported[0])
+	}
+	// Ownership is what makes the host directory's export lossless.
+	want := StorageEntryTask{
+		Name:      "app-data",
+		Path:      "/var/lib/dokku/data/storage/app-data",
+		Scheduler: "docker-local",
+		Chown:     "herokuish",
+	}
+	if first.Name != want.Name || first.Path != want.Path || first.Scheduler != want.Scheduler || first.Chown != want.Chown {
+		t.Errorf("expected %+v, got %+v", want, first)
+	}
+
+	second, ok := exported[1].(StorageEntryTask)
+	if !ok {
+		t.Fatalf("expected a StorageEntryTask, got %T", exported[1])
+	}
+	if second.Name != "k3s-data" || second.Size != "2Gi" || second.AccessMode != "ReadWriteOnce" ||
+		second.StorageClass != "longhorn" || second.Namespace != "apps" || second.ReclaimPolicy != "Retain" {
+		t.Errorf("k3s attributes did not round-trip: %+v", second)
+	}
+	if second.Annotations["team"] != "platform" {
+		t.Errorf("expected annotation team=platform, got %v", second.Annotations)
+	}
+	if second.Labels["tier"] != "data" {
+		t.Errorf("expected label tier=data, got %v", second.Labels)
+	}
+	// An exported k3s entry must satisfy the task's own rules, or the
+	// recipe export writes would not apply.
+	if err := second.Validate(); err != nil {
+		t.Errorf("exported k3s entry does not validate: %v", err)
 	}
 }

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -614,6 +614,124 @@ func TestValidateStorageEnsureNumericChownValid(t *testing.T) {
 	}
 }
 
+func TestValidateStorageEntryInvalidChown(t *testing.T) {
+	// dokku_storage_entry forwards --chown to storage:create, so it shares
+	// the same preset-or-uid rule dokku_storage_ensure enforces.
+	data := []byte(`---
+- tasks:
+    - dokku_storage_entry:
+        name: node-js-app-data
+        chown: packeto
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "invalid_task_input")
+	if p == nil {
+		t.Fatalf("expected invalid_task_input problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, "'chown' must be one of") {
+		t.Errorf("expected message to mention the allowed chown values, got: %q", p.Message)
+	}
+}
+
+func TestValidateStorageEntryDockerLocalRejectsK3sFields(t *testing.T) {
+	// The scheduler default is applied before Validate runs, so a recipe
+	// that never names a scheduler is still checked against dokku's
+	// docker-local rules.
+	data := []byte(`---
+- tasks:
+    - dokku_storage_entry:
+        name: node-js-app-data
+        size: 2Gi
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "invalid_task_input")
+	if p == nil {
+		t.Fatalf("expected invalid_task_input problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, "'size' must not be set for scheduler 'docker-local'") {
+		t.Errorf("expected message to name the scheduler, got: %q", p.Message)
+	}
+}
+
+func TestValidateStorageEntryK3sRequiresSize(t *testing.T) {
+	data := []byte(`---
+- tasks:
+    - dokku_storage_entry:
+        name: node-js-app-data
+        scheduler: k3s
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "invalid_task_input")
+	if p == nil {
+		t.Fatalf("expected invalid_task_input problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, "'size' is required for scheduler 'k3s'") {
+		t.Errorf("expected message to require a size, got: %q", p.Message)
+	}
+}
+
+func TestValidateStorageEntryAbsentRejectsCreateOptions(t *testing.T) {
+	// storage:destroy takes only the entry name, so a chown alongside
+	// state 'absent' would be silently discarded.
+	data := []byte(`---
+- tasks:
+    - dokku_storage_entry:
+        name: node-js-app-data
+        chown: herokuish
+        state: absent
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "invalid_task_input")
+	if p == nil {
+		t.Fatalf("expected invalid_task_input problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, "'chown' must not be set for state 'absent'") {
+		t.Errorf("expected message to name the discarded field, got: %q", p.Message)
+	}
+}
+
+func TestValidateStorageEntryAnnotationsValid(t *testing.T) {
+	// The annotations and labels maps reach dokku as repeated
+	// `--annotation key=value` flags; a clean map validates.
+	data := []byte(`---
+- tasks:
+    - dokku_storage_entry:
+        name: node-js-app-data
+        scheduler: k3s
+        size: 2Gi
+        annotations:
+          team: platform
+        labels:
+          tier: data
+`)
+	problems := Validate(data, ValidateOptions{})
+	if n := countProblems(problems, "invalid_task_input"); n != 0 {
+		t.Errorf("expected no invalid_task_input, got %d: %+v", n, problems)
+	}
+}
+
+func TestValidateStorageEntryAnnotationKeyWithComma(t *testing.T) {
+	// The flag is a pflag string slice, so a comma splits the pair before
+	// dokku ever parses it.
+	data := []byte(`---
+- tasks:
+    - dokku_storage_entry:
+        name: node-js-app-data
+        scheduler: k3s
+        size: 2Gi
+        annotations:
+          "team,owner": platform
+`)
+	problems := Validate(data, ValidateOptions{})
+	p := findProblem(problems, "invalid_task_input")
+	if p == nil {
+		t.Fatalf("expected invalid_task_input problem, got: %+v", problems)
+	}
+	if !strings.Contains(p.Message, "'annotations' key") {
+		t.Errorf("expected message to name the annotations key, got: %q", p.Message)
+	}
+}
+
 func TestValidateInvalidTaskInputSkippedWhenRequiredMissing(t *testing.T) {
 	// When a required field is missing, only missing_required_field is
 	// reported; the conditional Validate() check (which depends on that

--- a/tests/bats/ansible.bats
+++ b/tests/bats/ansible.bats
@@ -117,6 +117,54 @@ EOF
   assert_output --partial 'v=[{{ .Values.name }}]'
 }
 
+# The host-directory half of a dokku_storage module call: one
+# dokku_storage_entry per host directory, ahead of the mount tasks that
+# reference it. `create_host_dir` plus `user`/`group` collapse into the
+# entry's chown, which the wrapper must send as a single value.
+@test "a storage host-directory payload validates" {
+  cd "$BATS_TEST_TMPDIR"
+  cat >storage.json <<'EOF'
+[
+  {
+    "name": "dokku_storage",
+    "tasks": [
+      {
+        "name": "create the host directory for hello-world",
+        "dokku_storage_entry": {
+          "name": "hello-world-data",
+          "chown": "herokuish",
+          "state": "present"
+        }
+      },
+      {
+        "name": "mount storage on hello-world",
+        "dokku_storage_mount": {
+          "app": "hello-world",
+          "entry_name": "hello-world-data",
+          "container_dir": "/data",
+          "state": "present"
+        }
+      }
+    ]
+  }
+]
+EOF
+  run bash -c "\"$(docket_bin)\" validate --tasks-format json5 - <storage.json"
+  assert_success
+  assert_output --partial "is valid"
+}
+
+@test "a bad storage chown reports a validate_problem a wrapper can branch on" {
+  cd "$BATS_TEST_TMPDIR"
+  cat >storage.json <<'EOF'
+[{"tasks": [{"name": "bad chown", "dokku_storage_entry": {"name": "hello-world-data", "chown": "packeto"}}]}]
+EOF
+  run bash -c "\"$(docket_bin)\" validate --tasks-format json5 --json - <storage.json"
+  assert_failure
+  echo "$output" | jq -e '.code == "invalid_task_input"' >/dev/null || fail "expected invalid_task_input: $output"
+  echo "$output" | jq -e '.message | test("chown")' >/dev/null || fail "expected the message to name chown: $output"
+}
+
 @test "a load-time failure writes no JSON to stdout" {
   cd "$BATS_TEST_TMPDIR"
   cat >typo.json <<'EOF'


### PR DESCRIPTION
docket covers storage host directories exactly as far as `storage:create` reaches, so `dokku_storage_entry` gains the `annotations` and `labels` it was missing, validates its inputs offline against the same rules dokku enforces, and exports every attribute it can set rather than three of them. The `0o777` chmod and the `destroy_host_dir` removal that `ansible-dokku`'s `dokku_storage` does with raw filesystem calls stay in the wrapper, since dokku exposes no command for either and docket may be driving the host over SSH. A create-time option supplied alongside `state: absent` is now rejected rather than silently discarded.

`docs/ansible-dokku.md` records the decision as a per-option table under the module mapping, and host-directory management leaves the list of things a wrapper cannot delegate. The two pieces that stay behind are tracked in dokku/dokku#8913, and the fact that `chown` applies at create time only is tracked in #439.

Closes #416.
