### PR TITLE
fix: export the http-auth state of each app

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: install dokku redis plugin
         run: sudo dokku plugin:install https://github.com/dokku/dokku-redis.git redis
       - name: install dokku http-auth plugin
-        run: sudo dokku plugin:install https://github.com/dokku/dokku-http-auth.git http-auth
+        run: sudo dokku plugin:install https://github.com/dokku/dokku-http-auth.git --committish 0.13.0 http-auth
       - name: install dokku global-cert plugin
         run: sudo dokku plugin:install https://github.com/dokku-community/dokku-global-cert.git global-cert
       - name: install dokku letsencrypt plugin
@@ -96,7 +96,7 @@ jobs:
       - name: install dokku redis plugin
         run: sudo dokku plugin:install https://github.com/dokku/dokku-redis.git redis
       - name: install dokku http-auth plugin
-        run: sudo dokku plugin:install https://github.com/dokku/dokku-http-auth.git http-auth
+        run: sudo dokku plugin:install https://github.com/dokku/dokku-http-auth.git --committish 0.13.0 http-auth
       - name: install dokku global-cert plugin
         run: sudo dokku plugin:install https://github.com/dokku-community/dokku-global-cert.git global-cert
       - name: install dokku letsencrypt plugin
@@ -185,6 +185,8 @@ jobs:
           sudo apt-get update -qq
           sudo DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true apt-get install -qq -y dokku=0.38.22
           sudo dokku plugin:install-dependencies --core
+      - name: install dokku http-auth plugin
+        run: sudo dokku plugin:install https://github.com/dokku/dokku-http-auth.git --committish 0.13.0 http-auth
       - name: install bats
         run: sudo apt-get install -qq -y bats bats-support bats-assert
       - name: build docket

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,6 +40,7 @@ code into it:
 
 - **Dokku >= 0.38.22.**
 - **dokku-letsencrypt >= 0.25.0.**
+- **dokku-http-auth >= 0.13.0**, if your recipe uses the `dokku_http_auth*` tasks.
 
 ## Installation
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -20,6 +20,7 @@ covered below.
 | Domains and ports (`dokku_domains`, `dokku_ports`) | DNS records |
 | Service structure (`dokku_service_create`, `dokku_service_expose`, `dokku_service_link`, backup schedule, `dokku_acl_service`) | letsencrypt-issued certificates |
 | Storage *mounts* (`dokku_storage_mount`) | Secret values not in the recipe |
+| HTTP basic auth (`dokku_http_auth`, `dokku_http_auth_user`, `dokku_http_auth_allowed_ip`, `dokku_http_auth_domain`) | HTTP auth passwords |
 | Manual certs inlined via `dokku_certs` `cert_content` / `key_content` | Host-level OS configuration |
 | Buildpacks, scheduler and proxy config | Datastore backup credentials and `dokku_service_property` values |
 | SSH keys (`dokku_ssh_key`) | |
@@ -62,6 +63,11 @@ Some state cannot be read back and is left out with a warning - notably write-on
 (`dokku_git_auth`, `dokku_registry_auth`, and datastore backup credentials), datastore service data,
 and service properties (`dokku_service_property`), which you add by hand. Each task's
 [reference page](tasks/README.md) has an Export support section noting its limits.
+
+HTTP basic auth is reconstructed in full - whether it is serving, its users, allowed IPs and auth
+domains - except for the passwords themselves, which the plugin only stores as hashes. Each user's
+password becomes a required input you fill in before applying
+([#443](https://github.com/dokku/docket/issues/443) tracks carrying the hashes across instead).
 
 ## Step 2: Apply the recipe to the new server
 

--- a/docs/tasks/dokku_http_auth.md
+++ b/docs/tasks/dokku_http_auth.md
@@ -6,19 +6,19 @@ Manages HTTP authentication for a given dokku application
 
 ## Requirements
 
-- dokku-http-auth plugin
+- dokku-http-auth plugin >= 0.13.0
 
 ## Export support
 
-Partial - credentials are not readable and become required inputs.
+Partial - the enabled state is exported; the seed credentials are not readable and come back as dokku_http_auth_user.
 
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | yes |  |  | Name of the app |
-| `username` | string | no |  |  | HTTP auth username |
-| `password` | string | no |  |  | HTTP auth password (sensitive) |
+| `username` | string | no |  |  | HTTP auth username to seed when enabling; supplied together with password |
+| `password` | string | no |  |  | HTTP auth password for the seeded username; supplied together with username (sensitive) |
 | `state` | string | no | present | present, absent | State of the HTTP auth |
 
 ## Examples
@@ -30,6 +30,13 @@ dokku_http_auth:
     app: hello-world
     username: admin
     password: secret
+```
+
+### Enable HTTP authentication without seeding a user
+
+```yaml
+dokku_http_auth:
+    app: hello-world
 ```
 
 ### Disable HTTP authentication for an app

--- a/docs/tasks/dokku_http_auth_allowed_ip.md
+++ b/docs/tasks/dokku_http_auth_allowed_ip.md
@@ -6,7 +6,7 @@ Manages the set of IP addresses allowed to bypass HTTP auth for a dokku applicat
 
 ## Requirements
 
-- dokku-http-auth plugin
+- dokku-http-auth plugin >= 0.13.0
 
 ## Export support
 

--- a/docs/tasks/dokku_http_auth_domain.md
+++ b/docs/tasks/dokku_http_auth_domain.md
@@ -6,7 +6,7 @@ Manages the set of domains HTTP auth is restricted to for a dokku application
 
 ## Requirements
 
-- dokku-http-auth plugin
+- dokku-http-auth plugin >= 0.13.0
 
 ## Export support
 

--- a/docs/tasks/dokku_http_auth_user.md
+++ b/docs/tasks/dokku_http_auth_user.md
@@ -6,7 +6,7 @@ Manages the set of HTTP auth users for a dokku application
 
 ## Requirements
 
-- dokku-http-auth plugin
+- dokku-http-auth plugin >= 0.13.0
 
 ## Export support
 

--- a/tasks/export.go
+++ b/tasks/export.go
@@ -124,6 +124,11 @@ var appExportOrder = []string{
 	"dokku_http_auth_user",
 	"dokku_http_auth_allowed_ip",
 	"dokku_http_auth_domain",
+	// dokku_http_auth trails the rest of the http-auth family on purpose:
+	// http-auth:add-user, add-allowed-ip and add-domain each write enabled=true
+	// as a side effect, so the task that owns the enabled flag has to run last
+	// for the recipe's stated auth state to be the one that sticks.
+	"dokku_http_auth",
 	"dokku_acl_app",
 	"dokku_certs",
 	"dokku_letsencrypt",

--- a/tasks/export_coverage_test.go
+++ b/tasks/export_coverage_test.go
@@ -2,6 +2,70 @@ package tasks
 
 import "testing"
 
+// exportOrderMembership returns, for each task type-key, whether it appears in
+// appExportOrder and globalExportOrder.
+func exportOrderMembership() (app, global map[string]bool) {
+	app = map[string]bool{}
+	global = map[string]bool{}
+	for _, key := range appExportOrder {
+		app[key] = true
+	}
+	for _, key := range globalExportOrder {
+		global[key] = true
+	}
+	return app, global
+}
+
+// TestExportSupportMatchesExportWiring asserts that a task's declared export
+// support and its actual wiring agree. TestAppExportOrderIsValid and
+// TestGlobalExportOrderIsValid only check one direction - every key in an order
+// list resolves to a task implementing the matching interface - which let
+// dokku_http_auth declare ExportPartial while implementing no exporter and
+// appearing in no order list, so `docket export` silently dropped an app's
+// http-auth state (#428). These are the converse invariants, and they rule out
+// the whole class: a task that claims to export must actually be reachable from
+// ExportRecipe, a task that claims it cannot must not be, and an exporter that
+// is never listed is dead code.
+func TestExportSupportMatchesExportWiring(t *testing.T) {
+	inAppOrder, inGlobalOrder := exportOrderMembership()
+
+	for name, task := range RegisteredTasks {
+		support, ok := TaskExportSupport(task)
+		if !ok {
+			continue // TestEveryTaskDeclaresExportSupport reports this
+		}
+
+		_, isAppExporter := task.(AppExporter)
+		_, isGlobalExporter := task.(GlobalExporter)
+
+		// An exporter that no order list names is never called.
+		if isAppExporter && !inAppOrder[name] {
+			t.Errorf("task %q implements AppExporter but is missing from appExportOrder", name)
+		}
+		if isGlobalExporter && !inGlobalOrder[name] {
+			t.Errorf("task %q implements GlobalExporter but is missing from globalExportOrder", name)
+		}
+
+		switch support.Status {
+		case ExportSupported, ExportPartial:
+			if !isAppExporter && !isGlobalExporter {
+				t.Errorf("task %q declares export status %q but implements neither AppExporter nor GlobalExporter", name, support.Status)
+				continue
+			}
+			if !inAppOrder[name] && !inGlobalOrder[name] {
+				t.Errorf("task %q declares export status %q but appears in no export order, so it is never exported", name, support.Status)
+			}
+		case ExportUnsupported:
+			if isAppExporter || isGlobalExporter {
+				t.Errorf("task %q declares export status %q but implements an exporter", name, support.Status)
+			}
+			if inAppOrder[name] || inGlobalOrder[name] {
+				t.Errorf("task %q declares export status %q but appears in an export order", name, support.Status)
+			}
+		}
+	}
+}
+
 // TestEveryTaskDeclaresExportSupport asserts that every registered task
 // declares its export support via ExportSupport(). This is what makes "export
 // covers every task type" enforceable: adding a new task without an

--- a/tasks/export_integration_test.go
+++ b/tasks/export_integration_test.go
@@ -717,3 +717,61 @@ func TestIntegrationExportLetsencrypt(t *testing.T) {
 		t.Errorf("expected no letsencrypt task for an inactive app, got %d", len(bodies))
 	}
 }
+
+// TestIntegrationExportHttpAuth walks the http-auth export state table against
+// a real server (#428): serving auth exports as present, disabling it leaves the
+// users behind so it exports as absent, and only once the users are gone does
+// the app fall out of the export entirely. Gated on the http-auth plugin.
+func TestIntegrationExportHttpAuth(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "http-auth")
+
+	app := "docket-test-export-http-auth"
+	destroyApp(app)
+	createApp(app)
+	defer destroyApp(app)
+
+	exported := func(t *testing.T, label string) []interface{} {
+		t.Helper()
+		bodies, err := HttpAuthTask{}.ExportApp(app)
+		if err != nil {
+			t.Fatalf("%s: ExportApp: %v", label, err)
+		}
+		return bodies
+	}
+	assertState := func(t *testing.T, label string, bodies []interface{}, want State) {
+		t.Helper()
+		if len(bodies) != 1 {
+			t.Fatalf("%s: expected 1 exported task, got %d", label, len(bodies))
+		}
+		auth := bodies[0].(HttpAuthTask)
+		if auth.State != want {
+			t.Errorf("%s: State = %q, want %q", label, auth.State, want)
+		}
+		if err := auth.Validate(); err != nil {
+			t.Errorf("%s: exported task must be valid, got: %v", label, err)
+		}
+		if plan := auth.Plan(); !plan.InSync {
+			t.Errorf("%s: exported task should report no drift, got status %v reason %q", label, plan.Status, plan.Reason)
+		}
+	}
+
+	if r := (HttpAuthTask{App: app, Username: "admin", Password: "secret", State: StatePresent}).Execute(); r.Error != nil {
+		t.Fatalf("enable http auth: %v", r.Error)
+	}
+	assertState(t, "enabled", exported(t, "enabled"), StatePresent)
+
+	// http-auth:disable only writes enabled=false; the htpasswd survives, so
+	// re-applying the exported users would turn auth back on without this.
+	if r := (HttpAuthTask{App: app, State: StateAbsent}).Execute(); r.Error != nil {
+		t.Fatalf("disable http auth: %v", r.Error)
+	}
+	assertState(t, "disabled with users", exported(t, "disabled with users"), StateAbsent)
+
+	if r := (HttpAuthUserTask{App: app, State: StateAbsent}).Execute(); r.Error != nil {
+		t.Fatalf("remove http auth users: %v", r.Error)
+	}
+	if bodies := exported(t, "disabled and unconfigured"); len(bodies) != 0 {
+		t.Errorf("expected no exported task once nothing is configured, got %v", bodies)
+	}
+}

--- a/tasks/export_support.go
+++ b/tasks/export_support.go
@@ -33,8 +33,13 @@ type ExportSupport struct {
 // test enforces that so no task ships without an export decision - but it is
 // modelled as an optional interface to match DeprecationDocer and
 // RequirementsDocer. The docs generator renders the result in an Export
-// support section on the task's page; the export engine reads it to decide
-// whether to emit or skip (and warn) the task.
+// support section on the task's page.
+//
+// The export engine itself never reads this: emission is driven purely by
+// membership in appExportOrder/globalExportOrder plus the AppExporter/
+// GlobalExporter type assertion. What keeps the declaration honest is
+// TestExportSupportMatchesExportWiring, which fails when a task claims to be
+// exportable without being wired into an order list (or vice versa).
 type ExportDocer interface {
 	ExportSupport() ExportSupport
 }

--- a/tasks/export_test.go
+++ b/tasks/export_test.go
@@ -198,6 +198,174 @@ func TestExportHttpAuthUserPasswordsBecomeInputs(t *testing.T) {
 	}
 }
 
+// TestExportHttpAuthEnabledBecomesTask covers the first row of the export state
+// table (#428): an app serving http-auth emits dokku_http_auth with state
+// present, after the rest of the family so it is authoritative.
+func TestExportHttpAuthEnabledBecomesTask(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list":                  "web",
+		"http-auth:report web --format json": `{"enabled":"true","users":"admin","allowed-ips":"","domains":""}`,
+	}))()
+
+	bodies, err := HttpAuthTask{}.ExportApp("web")
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 exported task, got %d", len(bodies))
+	}
+	auth := bodies[0].(HttpAuthTask)
+	if auth.State != StatePresent {
+		t.Errorf("State = %q, want %q", auth.State, StatePresent)
+	}
+	// The credentials are asserted on the struct, not by grepping the rendered
+	// recipe: the sibling dokku_http_auth_user task legitimately emits a
+	// username for each user, so a whole-recipe check would match that instead.
+	if auth.Username != "" || auth.Password != "" {
+		t.Errorf("exported enable task should carry no credentials, got username=%q password=%q", auth.Username, auth.Password)
+	}
+	if err := auth.Validate(); err != nil {
+		t.Errorf("exported http-auth task must be valid, got: %v", err)
+	}
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	recipe, _ := res.MarshalRecipe("yaml")
+	out := string(recipe)
+	for _, want := range []string{"dokku_http_auth:", "state: present"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("recipe missing %q:\n%s", want, out)
+		}
+	}
+	// http-auth:add-user writes enabled=true as a side effect, so the task that
+	// owns the flag has to come last for the stated state to stick.
+	enable := strings.Index(out, "dokku_http_auth:")
+	users := strings.Index(out, "dokku_http_auth_user:")
+	if users < 0 {
+		t.Fatalf("recipe missing the user task:\n%s", out)
+	}
+	if enable < users {
+		t.Errorf("dokku_http_auth must be emitted after dokku_http_auth_user:\n%s", out)
+	}
+}
+
+// TestExportHttpAuthEnabledWithoutUsersBecomesTask covers the second row: a bare
+// `http-auth:enable <app>` leaves no users, allowed IPs or domains behind, so
+// nothing else's enable side effect would restore it and this task is the only
+// thing that carries the state.
+func TestExportHttpAuthEnabledWithoutUsersBecomesTask(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list":                  "web",
+		"http-auth:report web --format json": `{"enabled":"true","users":"","allowed-ips":"","domains":""}`,
+	}))()
+
+	bodies, err := HttpAuthTask{}.ExportApp("web")
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 exported task, got %d", len(bodies))
+	}
+	if got := bodies[0].(HttpAuthTask).State; got != StatePresent {
+		t.Errorf("State = %q, want %q", got, StatePresent)
+	}
+	if err := bodies[0].(HttpAuthTask).Validate(); err != nil {
+		t.Errorf("exported http-auth task must be valid, got: %v", err)
+	}
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	recipe, _ := res.MarshalRecipe("yaml")
+	out := string(recipe)
+	if !strings.Contains(out, "dokku_http_auth:") {
+		t.Errorf("recipe missing the enable task:\n%s", out)
+	}
+	if strings.Contains(out, "dokku_http_auth_user:") {
+		t.Errorf("no user task expected when the app has no http-auth users:\n%s", out)
+	}
+}
+
+// TestExportHttpAuthDisabledWithConfigBecomesAbsentTask covers the third row:
+// http-auth:disable leaves the users, allowed IPs and auth domains in place, and
+// re-applying those turns auth back on, so the export has to state absent
+// explicitly to undo it.
+func TestExportHttpAuthDisabledWithConfigBecomesAbsentTask(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		report string
+	}{
+		{"users remain", `{"enabled":"false","users":"admin","allowed-ips":"","domains":""}`},
+		{"allowed ips remain", `{"enabled":"false","users":"","allowed-ips":"192.0.2.1","domains":""}`},
+		{"auth domains remain", `{"enabled":"false","users":"","allowed-ips":"","domains":"web.example.com"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+				"--quiet apps:list":                  "web",
+				"http-auth:report web --format json": tc.report,
+			}))()
+
+			bodies, err := HttpAuthTask{}.ExportApp("web")
+			if err != nil {
+				t.Fatalf("ExportApp: %v", err)
+			}
+			if len(bodies) != 1 {
+				t.Fatalf("expected 1 exported task, got %d", len(bodies))
+			}
+			auth := bodies[0].(HttpAuthTask)
+			if auth.State != StateAbsent {
+				t.Errorf("State = %q, want %q", auth.State, StateAbsent)
+			}
+			if err := auth.Validate(); err != nil {
+				t.Errorf("exported http-auth task must be valid, got: %v", err)
+			}
+
+			res, err := ExportRecipe(ExportOptions{})
+			if err != nil {
+				t.Fatalf("ExportRecipe: %v", err)
+			}
+			recipe, _ := res.MarshalRecipe("yaml")
+			out := string(recipe)
+			if !strings.Contains(out, "dokku_http_auth:") {
+				t.Errorf("recipe missing the disable task:\n%s", out)
+			}
+			if !strings.Contains(out, "state: absent") {
+				t.Errorf("recipe missing the absent state:\n%s", out)
+			}
+		})
+	}
+}
+
+// TestExportHttpAuthDisabledEmitsNoTask covers the fourth row: an app with auth
+// off and nothing configured is the default for every app on a server, so it
+// must not litter every play with a no-op disable task.
+func TestExportHttpAuthDisabledEmitsNoTask(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list":                  "web",
+		"http-auth:report web --format json": `{"enabled":"false","users":"","allowed-ips":"","domains":""}`,
+	}))()
+
+	bodies, err := HttpAuthTask{}.ExportApp("web")
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+	if len(bodies) != 0 {
+		t.Errorf("expected no exported task for an unconfigured app, got %v", bodies)
+	}
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	recipe, _ := res.MarshalRecipe("yaml")
+	if strings.Contains(string(recipe), "dokku_http_auth:") {
+		t.Errorf("expected no dokku_http_auth task:\n%s", recipe)
+	}
+}
+
 func TestExportMaintenanceCustomPageBecomesInput(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
 		"--quiet apps:list":                    "web",

--- a/tasks/http_auth_allowed_ip_task.go
+++ b/tasks/http_auth_allowed_ip_task.go
@@ -49,7 +49,7 @@ func (t HttpAuthAllowedIpTask) ExportSupport() ExportSupport {
 
 // Requirements lists the non-core dokku plugins this task depends on.
 func (t HttpAuthAllowedIpTask) Requirements() []string {
-	return []string{"dokku-http-auth plugin"}
+	return []string{"dokku-http-auth plugin >= 0.13.0"}
 }
 
 // Examples returns a list of HttpAuthAllowedIpTaskExamples as yaml

--- a/tasks/http_auth_domain_task.go
+++ b/tasks/http_auth_domain_task.go
@@ -49,7 +49,7 @@ func (t HttpAuthDomainTask) ExportSupport() ExportSupport {
 
 // Requirements lists the non-core dokku plugins this task depends on.
 func (t HttpAuthDomainTask) Requirements() []string {
-	return []string{"dokku-http-auth plugin"}
+	return []string{"dokku-http-auth plugin >= 0.13.0"}
 }
 
 // Examples returns a list of HttpAuthDomainTaskExamples as yaml

--- a/tasks/http_auth_task.go
+++ b/tasks/http_auth_task.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/dokku/docket/subprocess"
 )
@@ -13,11 +14,11 @@ type HttpAuthTask struct {
 	// App is the name of the app
 	App string `required:"true" yaml:"app" description:"Name of the app"`
 
-	// Username is the HTTP auth username
-	Username string `required:"false" yaml:"username,omitempty" description:"HTTP auth username"`
+	// Username is the HTTP auth username seeded when auth is enabled
+	Username string `required:"false" yaml:"username,omitempty" description:"HTTP auth username to seed when enabling; supplied together with password"`
 
-	// Password is the HTTP auth password
-	Password string `required:"false" sensitive:"true" yaml:"password,omitempty" description:"HTTP auth password"`
+	// Password is the HTTP auth password seeded when auth is enabled
+	Password string `required:"false" sensitive:"true" yaml:"password,omitempty" description:"HTTP auth password for the seeded username; supplied together with username"`
 
 	// State is the state of the HTTP auth
 	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"State of the HTTP auth"`
@@ -44,12 +45,12 @@ func (t HttpAuthTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t HttpAuthTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportPartial, Caveat: "credentials are not readable and become required inputs"}
+	return ExportSupport{Status: ExportPartial, Caveat: "the enabled state is exported; the seed credentials are not readable and come back as dokku_http_auth_user"}
 }
 
 // Requirements lists the non-core dokku plugins this task depends on.
 func (t HttpAuthTask) Requirements() []string {
-	return []string{"dokku-http-auth plugin"}
+	return []string{"dokku-http-auth plugin >= 0.13.0"}
 }
 
 // Examples returns a list of HttpAuthTaskExamples as yaml
@@ -61,6 +62,12 @@ func (t HttpAuthTask) Examples() ([]Doc, error) {
 				App:      "hello-world",
 				Username: "admin",
 				Password: "secret",
+			},
+		},
+		{
+			Name: "Enable HTTP authentication without seeding a user",
+			DokkuHttpAuth: HttpAuthTask{
+				App: "hello-world",
 			},
 		},
 		{
@@ -79,12 +86,21 @@ func (t HttpAuthTask) Execute() TaskOutputState {
 }
 
 // Validate checks the HttpAuthTask's inputs without contacting the server.
+//
+// `http-auth:enable` takes the username and password as optional positional
+// arguments (`<app> [<user>] [<password>]`) and skips user initialization when
+// they are absent, so a credential-free `state: present` is valid and simply
+// turns auth on. What is not valid is half a credential, so the pair is
+// required together.
 func (t HttpAuthTask) Validate() error {
-	if t.State == StatePresent && t.Username == "" {
-		return fmt.Errorf("username is required when state is present")
+	if t.State != StatePresent {
+		return nil
 	}
-	if t.State == StatePresent && t.Password == "" {
-		return fmt.Errorf("password is required when state is present")
+	if t.Username == "" && t.Password != "" {
+		return fmt.Errorf("username is required when a password is set")
+	}
+	if t.Password == "" && t.Username != "" {
+		return fmt.Errorf("password is required when a username is set")
 	}
 	return nil
 }
@@ -103,9 +119,16 @@ func (t HttpAuthTask) Plan() PlanResult {
 			if enabled {
 				return PlanResult{InSync: true, Status: PlanStatusOK}
 			}
+			// The credentials are optional trailing arguments; passing them as
+			// empty strings would work but reads as a malformed command line in
+			// plan output and the trace log, so they are omitted instead.
+			args := []string{"--quiet", "http-auth:enable", t.App}
+			if t.Username != "" && t.Password != "" {
+				args = append(args, t.Username, t.Password)
+			}
 			inputs := []subprocess.ExecCommandInput{{
 				Command: "dokku",
-				Args:    []string{"--quiet", "http-auth:enable", t.App, t.Username, t.Password},
+				Args:    args,
 			}}
 			return PlanResult{
 				InSync:    false,
@@ -176,6 +199,83 @@ func httpAuthEnabled(appName string) (bool, error) {
 	}
 
 	return report.Enabled == "true", nil
+}
+
+// httpAuthState is the whole `http-auth:report --format json` payload the
+// exporter needs: whether auth is serving, plus whether the app still carries
+// any http-auth configuration. Disabling an app leaves its users, allowed IPs
+// and auth domains in place, so those three are independent of Enabled.
+type httpAuthState struct {
+	Enabled    bool
+	Configured bool
+}
+
+// getHttpAuthState reads the app's whole http-auth state in one report call.
+// The four per-task readers each pull a single key; the exporter needs them
+// together to decide whether a disabled app still needs a task emitted, so it
+// reads them at once rather than making four round trips. Error handling
+// matches those readers: a transport-level failure (`*subprocess.SSHError`) is
+// propagated, a dokku-level non-zero exit (e.g. app does not exist) is treated
+// as "nothing set", and malformed JSON surfaces as an error.
+func getHttpAuthState(appName string) (httpAuthState, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args: []string{
+			"http-auth:report",
+			appName,
+			"--format",
+			"json",
+		},
+	})
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return httpAuthState{}, err
+		}
+		return httpAuthState{}, nil
+	}
+
+	var report struct {
+		Enabled    string `json:"enabled"`
+		Users      string `json:"users"`
+		AllowedIps string `json:"allowed-ips"`
+		Domains    string `json:"domains"`
+	}
+	if err := json.Unmarshal(result.StdoutBytes(), &report); err != nil {
+		return httpAuthState{}, err
+	}
+
+	return httpAuthState{
+		Enabled: report.Enabled == "true",
+		Configured: len(strings.Fields(report.Users)) > 0 ||
+			len(strings.Fields(report.AllowedIps)) > 0 ||
+			len(strings.Fields(report.Domains)) > 0,
+	}, nil
+}
+
+// ExportApp reconstructs whether HTTP auth is serving for an app. It is emitted
+// after the rest of the http-auth family (see appExportOrder), because
+// http-auth:add-user, add-allowed-ip and add-domain all write enabled=true as a
+// side effect: this task runs last so the recipe's stated auth state is the one
+// that sticks.
+//
+// An enabled app emits `state: present`, with no credentials - the users come
+// back as dokku_http_auth_user tasks, so seeding one here would only duplicate
+// an input. A disabled app that still carries users, allowed IPs or auth
+// domains emits `state: absent`, undoing the enable those tasks force; a
+// disabled app with nothing configured emits no task at all.
+func (t HttpAuthTask) ExportApp(app string) ([]interface{}, error) {
+	state, err := getHttpAuthState(app)
+	if err != nil {
+		return nil, err
+	}
+	if state.Enabled {
+		return []interface{}{HttpAuthTask{App: app, State: StatePresent}}, nil
+	}
+	if !state.Configured {
+		return nil, nil
+	}
+	return []interface{}{HttpAuthTask{App: app, State: StateAbsent}}, nil
 }
 
 // init registers the HttpAuthTask with the task registry

--- a/tasks/http_auth_task_integration_test.go
+++ b/tasks/http_auth_task_integration_test.go
@@ -82,3 +82,46 @@ func TestIntegrationHttpAuth(t *testing.T) {
 		t.Errorf("expected state 'absent', got '%s'", result.State)
 	}
 }
+
+// TestIntegrationHttpAuthEnableWithoutCredentials pins the credential-free
+// enable against the real plugin: `http-auth:enable <app>` takes the username
+// and password as optional trailing arguments and skips user initialization
+// when they are absent. This is the form the exporter emits (#428).
+func TestIntegrationHttpAuthEnableWithoutCredentials(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "http-auth")
+
+	appName := "docket-test-http-auth-bare"
+
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	task := HttpAuthTask{App: appName, State: StatePresent}
+	result := task.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to enable http auth without credentials: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected changed=true for enabling http auth")
+	}
+	if enabled, _ := httpAuthEnabled(appName); !enabled {
+		t.Error("expected http auth to be enabled after a credential-free enable")
+	}
+
+	// No user was seeded, so the app is enabled with an empty htpasswd - the
+	// state the exporter has to be able to represent.
+	users, err := getHttpAuthUsers(appName)
+	if err != nil {
+		t.Fatalf("getHttpAuthUsers failed: %v", err)
+	}
+	if len(users) != 0 {
+		t.Errorf("expected no seeded users, got %v", users)
+	}
+
+	if result := task.Execute(); result.Error != nil {
+		t.Fatalf("idempotent enable failed: %v", result.Error)
+	} else if result.Changed {
+		t.Error("expected changed=false for already-enabled http auth")
+	}
+}

--- a/tasks/http_auth_task_test.go
+++ b/tasks/http_auth_task_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dokku/docket/subprocess"
 	_ "github.com/gliderlabs/sigil/builtin"
 )
 
@@ -34,6 +35,37 @@ func TestHttpAuthTaskPresentWithoutPassword(t *testing.T) {
 	}
 	if !strings.Contains(result.Error.Error(), "password is required") {
 		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+// TestHttpAuthTaskPresentWithoutCredentialsIsValid pins the paired rule: the
+// plugin takes the credentials as optional trailing arguments and skips user
+// initialization without them, so a credential-free enable is valid. This is
+// what lets the exporter emit an app's auth state without duplicating the
+// password input dokku_http_auth_user already lifts (#428).
+func TestHttpAuthTaskPresentWithoutCredentialsIsValid(t *testing.T) {
+	task := HttpAuthTask{App: "test-app", State: StatePresent}
+	if err := task.Validate(); err != nil {
+		t.Errorf("credential-free present state should validate, got: %v", err)
+	}
+}
+
+func TestHttpAuthTaskEnableOmitsEmptyCredentials(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"http-auth:report test-app --format json": `{"enabled":"false"}`,
+	}))()
+
+	plan := HttpAuthTask{App: "test-app", State: StatePresent}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("Plan: %v", plan.Error)
+	}
+	if len(plan.Commands) != 1 {
+		t.Fatalf("expected 1 planned command, got %v", plan.Commands)
+	}
+	// The command line ends at the app name: no empty positional arguments
+	// standing in for the credentials that were never supplied.
+	if !strings.HasSuffix(plan.Commands[0], "http-auth:enable test-app") {
+		t.Errorf("planned command should end at the app name, got %q", plan.Commands[0])
 	}
 }
 

--- a/tasks/http_auth_user_task.go
+++ b/tasks/http_auth_user_task.go
@@ -66,7 +66,7 @@ func (t HttpAuthUserTask) ExportSupport() ExportSupport {
 
 // Requirements lists the non-core dokku plugins this task depends on.
 func (t HttpAuthUserTask) Requirements() []string {
-	return []string{"dokku-http-auth plugin"}
+	return []string{"dokku-http-auth plugin >= 0.13.0"}
 }
 
 // SensitiveValues returns the per-user passwords so they are masked in

--- a/tasks/integration_shard_test.go
+++ b/tasks/integration_shard_test.go
@@ -54,6 +54,7 @@ var integrationTestWeights = map[string]float64{
 	"TestIntegrationGitSync":                                7.3,
 	"TestIntegrationHaproxyPropertyAll":                     6.7,
 	"TestIntegrationHttpAuth":                               8.3,
+	"TestIntegrationHttpAuthEnableWithoutCredentials":       7.0,
 	"TestIntegrationLetsencrypt":                            6.9,
 	"TestIntegrationLetsencryptPropertyAll":                 32.6,
 	"TestIntegrationLogsPropertyAll":                        11.9,

--- a/tests/bats/export.bats
+++ b/tests/bats/export.bats
@@ -92,6 +92,32 @@ teardown() {
   assert [ ! -f tasks.yml ]
 }
 
+@test "docket export captures http-auth state after the users" {
+  require_plugin http-auth
+  dokku apps:create docket-test-export
+  dokku http-auth:enable docket-test-export testuser testpass
+  cd "$BATS_TEST_TMPDIR"
+  run "$(docket_bin)" export --app docket-test-export --output tasks.yml --vars-output tasks.vars.yml
+  assert_success
+
+  run grep -c 'dokku_http_auth:' tasks.yml
+  assert_output "1"
+  run grep -c 'dokku_http_auth_user:' tasks.yml
+  assert_output "1"
+
+  # add-user writes enabled=true as a side effect, so the task owning the
+  # enabled flag has to come last for the recipe's stated state to stick.
+  enable_line="$(grep -n 'dokku_http_auth:' tasks.yml | cut -d: -f1)"
+  users_line="$(grep -n 'dokku_http_auth_user:' tasks.yml | cut -d: -f1)"
+  assert [ "$enable_line" -gt "$users_line" ]
+
+  # The enable task carries no credentials, which only validates because the
+  # plugin takes them as optional trailing arguments.
+  run "$(docket_bin)" validate --tasks tasks.yml --vars-file tasks.vars.yml
+  assert_success
+  assert_output --partial "is valid"
+}
+
 @test "docket export reports a --vars-output left unwritten for want of secrets" {
   require_dokku
   # No config:set, so nothing is sensitive and no vars-file is produced.

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -97,6 +97,18 @@ require_dokku() {
   fi
 }
 
+# require_plugin skips the current test when a dokku plugin is not
+# installed. Mirrors skipIfPluginMissingT in the Go integration tests, so a
+# plugin-gated bats test skips cleanly on a dev box or a CI job that does not
+# install it rather than failing.
+require_plugin() {
+  local plugin="$1"
+  require_dokku
+  if ! dokku plugin:list | awk '{print $1}' | grep -qx "$plugin"; then
+    skip "dokku plugin $plugin not installed"
+  fi
+}
+
 # require_remote_dokku skips the current test when SSH transport tests
 # cannot run. The localhost-ssh-to-dokku fixture is only wired up on
 # Linux CI; macOS dev boxes typically lack a local dokku and the


### PR DESCRIPTION
`dokku_http_auth` advertised partial export support while implementing no exporter and appearing in no export order, so `docket export` silently dropped whether HTTP basic auth was serving on an app. It is now emitted after the rest of the http-auth family, because `http-auth:add-user`, `add-allowed-ip` and `add-domain` each turn auth on as a side effect and the task that owns the flag has to run last for the recipe's stated state to be the one that sticks. That also lets a disabled app whose users survived the disable export as `state: absent` rather than quietly coming back enabled. `state: present` no longer demands a username and password, matching the plugin, which takes them as optional trailing arguments and skips seeding a user without them. A new invariant test rules out the whole class by failing when a task claims to be exportable without being wired in, or is wired in while claiming it cannot be. The http-auth tasks now require dokku-http-auth 0.13.0.

The asymmetry that made the old ordering unworkable was fixed upstream in dokku/dokku-http-auth#40, released as 0.13.0, which is why the floor moves. Exporting the users as hashes rather than as required password inputs is tracked separately in #443.

Fixes #428
