### PR TITLE
fix: reject flags a streamed recipe cannot honour

### DIFF
--- a/commands/export.go
+++ b/commands/export.go
@@ -109,9 +109,9 @@ func (c *ExportCommand) AutocompleteFlags() complete.Flags {
 // Exit codes:
 //
 //	0 - export written (or streamed to stdout)
-//	1 - flag parse error, read error, an output file exists without
-//	    --overwrite (and the prompt was declined or stdin is not interactive),
-//	    or an IO error
+//	1 - flag parse error, a file-only flag combined with --output -, read
+//	    error, an output file exists without --overwrite (and the prompt was
+//	    declined or stdin is not interactive), or an IO error
 func (c *ExportCommand) Run(args []string) int {
 	flags := c.FlagSet()
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
@@ -138,6 +138,19 @@ func (c *ExportCommand) Run(args []string) int {
 	c.output, recipeFormat = resolveRecipeOutput(c.output, formatOverride, flags.Changed("output"))
 	if msg := recipeOutputFormatMismatch(c.output, formatOverride); msg != "" {
 		c.Ui.Warn(msg)
+	}
+
+	// A streamed recipe has no vars-file to place and no file on disk to
+	// replace, so both flags below would be silently dropped by the stdout
+	// branch further down (#419). Rejected here, before the SSH control
+	// master is opened and before the server is enumerated, so the failure
+	// is instant.
+	if err := stdoutInertFlagError(flags, c.output, []stdoutInertFlag{
+		{name: "vars-output", reason: "a streamed recipe inlines its values"},
+		{name: "overwrite", reason: "a streamed recipe writes no files"},
+	}); err != nil {
+		c.Ui.Error(err.Error())
+		return 1
 	}
 
 	resolvedHost := resolveSshFlags(c.host, c.sudo, c.acceptNewHostKeys)
@@ -251,6 +264,13 @@ func (c *ExportCommand) Run(args []string) int {
 		if c.redact {
 			c.Ui.Output("    (redacted; fill in the vars-file before applying)")
 		}
+	} else if flags.Changed("vars-output") {
+		// Asking for a vars-file at a named path and getting no file is the
+		// other half of #419. Here the flag was legitimate - there was just
+		// nothing sensitive to lift - so this is a note rather than an
+		// error. The derived default stays quiet: a path the user did not
+		// choose going unwritten is not news.
+		c.Ui.Output(fmt.Sprintf("    no sensitive values to export; %s not written", varsOutput))
 	}
 	c.Ui.Output("")
 	c.Ui.Output("Next steps:")

--- a/commands/export_test.go
+++ b/commands/export_test.go
@@ -419,6 +419,111 @@ func TestExportCommandRejectsUnknownFormatBeforeReadingServer(t *testing.T) {
 	}
 }
 
+// TestExportCommandRejectsStdoutInertFlags is the #419 regression. Like
+// TestExportCommandRejectsUnknownFormatBeforeReadingServer it installs no
+// fake exec runner, so passing proves the rejection lands before
+// tasks.ExportRecipe would have shelled out to dokku.
+func TestExportCommandRejectsStdoutInertFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		extra    []string
+		wantFlag string
+	}{
+		{name: "vars-output", extra: []string{"--vars-output", "VARS"}, wantFlag: "--vars-output"},
+		{name: "overwrite", extra: []string{"--overwrite"}, wantFlag: "--overwrite"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Chdir(dir)
+			vars := filepath.Join(dir, "secrets.yml")
+
+			args := []string{"--output", "-"}
+			for _, a := range tt.extra {
+				if a == "VARS" {
+					a = vars
+				}
+				args = append(args, a)
+			}
+
+			c, ui := newExportCommand()
+			if code := c.Run(args); code != 1 {
+				t.Fatalf("exit = %d, want 1", code)
+			}
+			errOut := ui.ErrorWriter.String()
+			if !strings.Contains(errOut, tt.wantFlag) {
+				t.Errorf("error should name %s:\n%s", tt.wantFlag, errOut)
+			}
+			if !strings.Contains(errOut, "--output -") {
+				t.Errorf("error should name --output -:\n%s", errOut)
+			}
+			if _, err := os.Stat(vars); err == nil {
+				t.Error("a rejected export should not write the vars-file")
+			}
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				t.Fatalf("read dir: %v", err)
+			}
+			if len(entries) != 0 {
+				t.Errorf("a rejected export should write nothing, found %d entries", len(entries))
+			}
+		})
+	}
+}
+
+// TestExportCommandReportsUnusedVarsOutput covers the other half of #419:
+// an explicit --vars-output that goes unwritten because the server held
+// nothing sensitive is reported rather than passed over. The derived
+// default stays silent.
+func TestExportCommandReportsUnusedVarsOutput(t *testing.T) {
+	// The fixture's only sensitive value is the config entry; an empty
+	// config export leaves ExportResult.Vars empty and writeVars false.
+	fixture := exportCommandFixture()
+	fixture["--quiet config:export --format json web"] = "{}"
+
+	t.Run("explicit --vars-output is reported", func(t *testing.T) {
+		defer subprocess.SetExecRunner(fakeExecRunner(fixture))()
+
+		dir := t.TempDir()
+		recipe := filepath.Join(dir, "tasks.yml")
+		vars := filepath.Join(dir, "secrets.yml")
+
+		c, ui := newExportCommand()
+		if code := c.Run([]string{"--output", recipe, "--vars-output", vars}); code != 0 {
+			t.Fatalf("Run exit = %d, want 0: %s", code, ui.ErrorWriter.String())
+		}
+		if _, err := os.Stat(vars); !os.IsNotExist(err) {
+			t.Errorf("no sensitive values means no vars-file: %v", err)
+		}
+		out := ui.OutputWriter.String()
+		if !strings.Contains(out, "no sensitive values") {
+			t.Errorf("summary should say why the vars-file is missing:\n%s", out)
+		}
+		if !strings.Contains(out, vars) {
+			t.Errorf("summary should name the path that was asked for:\n%s", out)
+		}
+		// apply needs no --vars-file when there is no vars-file.
+		if strings.Contains(out, "--vars-file") {
+			t.Errorf("next steps should not offer a vars-file that was never written:\n%s", out)
+		}
+	})
+
+	t.Run("derived default stays quiet", func(t *testing.T) {
+		defer subprocess.SetExecRunner(fakeExecRunner(fixture))()
+
+		dir := t.TempDir()
+		recipe := filepath.Join(dir, "tasks.yml")
+
+		c, ui := newExportCommand()
+		if code := c.Run([]string{"--output", recipe}); code != 0 {
+			t.Fatalf("Run exit = %d, want 0: %s", code, ui.ErrorWriter.String())
+		}
+		if out := ui.OutputWriter.String(); strings.Contains(out, "no sensitive values") {
+			t.Errorf("a path the user did not choose should not be reported:\n%s", out)
+		}
+	})
+}
+
 func TestExportCommandSummaryExcludesGlobalPlay(t *testing.T) {
 	// #345: one app plus a global play must report "(1 app)", not "(2 apps)".
 	responses := exportCommandFixture()

--- a/commands/init.go
+++ b/commands/init.go
@@ -105,8 +105,8 @@ func (c *InitCommand) AutocompleteFlags() complete.Flags {
 // Run renders the scaffold and writes it. Exit codes:
 //
 //	0 - scaffold written
-//	1 - flag parse error, output file already exists without --force,
-//	    template render error, IO error
+//	1 - flag parse error, --force combined with --output -, output file
+//	    already exists without --force, template render error, IO error
 func (c *InitCommand) Run(args []string) int {
 	flags := c.FlagSet()
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
@@ -131,6 +131,17 @@ func (c *InitCommand) Run(args []string) int {
 	c.output, format = resolveRecipeOutput(c.output, formatOverride, flags.Changed("output"))
 	if msg := recipeOutputFormatMismatch(c.output, formatOverride); msg != "" {
 		c.Ui.Warn(msg)
+	}
+
+	// --force only means "replace the file that is there", and the exists
+	// check below is skipped entirely when streaming, so the flag would
+	// otherwise be read and dropped - the same silence #419 reports on
+	// export.
+	if err := stdoutInertFlagError(flags, c.output, []stdoutInertFlag{
+		{name: "force", reason: "a streamed recipe writes no files"},
+	}); err != nil {
+		c.Ui.Error(err.Error())
+		return 1
 	}
 
 	toStdout := c.output == taskFileStdin

--- a/commands/init_test.go
+++ b/commands/init_test.go
@@ -534,6 +534,31 @@ func TestInitOutputDashWritesToStdout(t *testing.T) {
 	}
 }
 
+// TestInitRejectsForceWithStdout is init's half of #419: the exists check
+// --force governs is skipped entirely when streaming, so the flag would
+// otherwise be read off the flag set and dropped.
+func TestInitRejectsForceWithStdout(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	c, ui := newTestInitCommandUi()
+	if exit := c.Run([]string{"--output", "-", "--force", "--name", "demo"}); exit != 1 {
+		t.Fatalf("exit = %d, want 1", exit)
+	}
+	errOut := ui.ErrorWriter.String()
+	if !strings.Contains(errOut, "--force") {
+		t.Errorf("error should name --force:\n%s", errOut)
+	}
+	if !strings.Contains(errOut, "--output -") {
+		t.Errorf("error should name --output -:\n%s", errOut)
+	}
+	for _, name := range []string{"tasks.yml", "tasks.json"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			t.Errorf("a rejected init should not write %s", name)
+		}
+	}
+}
+
 // TestInitFormatJSON5WritesTasksJSON covers the headline of #410: asking
 // for JSON5 by name, with no --output, writes tasks.json rather than a
 // JSON5 document under a .yml name.

--- a/commands/task_file.go
+++ b/commands/task_file.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mattn/go-isatty"
 	"github.com/posener/complete"
+	flag "github.com/spf13/pflag"
 )
 
 // Task file format identifiers used throughout the commands package and
@@ -207,6 +208,43 @@ func recipeOutputFormatMismatch(path, override string) string {
 	}
 	return fmt.Sprintf("warning: --format %s does not match the %s extension; reading %s back needs --tasks-format %s",
 		override, path, path, override)
+}
+
+// stdoutInertFlag names a flag on a recipe-writing command that only means
+// something once there is a file to write, together with the clause
+// explaining why a stream cannot honour it.
+type stdoutInertFlag struct {
+	name   string
+	reason string
+}
+
+// stdoutInertFlagError rejects those flags when --output - has turned the
+// write into a stream. Both init and export return from their stdout
+// branch before the file-only flags are ever consulted, so without this
+// the flag is read off the flag set and dropped: `docket export --output -
+// --vars-output secrets.yml` exited 0, wrote nothing to that path, and said
+// nothing about it (#419). Erroring beats warning because there is no
+// reading of such a command line under which being ignored is what was
+// wanted.
+//
+// flags.Changed - not the parsed value - is the test, so this fires on the
+// flag having been typed rather than on what it was set to, and
+// `--overwrite=false --output -` is rejected too: the objection is to the
+// combination, not to the value. Changed is only meaningful after
+// flags.Parse, the same ordering constraint resolveRecipeOutput documents.
+//
+// Callers must run this after resolveRecipeOutput so output is the path
+// that will actually be written.
+func stdoutInertFlagError(flags *flag.FlagSet, output string, inert []stdoutInertFlag) error {
+	if output != taskFileStdin {
+		return nil
+	}
+	for _, f := range inert {
+		if flags.Changed(f.name) {
+			return fmt.Errorf("--%s cannot be used with --output -; %s", f.name, f.reason)
+		}
+	}
+	return nil
 }
 
 // taskFileFetchTimeout bounds a remote recipe fetch so a hung server does

--- a/commands/task_file_test.go
+++ b/commands/task_file_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/posener/complete"
+	flag "github.com/spf13/pflag"
 )
 
 func TestDetectTaskFileFormat(t *testing.T) {
@@ -191,6 +192,69 @@ func TestRecipeOutputFormatMismatch(t *testing.T) {
 	}
 	if !strings.Contains(got, "--tasks-format json5") {
 		t.Errorf("warning %q should name the flag needed to read it back", got)
+	}
+}
+
+// TestStdoutInertFlagError covers the #419 rejection: a flag that only
+// means something when there is a file to write must not be silently
+// dropped by --output -. The cases exercise a real pflag.FlagSet so the
+// Changed-after-Parse contract is the one being tested.
+func TestStdoutInertFlagError(t *testing.T) {
+	inert := []stdoutInertFlag{
+		{name: "vars-output", reason: "a streamed recipe inlines its values"},
+		{name: "overwrite", reason: "a streamed recipe writes no files"},
+	}
+
+	tests := []struct {
+		name     string
+		args     []string
+		wantFlag string
+	}{
+		{name: "file output with no inert flags", args: []string{"--output", "tasks.yml"}},
+		{name: "file output with every inert flag", args: []string{"--output", "tasks.yml", "--vars-output", "vars.yml", "--overwrite"}},
+		{name: "stdout alone", args: []string{"--output", "-"}},
+		{name: "stdout with an unrelated flag", args: []string{"--output", "-", "--format", "json5"}},
+		{name: "stdout with vars-output", args: []string{"--output", "-", "--vars-output", "vars.yml"}, wantFlag: "--vars-output"},
+		{name: "stdout with an empty vars-output", args: []string{"--output", "-", "--vars-output", ""}, wantFlag: "--vars-output"},
+		{name: "stdout with overwrite", args: []string{"--output", "-", "--overwrite"}, wantFlag: "--overwrite"},
+		// The objection is to the combination, not the value: an
+		// explicitly false boolean is still a flag that cannot apply.
+		{name: "stdout with overwrite set false", args: []string{"--output", "-", "--overwrite=false"}, wantFlag: "--overwrite"},
+		// Slice order decides which conflict is reported when several are
+		// typed, so the message is stable rather than map-ordered.
+		{name: "stdout with both inert flags", args: []string{"--output", "-", "--overwrite", "--vars-output", "vars.yml"}, wantFlag: "--vars-output"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output, varsOutput, format string
+			var overwrite bool
+			flags := flag.NewFlagSet("export", flag.ContinueOnError)
+			flags.StringVar(&output, "output", defaultRecipeOutput, "")
+			flags.StringVar(&varsOutput, "vars-output", "", "")
+			flags.StringVar(&format, "format", "", "")
+			flags.BoolVar(&overwrite, "overwrite", false, "")
+			if err := flags.Parse(tt.args); err != nil {
+				t.Fatalf("parse %v: %v", tt.args, err)
+			}
+
+			err := stdoutInertFlagError(flags, output, inert)
+			if tt.wantFlag == "" {
+				if err != nil {
+					t.Fatalf("stdoutInertFlagError(%v) = %v, want no error", tt.args, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("stdoutInertFlagError(%v) = nil, want an error naming %s", tt.args, tt.wantFlag)
+			}
+			if !strings.Contains(err.Error(), tt.wantFlag) {
+				t.Errorf("error %q should name %s", err, tt.wantFlag)
+			}
+			if !strings.Contains(err.Error(), "--output -") {
+				t.Errorf("error %q should name the conflicting --output -", err)
+			}
+		})
 	}
 }
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -94,9 +94,9 @@ Next steps:
 | Flag | Effect |
 |------|--------|
 | (default) | Write `./tasks.yml`; refuse if it already exists. |
-| `--output <path>` | Write to a path; `-` writes to stdout. Format inferred from the extension unless `--format` says otherwise. |
+| `--output <path>` | Write to a path; `-` writes to stdout. Format inferred from the extension unless `--format` says otherwise. A stream touches no file on disk, so combining `-` with `--force` is an error rather than a silently ignored flag. |
 | `--format <fmt>` | Write `yaml` or `json5` regardless of the `--output` extension. Without an explicit `--output`, `--format json5` writes `./tasks.json`. |
-| `--force` | Overwrite an existing file. |
+| `--force` | Overwrite an existing file. Not valid with `--output -`. |
 | `--name <name>` | Set the play and `app` input default (defaults to the directory name). |
 | `--repo <url>` | Set the `repo` input default (defaults to `remote.origin.url` in `./.git/config`). |
 | `--minimal` | A one-task example with no `inputs:` block. |
@@ -376,10 +376,10 @@ no drift (`plan` shows every task `[ok]`).
 
 | Flag | Effect |
 |------|--------|
-| `--output <path>` | Where to write the recipe (default `tasks.yml`). Pass `-` to stream a single self-contained recipe (values inlined, no vars-file) to stdout for inspection. |
+| `--output <path>` | Where to write the recipe (default `tasks.yml`). Pass `-` to stream a single self-contained recipe (values inlined, no vars-file) to stdout for inspection. Because a stream has no vars-file and touches no file on disk, combining `-` with `--vars-output` or `--overwrite` is an error rather than a silently ignored flag. |
 | `--format <fmt>` | Write `yaml` or `json5` regardless of the `--output` extension, for both the recipe and the vars-file. Without an explicit `--output`, `--format json5` writes `./tasks.json` and `./tasks.vars.json`. Required to stream JSON5 with `--output -`, which has no extension to read. |
-| `--vars-output <path>` | Where to write the companion vars-file (default `<output-base>.vars.<ext>`, e.g. `tasks.vars.yml`). |
-| `--overwrite` | Overwrite existing output files without prompting. Without it, export prompts before replacing either file, and aborts writing nothing if declined (or if stdin is not interactive). |
+| `--vars-output <path>` | Where to write the companion vars-file (default `<output-base>.vars.<ext>`, e.g. `tasks.vars.yml`). Not valid with `--output -`. When the server holds nothing sensitive there is no vars-file to write, and an explicit path is reported as unwritten rather than passed over. |
+| `--overwrite` | Overwrite existing output files without prompting. Without it, export prompts before replacing either file, and aborts writing nothing if declined (or if stdin is not interactive). Not valid with `--output -`. |
 | `--redact` | Write placeholder values into the vars-file instead of real secrets, producing a shareable recipe plus a fill-in-the-blanks vars template. The `required` inputs mean `apply` fails loudly until the vars-file is filled in. |
 | `--app <name>` | Restrict the export to the named app. Repeatable. |
 | `--host <user@host:port>` | Read a remote server over SSH. Overrides `DOKKU_HOST`. See [remote execution](remote-execution.md). |

--- a/tests/bats/export.bats
+++ b/tests/bats/export.bats
@@ -2,8 +2,10 @@
 
 load test_helper
 
+# Flag conflicts are resolved before export contacts the server, so those
+# tests stay ungated; everything that reads a real server calls
+# require_dokku as the first line of its body.
 setup() {
-  require_dokku
   docket_build
   dokku_clean_app docket-test-export
 }
@@ -13,6 +15,7 @@ teardown() {
 }
 
 @test "docket export fails on a nonexistent --app and writes nothing" {
+  require_dokku
   run "$(docket_bin)" export --app docket-nonexistent-xyz --output "$BATS_TEST_TMPDIR/tasks.yml"
   assert_failure
   assert_output --partial "not found on server"
@@ -21,6 +24,7 @@ teardown() {
 }
 
 @test "docket export writes existing apps but fails when an --app is missing" {
+  require_dokku
   dokku apps:create docket-test-export
   run "$(docket_bin)" export --app docket-test-export --app docket-nonexistent-xyz --output "$BATS_TEST_TMPDIR/tasks.yml"
   assert_failure
@@ -31,6 +35,7 @@ teardown() {
 }
 
 @test "docket export --app reports the app count without the global play" {
+  require_dokku
   dokku apps:create docket-test-export
   run "$(docket_bin)" export --app docket-test-export --output "$BATS_TEST_TMPDIR/tasks.yml"
   assert_success
@@ -38,6 +43,7 @@ teardown() {
 }
 
 @test "docket export --format json5 writes a tasks.json / tasks.vars.json pair" {
+  require_dokku
   dokku apps:create docket-test-export
   # A config value is what gets lifted into the vars-file; without one
   # the export has no vars and writes no companion file at all.
@@ -58,10 +64,43 @@ teardown() {
 }
 
 @test "docket export --output - --format json5 round-trips into apply" {
+  require_dokku
   dokku apps:create docket-test-export
   # The motivating command from #410, with --list-tasks so the pipe is
   # exercised without applying anything back to the server.
   run bash -c "\"$(docket_bin)\" export --app docket-test-export --output - --format json5 | \"$(docket_bin)\" apply --tasks-format json5 --list-tasks -"
   assert_success
   assert_output --partial "docket-test-export"
+}
+
+@test "docket export --output - rejects --vars-output" {
+  # #419: a streamed recipe inlines its values, so the vars-file the flag
+  # asks for can never be written. Rejected before the server is read,
+  # which is why this needs no dokku.
+  cd "$BATS_TEST_TMPDIR"
+  run "$(docket_bin)" export --output - --vars-output secrets.yml
+  assert_failure
+  assert_output --partial "--vars-output cannot be used with --output -"
+  assert [ ! -f secrets.yml ]
+}
+
+@test "docket export --output - rejects --overwrite" {
+  cd "$BATS_TEST_TMPDIR"
+  run "$(docket_bin)" export --output - --overwrite
+  assert_failure
+  assert_output --partial "--overwrite cannot be used with --output -"
+  assert [ ! -f tasks.yml ]
+}
+
+@test "docket export reports a --vars-output left unwritten for want of secrets" {
+  require_dokku
+  # No config:set, so nothing is sensitive and no vars-file is produced.
+  dokku apps:create docket-test-export
+  cd "$BATS_TEST_TMPDIR"
+  run "$(docket_bin)" export --app docket-test-export --output tasks.yml --vars-output secrets.yml
+  assert_success
+  assert_output --partial "no sensitive values to export"
+  assert_output --partial "secrets.yml"
+  assert [ -f tasks.yml ]
+  assert [ ! -f secrets.yml ]
 }

--- a/tests/bats/init.bats
+++ b/tests/bats/init.bats
@@ -107,6 +107,16 @@ CFG
   assert [ ! -f tasks.yml ]
 }
 
+@test "docket init --output - rejects --force" {
+  # #419: --force governs an exists check that streaming skips entirely,
+  # so the flag would otherwise be read and dropped.
+  cd "$BATS_TEST_TMPDIR"
+  run "$(docket_bin)" init --output - --force
+  assert_failure
+  assert_output --partial "--force cannot be used with --output -"
+  assert [ ! -f tasks.yml ]
+}
+
 @test "docket init output validates" {
   cd "$BATS_TEST_TMPDIR"
   "$(docket_bin)" init


### PR DESCRIPTION
`docket export --output -` streams a self-contained recipe with every value inlined, so its stdout branch returned before `--vars-output` and `--overwrite` were ever consulted and both were dropped without a word. `docket init --output - --force` had the same shape. Each combination is now an error naming the flag, raised before the server is read. An explicit `--vars-output` that goes unwritten because the server held nothing sensitive is reported in the summary rather than passed over.

Closes #419
