### PR TITLE
feat: export http-auth users as htpasswd hashes

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -20,9 +20,9 @@ covered below.
 | Domains and ports (`dokku_domains`, `dokku_ports`) | DNS records |
 | Service structure (`dokku_service_create`, `dokku_service_expose`, `dokku_service_link`, backup schedule, `dokku_acl_service`) | letsencrypt-issued certificates |
 | Storage *mounts* (`dokku_storage_mount`) | Secret values not in the recipe |
-| HTTP basic auth (`dokku_http_auth`, `dokku_http_auth_user`, `dokku_http_auth_allowed_ip`, `dokku_http_auth_domain`) | HTTP auth passwords |
-| Manual certs inlined via `dokku_certs` `cert_content` / `key_content` | Host-level OS configuration |
-| Buildpacks, scheduler and proxy config | Datastore backup credentials and `dokku_service_property` values |
+| HTTP basic auth, credentials included (`dokku_http_auth`, `dokku_http_auth_user`, `dokku_http_auth_allowed_ip`, `dokku_http_auth_domain`) | Host-level OS configuration |
+| Manual certs inlined via `dokku_certs` `cert_content` / `key_content` | Datastore backup credentials and `dokku_service_property` values |
+| Buildpacks, scheduler and proxy config | |
 | SSH keys (`dokku_ssh_key`) | |
 | App code (`dokku_git_sync`, `dokku_git_from_image`, `dokku_git_from_archive`) | |
 
@@ -55,9 +55,10 @@ services are reconstructed into that same global play - the service itself, its 
 backup schedule, and its dokku-acl access list - with each app's service links emitted into the
 app's own play. Globally-set plugin properties are reconstructed into that global play too - for
 example the scheduler-k3s bootstrap keys such as the cluster token, ingress class, and letsencrypt
-emails. Sensitive values (config, the k3s token, and other secrets) are lifted into `tasks.vars.yml`;
-the recipe references them through inputs, so the pair is applied together with `--vars-file`. If you
-already maintain a recipe as the source of truth for the old server, skip this and use it directly.
+emails. Sensitive values (config, the k3s token, HTTP auth password hashes, and other secrets) are
+lifted into `tasks.vars.yml`; the recipe references them through inputs, so the pair is applied
+together with `--vars-file`. If you already maintain a recipe as the source of truth for the old
+server, skip this and use it directly.
 
 Some state cannot be read back and is left out with a warning - notably write-only credentials
 (`dokku_git_auth`, `dokku_registry_auth`, and datastore backup credentials), datastore service data,
@@ -65,9 +66,10 @@ and service properties (`dokku_service_property`), which you add by hand. Each t
 [reference page](tasks/README.md) has an Export support section noting its limits.
 
 HTTP basic auth is reconstructed in full - whether it is serving, its users, allowed IPs and auth
-domains - except for the passwords themselves, which the plugin only stores as hashes. Each user's
-password becomes a required input you fill in before applying
-([#443](https://github.com/dokku/docket/issues/443) tracks carrying the hashes across instead).
+domains. The plugin never stores a password, only its htpasswd hash, and export carries those
+hashes across: each user is emitted as a `hash` referencing a value in `tasks.vars.yml`, so the new
+server ends up with the same credentials working without anyone having to know the passwords behind
+them. Nothing about HTTP auth needs supplying by hand.
 
 ## Step 2: Apply the recipe to the new server
 

--- a/docs/tasks/dokku_http_auth.md
+++ b/docs/tasks/dokku_http_auth.md
@@ -10,7 +10,7 @@ Manages HTTP authentication for a given dokku application
 
 ## Export support
 
-Partial - the enabled state is exported; the seed credentials are not readable and come back as dokku_http_auth_user.
+Partial - the enabled state is exported; the seeded credentials are not carried on this task and come back as dokku_http_auth_user htpasswd hashes.
 
 ## Parameters
 

--- a/docs/tasks/dokku_http_auth_user.md
+++ b/docs/tasks/dokku_http_auth_user.md
@@ -10,16 +10,16 @@ Manages the set of HTTP auth users for a dokku application
 
 ## Export support
 
-Partial - usernames are exported; each password is not readable and becomes a required input.
+Supported.
 
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |
 | --- | --- | --- | --- | --- | --- |
 | `app` | string | yes |  |  | Name of the app |
-| `users` | list | no |  |  | List of HTTP auth users to add or remove. Each item has: username, password. |
-| `update_password` | bool | no | false |  | Re-issue add-user for users that already exist so their password converges |
-| `state` | string | no | present | present, absent | Desired state of the HTTP auth users |
+| `users` | list | no |  |  | List of HTTP auth users to add or remove. Each item gives the credential as exactly one of password (cleartext, applied with http-auth:add-user) or hash (an htpasswd entry, applied with http-auth:import-users); both are sensitive. Each item has: username, password, hash. |
+| `update_password` | bool | no | false |  | Re-issue add-user for users that already exist so their cleartext password converges. Users given by hash converge on their own and ignore this |
+| `state` | string | no | present | present, absent, set | Desired state of the HTTP auth users |
 
 ## Examples
 
@@ -35,6 +35,16 @@ dokku_http_auth_user:
           password: hunter2
 ```
 
+### Add a user from an htpasswd hash, as `docket export` emits
+
+```yaml
+dokku_http_auth_user:
+    app: hello-world
+    users:
+        - username: deploy
+          hash: $6$s0Vd6Ns8Wq2Kx1Lp$Zq8mQ0zH1pR3tY7uJ5bN2cV4dX6fG8hK0lM2nP4rS6tU8vW0xY2zA4bC6dE8fG0
+```
+
 ### Rotate an existing user's password
 
 ```yaml
@@ -44,6 +54,17 @@ dokku_http_auth_user:
         - username: admin
           password: new-secret
     update_password: true
+```
+
+### Replace the app's users with exactly this set
+
+```yaml
+dokku_http_auth_user:
+    app: hello-world
+    users:
+        - username: deploy
+          hash: $6$s0Vd6Ns8Wq2Kx1Lp$Zq8mQ0zH1pR3tY7uJ5bN2cV4dX6fG8hK0lM2nP4rS6tU8vW0xY2zA4bC6dE8fG0
+    state: set
 ```
 
 ### Remove a user from an app

--- a/tasks/export.go
+++ b/tasks/export.go
@@ -181,7 +181,10 @@ type ExportOptions struct {
 	Apps []string
 
 	// Redact replaces sensitive values with placeholders instead of the real
-	// values (in the vars-file for file mode, in place for stdout mode).
+	// values (in the vars-file for file mode, in place for stdout mode). A
+	// value whose task would not validate when blank is lifted into a required
+	// input instead of being blanked, so the emitted recipe still parses and
+	// validates - see processHttpAuthUser and processMaintenanceCustomPage.
 	Redact bool
 
 	// Inline keeps sensitive values in the task bodies instead of lifting them
@@ -460,35 +463,59 @@ func yamlFieldName(field reflect.StructField) string {
 	return tag
 }
 
-// processHttpAuthUser lifts each user's password into a required input, since
-// http-auth:report never exposes password material. The recipe therefore always
-// needs the passwords supplied in the vars-file before apply.
+// processHttpAuthUser lifts each exported user's htpasswd hash out of the
+// recipe body. The hash is what reproduces the user without the password behind
+// it, so it is credential material and gets the same treatment a config value
+// does - except that blanking it is not an option, because an empty hash fails
+// HttpAuthUserTask.Validate() (#443).
+//
+// File mode lifts every hash into the vars-file behind a sensitive input.
+// Inline mode has no companion file, so the hash stays in the body and the
+// streamed recipe is self-contained enough to pipe straight into apply. Under
+// inline + --redact there is nowhere to put the value and nowhere to blank it
+// to, so it is lifted into a required input and the caller is told the values
+// have to be supplied at apply time (e.g. via a CLI --<name>=<value>) (#334).
 func (res *ExportResult) processHttpAuthUser(app string, b HttpAuthUserTask, opts ExportOptions) (interface{}, []map[string]interface{}) {
 	if len(b.Users) == 0 {
 		return b, nil
 	}
-	// The password is never readable (http-auth stores an htpasswd hash), so it
-	// is always lifted into a required input rather than emitted as an empty
-	// string, which would fail HttpAuthUserTask.Validate(). Inline mode has no
-	// companion vars-file, so warn that the passwords must be supplied at apply
-	// time (e.g. via a CLI --<name>=<value> input) (#334).
+	if opts.Inline && !opts.Redact {
+		return b, nil
+	}
+
 	var inputs []map[string]interface{}
 	users := make([]HttpAuthUser, len(b.Users))
-	for i, u := range b.Users {
-		name := res.uniqueVarName(app, "http_auth_password_"+u.Username)
-		u.Password = "{{ ." + name + " }}"
-		users[i] = u
-		res.Vars[name] = "" // password is not readable; the user fills this in
+	copy(users, b.Users)
+	changed := false
+	for i, u := range users {
+		if u.Hash == "" {
+			continue
+		}
+		name := res.uniqueVarName(app, "http_auth_hash_"+u.Username)
+		users[i].Hash = "{{ ." + name + " }}"
+		changed = true
+		// Inline mode has no vars-file, so the value is withheld entirely
+		// rather than written anywhere.
+		if !opts.Inline {
+			if opts.Redact {
+				res.Vars[name] = ""
+			} else {
+				res.Vars[name] = u.Hash
+			}
+		}
 		inputs = append(inputs, map[string]interface{}{
 			"name":      name,
 			"required":  true,
 			"sensitive": true,
 		})
 	}
+	if !changed {
+		return b, nil
+	}
 	b.Users = users
 	if opts.Inline {
 		res.Report.Warnings = append(res.Report.Warnings,
-			fmt.Sprintf("%s: http-auth passwords are not readable; supply them as inputs before apply", app))
+			fmt.Sprintf("%s: http-auth hashes are redacted from the streamed recipe; supply them as inputs before apply", app))
 	}
 	return b, inputs
 }

--- a/tasks/export_integration_test.go
+++ b/tasks/export_integration_test.go
@@ -775,3 +775,51 @@ func TestIntegrationExportHttpAuth(t *testing.T) {
 		t.Errorf("expected no exported task once nothing is configured, got %v", bodies)
 	}
 }
+
+// TestIntegrationExportHttpAuthUserHashes proves the migration story #443 is
+// about, against a real plugin: the exported users carry their stored htpasswd
+// hashes, the emitted task is valid and reports no drift, and no password ever
+// has to be supplied. An app with no users still exports nothing.
+func TestIntegrationExportHttpAuthUserHashes(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "http-auth")
+
+	app := "docket-test-export-http-auth-user"
+	destroyApp(app)
+	createApp(app)
+	defer destroyApp(app)
+
+	if bodies, err := (HttpAuthUserTask{}).ExportApp(app); err != nil {
+		t.Fatalf("ExportApp on a fresh app: %v", err)
+	} else if len(bodies) != 0 {
+		t.Errorf("expected no exported task before any user exists, got %v", bodies)
+	}
+
+	if r := (HttpAuthTask{App: app, Username: "admin", Password: "secret", State: StatePresent}).Execute(); r.Error != nil {
+		t.Fatalf("enable http auth: %v", r.Error)
+	}
+
+	bodies, err := HttpAuthUserTask{}.ExportApp(app)
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 exported task, got %d", len(bodies))
+	}
+	users := bodies[0].(HttpAuthUserTask)
+	if len(users.Users) != 1 || users.Users[0].Username != "admin" {
+		t.Fatalf("exported users = %+v, want just admin", users.Users)
+	}
+	if users.Users[0].Hash == "" {
+		t.Error("exported user must carry the stored htpasswd hash")
+	}
+	if users.Users[0].Password != "" {
+		t.Errorf("exported user must carry no cleartext password, got %q", users.Users[0].Password)
+	}
+	if err := users.Validate(); err != nil {
+		t.Errorf("exported task must be valid, got: %v", err)
+	}
+	if plan := users.Plan(); !plan.InSync {
+		t.Errorf("exported task should report no drift, got status %v reason %q", plan.Status, plan.Reason)
+	}
+}

--- a/tasks/export_test.go
+++ b/tasks/export_test.go
@@ -167,30 +167,77 @@ func TestExportRecipeFileMode(t *testing.T) {
 	}
 }
 
-func TestExportHttpAuthUserPasswordsBecomeInputs(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+// exportHttpAuthHash is the stored htpasswd entry the export tests read back
+// through http-auth:export-users.
+const exportHttpAuthHash = "$6$Xm3kx1s9$Zq8mQ0zH1p"
+
+// httpAuthExportFixture is a one-app server with http-auth serving for the
+// named users. Both the report and export-users have to answer: the report
+// drives dokku_http_auth, export-users drives dokku_http_auth_user.
+func httpAuthExportFixture(users, entries string) map[string]string {
+	return map[string]string{
 		"--quiet apps:list":                  "web",
-		"http-auth:report web --format json": `{"enabled":"true","users":"admin","allowed-ips":"","domains":""}`,
-	}))()
+		"http-auth:report web --format json": `{"enabled":"true","users":"` + users + `","allowed-ips":"","domains":""}`,
+		"--quiet http-auth:export-users web": entries,
+	}
+}
+
+// TestExportHttpAuthUserHashesBecomeVars is the payoff of #443: the users come
+// back carrying their htpasswd hashes, so the recipe reproduces them with no
+// operator-supplied password. The hash is still credential material, so it
+// lands in the vars-file behind a sensitive input rather than in the recipe.
+func TestExportHttpAuthUserHashesBecomeVars(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))()
+
+	bodies, err := HttpAuthUserTask{}.ExportApp("web")
+	if err != nil {
+		t.Fatalf("ExportApp: %v", err)
+	}
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 exported task, got %d", len(bodies))
+	}
+	users := bodies[0].(HttpAuthUserTask)
+	if len(users.Users) != 1 || users.Users[0].Hash != exportHttpAuthHash {
+		t.Fatalf("exported users = %+v, want admin carrying the stored hash", users.Users)
+	}
+	if users.Users[0].Password != "" {
+		t.Errorf("exported user must carry no cleartext password, got %q", users.Users[0].Password)
+	}
+	// State is explicit so the body is plannable straight out of the exporter.
+	if users.State != StatePresent {
+		t.Errorf("State = %q, want %q", users.State, StatePresent)
+	}
+	if err := users.Validate(); err != nil {
+		t.Errorf("exported task must be valid, got: %v", err)
+	}
+	if plan := users.Plan(); !plan.InSync {
+		t.Errorf("re-planning the exported task should report no drift, got status %v reason %q", plan.Status, plan.Reason)
+	}
 
 	res, err := ExportRecipe(ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
-
-	// The password is not readable, so it is lifted to a required input with an
-	// empty placeholder in the vars map.
-	v, ok := res.Vars["web_http_auth_password_admin"]
-	if !ok || v != "" {
-		t.Errorf("expected empty placeholder for http-auth password, got %q (ok=%v)", v, ok)
+	if got := res.Vars["web_http_auth_hash_admin"]; got != exportHttpAuthHash {
+		t.Errorf("vars[web_http_auth_hash_admin] = %q, want the real hash", got)
+	}
+	if len(res.Report.Warnings) != 0 {
+		for _, w := range res.Report.Warnings {
+			if strings.Contains(w, "http-auth") {
+				t.Errorf("unexpected http-auth export warning: %q", w)
+			}
+		}
 	}
 
 	recipe, _ := res.MarshalRecipe("yaml")
 	out := string(recipe)
+	if strings.Contains(out, exportHttpAuthHash) {
+		t.Errorf("recipe leaked the hash instead of lifting it:\n%s", out)
+	}
 	for _, want := range []string{
 		"username: admin",
-		"{{ .web_http_auth_password_admin }}",
-		"name: web_http_auth_password_admin",
+		"{{ .web_http_auth_hash_admin }}",
+		"name: web_http_auth_hash_admin",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("recipe missing %q:\n%s", want, out)
@@ -198,14 +245,30 @@ func TestExportHttpAuthUserPasswordsBecomeInputs(t *testing.T) {
 	}
 }
 
+// TestExportHttpAuthUserRedactBlanksTheVar keeps the redacted pair usable: the
+// recipe still references the input, only the vars-file value is withheld.
+func TestExportHttpAuthUserRedactBlanksTheVar(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))()
+
+	res, err := ExportRecipe(ExportOptions{Redact: true})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	v, ok := res.Vars["web_http_auth_hash_admin"]
+	if !ok || v != "" {
+		t.Errorf("expected an empty placeholder under --redact, got %q (ok=%v)", v, ok)
+	}
+	recipe, _ := res.MarshalRecipe("yaml")
+	if !strings.Contains(string(recipe), "{{ .web_http_auth_hash_admin }}") {
+		t.Errorf("redacted recipe must still reference the input:\n%s", recipe)
+	}
+}
+
 // TestExportHttpAuthEnabledBecomesTask covers the first row of the export state
 // table (#428): an app serving http-auth emits dokku_http_auth with state
 // present, after the rest of the family so it is authoritative.
 func TestExportHttpAuthEnabledBecomesTask(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
-		"--quiet apps:list":                  "web",
-		"http-auth:report web --format json": `{"enabled":"true","users":"admin","allowed-ips":"","domains":""}`,
-	}))()
+	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))()
 
 	bodies, err := HttpAuthTask{}.ExportApp("web")
 	if err != nil {
@@ -256,10 +319,9 @@ func TestExportHttpAuthEnabledBecomesTask(t *testing.T) {
 // nothing else's enable side effect would restore it and this task is the only
 // thing that carries the state.
 func TestExportHttpAuthEnabledWithoutUsersBecomesTask(t *testing.T) {
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
-		"--quiet apps:list":                  "web",
-		"http-auth:report web --format json": `{"enabled":"true","users":"","allowed-ips":"","domains":""}`,
-	}))()
+	// export-users is answered explicitly with nothing, so the "no user task"
+	// assertion below tests the empty htpasswd rather than a missing fixture.
+	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("", "")))()
 
 	bodies, err := HttpAuthTask{}.ExportApp("web")
 	if err != nil {
@@ -667,26 +729,61 @@ func TestExportMaintenanceCustomPageInlinesContent(t *testing.T) {
 	}
 }
 
-func TestExportHttpAuthUserInlineEmitsInputAndWarns(t *testing.T) {
-	// #334: stdout export can't read passwords back, so it emits an input block
-	// (a valid non-empty sigil) and warns that the passwords must be supplied.
-	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
-		"--quiet apps:list":                  "web",
-		"http-auth:report web --format json": `{"enabled":"true","users":"admin","allowed-ips":"","domains":""}`,
-	}))()
+// TestExportHttpAuthUserInlineKeepsTheHash covers #410's pipe: a streamed
+// recipe has no companion vars-file, and now that the hash is readable it can
+// simply ride along, so `export --output - | apply` reproduces the users with
+// nothing supplied by hand.
+func TestExportHttpAuthUserInlineKeepsTheHash(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))()
 
 	res, err := ExportRecipe(ExportOptions{Inline: true})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
+	if len(res.Vars) != 0 {
+		t.Errorf("inline mode has no vars-file to write to, got %v", res.Vars)
+	}
 	recipe, _ := res.MarshalRecipe("yaml")
 	out := string(recipe)
+	if !strings.Contains(out, exportHttpAuthHash) {
+		t.Errorf("streamed recipe should carry the hash inline:\n%s", out)
+	}
+	if strings.Contains(out, "{{ .web_http_auth_hash_admin }}") {
+		t.Errorf("streamed recipe should not lift the hash into an input:\n%s", out)
+	}
+	for _, w := range res.Report.Warnings {
+		if strings.Contains(w, "http-auth") {
+			t.Errorf("nothing needs supplying by hand any more, got warning %q", w)
+		}
+	}
+}
+
+// TestExportHttpAuthUserInlineRedactLiftsAndWarns is the one combination with
+// nowhere to put the value: stdout has no vars-file, and blanking the hash
+// would emit a task that fails its own Validate. It is lifted into a required
+// input instead, and the caller is told the values still have to be supplied
+// (#334).
+func TestExportHttpAuthUserInlineRedactLiftsAndWarns(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(httpAuthExportFixture("admin", "admin:"+exportHttpAuthHash+"\n")))()
+
+	res, err := ExportRecipe(ExportOptions{Inline: true, Redact: true})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	if len(res.Vars) != 0 {
+		t.Errorf("inline mode must not populate the vars map, got %v", res.Vars)
+	}
+	recipe, _ := res.MarshalRecipe("yaml")
+	out := string(recipe)
+	if strings.Contains(out, exportHttpAuthHash) {
+		t.Errorf("redacted recipe leaked the hash:\n%s", out)
+	}
 	for _, want := range []string{
-		"{{ .web_http_auth_password_admin }}",
-		"name: web_http_auth_password_admin",
+		"{{ .web_http_auth_hash_admin }}",
+		"name: web_http_auth_hash_admin",
 	} {
 		if !strings.Contains(out, want) {
-			t.Errorf("stdout recipe missing %q:\n%s", want, out)
+			t.Errorf("redacted stdout recipe missing %q:\n%s", want, out)
 		}
 	}
 	found := false
@@ -696,7 +793,7 @@ func TestExportHttpAuthUserInlineEmitsInputAndWarns(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Errorf("expected a warning about http-auth passwords, got %v", res.Report.Warnings)
+		t.Errorf("expected a warning that the hashes must be supplied, got %v", res.Report.Warnings)
 	}
 }
 

--- a/tasks/http_auth_task.go
+++ b/tasks/http_auth_task.go
@@ -45,7 +45,7 @@ func (t HttpAuthTask) Doc() string {
 
 // ExportSupport reports how docket export handles this task.
 func (t HttpAuthTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportPartial, Caveat: "the enabled state is exported; the seed credentials are not readable and come back as dokku_http_auth_user"}
+	return ExportSupport{Status: ExportPartial, Caveat: "the enabled state is exported; the seeded credentials are not carried on this task and come back as dokku_http_auth_user htpasswd hashes"}
 }
 
 // Requirements lists the non-core dokku plugins this task depends on.

--- a/tasks/http_auth_user_task.go
+++ b/tasks/http_auth_user_task.go
@@ -15,30 +15,52 @@ type HttpAuthUserTask struct {
 	// App is the name of the app
 	App string `required:"true" yaml:"app" description:"Name of the app"`
 
-	// Users is the list of HTTP auth users to add or remove
-	Users []HttpAuthUser `required:"false" yaml:"users" description:"List of HTTP auth users to add or remove"`
+	// Users is the list of HTTP auth users to add or remove. The docs generator
+	// lists an item's field names but cannot express that password and hash are
+	// alternatives, nor that both are secret, so this description carries it.
+	Users []HttpAuthUser `required:"false" yaml:"users" description:"List of HTTP auth users to add or remove. Each item gives the credential as exactly one of password (cleartext, applied with http-auth:add-user) or hash (an htpasswd entry, applied with http-auth:import-users); both are sensitive"`
 
 	// UpdatePassword re-issues http-auth:add-user for users that already exist
-	// so their password converges. Passwords are not exposed in the report, so
-	// a rotation cannot be drift-detected; enable this to force convergence. It
-	// is a *bool so the value survives decoding unchanged; nil defaults to false.
-	UpdatePassword *bool `required:"false" yaml:"update_password,omitempty" default:"false" description:"Re-issue add-user for users that already exist so their password converges"`
+	// so their password converges. Cleartext passwords are not exposed in the
+	// report, so a rotation cannot be drift-detected; enable this to force
+	// convergence. It governs the password path only - a hash user converges on
+	// its own, because http-auth:export-users reads the stored hash back. It is
+	// a *bool so the value survives decoding unchanged; nil defaults to false.
+	UpdatePassword *bool `required:"false" yaml:"update_password,omitempty" default:"false" description:"Re-issue add-user for users that already exist so their cleartext password converges. Users given by hash converge on their own and ignore this"`
 
-	// State is the desired state of the HTTP auth users
-	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent" description:"Desired state of the HTTP auth users"`
+	// State is the desired state of the HTTP auth users. There is no `clear`
+	// state, unlike the sibling dokku_http_auth_domain: `absent` with an empty
+	// `users` already removes every user.
+	State State `required:"false" yaml:"state,omitempty" default:"present" options:"present,absent,set" description:"Desired state of the HTTP auth users"`
 }
 
-// HttpAuthUser represents a single HTTP auth user
+// HttpAuthUser represents a single HTTP auth user. Exactly one of Password and
+// Hash carries the credential.
+//
+// The `sensitive:"true"` tags document intent, but because the fields live in a
+// slice-of-structs the reflection walker in sensitive.go cannot reach them -
+// the task's SensitiveValues method is what actually masks these values.
 type HttpAuthUser struct {
 	// Username is the HTTP auth username
 	Username string `required:"true" yaml:"username" description:"HTTP auth username"`
 
-	// Password is the HTTP auth password. The `sensitive:"true"` tag documents
-	// intent, but because the field lives in a slice-of-structs the reflection
-	// walker in sensitive.go cannot reach it - the task's SensitiveValues method
-	// is what actually masks these values.
-	Password string `required:"false" sensitive:"true" yaml:"password,omitempty" description:"HTTP auth password"`
+	// Password is the cleartext HTTP auth password, applied with
+	// http-auth:add-user. Mutually exclusive with Hash.
+	Password string `required:"false" sensitive:"true" yaml:"password,omitempty" description:"Cleartext HTTP auth password. Mutually exclusive with hash"`
+
+	// Hash is the user's htpasswd entry, as emitted by
+	// http-auth:export-users. Applied with http-auth:import-users over stdin,
+	// so the value never reaches argv. Mutually exclusive with Password; this
+	// is the form `docket export` emits, since the plugin can read hashes back
+	// but never the passwords behind them.
+	Hash string `required:"false" sensitive:"true" yaml:"hash,omitempty" description:"htpasswd hash for the user, as emitted by http-auth:export-users. Mutually exclusive with password; applied over stdin with http-auth:import-users so it never reaches argv"`
 }
+
+// exampleHttpAuthHash is the htpasswd entry the hash-form examples use. It is
+// a real salted SHA-512 crypt hash so the published snippets look like what
+// http-auth:export-users actually emits, and so the example integration run
+// applies something the plugin would accept.
+const exampleHttpAuthHash = "$6$s0Vd6Ns8Wq2Kx1Lp$Zq8mQ0zH1pR3tY7uJ5bN2cV4dX6fG8hK0lM2nP4rS6tU8vW0xY2zA4bC6dE8fG0"
 
 // HttpAuthUserTaskExample contains an example of an HttpAuthUserTask
 type HttpAuthUserTaskExample struct {
@@ -60,8 +82,15 @@ func (t HttpAuthUserTask) Doc() string {
 }
 
 // ExportSupport reports how docket export handles this task.
+//
+// Supported without a caveat because http-auth:export-users reads every user's
+// htpasswd entry back, so an exported recipe reproduces the users with no
+// operator-supplied credentials. That command is guaranteed by the >= 0.13.0
+// floor in Requirements(); the whole http-auth family already assumes it (a
+// credential-free http-auth:enable is a 0.13.0 behaviour too), so there is no
+// fallback for older plugins here.
 func (t HttpAuthUserTask) ExportSupport() ExportSupport {
-	return ExportSupport{Status: ExportPartial, Caveat: "usernames are exported; each password is not readable and becomes a required input"}
+	return ExportSupport{Status: ExportSupported}
 }
 
 // Requirements lists the non-core dokku plugins this task depends on.
@@ -69,14 +98,19 @@ func (t HttpAuthUserTask) Requirements() []string {
 	return []string{"dokku-http-auth plugin >= 0.13.0"}
 }
 
-// SensitiveValues returns the per-user passwords so they are masked in
+// SensitiveValues returns the per-user credentials so they are masked in
 // user-facing output. The tag-based walker in sensitive.go does not descend
-// into slices of structs, so the sensitive passwords are collected here.
+// into slices of structs, so they are collected here. Hashes are credential
+// material too - they are what an attacker needs to reproduce the htpasswd -
+// so they are masked alongside the cleartext passwords.
 func (t HttpAuthUserTask) SensitiveValues() []string {
 	out := make([]string, 0, len(t.Users))
 	for _, u := range t.Users {
 		if u.Password != "" {
 			out = append(out, u.Password)
+		}
+		if u.Hash != "" {
+			out = append(out, u.Hash)
 		}
 	}
 	return out
@@ -96,11 +130,30 @@ func (t HttpAuthUserTask) Examples() ([]Doc, error) {
 			},
 		},
 		{
+			Name: "Add a user from an htpasswd hash, as `docket export` emits",
+			DokkuHttpAuthUser: HttpAuthUserTask{
+				App: "hello-world",
+				Users: []HttpAuthUser{
+					{Username: "deploy", Hash: exampleHttpAuthHash},
+				},
+			},
+		},
+		{
 			Name: "Rotate an existing user's password",
 			DokkuHttpAuthUser: HttpAuthUserTask{
 				App:            "hello-world",
 				Users:          []HttpAuthUser{{Username: "admin", Password: "new-secret"}},
 				UpdatePassword: boolPtr(true),
+			},
+		},
+		{
+			Name: "Replace the app's users with exactly this set",
+			DokkuHttpAuthUser: HttpAuthUserTask{
+				App: "hello-world",
+				Users: []HttpAuthUser{
+					{Username: "deploy", Hash: exampleHttpAuthHash},
+				},
+				State: StateSet,
 			},
 		},
 		{
@@ -131,18 +184,43 @@ func (t HttpAuthUserTask) Validate() error {
 	if t.App == "" {
 		return fmt.Errorf("'app' is required")
 	}
+	seen := map[string]bool{}
 	for _, u := range t.Users {
 		if u.Username == "" {
 			return fmt.Errorf("'username' is required for each user")
 		}
+		// Two entries for one username used to be harmless (two add-user calls,
+		// last wins). Now that the credential forms dispatch to different
+		// commands, the winner would depend on nothing but list order, and two
+		// lines for one user in a single import stream is outside the plugin's
+		// contract.
+		if seen[u.Username] {
+			return fmt.Errorf("user %q is listed more than once", u.Username)
+		}
+		seen[u.Username] = true
+		if u.Password != "" && u.Hash != "" {
+			return fmt.Errorf("'password' and 'hash' are mutually exclusive for user %q", u.Username)
+		}
+		if u.Hash != "" {
+			// docket frames the `username:hash` stream itself, so a colon in
+			// the username or a newline in either half would write a corrupt
+			// htpasswd. Password users go on argv and are left alone, so no
+			// recipe that validates today starts failing.
+			if strings.Contains(u.Username, ":") {
+				return fmt.Errorf("'username' must not contain ':' for user %q given by hash", u.Username)
+			}
+			if strings.ContainsAny(u.Username, "\r\n") || strings.ContainsAny(u.Hash, "\r\n") {
+				return fmt.Errorf("'username' and 'hash' must not contain newlines for user %q", u.Username)
+			}
+		}
 	}
-	if t.State == StatePresent {
+	if t.State == StatePresent || t.State == StateSet {
 		if len(t.Users) == 0 {
-			return fmt.Errorf("'users' must not be empty for state 'present'")
+			return fmt.Errorf("'users' must not be empty for state '%s'", t.State)
 		}
 		for _, u := range t.Users {
-			if u.Password == "" {
-				return fmt.Errorf("'password' is required for user %q when state is present", u.Username)
+			if u.Password == "" && u.Hash == "" {
+				return fmt.Errorf("one of 'password' or 'hash' is required for user %q when state is '%s'", u.Username, t.State)
 			}
 		}
 	}
@@ -155,48 +233,8 @@ func (t HttpAuthUserTask) Plan() PlanResult {
 		return planErr(err)
 	}
 	return DispatchPlan(t.State, map[State]func() PlanResult{
-		StatePresent: func() PlanResult {
-			current, err := getHttpAuthUsers(t.App)
-			if err != nil {
-				return PlanResult{Status: PlanStatusError, Error: err}
-			}
-			toApply := []HttpAuthUser{}
-			mutations := []string{}
-			for _, u := range t.Users {
-				switch {
-				case !current[u.Username]:
-					toApply = append(toApply, u)
-					mutations = append(mutations, "add "+u.Username)
-				case boolValue(t.UpdatePassword, false):
-					toApply = append(toApply, u)
-					mutations = append(mutations, "update "+u.Username)
-				}
-			}
-			if len(toApply) == 0 {
-				return PlanResult{InSync: true, Status: PlanStatusOK}
-			}
-			status := PlanStatusModify
-			if len(current) == 0 {
-				status = PlanStatusCreate
-			}
-			inputs := make([]subprocess.ExecCommandInput, 0, len(toApply))
-			for _, u := range toApply {
-				inputs = append(inputs, subprocess.ExecCommandInput{
-					Command: "dokku",
-					Args:    []string{"--quiet", "http-auth:add-user", t.App, u.Username, u.Password},
-				})
-			}
-			return PlanResult{
-				InSync:    false,
-				Status:    status,
-				Reason:    fmt.Sprintf("%d user(s) to add or update", len(toApply)),
-				Mutations: mutations,
-				Commands:  resolveCommands(inputs),
-				apply: func() TaskOutputState {
-					return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
-				},
-			}
-		},
+		StatePresent: func() PlanResult { return planHttpAuthUsersPresent(t) },
+		StateSet:     func() PlanResult { return planHttpAuthUsersSet(t) },
 		StateAbsent: func() PlanResult {
 			current, err := getHttpAuthUsers(t.App)
 			if err != nil {
@@ -241,6 +279,278 @@ func (t HttpAuthUserTask) Plan() PlanResult {
 	})
 }
 
+// planHttpAuthUsersPresent reports drift for the upsert state: every listed
+// user ends up on the app, and users the task does not mention are untouched.
+//
+// A cleartext password is not readable, so a user that already exists converges
+// only when update_password forces it. A hash is readable, so a hash user
+// converges on its own - the stored-hash comparison is evaluated first, which
+// also stops update_password from re-importing a hash that already matches.
+func planHttpAuthUsersPresent(t HttpAuthUserTask) PlanResult {
+	current, hashes, res := readHttpAuthUserState(t)
+	if res != nil {
+		return *res
+	}
+
+	toApply := []HttpAuthUser{}
+	mutations := []string{}
+	for _, u := range t.Users {
+		switch {
+		case !current[u.Username]:
+			toApply = append(toApply, u)
+			mutations = append(mutations, "add "+u.Username)
+		case u.Hash != "":
+			if hashes[u.Username] != u.Hash {
+				toApply = append(toApply, u)
+				mutations = append(mutations, "update "+u.Username)
+			}
+		case boolValue(t.UpdatePassword, false):
+			toApply = append(toApply, u)
+			mutations = append(mutations, "update "+u.Username)
+		}
+	}
+	if len(toApply) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+
+	status := PlanStatusModify
+	if len(current) == 0 {
+		status = PlanStatusCreate
+	}
+	inputs := httpAuthUserUpsertInputs(t.App, toApply, false)
+	return PlanResult{
+		InSync:    false,
+		Status:    status,
+		Reason:    fmt.Sprintf("%d user(s) to add or update", len(toApply)),
+		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
+		apply: func() TaskOutputState {
+			return runExecInputs(TaskOutputState{State: StateAbsent}, StatePresent, inputs)
+		},
+	}
+}
+
+// planHttpAuthUsersSet reports drift for the exact-set state: after applying,
+// the app's users are exactly the listed ones.
+//
+// When every listed user carries a hash the whole set is expressible as one
+// `http-auth:import-users --replace`, which is what that flag is for. A
+// cleartext password cannot be written into the htpasswd stream, so a list with
+// any password user falls back to removing the strays and upserting the rest.
+func planHttpAuthUsersSet(t HttpAuthUserTask) PlanResult {
+	current, hashes, res := readHttpAuthUserState(t)
+	if res != nil {
+		return *res
+	}
+
+	desired := map[string]bool{}
+	for _, u := range t.Users {
+		desired[u.Username] = true
+	}
+
+	toApply := []HttpAuthUser{}
+	mutations := []string{}
+	allHashed := true
+	for _, u := range t.Users {
+		if u.Hash == "" {
+			allHashed = false
+		}
+		switch {
+		case !current[u.Username]:
+			toApply = append(toApply, u)
+			mutations = append(mutations, "add "+u.Username)
+		case u.Hash != "":
+			if hashes[u.Username] != u.Hash {
+				toApply = append(toApply, u)
+				mutations = append(mutations, "update "+u.Username)
+			}
+		case boolValue(t.UpdatePassword, false):
+			toApply = append(toApply, u)
+			mutations = append(mutations, "update "+u.Username)
+		}
+	}
+
+	toRemove := []string{}
+	for u := range current {
+		if !desired[u] {
+			toRemove = append(toRemove, u)
+		}
+	}
+	sort.Strings(toRemove)
+	for _, u := range toRemove {
+		mutations = append(mutations, "remove "+u)
+	}
+
+	if len(mutations) == 0 {
+		return PlanResult{InSync: true, Status: PlanStatusOK}
+	}
+
+	var inputs []subprocess.ExecCommandInput
+	if allHashed {
+		// One atomic write of the whole htpasswd. Every listed user goes in,
+		// not just the drifting ones, because --replace discards whatever it
+		// does not receive.
+		inputs = httpAuthUserUpsertInputs(t.App, t.Users, true)
+	} else {
+		for _, u := range toRemove {
+			inputs = append(inputs, subprocess.ExecCommandInput{
+				Command: "dokku",
+				Args:    []string{"--quiet", "http-auth:remove-user", t.App, u},
+			})
+		}
+		inputs = append(inputs, httpAuthUserUpsertInputs(t.App, toApply, false)...)
+	}
+
+	// Modify even when the only mutations are removals, matching
+	// planHttpAuthDomainsSet and planDomainsSet: a whole-set replacement is one
+	// operation, not a destroy.
+	return PlanResult{
+		InSync:    false,
+		Status:    PlanStatusModify,
+		Reason:    fmt.Sprintf("%d user change(s)", len(mutations)),
+		Mutations: mutations,
+		Commands:  resolveCommands(inputs),
+		apply: func() TaskOutputState {
+			return runExecInputs(TaskOutputState{State: StatePresent}, StateSet, inputs)
+		},
+	}
+}
+
+// readHttpAuthUserState probes the app's current users, and their stored hashes
+// when the task expresses any user by hash. A non-nil PlanResult is the caller's
+// early return.
+//
+// Membership keeps coming from `http-auth:report`, which every version of the
+// plugin answers, so a password-only recipe costs exactly one round trip and is
+// unaffected by the newer export-users command. The hash overlay is read only
+// when it is needed.
+func readHttpAuthUserState(t HttpAuthUserTask) (map[string]bool, map[string]string, *PlanResult) {
+	current, err := getHttpAuthUsers(t.App)
+	if err != nil {
+		return nil, nil, &PlanResult{Status: PlanStatusError, Error: err}
+	}
+
+	wantsHashes := false
+	for _, u := range t.Users {
+		if u.Hash != "" {
+			wantsHashes = true
+			break
+		}
+	}
+	if !wantsHashes {
+		return current, map[string]string{}, nil
+	}
+
+	hashes, err := getHttpAuthUserHashes(t.App)
+	if err != nil {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return nil, nil, &PlanResult{Status: PlanStatusError, Error: err}
+		}
+		// A dokku-level failure means the hashes could not be read, not that
+		// there are none: `plan` runs against servers where the app does not
+		// exist yet (created by an earlier task in the same recipe), which is
+		// why getHttpAuthUsers swallows too. Every hash user then reads as
+		// drift, which is right for the fresh-app case and cannot spin
+		// silently for the too-old-plugin case, since the import-users the
+		// plan proposes is the very command that would be missing.
+		return current, map[string]string{}, nil
+	}
+	return current, hashes, nil
+}
+
+// httpAuthUserUpsertInputs renders the commands that add or update users. Hash
+// users are collapsed into a single `http-auth:import-users` fed over stdin;
+// cleartext users each get an `http-auth:add-user`.
+//
+// The import comes first because it validates every line before writing
+// anything, and runExecInputs stops at the first failure with earlier commands
+// already applied - so the all-or-nothing command running first keeps the
+// partial-apply window as small as it can be. Order carries no other meaning:
+// both commands upsert by username.
+func httpAuthUserUpsertInputs(app string, users []HttpAuthUser, replace bool) []subprocess.ExecCommandInput {
+	var entries []string
+	var passwordUsers []HttpAuthUser
+	for _, u := range users {
+		if u.Hash != "" {
+			entries = append(entries, u.Username+":"+u.Hash)
+			continue
+		}
+		passwordUsers = append(passwordUsers, u)
+	}
+
+	inputs := make([]subprocess.ExecCommandInput, 0, len(passwordUsers)+1)
+	if len(entries) > 0 {
+		args := []string{"--quiet", "http-auth:import-users", app}
+		if replace {
+			args = append(args, "--replace")
+		}
+		inputs = append(inputs, subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    args,
+			// The payload never reaches argv, so it stays out of the plan
+			// output, the trace log, and the remote process table.
+			Stdin: strings.NewReader(strings.Join(entries, "\n") + "\n"),
+		})
+	}
+	for _, u := range passwordUsers {
+		inputs = append(inputs, subprocess.ExecCommandInput{
+			Command: "dokku",
+			Args:    []string{"--quiet", "http-auth:add-user", app, u.Username, u.Password},
+		})
+	}
+	return inputs
+}
+
+// getHttpAuthUserHashes reads the app's stored htpasswd entries back via
+// `dokku --quiet http-auth:export-users <app>`, which writes one `user:hash`
+// line per user to stdout and nothing else. `--quiet` is a deliberate
+// divergence from the `:report` readers in this package: the plugin logs a
+// notice when the app has no users, and only the entries should be parsed.
+//
+// The command exits 0 with empty stdout when the app has no users, and works
+// even while auth is disabled, so a missing entry means the user is absent
+// rather than unreadable. Every error is returned raw, unlike getHttpAuthUsers,
+// because Plan and ExportApp want different fallbacks for a dokku-level
+// failure.
+//
+// Parsing is deliberately strict, since anything let through here ends up in an
+// exported recipe: blank lines, lines with no separator, and lines with an
+// empty hash are skipped rather than producing a credential-less user that the
+// task's own Validate would reject. The split is on the first colon - a
+// username cannot contain one, a crypt hash can.
+//
+// Comparison against a desired hash is byte-exact. A future plugin that
+// normalized entries on import would surface as perpetual drift rather than
+// silent divergence.
+func getHttpAuthUserHashes(appName string) (map[string]string, error) {
+	result, err := subprocess.CallExecCommand(subprocess.ExecCommandInput{
+		Command: "dokku",
+		Args: []string{
+			"--quiet",
+			"http-auth:export-users",
+			appName,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	hashes := map[string]string{}
+	for _, line := range strings.Split(result.Stdout, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		username, hash, found := strings.Cut(line, ":")
+		if !found || username == "" || hash == "" {
+			continue
+		}
+		hashes[username] = hash
+	}
+	return hashes, nil
+}
+
 // getHttpAuthUsers reads the current set of HTTP auth users for an app from the
 // `users` key of `http-auth:report --format json`. The plugin strips the
 // `http-auth-` prefix from JSON report keys (so the key is `users`, not
@@ -280,22 +590,44 @@ func getHttpAuthUsers(appName string) (map[string]bool, error) {
 	return users, nil
 }
 
-// ExportApp reconstructs the app's HTTP-auth users. Usernames come from the
-// report; passwords are not exposed, so the engine lifts each into a required
-// input the user fills in before applying (see processHttpAuthUser).
+// ExportApp reconstructs the app's HTTP-auth users, each carrying the stored
+// htpasswd hash. That is the whole point of exporting by hash: the recipe
+// reproduces the users without anyone knowing the passwords behind them.
+//
+// http-auth:export-users reads the same htpasswd the report derives its `users`
+// key from, so it is the only probe needed here. A transport-level failure
+// (`*subprocess.SSHError`) is propagated; any other failure is treated as "no
+// users", matching the other readers in this package - that is what keeps a
+// server without the http-auth plugin from raising an export warning for every
+// app it has.
+//
+// State is set explicitly so the emitted body is directly plannable, rather
+// than depending on the decode-time default. It is `present`, not `set`, even
+// though every listed user is exported and the sibling exact-set exporters
+// (dokku_http_auth_domain, dokku_domains, dokku_ports) emit `set`: an exported
+// recipe should not silently delete a user that exists only on the destination.
 func (t HttpAuthUserTask) ExportApp(app string) ([]interface{}, error) {
-	users, err := getHttpAuthUsers(app)
+	hashes, err := getHttpAuthUserHashes(app)
 	if err != nil {
-		return nil, err
-	}
-	if len(users) == 0 {
+		var sshErr *subprocess.SSHError
+		if errors.As(err, &sshErr) {
+			return nil, err
+		}
 		return nil, nil
 	}
-	list := make([]HttpAuthUser, 0, len(users))
-	for _, name := range sortedSetKeys(users) {
-		list = append(list, HttpAuthUser{Username: name})
+	if len(hashes) == 0 {
+		return nil, nil
 	}
-	return []interface{}{HttpAuthUserTask{App: app, Users: list}}, nil
+	names := make([]string, 0, len(hashes))
+	for name := range hashes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	list := make([]HttpAuthUser, 0, len(names))
+	for _, name := range names {
+		list = append(list, HttpAuthUser{Username: name, Hash: hashes[name]})
+	}
+	return []interface{}{HttpAuthUserTask{App: app, Users: list, State: StatePresent}}, nil
 }
 
 // init registers the HttpAuthUserTask with the task registry

--- a/tasks/http_auth_user_task_integration_test.go
+++ b/tasks/http_auth_user_task_integration_test.go
@@ -1,6 +1,8 @@
 package tasks
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -128,5 +130,176 @@ func TestIntegrationHttpAuthUser(t *testing.T) {
 	}
 	if result.Changed {
 		t.Error("expected Changed=false on idempotent clear")
+	}
+}
+
+// TestIntegrationHttpAuthUserHashes exercises the credential form that survives
+// a migration (#443): users expressed as htpasswd hashes, applied over stdin
+// with http-auth:import-users. The hashes are read back from the live plugin
+// rather than invented, so the in-sync assertions also pin that the round trip
+// through import-users is byte-exact - a plugin that ever normalized entries on
+// import would fail here rather than causing silent perpetual drift.
+func TestIntegrationHttpAuthUserHashes(t *testing.T) {
+	skipIfNoDokkuT(t)
+	skipIfPluginMissingT(t, "http-auth")
+
+	appName := "docket-test-http-auth-hash"
+	destroyApp(appName)
+	createApp(appName)
+	defer destroyApp(appName)
+
+	storedHashes := func(t *testing.T, label string) map[string]string {
+		t.Helper()
+		got, err := getHttpAuthUserHashes(appName)
+		if err != nil {
+			t.Fatalf("%s: getHttpAuthUserHashes failed: %v", label, err)
+		}
+		return got
+	}
+	usernames := func(t *testing.T, label string) []string {
+		t.Helper()
+		got, err := getHttpAuthUsers(appName)
+		if err != nil {
+			t.Fatalf("%s: getHttpAuthUsers failed: %v", label, err)
+		}
+		return sortedSetKeys(got)
+	}
+
+	// Seed two users the ordinary way, then read their stored hashes back. This
+	// is exactly what `docket export` does.
+	seed := HttpAuthUserTask{
+		App: appName,
+		Users: []HttpAuthUser{
+			{Username: "alice", Password: "alice-pass"},
+			{Username: "bob", Password: "bob-pass"},
+		},
+		State: StatePresent,
+	}
+	if result := seed.Execute(); result.Error != nil {
+		t.Fatalf("failed to seed users: %v", result.Error)
+	}
+	seeded := storedHashes(t, "after seed")
+	if len(seeded) != 2 || seeded["alice"] == "" || seeded["bob"] == "" {
+		t.Fatalf("expected a stored hash for alice and bob, got %v", seeded)
+	}
+
+	// A task rebuilt from those hashes describes the server exactly, so it must
+	// report no drift. The cleartext path can never reach this state.
+	byHash := HttpAuthUserTask{
+		App: appName,
+		Users: []HttpAuthUser{
+			{Username: "alice", Hash: seeded["alice"]},
+			{Username: "bob", Hash: seeded["bob"]},
+		},
+		State: StatePresent,
+	}
+	if plan := byHash.Plan(); !plan.InSync {
+		t.Errorf("a task rebuilt from the stored hashes should be in sync, got status %v reason %q", plan.Status, plan.Reason)
+	}
+
+	// Importing a hash onto a fresh username reproduces the credential without
+	// anyone knowing the password behind it.
+	carolHash := seeded["alice"]
+	addCarol := HttpAuthUserTask{
+		App:   appName,
+		Users: []HttpAuthUser{{Username: "carol", Hash: carolHash}},
+		State: StatePresent,
+	}
+	result := addCarol.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to import carol: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected Changed=true when importing a new user by hash")
+	}
+	if got := storedHashes(t, "after import")["carol"]; got != carolHash {
+		t.Errorf("carol's stored hash = %q, want %q", got, carolHash)
+	}
+	// The hash rides on stdin, so it must not appear in any rendered command.
+	for _, c := range result.Commands {
+		if strings.Contains(c, carolHash) {
+			t.Errorf("hash leaked into a rendered command: %q", c)
+		}
+	}
+
+	// Re-importing the same hash is a no-op, even with update_password set:
+	// the stored hash is readable, so the comparison wins over the flag.
+	repeat := HttpAuthUserTask{
+		App:            appName,
+		Users:          []HttpAuthUser{{Username: "carol", Hash: carolHash}},
+		UpdatePassword: boolPtr(true),
+		State:          StatePresent,
+	}
+	if result := repeat.Execute(); result.Error != nil {
+		t.Fatalf("failed idempotent import: %v", result.Error)
+	} else if result.Changed {
+		t.Error("expected Changed=false when the stored hash already matches")
+	}
+
+	// A rotated hash converges without update_password, which the cleartext
+	// path cannot do because a password is never readable.
+	rotate := HttpAuthUserTask{
+		App:   appName,
+		Users: []HttpAuthUser{{Username: "carol", Hash: seeded["bob"]}},
+		State: StatePresent,
+	}
+	if result := rotate.Execute(); result.Error != nil {
+		t.Fatalf("failed to rotate carol's hash: %v", result.Error)
+	} else if !result.Changed {
+		t.Error("expected Changed=true when the desired hash differs from the stored one")
+	}
+	if got := storedHashes(t, "after rotate")["carol"]; got != seeded["bob"] {
+		t.Errorf("carol's stored hash = %q, want the rotated value", got)
+	}
+
+	// state: set with an all-hash list goes through import-users --replace, so
+	// the app ends up with exactly the listed users.
+	setTask := HttpAuthUserTask{
+		App:   appName,
+		Users: []HttpAuthUser{{Username: "alice", Hash: seeded["alice"]}},
+		State: StateSet,
+	}
+	result = setTask.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed to set users: %v", result.Error)
+	}
+	if !result.Changed {
+		t.Error("expected Changed=true when the set drops users")
+	}
+	// commands/apply.go relies on the resulting state matching the desired one.
+	if result.State != StateSet {
+		t.Errorf("expected state 'set', got '%s'", result.State)
+	}
+	if got := usernames(t, "after set"); !reflect.DeepEqual(got, []string{"alice"}) {
+		t.Errorf("users after set = %v, want [alice]", got)
+	}
+	if result := setTask.Execute(); result.Error != nil {
+		t.Fatalf("failed idempotent set: %v", result.Error)
+	} else if result.Changed {
+		t.Error("expected Changed=false on idempotent set")
+	}
+
+	// A set carrying a cleartext password cannot use --replace, since a
+	// password has no htpasswd line to stream; it removes the strays and
+	// upserts instead, and still lands the exact set.
+	mixed := HttpAuthUserTask{
+		App: appName,
+		Users: []HttpAuthUser{
+			{Username: "bob", Hash: seeded["bob"]},
+			{Username: "dave", Password: "dave-pass"},
+		},
+		State: StateSet,
+	}
+	result = mixed.Execute()
+	if result.Error != nil {
+		t.Fatalf("failed mixed set: %v", result.Error)
+	}
+	for _, c := range result.Commands {
+		if strings.Contains(c, "--replace") {
+			t.Errorf("a set containing a cleartext password must not use --replace, got %v", result.Commands)
+		}
+	}
+	if got := usernames(t, "after mixed set"); !reflect.DeepEqual(got, []string{"bob", "dave"}) {
+		t.Errorf("users after mixed set = %v, want [bob dave]", got)
 	}
 }

--- a/tasks/http_auth_user_task_test.go
+++ b/tasks/http_auth_user_task_test.go
@@ -1,10 +1,14 @@
 package tasks
 
 import (
+	"context"
+	"io"
 	"reflect"
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/dokku/docket/subprocess"
 
 	_ "github.com/gliderlabs/sigil/builtin"
 )
@@ -50,14 +54,120 @@ func TestHttpAuthUserTaskPresentEmptyUsers(t *testing.T) {
 	}
 }
 
-func TestHttpAuthUserTaskPresentWithoutPassword(t *testing.T) {
+func TestHttpAuthUserTaskPresentWithoutCredential(t *testing.T) {
 	task := HttpAuthUserTask{App: "test-app", Users: []HttpAuthUser{{Username: "admin"}}, State: StatePresent}
 	result := task.Execute()
 	if result.Error == nil {
-		t.Fatal("expected error when a present user has no password")
+		t.Fatal("expected error when a present user has neither password nor hash")
 	}
-	if !strings.Contains(result.Error.Error(), "'password' is required") {
+	if !strings.Contains(result.Error.Error(), "one of 'password' or 'hash' is required") {
 		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestHttpAuthUserTaskSetWithoutCredential(t *testing.T) {
+	task := HttpAuthUserTask{App: "test-app", Users: []HttpAuthUser{{Username: "admin"}}, State: StateSet}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when a set user has neither password nor hash")
+	}
+	if !strings.Contains(result.Error.Error(), "one of 'password' or 'hash' is required") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestHttpAuthUserTaskSetEmptyUsers(t *testing.T) {
+	task := HttpAuthUserTask{App: "test-app", State: StateSet}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when state=set has no users")
+	}
+	if !strings.Contains(result.Error.Error(), "'users' must not be empty for state 'set'") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+// TestHttpAuthUserTaskPasswordAndHashAreExclusive pins the either/or that the
+// generated parameter table cannot express: the two credential forms dispatch
+// to different dokku commands, so a user carrying both has no defined meaning.
+func TestHttpAuthUserTaskPasswordAndHashAreExclusive(t *testing.T) {
+	task := HttpAuthUserTask{
+		App:   "test-app",
+		Users: []HttpAuthUser{{Username: "admin", Password: "secret", Hash: "$6$abc$def"}},
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when a user carries both password and hash")
+	}
+	if !strings.Contains(result.Error.Error(), "mutually exclusive") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+func TestHttpAuthUserTaskDuplicateUsernameRejected(t *testing.T) {
+	// Once the credential forms split across import-users and add-user, the
+	// winner for a repeated username would depend on nothing but list order.
+	task := HttpAuthUserTask{
+		App: "test-app",
+		Users: []HttpAuthUser{
+			{Username: "admin", Hash: "$6$abc$def"},
+			{Username: "admin", Password: "secret"},
+		},
+	}
+	result := task.Execute()
+	if result.Error == nil {
+		t.Fatal("expected error when a username is listed twice")
+	}
+	if !strings.Contains(result.Error.Error(), "listed more than once") {
+		t.Errorf("unexpected error: %v", result.Error)
+	}
+}
+
+// TestHttpAuthUserTaskHashFramingRejected covers the guard on the stdin stream
+// docket frames itself: a colon in the username or a newline in either half
+// would write a corrupt htpasswd through http-auth:import-users.
+func TestHttpAuthUserTaskHashFramingRejected(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		user HttpAuthUser
+		want string
+	}{
+		{
+			name: "colon in username",
+			user: HttpAuthUser{Username: "ad:min", Hash: "$6$abc$def"},
+			want: "must not contain ':'",
+		},
+		{
+			name: "newline in hash",
+			user: HttpAuthUser{Username: "admin", Hash: "$6$abc$def\nroot:$6$evil"},
+			want: "must not contain newlines",
+		},
+		{
+			name: "newline in username",
+			user: HttpAuthUser{Username: "admin\nroot", Hash: "$6$abc$def"},
+			want: "must not contain newlines",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			task := HttpAuthUserTask{App: "test-app", Users: []HttpAuthUser{tc.user}}
+			result := task.Execute()
+			if result.Error == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+			if !strings.Contains(result.Error.Error(), tc.want) {
+				t.Errorf("unexpected error: %v", result.Error)
+			}
+		})
+	}
+}
+
+// TestHttpAuthUserTaskPasswordUsernameColonAllowed pins that the framing guard
+// is scoped to the hash form. A password goes on argv, never into the htpasswd
+// stream docket writes, so no recipe that validates today starts failing.
+func TestHttpAuthUserTaskPasswordUsernameColonAllowed(t *testing.T) {
+	task := HttpAuthUserTask{App: "test-app", Users: []HttpAuthUser{{Username: "ad:min", Password: "secret"}}}
+	if err := task.Validate(); err != nil {
+		t.Errorf("password users should not be subject to the stdin framing guard, got: %v", err)
 	}
 }
 
@@ -78,14 +188,327 @@ func TestHttpAuthUserTaskSensitiveValues(t *testing.T) {
 		Users: []HttpAuthUser{
 			{Username: "admin", Password: "secret"},
 			{Username: "ops", Password: "hunter2"},
+			{Username: "deploy", Hash: "$6$salt$hash"},
 			{Username: "guest"},
 		},
 	}
 	got := task.SensitiveValues()
 	sort.Strings(got)
-	want := []string{"hunter2", "secret"}
+	// The hash reproduces the user without the password behind it, so it is
+	// masked alongside the cleartext values.
+	want := []string{"$6$salt$hash", "hunter2", "secret"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("SensitiveValues() = %v, want %v", got, want)
+	}
+}
+
+// httpAuthUserFixture is the canned server the hash plan tests share: alice and
+// bob exist with the given hashes, and both the report and export-users answer
+// consistently.
+func httpAuthUserFixture(entries string, usernames string) map[string]string {
+	return map[string]string{
+		"http-auth:report test-app --format json": `{"enabled":"true","users":"` + usernames + `","allowed-ips":"","domains":""}`,
+		"--quiet http-auth:export-users test-app": entries,
+	}
+}
+
+const (
+	aliceHash = "$6$aaaa$AAAA"
+	bobHash   = "$6$bbbb$BBBB"
+)
+
+// TestHttpAuthUserTaskHashInSync is the property the cleartext path could never
+// have: because http-auth:export-users reads the stored hash back, a task that
+// already matches the server plans nothing.
+func TestHttpAuthUserTaskHashInSync(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(httpAuthUserFixture(
+		"alice:"+aliceHash+"\nbob:"+bobHash+"\n", "alice bob")))()
+
+	plan := HttpAuthUserTask{
+		App:   "test-app",
+		Users: []HttpAuthUser{{Username: "alice", Hash: aliceHash}},
+		State: StatePresent,
+	}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if !plan.InSync {
+		t.Fatalf("expected in-sync for a matching hash, got status %v reason %q", plan.Status, plan.Reason)
+	}
+	if len(plan.Commands) != 0 {
+		t.Errorf("expected no commands when in sync, got %v", plan.Commands)
+	}
+}
+
+// TestHttpAuthUserTaskHashIgnoresUpdatePassword guards the branch ordering: the
+// stored-hash comparison has to win over the update_password arm, or a matching
+// hash user would be re-imported on every run and Changed would never be false.
+func TestHttpAuthUserTaskHashIgnoresUpdatePassword(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(httpAuthUserFixture(
+		"alice:"+aliceHash+"\n", "alice")))()
+
+	plan := HttpAuthUserTask{
+		App:            "test-app",
+		Users:          []HttpAuthUser{{Username: "alice", Hash: aliceHash}},
+		UpdatePassword: boolPtr(true),
+		State:          StatePresent,
+	}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if !plan.InSync {
+		t.Errorf("update_password must not disturb an already-matching hash, got status %v reason %q", plan.Status, plan.Reason)
+	}
+}
+
+func TestHttpAuthUserTaskHashDriftPlansImport(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(httpAuthUserFixture(
+		"alice:"+aliceHash+"\n", "alice")))()
+
+	plan := HttpAuthUserTask{
+		App:   "test-app",
+		Users: []HttpAuthUser{{Username: "alice", Hash: "$6$rotated$ROTATED"}},
+		State: StatePresent,
+	}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Fatal("expected drift when the stored hash differs")
+	}
+	if len(plan.Commands) != 1 || !strings.HasSuffix(plan.Commands[0], "http-auth:import-users test-app") {
+		t.Fatalf("expected a single import-users command, got %v", plan.Commands)
+	}
+	if !reflect.DeepEqual(plan.Mutations, []string{"update alice"}) {
+		t.Errorf("Mutations = %v, want [update alice]", plan.Mutations)
+	}
+	// The hash rides on stdin, so neither the rendered command nor the
+	// itemized mutations may carry it.
+	for _, s := range append(append([]string{}, plan.Commands...), plan.Mutations...) {
+		if strings.Contains(s, "ROTATED") {
+			t.Errorf("hash leaked into plan output: %q", s)
+		}
+	}
+}
+
+// TestHttpAuthUserTaskMixedPlansImportFirst pins the ordering: import-users
+// validates its whole stream before writing, so it runs before any add-user
+// that could otherwise land first and leave a partial apply behind.
+func TestHttpAuthUserTaskMixedPlansImportFirst(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(httpAuthUserFixture("", "")))()
+
+	plan := HttpAuthUserTask{
+		App: "test-app",
+		Users: []HttpAuthUser{
+			{Username: "carol", Password: "secret"},
+			{Username: "alice", Hash: aliceHash},
+		},
+		State: StatePresent,
+	}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if len(plan.Commands) != 2 {
+		t.Fatalf("expected two commands, got %v", plan.Commands)
+	}
+	if !strings.Contains(plan.Commands[0], "http-auth:import-users") {
+		t.Errorf("import-users must run first, got %v", plan.Commands)
+	}
+	if !strings.Contains(plan.Commands[1], "http-auth:add-user") {
+		t.Errorf("add-user must follow the import, got %v", plan.Commands)
+	}
+	if plan.Status != PlanStatusCreate {
+		t.Errorf("Status = %v, want create for an app with no users", plan.Status)
+	}
+}
+
+// TestHttpAuthUserTaskPasswordOnlySkipsExportUsers keeps the cleartext path on
+// exactly one report round trip: export-users is a hash overlay, not a
+// replacement for the membership probe, so a password-only recipe still works
+// against a plugin that predates the command.
+func TestHttpAuthUserTaskPasswordOnlySkipsExportUsers(t *testing.T) {
+	asked := false
+	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		joined := strings.Join(in.Args, " ")
+		if strings.Contains(joined, "export-users") {
+			asked = true
+		}
+		if strings.Contains(joined, "http-auth:report") {
+			return subprocess.ExecCommandResponse{Stdout: `{"enabled":"true","users":"alice","allowed-ips":"","domains":""}`}, nil
+		}
+		return subprocess.ExecCommandResponse{}, nil
+	})()
+
+	HttpAuthUserTask{
+		App:   "test-app",
+		Users: []HttpAuthUser{{Username: "alice", Password: "secret"}},
+		State: StatePresent,
+	}.Plan()
+	if asked {
+		t.Error("a password-only task must not probe http-auth:export-users")
+	}
+}
+
+// TestHttpAuthUserTaskExecuteStreamsEntries asserts the payload that never
+// appears in plan output: resolveCommands ignores Stdin, so the only way to see
+// what import-users receives is to read the reader off the exec input.
+func TestHttpAuthUserTaskExecuteStreamsEntries(t *testing.T) {
+	var payload string
+	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		joined := strings.Join(in.Args, " ")
+		if strings.Contains(joined, "http-auth:report") {
+			return subprocess.ExecCommandResponse{Stdout: `{"enabled":"true","users":"alice bob","allowed-ips":"","domains":""}`}, nil
+		}
+		if strings.Contains(joined, "export-users") {
+			return subprocess.ExecCommandResponse{Stdout: "alice:" + aliceHash + "\nbob:" + bobHash + "\n"}, nil
+		}
+		if in.Stdin != nil {
+			// Read once: the reader is single-use, so a second Execute in this
+			// test would see an empty stream.
+			b, err := io.ReadAll(in.Stdin)
+			if err != nil {
+				t.Fatalf("read stdin: %v", err)
+			}
+			payload = string(b)
+		}
+		return subprocess.ExecCommandResponse{}, nil
+	})()
+
+	result := HttpAuthUserTask{
+		App: "test-app",
+		Users: []HttpAuthUser{
+			{Username: "alice", Hash: aliceHash},
+			{Username: "bob", Hash: "$6$rotated$ROTATED"},
+			{Username: "carol", Hash: "$6$cccc$CCCC"},
+		},
+		State: StatePresent,
+	}.Execute()
+	if result.Error != nil {
+		t.Fatalf("Execute: %v", result.Error)
+	}
+	// alice already matches, so she is absent from the stream.
+	want := "bob:$6$rotated$ROTATED\ncarol:$6$cccc$CCCC\n"
+	if payload != want {
+		t.Errorf("import-users stdin = %q, want %q", payload, want)
+	}
+}
+
+func TestHttpAuthUserTaskSetAllHashesUsesReplace(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(httpAuthUserFixture(
+		"alice:"+aliceHash+"\nbob:"+bobHash+"\n", "alice bob")))()
+
+	plan := HttpAuthUserTask{
+		App:   "test-app",
+		Users: []HttpAuthUser{{Username: "alice", Hash: aliceHash}},
+		State: StateSet,
+	}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if plan.InSync {
+		t.Fatal("expected drift while bob is still on the app")
+	}
+	if len(plan.Commands) != 1 || !strings.HasSuffix(plan.Commands[0], "http-auth:import-users test-app --replace") {
+		t.Fatalf("expected a single --replace import, got %v", plan.Commands)
+	}
+	if !reflect.DeepEqual(plan.Mutations, []string{"remove bob"}) {
+		t.Errorf("Mutations = %v, want [remove bob]", plan.Mutations)
+	}
+	// A whole-set replacement is one operation, matching the domains and ports
+	// exporters, so removals alone still read as a modify.
+	if plan.Status != PlanStatusModify {
+		t.Errorf("Status = %v, want modify", plan.Status)
+	}
+}
+
+// TestHttpAuthUserTaskSetWithPasswordAvoidsReplace covers the fallback: a
+// cleartext password cannot be written into the htpasswd stream, so the exact
+// set is reached by removing the strays and upserting instead.
+func TestHttpAuthUserTaskSetWithPasswordAvoidsReplace(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(httpAuthUserFixture(
+		"alice:"+aliceHash+"\nbob:"+bobHash+"\n", "alice bob")))()
+
+	plan := HttpAuthUserTask{
+		App: "test-app",
+		Users: []HttpAuthUser{
+			{Username: "alice", Hash: aliceHash},
+			{Username: "carol", Password: "secret"},
+		},
+		State: StateSet,
+	}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if len(plan.Commands) != 2 {
+		t.Fatalf("expected remove + add, got %v", plan.Commands)
+	}
+	if !strings.HasSuffix(plan.Commands[0], "http-auth:remove-user test-app bob") {
+		t.Errorf("removals must lead, got %v", plan.Commands)
+	}
+	if !strings.HasSuffix(plan.Commands[1], "http-auth:add-user test-app carol secret") {
+		t.Errorf("expected add-user for the password user, got %v", plan.Commands)
+	}
+	for _, c := range plan.Commands {
+		if strings.Contains(c, "--replace") {
+			t.Errorf("--replace cannot express a set containing a cleartext password, got %v", plan.Commands)
+		}
+	}
+}
+
+func TestHttpAuthUserTaskSetInSync(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(httpAuthUserFixture(
+		"alice:"+aliceHash+"\n", "alice")))()
+
+	plan := HttpAuthUserTask{
+		App:   "test-app",
+		Users: []HttpAuthUser{{Username: "alice", Hash: aliceHash}},
+		State: StateSet,
+	}.Plan()
+	if plan.Error != nil {
+		t.Fatalf("unexpected plan error: %v", plan.Error)
+	}
+	if !plan.InSync {
+		t.Errorf("expected in-sync when the set already matches, got status %v reason %q", plan.Status, plan.Reason)
+	}
+}
+
+func TestHttpAuthUserTaskSetReportsSetState(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(httpAuthUserFixture("", "")))()
+
+	result := HttpAuthUserTask{
+		App:   "test-app",
+		Users: []HttpAuthUser{{Username: "alice", Hash: aliceHash}},
+		State: StateSet,
+	}.Execute()
+	if result.Error != nil {
+		t.Fatalf("Execute: %v", result.Error)
+	}
+	// commands/apply.go relies on State matching DesiredState, which
+	// DispatchPlan stamps as "set".
+	if result.State != StateSet {
+		t.Errorf("State = %q, want %q", result.State, StateSet)
+	}
+	if result.DesiredState != StateSet {
+		t.Errorf("DesiredState = %q, want %q", result.DesiredState, StateSet)
+	}
+}
+
+// TestGetHttpAuthUserHashesSkipsMalformedLines guards the export path: anything
+// this parser lets through lands in a recipe, and a credential-less user would
+// make `docket export` emit a body its own Validate rejects.
+func TestGetHttpAuthUserHashesSkipsMalformedLines(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet http-auth:export-users test-app": "# a comment\n\nalice:" + aliceHash + "\ntruncated:\nnoseparator\nbob:$6$b:b$BB\n",
+	}))()
+
+	got, err := getHttpAuthUserHashes("test-app")
+	if err != nil {
+		t.Fatalf("getHttpAuthUserHashes: %v", err)
+	}
+	// bob's hash contains a colon, which only the first-colon split survives.
+	want := map[string]string{"alice": aliceHash, "bob": "$6$b:b$BB"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("getHttpAuthUserHashes() = %v, want %v", got, want)
 	}
 }
 

--- a/tasks/integration_shard_test.go
+++ b/tasks/integration_shard_test.go
@@ -55,6 +55,8 @@ var integrationTestWeights = map[string]float64{
 	"TestIntegrationHaproxyPropertyAll":                     6.7,
 	"TestIntegrationHttpAuth":                               8.3,
 	"TestIntegrationHttpAuthEnableWithoutCredentials":       7.0,
+	"TestIntegrationHttpAuthUser":                           12.0,
+	"TestIntegrationHttpAuthUserHashes":                     14.0,
 	"TestIntegrationLetsencrypt":                            6.9,
 	"TestIntegrationLetsencryptPropertyAll":                 32.6,
 	"TestIntegrationLogsPropertyAll":                        11.9,

--- a/tasks/validate_test.go
+++ b/tasks/validate_test.go
@@ -772,8 +772,9 @@ func TestValidateInvalidTaskInputSkippedWithPlaceholder(t *testing.T) {
 }
 
 func TestValidateInvalidTaskInputNestedItem(t *testing.T) {
-	// http_auth_user validates each user in the list; a present user without
-	// a password is a conditional error the offline validator now catches.
+	// http_auth_user validates each user in the list; a present user with
+	// neither credential form is a conditional error the offline validator
+	// now catches.
 	data := []byte(`---
 - tasks:
     - dokku_http_auth_user:
@@ -787,8 +788,8 @@ func TestValidateInvalidTaskInputNestedItem(t *testing.T) {
 	if p == nil {
 		t.Fatalf("expected invalid_task_input problem, got: %+v", problems)
 	}
-	if !strings.Contains(p.Message, "'password' is required") {
-		t.Errorf("expected message to mention required password, got: %q", p.Message)
+	if !strings.Contains(p.Message, "one of 'password' or 'hash' is required") {
+		t.Errorf("expected message to mention the required credential, got: %q", p.Message)
 	}
 }
 

--- a/tests/bats/export.bats
+++ b/tests/bats/export.bats
@@ -145,14 +145,17 @@ teardown() {
 }
 
 @test "docket export round-trips http-auth users back onto the server" {
-  # The migration story end to end: export, drop the users, re-apply, and the
-  # stored htpasswd comes back byte-identical with no password supplied.
+  # The migration story end to end: export, drop the users, re-apply, and every
+  # credential comes back with no password supplied anywhere.
   require_plugin http-auth
   dokku apps:create docket-test-export
   dokku http-auth:enable docket-test-export testuser testpass
   dokku http-auth:add-user docket-test-export seconduser secondpass
   cd "$BATS_TEST_TMPDIR"
-  original="$(dokku http-auth:export-users docket-test-export)"
+  # Compared as a set of entries, not as a file: the exporter sorts users by
+  # username so its output is deterministic, which need not match the order the
+  # users happened to be added in. Position in an htpasswd carries no meaning.
+  dokku http-auth:export-users docket-test-export | sort >original.htpasswd
 
   run "$(docket_bin)" export --app docket-test-export --output tasks.yml --vars-output tasks.vars.yml
   assert_success
@@ -163,8 +166,9 @@ teardown() {
   run "$(docket_bin)" apply --tasks tasks.yml --vars-file tasks.vars.yml
   assert_success
 
-  restored="$(dokku http-auth:export-users docket-test-export)"
-  assert_equal "$restored" "$original"
+  dokku http-auth:export-users docket-test-export | sort >restored.htpasswd
+  run diff -u original.htpasswd restored.htpasswd
+  assert_success
 }
 
 @test "docket export --output - inlines http-auth hashes" {

--- a/tests/bats/export.bats
+++ b/tests/bats/export.bats
@@ -118,6 +118,76 @@ teardown() {
   assert_output --partial "is valid"
 }
 
+@test "docket export carries http-auth users as hashes, not password inputs" {
+  # #443: http-auth:export-users reads the stored htpasswd entries back, so the
+  # recipe reproduces the users with nothing for the operator to fill in.
+  require_plugin http-auth
+  dokku apps:create docket-test-export
+  dokku http-auth:enable docket-test-export testuser testpass
+  cd "$BATS_TEST_TMPDIR"
+  run "$(docket_bin)" export --app docket-test-export --output tasks.yml --vars-output tasks.vars.yml
+  assert_success
+
+  # The credential is expressed as a hash, and the cleartext form is absent.
+  run grep -c 'hash:' tasks.yml
+  assert_output "1"
+  run grep -q 'password:' tasks.yml
+  assert_failure
+
+  # The hash itself lives in the vars-file, with a real value rather than the
+  # empty placeholder a required password input used to get.
+  run grep -c '^docket_test_export_http_auth_hash_testuser: .\+$' tasks.vars.yml
+  assert_output "1"
+
+  # ...and the recipe references it rather than carrying it.
+  run grep -q '{{ .docket_test_export_http_auth_hash_testuser }}' tasks.yml
+  assert_success
+}
+
+@test "docket export round-trips http-auth users back onto the server" {
+  # The migration story end to end: export, drop the users, re-apply, and the
+  # stored htpasswd comes back byte-identical with no password supplied.
+  require_plugin http-auth
+  dokku apps:create docket-test-export
+  dokku http-auth:enable docket-test-export testuser testpass
+  dokku http-auth:add-user docket-test-export seconduser secondpass
+  cd "$BATS_TEST_TMPDIR"
+  original="$(dokku http-auth:export-users docket-test-export)"
+
+  run "$(docket_bin)" export --app docket-test-export --output tasks.yml --vars-output tasks.vars.yml
+  assert_success
+
+  dokku http-auth:remove-user docket-test-export testuser
+  dokku http-auth:remove-user docket-test-export seconduser
+
+  run "$(docket_bin)" apply --tasks tasks.yml --vars-file tasks.vars.yml
+  assert_success
+
+  restored="$(dokku http-auth:export-users docket-test-export)"
+  assert_equal "$restored" "$original"
+}
+
+@test "docket export --output - inlines http-auth hashes" {
+  # A streamed recipe has no companion vars-file, so the hash rides along and
+  # the pipe stays self-contained.
+  require_plugin http-auth
+  dokku apps:create docket-test-export
+  dokku http-auth:enable docket-test-export testuser testpass
+  cd "$BATS_TEST_TMPDIR"
+  stored="$(dokku http-auth:export-users docket-test-export | cut -d: -f2-)"
+  run bash -c "\"$(docket_bin)\" export --app docket-test-export --output - > streamed.yml"
+  assert_success
+
+  run grep -qF "$stored" streamed.yml
+  assert_success
+  run grep -q 'http_auth_hash' streamed.yml
+  assert_failure
+
+  run "$(docket_bin)" apply --tasks streamed.yml --list-tasks
+  assert_success
+  assert_output --partial "dokku_http_auth_user"
+}
+
 @test "docket export reports a --vars-output left unwritten for want of secrets" {
   require_dokku
   # No config:set, so nothing is sensitive and no vars-file is produced.


### PR DESCRIPTION
An exported recipe used to name each http-auth user and lift their password into a required input with an empty placeholder, so migrating a server meant reconstructing every password by hand before the recipe would apply. `http-auth:export-users` reads the stored htpasswd entries back and `http-auth:import-users` writes them from stdin, both shipped in the 0.13.0 floor docket already declares, so each user now carries a `hash` alongside the authoring-friendly `password` and the export reproduces the credentials with nothing supplied by hand. The hash is credential material, so it is masked like a password and lifted into the vars-file rather than inlined, except under `--output -`, which has no companion file and can now stream a recipe that applies as-is.

Because the stored hash is readable, a user given by hash converges on its own rather than needing `update_password`, which makes a re-applied export report in sync for the first time. A new `state: set` maps to `import-users --replace` for callers who want the app's users to be exactly the listed ones; export stays on `present` so it cannot silently delete a user that exists only on the destination.

Fixes #443
