### PR TITLE
feat: declare whether each task can probe its own state

### DIFF
--- a/commands/list_tasks.go
+++ b/commands/list_tasks.go
@@ -174,8 +174,10 @@ func renderListEnvelope(
 	skipMarker := evaluateListWhen(env, playExprCtx)
 	display := listingDisplayName(env, name)
 	deprecation := ""
+	var probe tasks.ProbeSupport
 	if env != nil && env.Task != nil {
 		deprecation = tasks.TaskDeprecation(env.Task)
+		probe, _ = tasks.TaskProbeSupport(env.Task)
 	}
 
 	if jsonOut {
@@ -197,6 +199,10 @@ func renderListEnvelope(
 		if deprecation != "" {
 			ev["deprecated"] = true
 			ev["deprecation"] = deprecation
+		}
+		if probe.Status == tasks.ProbeUnsupported || probe.Status == tasks.ProbePartial {
+			ev["probe"] = string(probe.Status)
+			ev["probe_caveat"] = probe.Caveat
 		}
 		switch skipMarker {
 		case "skipped":
@@ -241,6 +247,12 @@ func renderListEnvelope(
 		}
 		if deprecation != "" {
 			b.WriteString("  (deprecated)")
+		}
+		switch probe.Status {
+		case tasks.ProbeUnsupported:
+			b.WriteString("  (never converges)")
+		case tasks.ProbePartial:
+			b.WriteString("  (partial probe)")
 		}
 		if len(env.Tags) > 0 {
 			b.WriteString(fmt.Sprintf("  [tags=%s]", strings.Join(env.Tags, ",")))

--- a/commands/list_tasks_test.go
+++ b/commands/list_tasks_test.go
@@ -65,6 +65,46 @@ func TestApplyListTasksUnnamedTasksShowBodyIdentifier(t *testing.T) {
 	}
 }
 
+// TestApplyListTasksMarksProbeSupport pins the probe markers: a task type
+// that cannot read its own state plans as drift on every run, so --list-tasks
+// says so up front rather than leaving the user to infer it from a perpetual
+// `~` in plan output. The two markers are distinct because they mean different
+// things: `(never converges)` is total, `(partial probe)` converges for the
+// fields it does read. A task that probes everything it manages is unmarked.
+func TestApplyListTasksMarksProbeSupport(t *testing.T) {
+	defer stubReset()
+	path := writeTasksFile(t, `---
+- tasks:
+    - name: unprobeable
+      dokku_git_auth:
+        host: github.com
+        username: deploy-bot
+        password: examplepassword
+    - name: partially probed
+      dokku_git_from_image:
+        app: api
+        image: dokku/smoke-test-app:dockerfile
+    - name: fully probed
+      dokku_app: { app: api }
+`)
+	stdout, _, exit := runApply(t, path, "--list-tasks")
+	if exit != 0 {
+		t.Fatalf("exit = %d, want 0; stdout=%s", exit, stdout)
+	}
+	for _, want := range []string{
+		"[0] unprobeable  (never converges)",
+		"[1] partially probed  (partial probe)",
+		"[2] fully probed",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("expected %q in the listing; got:\n%s", want, stdout)
+		}
+	}
+	if strings.Contains(stdout, "fully probed  (") {
+		t.Errorf("a fully probed task should carry no probe marker; got:\n%s", stdout)
+	}
+}
+
 // TestApplyListTasksHonorsTags pins the interaction with --tags: the
 // listing should omit tasks the tag filter would drop, just like the
 // executor does.
@@ -245,6 +285,10 @@ func TestListTasksJSONMatchesSchema(t *testing.T) {
     - name: deprecated
       dokku_storage_ensure:
         app: api
+    - name: partially probed
+      dokku_git_from_image:
+        app: api
+        image: dokku/smoke-test-app:dockerfile
     - name: group
       block:
         - name: in block
@@ -272,6 +316,9 @@ func TestListTasksJSONMatchesSchema(t *testing.T) {
 		`"skipped":true`,
 		`"unknown":true`,
 		`"deprecated":true`,
+		`"probe":"unsupported"`,
+		`"probe":"partial"`,
+		`"probe_caveat":`,
 		`"group":true`,
 		`"phase":"block"`,
 		`"phase":"rescue"`,

--- a/docs/ansible-dokku.md
+++ b/docs/ansible-dokku.md
@@ -194,10 +194,19 @@ Ansible's `check_mode` maps onto `plan`, which reads the server and reports what
 without mutating anything. Per task, `would_change` feeds `changed` and `mutations` - an itemized list
 of the operations `apply` would perform - feeds `diff`.
 
-A few tasks cannot read their state without running the underlying command (notably `dokku_git_auth`,
-`dokku_registry_auth`, and `dokku_storage_ensure`); they always report drift with a `(... not probed)`
-reason. When the probe itself fails - no `dokku` binary, unreachable host - the task reports
-`"status": "error"` and `plan` exits `1` rather than optimistically predicting a create.
+Some tasks cannot read their state without running the underlying command, so they report drift on
+every run and never converge. Which ones is a declared per-task property rather than a fixed list:
+each task's [reference page](tasks/README.md) carries a **Probe support** section, the tasks index
+marks them `(never converges)`, and `--list-tasks --json` carries a `probe` field
+(`unsupported` for a task that reads nothing, `partial` for one that reads only some of its fields)
+plus a `probe_caveat` naming what cannot be read. A wrapper that reports "no changes needed" should
+read that field rather than treating a perpetual `would_change` as a bug.
+
+That is a different thing from a probe that fails at runtime. When the probe itself fails - no
+`dokku` binary, unreachable host - the task reports `"status": "error"` and `plan` exits `1` rather
+than optimistically predicting a create. When a probe is merely inconclusive - an unknown property
+key, an older plugin that rejects `:report --format json` - the task emits a `warning` event and
+still mutates.
 
 ### Secrets
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -208,9 +208,14 @@ Plan: 1 task(s); 1 would change, 0 in sync, 0 error(s).
 ```
 
 The same probe drives `apply`: each task reads the server once, and `apply` reuses that read to
-decide whether to mutate. A few tasks (notably `dokku_git_auth`, `dokku_registry_auth`, and
-`dokku_storage_ensure`) cannot read their state without running the underlying command, so they
-always report drift with a `(... not probed)` reason.
+decide whether to mutate. How much of its own state a task can read is a per-task property: each
+task's reference page carries a **Probe support** section stating whether it is supported, partial
+(some fields have no read command), or not supported. A task that is not supported reports drift on
+every run - it can never converge, so a recipe containing one never exits `0` under
+`--detailed-exitcode`, no matter how many times you apply it. The [tasks index](tasks/README.md)
+marks those with `(never converges)`, and `--list-tasks` marks them per recipe (see
+[Inspecting and resuming](#inspecting-and-resuming)). Gate a deploy on the rest by moving those
+tasks behind a tag and planning with `--skip-tags`.
 
 When the probe command cannot run at all - for example the local `dokku` CLI is not installed, or
 the configured SSH host is unreachable - the task renders `[!]` and `plan` exits `1`, rather than
@@ -324,6 +329,23 @@ $ docket apply --list-tasks
 A `when:` that is false against the inputs renders as `[skipped]`. A `when:` that references
 `.registered.<name>` cannot be decided without running earlier tasks, so it renders as `[unknown]`
 rather than guessing.
+
+A task whose type is deprecated is marked `(deprecated)`. A task whose type cannot read its own
+state is marked `(never converges)`, and one that can read only part of it is marked
+`(partial probe)` - both come from the same declaration the reference pages render as **Probe
+support**, so this is the way to find out which tasks in a recipe will report drift forever before
+running anything:
+
+```text
+$ docket apply --list-tasks
+==> Play: api
+[0] dokku apps:create api  [tags=core]
+[1] dokku git:auth github.com  (never converges)
+[2] dokku git:from-image api  (partial probe)
+```
+
+With `--json`, the same information is a `probe` field (`unsupported` or `partial`) plus a
+`probe_caveat` naming what cannot be read; a task that probes everything it manages carries neither.
 
 `--start-at-task <name>` takes an exact task `name:`. Earlier tasks render as `[skipped]` with a
 `(before --start-at-task)` reason and do not run; the matched task and everything after it run:

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -55,6 +55,14 @@ example server stderr echoed by a rejected probe) renders as `***`. `--list-task
 emit a separate `warning` event; instead, the `list_task` event for a deprecated task carries
 `"deprecated": true` and a `deprecation` field with the message.
 
+`unknown_property` and `probe_rejected` are probe failures: this run could not read the state, and
+another run against a different server or a newer plugin might. A task type that can *never* read
+its state is a different thing, declared rather than discovered, and it is not a warning at all. The
+`list_task` event carries it as `"probe": "unsupported"` (the task reports drift on every run) or
+`"probe": "partial"` (only some of its fields are read), each with a `probe_caveat` naming what
+cannot be read. Both keys are absent for a task that probes everything it manages. A recipe
+containing an `unsupported` task never exits `0` under `--detailed-exitcode`.
+
 ## Commands
 
 Both `task` flavors include `commands` as an array of resolved, masked `dokku` command strings. It

--- a/docs/schemas/list-tasks-v1.schema.json
+++ b/docs/schemas/list-tasks-v1.schema.json
@@ -66,6 +66,15 @@
           "type": "string",
           "description": "The deprecation notice. --list-tasks --json carries it here instead of emitting a separate warning event."
         },
+        "probe": {
+          "type": "string",
+          "enum": ["partial", "unsupported"],
+          "description": "How much of its own state the task type can read. `unsupported` means it plans as drift on every run and never converges; `partial` means some of its fields do. Absent when the task probes everything it manages."
+        },
+        "probe_caveat": {
+          "type": "string",
+          "description": "Human-readable note naming what cannot be read. Present whenever `probe` is."
+        },
         "skipped": {
           "type": "boolean",
           "const": true,

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -2,6 +2,8 @@
 
 Reference for every task type docket can run inside a recipe. Each page lists the task's fields and example usage. These pages are generated from the task definitions with `make docs`.
 
+A task marked `(never converges)` cannot read its own state, so it plans as drift on every run. See the Probe support section on its page.
+
 - [dokku_acl_app](dokku_acl_app.md) - Manages the dokku-acl access list for a dokku application
 - [dokku_acl_service](dokku_acl_service.md) - Manages the dokku-acl access list for a dokku service
 - [dokku_app](dokku_app.md) - Creates or destroys an app
@@ -28,7 +30,7 @@ Reference for every task type docket can run inside a recipe. Each page lists th
 - [dokku_docker_options](dokku_docker_options.md) - Manages docker-options for a given dokku application
 - [dokku_domains](dokku_domains.md) - Manages the domains for a given dokku application or globally
 - [dokku_domains_toggle](dokku_domains_toggle.md) - Enables or disables the domains plugin for a given dokku application
-- [dokku_git_auth](dokku_git_auth.md) - Manages netrc credentials for a git host
+- [dokku_git_auth](dokku_git_auth.md) - Manages netrc credentials for a git host (never converges)
 - [dokku_git_from_archive](dokku_git_from_archive.md) - Deploys a git repository from an archive URL
 - [dokku_git_from_image](dokku_git_from_image.md) - Deploys a git repository from a docker image
 - [dokku_git_property](dokku_git_property.md) - Manages the git configuration for a given dokku application
@@ -53,7 +55,7 @@ Reference for every task type docket can run inside a recipe. Each page lists th
 - [dokku_proxy_toggle](dokku_proxy_toggle.md) - Enables or disables the proxy plugin for a given dokku application
 - [dokku_ps_property](dokku_ps_property.md) - Manages the ps configuration for a given dokku application
 - [dokku_ps_scale](dokku_ps_scale.md) - Manages the process scale for a given dokku application
-- [dokku_registry_auth](dokku_registry_auth.md) - Manages docker registry authentication for a dokku application or globally
+- [dokku_registry_auth](dokku_registry_auth.md) - Manages docker registry authentication for a dokku application or globally (never converges)
 - [dokku_registry_property](dokku_registry_property.md) - Manages the registry configuration for a given dokku application
 - [dokku_resource_limit](dokku_resource_limit.md) - Manages the resource limits for a given dokku application
 - [dokku_resource_reserve](dokku_resource_reserve.md) - Manages the resource reservations for a given dokku application
@@ -69,9 +71,9 @@ Reference for every task type docket can run inside a recipe. Each page lists th
 - [dokku_service_create](dokku_service_create.md) - Creates or destroys a dokku service
 - [dokku_service_expose](dokku_service_expose.md) - Exposes or unexposes a dokku service on host ports
 - [dokku_service_link](dokku_service_link.md) - Links or unlinks a dokku service to an app
-- [dokku_service_property](dokku_service_property.md) - Manages a property for a given dokku service
+- [dokku_service_property](dokku_service_property.md) - Manages a property for a given dokku service (never converges)
 - [dokku_ssh_key](dokku_ssh_key.md) - Manages an SSH public key for git push access via dokku's ssh-keys plugin
-- [dokku_storage_ensure](dokku_storage_ensure.md) - Ensures the storage for a given dokku application (deprecated)
+- [dokku_storage_ensure](dokku_storage_ensure.md) - Ensures the storage for a given dokku application (deprecated) (never converges)
 - [dokku_storage_entry](dokku_storage_entry.md) - Creates or destroys a named storage registry entry
 - [dokku_storage_mount](dokku_storage_mount.md) - Attaches or detaches storage on a dokku application
 - [dokku_traefik_property](dokku_traefik_property.md) - Manages the traefik configuration for a given dokku application

--- a/docs/tasks/dokku_acl_app.md
+++ b/docs/tasks/dokku_acl_app.md
@@ -12,6 +12,10 @@ Manages the dokku-acl access list for a dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_acl_service.md
+++ b/docs/tasks/dokku_acl_service.md
@@ -12,6 +12,10 @@ Manages the dokku-acl access list for a dokku service
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_app.md
+++ b/docs/tasks/dokku_app.md
@@ -8,6 +8,10 @@ Creates or destroys an app
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_app_clone.md
+++ b/docs/tasks/dokku_app_clone.md
@@ -8,6 +8,10 @@ Clones an existing dokku app to a new app
 
 Not supported - an imperative clone operation, not reconstructable state.
 
+## Probe support
+
+Partial - only the target app's existence is probed; the clone source and the cloned contents are never read back.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_app_json_property.md
+++ b/docs/tasks/dokku_app_json_property.md
@@ -8,6 +8,10 @@ Manages the app.json configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_app_lock.md
+++ b/docs/tasks/dokku_app_lock.md
@@ -8,6 +8,10 @@ Locks or unlocks a dokku application from deployment
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_apps_property.md
+++ b/docs/tasks/dokku_apps_property.md
@@ -8,6 +8,10 @@ Manages the apps plugin configuration for a given dokku application or globally
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_builder_dockerfile_property.md
+++ b/docs/tasks/dokku_builder_dockerfile_property.md
@@ -8,6 +8,10 @@ Manages the builder-dockerfile configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_builder_herokuish_property.md
+++ b/docs/tasks/dokku_builder_herokuish_property.md
@@ -8,6 +8,10 @@ Manages the builder-herokuish configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_builder_lambda_property.md
+++ b/docs/tasks/dokku_builder_lambda_property.md
@@ -8,6 +8,10 @@ Manages the builder-lambda configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_builder_nixpacks_property.md
+++ b/docs/tasks/dokku_builder_nixpacks_property.md
@@ -8,6 +8,10 @@ Manages the builder-nixpacks configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_builder_pack_property.md
+++ b/docs/tasks/dokku_builder_pack_property.md
@@ -8,6 +8,10 @@ Manages the builder-pack configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_builder_property.md
+++ b/docs/tasks/dokku_builder_property.md
@@ -8,6 +8,10 @@ Manages the builder configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_builder_railpack_property.md
+++ b/docs/tasks/dokku_builder_railpack_property.md
@@ -8,6 +8,10 @@ Manages the builder-railpack configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_buildpacks.md
+++ b/docs/tasks/dokku_buildpacks.md
@@ -8,6 +8,10 @@ Manages the buildpacks for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_buildpacks_property.md
+++ b/docs/tasks/dokku_buildpacks_property.md
@@ -8,6 +8,10 @@ Manages the buildpacks configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_builds_property.md
+++ b/docs/tasks/dokku_builds_property.md
@@ -8,6 +8,10 @@ Manages the builds configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_caddy_property.md
+++ b/docs/tasks/dokku_caddy_property.md
@@ -8,6 +8,10 @@ Manages the caddy configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_certs.md
+++ b/docs/tasks/dokku_certs.md
@@ -12,6 +12,10 @@ Manages SSL certificates for a dokku app or globally.
 
 Partial - app and global certificate PEM material is exported (via certs:show and global-cert:show) and written to the companion vars-file.
 
+## Probe support
+
+Partial - only whether a certificate is installed is probed; the certificate material is never read back, so replacing an existing certificate plans as in sync.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_checks_property.md
+++ b/docs/tasks/dokku_checks_property.md
@@ -8,6 +8,10 @@ Manages the checks configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_checks_toggle.md
+++ b/docs/tasks/dokku_checks_toggle.md
@@ -8,6 +8,10 @@ Enables or disables the checks plugin for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_config.md
+++ b/docs/tasks/dokku_config.md
@@ -8,6 +8,10 @@ Manages the configuration for a given dokku application
 
 Partial - config values are written to the companion vars-file.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_cron_property.md
+++ b/docs/tasks/dokku_cron_property.md
@@ -8,6 +8,10 @@ Manages the cron configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_docker_options.md
+++ b/docs/tasks/dokku_docker_options.md
@@ -8,6 +8,10 @@ Manages docker-options for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_domains.md
+++ b/docs/tasks/dokku_domains.md
@@ -8,6 +8,10 @@ Manages the domains for a given dokku application or globally
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_domains_toggle.md
+++ b/docs/tasks/dokku_domains_toggle.md
@@ -8,6 +8,10 @@ Enables or disables the domains plugin for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_git_auth.md
+++ b/docs/tasks/dokku_git_auth.md
@@ -8,6 +8,10 @@ Manages netrc credentials for a git host
 
 Not supported - netrc credentials are write-only and cannot be read back.
 
+## Probe support
+
+Not supported - netrc state has no read command, so the task plans as drift on every run.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_git_from_archive.md
+++ b/docs/tasks/dokku_git_from_archive.md
@@ -8,6 +8,10 @@ Deploys a git repository from an archive URL
 
 Supported.
 
+## Probe support
+
+Partial - the recorded archive source is probed; the archive contents are not hashed, so a changed archive at the same url plans as in sync.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_git_from_image.md
+++ b/docs/tasks/dokku_git_from_image.md
@@ -8,6 +8,10 @@ Deploys a git repository from a docker image
 
 Partial - the image reference is written to the companion vars-file.
 
+## Probe support
+
+Partial - the recorded image reference is probed; the image digest is not, so a mutable tag that moved plans as in sync.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_git_property.md
+++ b/docs/tasks/dokku_git_property.md
@@ -8,6 +8,10 @@ Manages the git configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_git_sync.md
+++ b/docs/tasks/dokku_git_sync.md
@@ -8,6 +8,10 @@ Syncs a git repository to a dokku application
 
 Supported.
 
+## Probe support
+
+Partial - dokku records the resolved commit as `<remote>#<sha>`, which cannot be compared against a branch or tag name, so only the remote and the persisted deploy branch are probed.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_haproxy_property.md
+++ b/docs/tasks/dokku_haproxy_property.md
@@ -8,6 +8,10 @@ Manages the haproxy configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_http_auth.md
+++ b/docs/tasks/dokku_http_auth.md
@@ -12,6 +12,10 @@ Manages HTTP authentication for a given dokku application
 
 Partial - the enabled state is exported; the seeded credentials are not carried on this task and come back as dokku_http_auth_user htpasswd hashes.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_http_auth_allowed_ip.md
+++ b/docs/tasks/dokku_http_auth_allowed_ip.md
@@ -12,6 +12,10 @@ Manages the set of IP addresses allowed to bypass HTTP auth for a dokku applicat
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_http_auth_domain.md
+++ b/docs/tasks/dokku_http_auth_domain.md
@@ -12,6 +12,10 @@ Manages the set of domains HTTP auth is restricted to for a dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_http_auth_user.md
+++ b/docs/tasks/dokku_http_auth_user.md
@@ -12,6 +12,10 @@ Manages the set of HTTP auth users for a dokku application
 
 Supported.
 
+## Probe support
+
+Partial - an existing user's htpasswd hash is probed; a cleartext password is not readable, so a user that already exists converges only when update_password forces it.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_letsencrypt.md
+++ b/docs/tasks/dokku_letsencrypt.md
@@ -12,6 +12,10 @@ Enables or disables letsencrypt SSL certificates for a dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_letsencrypt_property.md
+++ b/docs/tasks/dokku_letsencrypt_property.md
@@ -12,6 +12,10 @@ Manages the letsencrypt configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Partial - the mapped properties are probed; the dynamic `dns-provider-*` family has no report key and plans as drift on every run.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_logs_property.md
+++ b/docs/tasks/dokku_logs_property.md
@@ -8,6 +8,10 @@ Manages the logs configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_maintenance.md
+++ b/docs/tasks/dokku_maintenance.md
@@ -12,6 +12,10 @@ Enables or disables maintenance mode for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_maintenance_custom_page.md
+++ b/docs/tasks/dokku_maintenance_custom_page.md
@@ -12,6 +12,10 @@ Installs or removes a custom maintenance page for a dokku application.
 
 Partial - export reads the current page back via maintenance:custom-page-export and inlines maintenance.html as content. Multi-file tarball pages collapse to that single content field, so extra assets are not captured. On an older dokku-maintenance without the export command the content cannot be read back and is lifted into a required content input the user supplies before apply.
 
+## Probe support
+
+Partial - the page checksum is probed when the plugin reports it; plugin versions that do not report it make the page plan as drift on every run.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_network.md
+++ b/docs/tasks/dokku_network.md
@@ -8,6 +8,10 @@ Creates or destroys a Docker network
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_network_property.md
+++ b/docs/tasks/dokku_network_property.md
@@ -8,6 +8,10 @@ Manages the network property for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_nginx_property.md
+++ b/docs/tasks/dokku_nginx_property.md
@@ -8,6 +8,10 @@ Manages the nginx configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_openresty_property.md
+++ b/docs/tasks/dokku_openresty_property.md
@@ -8,6 +8,10 @@ Manages the openresty configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_plugin.md
+++ b/docs/tasks/dokku_plugin.md
@@ -8,6 +8,10 @@ Installs or uninstalls a third-party dokku plugin. Installation is a root-level 
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_ports.md
+++ b/docs/tasks/dokku_ports.md
@@ -8,6 +8,10 @@ Manages the ports for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_proxy_property.md
+++ b/docs/tasks/dokku_proxy_property.md
@@ -8,6 +8,10 @@ Manages the proxy configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_proxy_toggle.md
+++ b/docs/tasks/dokku_proxy_toggle.md
@@ -8,6 +8,10 @@ Enables or disables the proxy plugin for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_ps_property.md
+++ b/docs/tasks/dokku_ps_property.md
@@ -8,6 +8,10 @@ Manages the ps configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_ps_scale.md
+++ b/docs/tasks/dokku_ps_scale.md
@@ -8,6 +8,10 @@ Manages the process scale for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_registry_auth.md
+++ b/docs/tasks/dokku_registry_auth.md
@@ -8,6 +8,10 @@ Manages docker registry authentication for a dokku application or globally
 
 Not supported - registry login credentials are write-only and cannot be read back.
 
+## Probe support
+
+Not supported - registry login state has no read command, so the task plans as drift on every run.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_registry_property.md
+++ b/docs/tasks/dokku_registry_property.md
@@ -8,6 +8,10 @@ Manages the registry configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_resource_limit.md
+++ b/docs/tasks/dokku_resource_limit.md
@@ -8,6 +8,10 @@ Manages the resource limits for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_resource_reserve.md
+++ b/docs/tasks/dokku_resource_reserve.md
@@ -8,6 +8,10 @@ Manages the resource reservations for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_scheduler_docker_local_property.md
+++ b/docs/tasks/dokku_scheduler_docker_local_property.md
@@ -8,6 +8,10 @@ Manages the scheduler-docker-local configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_scheduler_k3s_annotations.md
+++ b/docs/tasks/dokku_scheduler_k3s_annotations.md
@@ -8,6 +8,10 @@ Manages scheduler-k3s annotations scoped to a (process_type, resource_type) pair
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_scheduler_k3s_autoscaling_auth.md
+++ b/docs/tasks/dokku_scheduler_k3s_autoscaling_auth.md
@@ -8,6 +8,10 @@ Manages KEDA TriggerAuthentication metadata grouped under a single trigger for a
 
 Partial - trigger authentication metadata values are secrets, so they are written to the companion vars-file.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_scheduler_k3s_chart.md
+++ b/docs/tasks/dokku_scheduler_k3s_chart.md
@@ -8,6 +8,10 @@ Manages helm chart value overrides for a dokku scheduler-k3s bundled chart
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_scheduler_k3s_labels.md
+++ b/docs/tasks/dokku_scheduler_k3s_labels.md
@@ -8,6 +8,10 @@ Manages scheduler-k3s labels scoped to a (process_type, resource_type) pair for 
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_scheduler_k3s_profile.md
+++ b/docs/tasks/dokku_scheduler_k3s_profile.md
@@ -8,6 +8,10 @@ Manages a global scheduler-k3s node profile used when joining nodes to a cluster
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_scheduler_k3s_property.md
+++ b/docs/tasks/dokku_scheduler_k3s_property.md
@@ -8,6 +8,10 @@ Manages the scheduler-k3s configuration for a given dokku application. chart.* p
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_scheduler_property.md
+++ b/docs/tasks/dokku_scheduler_property.md
@@ -8,6 +8,10 @@ Manages the scheduler configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_service_backup.md
+++ b/docs/tasks/dokku_service_backup.md
@@ -12,6 +12,10 @@ Manages the S3 backup schedule, authentication, and encryption for a dokku servi
 
 Partial - the backup schedule, bucket, and use_iam flag are exported; the AWS credentials and encryption passphrase are write-only and must be re-supplied before the recipe can back up.
 
+## Probe support
+
+Partial - the backup schedule and bucket are probed; the AWS credentials and the encryption passphrase have no read command and are re-applied on every run when supplied.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_service_create.md
+++ b/docs/tasks/dokku_service_create.md
@@ -12,6 +12,10 @@ Creates or destroys a dokku service
 
 Partial - the service and the image it is running are exported; the remaining create-time options (config_options, custom_env, memory, shm_size, the networks, and the passwords) have no read command and must be re-supplied.
 
+## Probe support
+
+Partial - the service's existence and image are probed; config_options, custom_env, memory, shm_size, the networks, and the passwords have no read command and are not drift-detected.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_service_expose.md
+++ b/docs/tasks/dokku_service_expose.md
@@ -12,6 +12,10 @@ Exposes or unexposes a dokku service on host ports
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_service_link.md
+++ b/docs/tasks/dokku_service_link.md
@@ -12,6 +12,10 @@ Links or unlinks a dokku service to an app
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_service_property.md
+++ b/docs/tasks/dokku_service_property.md
@@ -12,6 +12,10 @@ Manages a property for a given dokku service
 
 Not supported - no datastore plugin exposes a machine-readable report of the properties set via `<service>:set`, so they cannot be read back (tracked upstream in dokku/dokku-datastore#98).
 
+## Probe support
+
+Not supported - the service's existence is probed but the property value is not, so the task plans as drift on every run.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_ssh_key.md
+++ b/docs/tasks/dokku_ssh_key.md
@@ -8,6 +8,10 @@ Manages an SSH public key for git push access via dokku's ssh-keys plugin
 
 Supported.
 
+## Probe support
+
+Supported.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_storage_ensure.md
+++ b/docs/tasks/dokku_storage_ensure.md
@@ -10,6 +10,10 @@ Ensures the storage for a given dokku application
 
 Not supported - deprecated; storage state is exported via dokku_storage_mount.
 
+## Probe support
+
+Not supported - `storage:ensure-directory` has no read command, so the task plans as drift on every run.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_storage_entry.md
+++ b/docs/tasks/dokku_storage_entry.md
@@ -8,6 +8,10 @@ Creates or destroys a named storage registry entry
 
 Supported.
 
+## Probe support
+
+Partial - idempotency is keyed on the entry name; scheduler, size, and chown changes to an existing entry are not drift-detected (tracked in dokku/docket#439).
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_storage_mount.md
+++ b/docs/tasks/dokku_storage_mount.md
@@ -8,6 +8,10 @@ Attaches or detaches storage on a dokku application
 
 Supported.
 
+## Probe support
+
+Partial - the mount source, container path, and volume options are probed; phases, process_type, subpath, readonly, and volume_chown apply at mount time and are not drift-detected.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/tasks/dokku_traefik_property.md
+++ b/docs/tasks/dokku_traefik_property.md
@@ -8,6 +8,10 @@ Manages the traefik configuration for a given dokku application
 
 Supported.
 
+## Probe support
+
+Partial - the mapped properties are probed; the dynamic `dns-provider-*` family has no report key and plans as drift on every run.
+
 ## Parameters
 
 | Parameter | Type | Required | Default | Choices | Description |

--- a/docs/writing-tasks.md
+++ b/docs/writing-tasks.md
@@ -89,6 +89,19 @@ A few conventions to follow:
   `apply` and `plan` emit a one-time `warning` line above each deprecated task's result line.
   Keep the message short and name the replacement, e.g.
   `"use dokku_storage_entry instead; storage:ensure-directory has been deprecated"`.
+- Every task must implement `ExportSupport() ExportSupport`, declaring whether `docket export` can
+  reconstruct it from a live server: `ExportSupported`, `ExportPartial`, or `ExportUnsupported`,
+  with a `Caveat` explaining anything short of supported. The generator renders it in an Export
+  support section, and a coverage test fails the build if a task ships without a decision.
+- Every task must also implement `ProbeSupport() ProbeSupport`, declaring how much of its own state
+  `Plan()` can read back: `ProbeSupported`, `ProbePartial` (some fields have no read command), or
+  `ProbeUnsupported` (none do, so the task reports drift on every run and never converges). Name
+  what cannot be read in the `Caveat`. The generator renders it in a Probe support section, the
+  tasks index marks an unsupported task `(never converges)`, and `--list-tasks` marks it the same
+  way. `TestProbeSupportMatchesPlanWiring` cross-checks the declaration against the code: a task
+  that claims it converges must have an `InSync: true` result reachable from its `Plan()`, and one
+  that claims it cannot must not. Declare it for the task type, not for the run - a probe that
+  fails on a particular server is a `PlanWarning`, not a `ProbeUnsupported` task.
 - When a task has conditional or semantic input rules that a `required:"true"` tag cannot express -
   a list that must be non-empty only when `state: present`, mutually-exclusive fields, an enum, a
   per-item requirement on a slice field - put them in the optional `Validate() error` method (the
@@ -199,15 +212,17 @@ func (t NginxPropertyTask) Plan() PlanResult {
 Keep the `PropertyKeys` map in sync with the plugin's `:report` output - that mapping is how `plan`
 and `apply` detect drift without mutating. A property whose report key only appears after it is set
 (a dynamic family such as letsencrypt's `dns-provider-*`) skips probing and is applied
-unconditionally; those are recognized by `isDynamicProperty` in `tasks/properties.go`.
+unconditionally; those are recognized by `isDynamicProperty` in `tasks/properties.go`. A task whose
+key map has such a family is `ProbePartial`, not `ProbeSupported`.
 
 ## Regenerating the task docs
 
 The per-task pages under [`docs/tasks/`](tasks/README.md) are generated from each task's `Doc()`,
-`Examples()`, and optional `Requirements()` methods plus its struct field tags - they are not
-hand-edited. Each page carries a Synopsis (from `Doc()`), a Requirements section (when the task
-implements `Requirements()`), a Parameters table (reflected from the field tags), the examples, and
-a shared Return Values table. After adding or changing a task, regenerate them:
+`Examples()`, `ExportSupport()`, `ProbeSupport()`, and optional `Requirements()` methods plus its
+struct field tags - they are not hand-edited. Each page carries a Synopsis (from `Doc()`), a
+Requirements section (when the task implements `Requirements()`), Export support and Probe support
+sections, a Parameters table (reflected from the field tags), the examples, and a shared Return
+Values table. After adding or changing a task, regenerate them:
 
 ```bash
 make docs

--- a/generate/docs.go
+++ b/generate/docs.go
@@ -227,6 +227,35 @@ func exportSupportSection(task tasks.Task) string {
 	return "## Export support\n\n" + line + "."
 }
 
+// probeSupportSection renders the Probe support section, stating whether
+// `plan` can read the task's current state before deciding on drift. Every task
+// declares this via ProbeSupport(); the section is omitted only if a task does
+// not (the probe coverage test prevents that in practice). A task rendered as
+// "Not supported" here plans as drift on every run, so it never lets
+// `plan --detailed-exitcode` exit 0.
+func probeSupportSection(task tasks.Task) string {
+	support, ok := tasks.TaskProbeSupport(task)
+	if !ok {
+		return ""
+	}
+	var label string
+	switch support.Status {
+	case tasks.ProbeSupported:
+		label = "Supported"
+	case tasks.ProbePartial:
+		label = "Partial"
+	case tasks.ProbeUnsupported:
+		label = "Not supported"
+	default:
+		label = string(support.Status)
+	}
+	line := label
+	if support.Caveat != "" {
+		line += " - " + support.Caveat
+	}
+	return "## Probe support\n\n" + line + "."
+}
+
 // deprecationSection renders the Deprecated admonition for a task that
 // implements DeprecationDocer. The notice sits between the Synopsis and
 // the Requirements/Parameters sections so the reader sees it before
@@ -301,6 +330,9 @@ func renderPage(taskName string, task tasks.Task, examples []tasks.Doc) string {
 	if es := exportSupportSection(task); es != "" {
 		sections = append(sections, es)
 	}
+	if ps := probeSupportSection(task); ps != "" {
+		sections = append(sections, ps)
+	}
 	if pt := parametersSection(buildParams(rt)); pt != "" {
 		sections = append(sections, strings.TrimRight(pt, "\n"))
 	}
@@ -355,10 +387,14 @@ func main() {
 	var index strings.Builder
 	index.WriteString("# Tasks\n\n")
 	index.WriteString("Reference for every task type docket can run inside a recipe. Each page lists the task's fields and example usage. These pages are generated from the task definitions with `make docs`.\n\n")
+	index.WriteString("A task marked `(never converges)` cannot read its own state, so it plans as drift on every run. See the Probe support section on its page.\n\n")
 	for _, name := range names {
 		suffix := ""
 		if tasks.TaskDeprecation(registeredTasks[name]) != "" {
-			suffix = " (deprecated)"
+			suffix += " (deprecated)"
+		}
+		if support, ok := tasks.TaskProbeSupport(registeredTasks[name]); ok && support.Status == tasks.ProbeUnsupported {
+			suffix += " (never converges)"
 		}
 		index.WriteString(fmt.Sprintf("- [%s](%s.md) - %s%s\n", name, name, summarize(registeredTasks[name].Doc()), suffix))
 	}

--- a/tasks/acl_app_task.go
+++ b/tasks/acl_app_task.go
@@ -43,6 +43,11 @@ func (t AclAppTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t AclAppTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Requirements lists the non-core dokku plugins this task depends on.
 func (t AclAppTask) Requirements() []string {
 	return []string{"dokku-acl plugin"}

--- a/tasks/acl_service_task.go
+++ b/tasks/acl_service_task.go
@@ -47,6 +47,11 @@ func (t AclServiceTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t AclServiceTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // ExportGlobal reconstructs the dokku-acl access list of every datastore
 // service on the server. Discovery is via listServices; the members are read
 // from `acl:list-service <type> <name>` (reusing getAclServiceUsers). Note the

--- a/tasks/app_clone_task.go
+++ b/tasks/app_clone_task.go
@@ -45,6 +45,11 @@ func (t AppCloneTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportUnsupported, Caveat: "an imperative clone operation, not reconstructable state"}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t AppCloneTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbePartial, Caveat: "only the target app's existence is probed; the clone source and the cloned contents are never read back"}
+}
+
 // Examples returns the examples for the app clone task
 func (t AppCloneTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]AppCloneTaskExample{

--- a/tasks/app_json_property_task.go
+++ b/tasks/app_json_property_task.go
@@ -42,6 +42,11 @@ func (t AppJsonPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t AppJsonPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the app.json property task
 func (t AppJsonPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]AppJsonPropertyTaskExample{

--- a/tasks/app_lock_task.go
+++ b/tasks/app_lock_task.go
@@ -39,6 +39,11 @@ func (t AppLockTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t AppLockTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the app lock task
 func (t AppLockTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]AppLockTaskExample{

--- a/tasks/app_task.go
+++ b/tasks/app_task.go
@@ -37,6 +37,11 @@ func (t AppTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t AppTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns a list of AppTaskExamples as yaml
 func (t AppTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]AppTaskExample{

--- a/tasks/apps_property_task.go
+++ b/tasks/apps_property_task.go
@@ -42,6 +42,11 @@ func (t AppsPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t AppsPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the apps property task
 func (t AppsPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]AppsPropertyTaskExample{

--- a/tasks/builder_dockerfile_property_task.go
+++ b/tasks/builder_dockerfile_property_task.go
@@ -42,6 +42,11 @@ func (t BuilderDockerfilePropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t BuilderDockerfilePropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the builder-dockerfile property task
 func (t BuilderDockerfilePropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]BuilderDockerfilePropertyTaskExample{

--- a/tasks/builder_herokuish_property_task.go
+++ b/tasks/builder_herokuish_property_task.go
@@ -42,6 +42,11 @@ func (t BuilderHerokuishPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t BuilderHerokuishPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the builder-herokuish property task
 func (t BuilderHerokuishPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]BuilderHerokuishPropertyTaskExample{

--- a/tasks/builder_lambda_property_task.go
+++ b/tasks/builder_lambda_property_task.go
@@ -42,6 +42,11 @@ func (t BuilderLambdaPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t BuilderLambdaPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the builder-lambda property task
 func (t BuilderLambdaPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]BuilderLambdaPropertyTaskExample{

--- a/tasks/builder_nixpacks_property_task.go
+++ b/tasks/builder_nixpacks_property_task.go
@@ -42,6 +42,11 @@ func (t BuilderNixpacksPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t BuilderNixpacksPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the builder-nixpacks property task
 func (t BuilderNixpacksPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]BuilderNixpacksPropertyTaskExample{

--- a/tasks/builder_pack_property_task.go
+++ b/tasks/builder_pack_property_task.go
@@ -42,6 +42,11 @@ func (t BuilderPackPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t BuilderPackPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the builder-pack property task
 func (t BuilderPackPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]BuilderPackPropertyTaskExample{

--- a/tasks/builder_property_task.go
+++ b/tasks/builder_property_task.go
@@ -42,6 +42,11 @@ func (t BuilderPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t BuilderPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the builder property task
 func (t BuilderPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]BuilderPropertyTaskExample{

--- a/tasks/builder_railpack_property_task.go
+++ b/tasks/builder_railpack_property_task.go
@@ -42,6 +42,11 @@ func (t BuilderRailpackPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t BuilderRailpackPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the builder-railpack property task
 func (t BuilderRailpackPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]BuilderRailpackPropertyTaskExample{

--- a/tasks/buildpacks_property_task.go
+++ b/tasks/buildpacks_property_task.go
@@ -42,6 +42,11 @@ func (t BuildpacksPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t BuildpacksPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the buildpacks property task
 func (t BuildpacksPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]BuildpacksPropertyTaskExample{

--- a/tasks/buildpacks_task.go
+++ b/tasks/buildpacks_task.go
@@ -46,6 +46,11 @@ func (t BuildpacksTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t BuildpacksTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the buildpacks task
 func (t BuildpacksTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]BuildpacksTaskExample{

--- a/tasks/builds_property_task.go
+++ b/tasks/builds_property_task.go
@@ -42,6 +42,11 @@ func (t BuildsPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t BuildsPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the builds property task
 func (t BuildsPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]BuildsPropertyTaskExample{

--- a/tasks/caddy_property_task.go
+++ b/tasks/caddy_property_task.go
@@ -42,6 +42,11 @@ func (t CaddyPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t CaddyPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the caddy property task
 func (t CaddyPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]CaddyPropertyTaskExample{

--- a/tasks/certs_task.go
+++ b/tasks/certs_task.go
@@ -61,6 +61,11 @@ func (t CertsTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportPartial, Caveat: "app and global certificate PEM material is exported (via certs:show and global-cert:show) and written to the companion vars-file"}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t CertsTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbePartial, Caveat: "only whether a certificate is installed is probed; the certificate material is never read back, so replacing an existing certificate plans as in sync"}
+}
+
 // Requirements lists the non-core dokku plugins this task depends on.
 func (t CertsTask) Requirements() []string {
 	return []string{"dokku-global-cert plugin (required only when global: true)"}

--- a/tasks/checks_property_task.go
+++ b/tasks/checks_property_task.go
@@ -42,6 +42,11 @@ func (t ChecksPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t ChecksPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the checks property task
 func (t ChecksPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]ChecksPropertyTaskExample{

--- a/tasks/checks_toggle_task.go
+++ b/tasks/checks_toggle_task.go
@@ -76,6 +76,11 @@ func (t ChecksToggleTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t ChecksToggleTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the checks toggle task
 func (t ChecksToggleTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]ChecksToggleTaskExample{

--- a/tasks/config_task.go
+++ b/tasks/config_task.go
@@ -52,6 +52,11 @@ func (t ConfigTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportPartial, Caveat: "config values are written to the companion vars-file"}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t ConfigTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the config task
 func (t ConfigTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]ConfigTaskExample{

--- a/tasks/cron_property_task.go
+++ b/tasks/cron_property_task.go
@@ -42,6 +42,11 @@ func (t CronPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t CronPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the cron property task
 func (t CronPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]CronPropertyTaskExample{

--- a/tasks/docker_options_task.go
+++ b/tasks/docker_options_task.go
@@ -60,6 +60,11 @@ func (t DockerOptionsTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t DockerOptionsTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // ExportApp reconstructs the app's docker options as one task per individual
 // option, per (phase, process type). Options are read from the structured
 // `<phase>-list` report keys (dokku/dokku#8799), so each stored option -

--- a/tasks/domains_task.go
+++ b/tasks/domains_task.go
@@ -46,6 +46,11 @@ func (t DomainsTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t DomainsTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the domains task
 func (t DomainsTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]DomainsTaskExample{

--- a/tasks/domains_toggle_task.go
+++ b/tasks/domains_toggle_task.go
@@ -65,6 +65,11 @@ func (t DomainsToggleTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t DomainsToggleTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the domains toggle task
 func (t DomainsToggleTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]DomainsToggleTaskExample{

--- a/tasks/git_auth_task.go
+++ b/tasks/git_auth_task.go
@@ -51,6 +51,11 @@ func (t GitAuthTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportUnsupported, Caveat: "netrc credentials are write-only and cannot be read back"}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t GitAuthTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeUnsupported, Caveat: "netrc state has no read command, so the task plans as drift on every run"}
+}
+
 // Examples returns the examples for the git auth task
 func (t GitAuthTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]GitAuthTaskExample{

--- a/tasks/git_from_archive_task.go
+++ b/tasks/git_from_archive_task.go
@@ -53,6 +53,11 @@ func (t GitFromArchiveTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t GitFromArchiveTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbePartial, Caveat: "the recorded archive source is probed; the archive contents are not hashed, so a changed archive at the same url plans as in sync"}
+}
+
 // Examples returns the examples for the git from archive task
 func (t GitFromArchiveTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]GitFromArchiveTaskExample{

--- a/tasks/git_from_image_task.go
+++ b/tasks/git_from_image_task.go
@@ -55,6 +55,11 @@ func (t GitFromImageTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportPartial, Caveat: "the image reference is written to the companion vars-file"}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t GitFromImageTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbePartial, Caveat: "the recorded image reference is probed; the image digest is not, so a mutable tag that moved plans as in sync"}
+}
+
 // Examples returns the examples for the git from image task
 func (t GitFromImageTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]GitFromImageTaskExample{

--- a/tasks/git_property_task.go
+++ b/tasks/git_property_task.go
@@ -42,6 +42,11 @@ func (t GitPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t GitPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the git property task
 func (t GitPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]GitPropertyTaskExample{

--- a/tasks/git_sync_task.go
+++ b/tasks/git_sync_task.go
@@ -57,6 +57,11 @@ func (t GitSyncTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t GitSyncTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbePartial, Caveat: "dokku records the resolved commit as `<remote>#<sha>`, which cannot be compared against a branch or tag name, so only the remote and the persisted deploy branch are probed"}
+}
+
 // Examples returns the examples for the git sync task
 func (t GitSyncTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]GitSyncTaskExample{

--- a/tasks/haproxy_property_task.go
+++ b/tasks/haproxy_property_task.go
@@ -42,6 +42,11 @@ func (t HaproxyPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t HaproxyPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the haproxy property task
 func (t HaproxyPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]HaproxyPropertyTaskExample{

--- a/tasks/http_auth_allowed_ip_task.go
+++ b/tasks/http_auth_allowed_ip_task.go
@@ -47,6 +47,11 @@ func (t HttpAuthAllowedIpTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t HttpAuthAllowedIpTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Requirements lists the non-core dokku plugins this task depends on.
 func (t HttpAuthAllowedIpTask) Requirements() []string {
 	return []string{"dokku-http-auth plugin >= 0.13.0"}

--- a/tasks/http_auth_domain_task.go
+++ b/tasks/http_auth_domain_task.go
@@ -47,6 +47,11 @@ func (t HttpAuthDomainTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t HttpAuthDomainTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Requirements lists the non-core dokku plugins this task depends on.
 func (t HttpAuthDomainTask) Requirements() []string {
 	return []string{"dokku-http-auth plugin >= 0.13.0"}

--- a/tasks/http_auth_task.go
+++ b/tasks/http_auth_task.go
@@ -48,6 +48,11 @@ func (t HttpAuthTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportPartial, Caveat: "the enabled state is exported; the seeded credentials are not carried on this task and come back as dokku_http_auth_user htpasswd hashes"}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t HttpAuthTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Requirements lists the non-core dokku plugins this task depends on.
 func (t HttpAuthTask) Requirements() []string {
 	return []string{"dokku-http-auth plugin >= 0.13.0"}

--- a/tasks/http_auth_user_task.go
+++ b/tasks/http_auth_user_task.go
@@ -93,6 +93,11 @@ func (t HttpAuthUserTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t HttpAuthUserTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbePartial, Caveat: "an existing user's htpasswd hash is probed; a cleartext password is not readable, so a user that already exists converges only when update_password forces it"}
+}
+
 // Requirements lists the non-core dokku plugins this task depends on.
 func (t HttpAuthUserTask) Requirements() []string {
 	return []string{"dokku-http-auth plugin >= 0.13.0"}

--- a/tasks/letsencrypt_property_task.go
+++ b/tasks/letsencrypt_property_task.go
@@ -44,6 +44,11 @@ func (t LetsencryptPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t LetsencryptPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbePartial, Caveat: "the mapped properties are probed; the dynamic `dns-provider-*` family has no report key and plans as drift on every run"}
+}
+
 // Requirements lists the non-core dokku plugins this task depends on.
 func (t LetsencryptPropertyTask) Requirements() []string {
 	return []string{"dokku-letsencrypt plugin"}

--- a/tasks/letsencrypt_task.go
+++ b/tasks/letsencrypt_task.go
@@ -40,6 +40,11 @@ func (t LetsencryptTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t LetsencryptTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Requirements lists the non-core dokku plugins this task depends on.
 func (t LetsencryptTask) Requirements() []string {
 	return []string{"dokku-letsencrypt plugin"}

--- a/tasks/logs_property_task.go
+++ b/tasks/logs_property_task.go
@@ -42,6 +42,11 @@ func (t LogsPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t LogsPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the logs property task
 func (t LogsPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]LogsPropertyTaskExample{

--- a/tasks/maintenance_custom_page_task.go
+++ b/tasks/maintenance_custom_page_task.go
@@ -60,6 +60,11 @@ func (t MaintenanceCustomPageTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportPartial, Caveat: "export reads the current page back via maintenance:custom-page-export and inlines maintenance.html as content. Multi-file tarball pages collapse to that single content field, so extra assets are not captured. On an older dokku-maintenance without the export command the content cannot be read back and is lifted into a required content input the user supplies before apply"}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t MaintenanceCustomPageTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbePartial, Caveat: "the page checksum is probed when the plugin reports it; plugin versions that do not report it make the page plan as drift on every run"}
+}
+
 // Requirements lists the non-core dokku plugins this task depends on.
 func (t MaintenanceCustomPageTask) Requirements() []string {
 	return []string{"dokku-maintenance plugin"}

--- a/tasks/maintenance_task.go
+++ b/tasks/maintenance_task.go
@@ -74,6 +74,11 @@ func (t MaintenanceTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t MaintenanceTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Requirements lists the non-core dokku plugins this task depends on.
 func (t MaintenanceTask) Requirements() []string {
 	return []string{"dokku-maintenance plugin"}

--- a/tasks/network_property_task.go
+++ b/tasks/network_property_task.go
@@ -42,6 +42,11 @@ func (t NetworkPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t NetworkPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the network property task
 func (t NetworkPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]NetworkPropertyTaskExample{

--- a/tasks/network_task.go
+++ b/tasks/network_task.go
@@ -41,6 +41,11 @@ func (t NetworkTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t NetworkTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns a list of NetworkTaskExamples as yaml
 func (t NetworkTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]NetworkTaskExample{

--- a/tasks/nginx_property_task.go
+++ b/tasks/nginx_property_task.go
@@ -42,6 +42,11 @@ func (t NginxPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t NginxPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the nginx property task
 func (t NginxPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]NginxPropertyTaskExample{

--- a/tasks/openresty_property_task.go
+++ b/tasks/openresty_property_task.go
@@ -42,6 +42,11 @@ func (t OpenrestyPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t OpenrestyPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the openresty property task
 func (t OpenrestyPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]OpenrestyPropertyTaskExample{

--- a/tasks/plan_result_test.go
+++ b/tasks/plan_result_test.go
@@ -4,42 +4,29 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
-// TestPlanResultCommandsContractStatic walks every *_task.go (and the shared
-// helper files properties.go / toggle.go / resources.go) in the tasks package
-// and asserts that every PlanResult composite literal carrying a non-empty
-// `apply:` field also sets `Commands:`. Catches future tasks added without
-// populating Commands when drift is reported - a regression would silently
-// drop the `commands` array from `docket plan --json` output.
+// TestPlanResultCommandsContractStatic walks every non-test file in the tasks
+// package and asserts that every PlanResult composite literal carrying a
+// non-empty `apply:` field also sets `Commands:`. Catches future tasks added
+// without populating Commands when drift is reported - a regression would
+// silently drop the `commands` array from `docket plan --json` output.
+//
+// The walk deliberately has no file whitelist. It used to scan only *_task.go
+// plus properties.go / toggle.go / resources.go, which left the `apply:`
+// literals in pairs.go and scheduler_k3s_autoscaling_auth.go unchecked; they
+// happened to be correct, so the hole was silent. packageSourceFiles (see
+// probe_coverage_test.go) is the shared file list.
 //
 // The check is purely structural and runs without a Dokku server, complementing
 // the integration tests in plan_integration_test.go that exercise Plan() end
 // to end against a real server.
 func TestPlanResultCommandsContractStatic(t *testing.T) {
-	dir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	files, err := filepath.Glob(filepath.Join(dir, "*.go"))
-	if err != nil {
-		t.Fatalf("glob: %v", err)
-	}
-
 	fs := token.NewFileSet()
-	for _, path := range files {
-		if strings.HasSuffix(path, "_test.go") {
-			continue
-		}
+	for _, path := range packageSourceFiles(t) {
 		base := filepath.Base(path)
-		if !strings.HasSuffix(base, "_task.go") &&
-			base != "properties.go" && base != "toggle.go" && base != "resources.go" {
-			continue
-		}
 
 		f, err := parser.ParseFile(fs, path, nil, parser.SkipObjectResolution)
 		if err != nil {

--- a/tasks/plugin_task.go
+++ b/tasks/plugin_task.go
@@ -58,6 +58,11 @@ func (t PluginTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t PluginTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the plugin task
 func (t PluginTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]PluginTaskExample{

--- a/tasks/ports_task.go
+++ b/tasks/ports_task.go
@@ -69,6 +69,11 @@ func (t PortsTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t PortsTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the ports task
 func (t PortsTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]PortsTaskExample{

--- a/tasks/probe_coverage_test.go
+++ b/tasks/probe_coverage_test.go
@@ -1,0 +1,319 @@
+package tasks
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestEveryTaskDeclaresProbeSupport asserts that every registered task declares
+// whether Plan() can read its current state via ProbeSupport(). This is what
+// makes "which tasks never converge" answerable from code rather than from a
+// hand-maintained prose list: adding a new task without a ProbeSupport()
+// declaration fails the build here rather than silently shipping without a
+// probe decision.
+func TestEveryTaskDeclaresProbeSupport(t *testing.T) {
+	for name, task := range RegisteredTasks {
+		support, ok := TaskProbeSupport(task)
+		if !ok {
+			t.Errorf("task %q does not implement ProbeDocer (add a ProbeSupport() declaration)", name)
+			continue
+		}
+		switch support.Status {
+		case ProbeSupported, ProbePartial, ProbeUnsupported:
+			// valid
+		default:
+			t.Errorf("task %q declares an unknown probe status %q", name, support.Status)
+		}
+		if support.Status != ProbeSupported && support.Caveat == "" {
+			t.Errorf("task %q is %q but has no caveat naming what cannot be read", name, support.Status)
+		}
+	}
+}
+
+// TestProbeSupportMatchesPlanWiring asserts that a task's declared probe
+// support and its actual Plan() agree. The declaration would otherwise be
+// decorative - the plan and apply paths never read it - which is exactly how
+// dokku_service_property came to behave identically to the three tasks the docs
+// named while being absent from every list (#426). The invariant is:
+//
+//   - ProbeUnsupported means Plan() can never report in sync.
+//   - ProbeSupported and ProbePartial mean it can.
+//
+// "Can report in sync" is decided statically: a PlanResult composite literal
+// with `InSync: true` reachable from the task's Plan() through intra-package
+// calls. ProbePartial is not distinguishable from ProbeSupported this way -
+// both converge for some inputs - so the caveat text stays a human judgement,
+// but the always-drift case is machine-checked in both directions.
+func TestProbeSupportMatchesPlanWiring(t *testing.T) {
+	g := buildPlanGraph(t)
+
+	for name, task := range RegisteredTasks {
+		support, ok := TaskProbeSupport(task)
+		if !ok {
+			continue // TestEveryTaskDeclaresProbeSupport reports this
+		}
+
+		typ := reflect.TypeOf(task)
+		for typ.Kind() == reflect.Ptr {
+			typ = typ.Elem()
+		}
+		key := planFuncKey(typ.Name() + ".Plan")
+		if !g.known(key) {
+			t.Errorf("task %q: no Plan() method found for type %s while walking the tasks package", name, typ.Name())
+			continue
+		}
+
+		capable := g.inSyncCapable(key)
+		switch support.Status {
+		case ProbeUnsupported:
+			if capable {
+				t.Errorf("task %q declares probe status %q but its Plan() can return an in-sync result, "+
+					"so it does converge - declare %q or %q instead",
+					name, support.Status, ProbeSupported, ProbePartial)
+			}
+		case ProbeSupported, ProbePartial:
+			if !capable {
+				t.Errorf("task %q declares probe status %q but no `InSync: true` result is reachable from its Plan(), "+
+					"so it plans as drift on every run - declare %q instead",
+					name, support.Status, ProbeUnsupported)
+			}
+		}
+	}
+}
+
+// TestPlanResultInSyncImpliesStatusOK asserts that every `InSync: true`
+// PlanResult also sets `Status: PlanStatusOK`. TestProbeSupportMatchesPlanWiring
+// treats the two as the same statement about a task; this keeps them from
+// drifting apart.
+func TestPlanResultInSyncImpliesStatusOK(t *testing.T) {
+	fs := token.NewFileSet()
+	for _, path := range packageSourceFiles(t) {
+		f, err := parser.ParseFile(fs, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parse %s: %v", filepath.Base(path), err)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			lit, ok := n.(*ast.CompositeLit)
+			if !ok || !isIdent(lit.Type, "PlanResult") {
+				return true
+			}
+			if !litHasIdentField(lit, "InSync", "true") {
+				return true
+			}
+			if !litHasIdentField(lit, "Status", "PlanStatusOK") {
+				pos := fs.Position(lit.Pos())
+				t.Errorf("%s:%d: PlanResult sets `InSync: true` without `Status: PlanStatusOK`",
+					filepath.Base(pos.Filename), pos.Line)
+			}
+			return true
+		})
+	}
+}
+
+// planFuncKey identifies a function the static analysis can reach: a
+// package-level func ("planProperty") or a method ("GitAuthTask.Plan").
+// Methods must be keyed by receiver type - every task's Execute() is
+// `return ExecutePlan(t.Plan())`, so a bare "Plan" key would merge all 73
+// method bodies into one node and the invariant would hold vacuously.
+type planFuncKey string
+
+// planGraph is the intra-package call graph restricted to functions that
+// return a PlanResult. Restricting edges by return type is what excludes the
+// `apply:` closures: they return TaskOutputState and call runExecInputs /
+// applyPropertySet / applyToggle, none of which is a plan path.
+type planGraph struct {
+	inSync   map[planFuncKey]bool
+	calls    map[planFuncKey][]planFuncKey
+	planFunc map[string]bool
+	memo     map[planFuncKey]bool
+}
+
+func (g *planGraph) known(k planFuncKey) bool {
+	_, ok := g.calls[k]
+	return ok
+}
+
+// inSyncCapable reports whether an `InSync: true` PlanResult is reachable from
+// k. Memoized, and cycle-guarded via the memo table so mutual recursion
+// terminates.
+func (g *planGraph) inSyncCapable(k planFuncKey) bool {
+	if v, ok := g.memo[k]; ok {
+		return v
+	}
+	g.memo[k] = false // provisional: breaks cycles
+	if g.inSync[k] {
+		g.memo[k] = true
+		return true
+	}
+	for _, callee := range g.calls[k] {
+		if g.inSyncCapable(callee) {
+			g.memo[k] = true
+			return true
+		}
+	}
+	return g.memo[k]
+}
+
+// packageSourceFiles returns every non-test .go file in the tasks package
+// directory. Deliberately unfiltered: the in-sync results live in
+// properties.go, toggle.go, pairs.go, resources.go, scheduler_k3s_scoped_pairs.go
+// and scheduler_k3s_autoscaling_auth.go as well as in the *_task.go files, so
+// any whitelist would miss most of the graph.
+func packageSourceFiles(t *testing.T) []string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	all, err := filepath.Glob(filepath.Join(dir, "*.go"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	var out []string
+	for _, path := range all {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		out = append(out, path)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// buildPlanGraph parses the tasks package and records, for every function
+// returning a PlanResult, whether its body builds an in-sync result and which
+// other plan-returning functions it calls.
+func buildPlanGraph(t *testing.T) *planGraph {
+	t.Helper()
+
+	files := packageSourceFiles(t)
+	fs := token.NewFileSet()
+	parsed := make([]*ast.File, 0, len(files))
+	for _, path := range files {
+		f, err := parser.ParseFile(fs, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parse %s: %v", filepath.Base(path), err)
+		}
+		parsed = append(parsed, f)
+	}
+
+	g := &planGraph{
+		inSync:   map[planFuncKey]bool{},
+		calls:    map[planFuncKey][]planFuncKey{},
+		planFunc: map[string]bool{},
+		memo:     map[planFuncKey]bool{},
+	}
+
+	// Pass 1: name every plan-returning function.
+	type decl struct {
+		key  planFuncKey
+		body *ast.BlockStmt
+	}
+	var decls []decl
+	for _, f := range parsed {
+		for _, d := range f.Decls {
+			fn, ok := d.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || !returnsPlanResult(fn) {
+				continue
+			}
+			if fn.Recv == nil {
+				g.planFunc[fn.Name.Name] = true
+				decls = append(decls, decl{key: planFuncKey(fn.Name.Name), body: fn.Body})
+				continue
+			}
+			recv := receiverTypeName(fn)
+			if recv == "" {
+				t.Errorf("%s: cannot resolve receiver type for method %s returning PlanResult",
+					filepath.Base(fs.Position(fn.Pos()).Filename), fn.Name.Name)
+				continue
+			}
+			// The graph only follows bare identifiers, so a plan-returning
+			// method other than Plan() would be an unfollowed edge and would
+			// make a task look unable to converge. Fail with a pointed message
+			// rather than letting an innocent task take the blame.
+			if fn.Name.Name != "Plan" {
+				t.Errorf("%s.%s returns PlanResult; only Plan() may be a plan-returning method, "+
+					"otherwise TestProbeSupportMatchesPlanWiring cannot follow the call. "+
+					"Make it a package-level func instead.", recv, fn.Name.Name)
+				continue
+			}
+			decls = append(decls, decl{key: planFuncKey(recv + ".Plan"), body: fn.Body})
+		}
+	}
+
+	// Pass 2: record in-sync results and call edges. ast.Inspect descends into
+	// function literals, which is what covers the closures every task passes to
+	// DispatchPlan.
+	for _, d := range decls {
+		if _, seen := g.calls[d.key]; !seen {
+			g.calls[d.key] = nil
+		}
+		ast.Inspect(d.body, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.CompositeLit:
+				if isIdent(node.Type, "PlanResult") && litHasIdentField(node, "InSync", "true") {
+					g.inSync[d.key] = true
+				}
+			case *ast.CallExpr:
+				if id, ok := node.Fun.(*ast.Ident); ok && g.planFunc[id.Name] {
+					g.calls[d.key] = append(g.calls[d.key], planFuncKey(id.Name))
+				}
+			}
+			return true
+		})
+	}
+
+	return g
+}
+
+// returnsPlanResult reports whether fn's result list is exactly one PlanResult.
+func returnsPlanResult(fn *ast.FuncDecl) bool {
+	res := fn.Type.Results
+	if res == nil || len(res.List) != 1 || len(res.List[0].Names) > 1 {
+		return false
+	}
+	return isIdent(res.List[0].Type, "PlanResult")
+}
+
+// receiverTypeName returns fn's receiver type name, dereferencing a pointer
+// receiver so a future `func (t *FooTask) Plan()` still resolves.
+func receiverTypeName(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) != 1 {
+		return ""
+	}
+	expr := fn.Recv.List[0].Type
+	if star, ok := expr.(*ast.StarExpr); ok {
+		expr = star.X
+	}
+	if id, ok := expr.(*ast.Ident); ok {
+		return id.Name
+	}
+	return ""
+}
+
+func isIdent(expr ast.Expr, name string) bool {
+	id, ok := expr.(*ast.Ident)
+	return ok && id.Name == name
+}
+
+// litHasIdentField reports whether lit sets field to the bare identifier want
+// (`InSync: true`, `Status: PlanStatusOK`).
+func litHasIdentField(lit *ast.CompositeLit, field, want string) bool {
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok || !isIdent(kv.Key, field) {
+			continue
+		}
+		if isIdent(kv.Value, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/tasks/probe_support.go
+++ b/tasks/probe_support.go
@@ -1,0 +1,66 @@
+package tasks
+
+// ProbeStatus classifies how much of a task's current state Plan() can read
+// back from the server before it decides whether to mutate.
+type ProbeStatus string
+
+const (
+	// ProbeSupported means Plan() reads the resource it manages, so a server
+	// that already matches the recipe plans as in sync and a second apply is
+	// a no-op.
+	ProbeSupported ProbeStatus = "supported"
+
+	// ProbePartial means Plan() reads some of the resource but not all of it:
+	// a write-only field with no read command, or an idempotency key that is
+	// coarser than the task's inputs. The task converges for the dimensions it
+	// probes and plans as drift forever for the rest.
+	ProbePartial ProbeStatus = "partial"
+
+	// ProbeUnsupported means Plan() cannot read the resource at all. The task
+	// plans as drift on every run and never converges, so a recipe containing
+	// one never settles to `plan --detailed-exitcode` exit 0.
+	ProbeUnsupported ProbeStatus = "unsupported"
+)
+
+// ProbeSupport describes a task's read-state behaviour. Status is required;
+// Caveat is a human-readable note naming what cannot be read (and may be empty
+// for a task that probes everything it manages).
+type ProbeSupport struct {
+	Status ProbeStatus
+	Caveat string
+}
+
+// ProbeDocer is the interface a task implements to declare whether Plan() can
+// read its current state. Every registered task is expected to implement it - a
+// coverage test enforces that so no task ships without a probe decision - but
+// it is modelled as an optional interface to match ExportDocer,
+// DeprecationDocer and RequirementsDocer. The docs generator renders the result
+// in a Probe support section on the task's page, and `--list-tasks` marks the
+// tasks that will never converge.
+//
+// This declares a *structural* inability to read state: dokku exposes no
+// command that reports the resource, so the answer is the same on every server
+// and every run. It is not the same thing as a probe that fails at runtime - a
+// stale property key map, an older plugin that rejects `:report --format json`,
+// an unreachable host. Those stay what they are today: a PlanWarning (see
+// WarnReasonUnknownProperty / WarnReasonProbeRejected) or a PlanStatusError,
+// raised per-run by the probe call site, and they never change a task's
+// declared status.
+//
+// Nothing in the plan or apply path reads this: drift is decided entirely by
+// each Plan() implementation. What keeps the declaration honest is
+// TestProbeSupportMatchesPlanWiring, which fails when a task claims it can
+// converge but its Plan() has no reachable in-sync result (or vice versa).
+type ProbeDocer interface {
+	ProbeSupport() ProbeSupport
+}
+
+// TaskProbeSupport returns the probe support for t, and whether t declared it.
+// Centralised so docs generation, --list-tasks, and the coverage test share one
+// read site, mirroring TaskExportSupport.
+func TaskProbeSupport(t Task) (ProbeSupport, bool) {
+	if d, ok := t.(ProbeDocer); ok {
+		return d.ProbeSupport(), true
+	}
+	return ProbeSupport{}, false
+}

--- a/tasks/probe_support_test.go
+++ b/tasks/probe_support_test.go
@@ -1,0 +1,65 @@
+package tasks
+
+import (
+	"testing"
+)
+
+// probelessTask is a Task that does not implement ProbeDocer, standing in for a
+// task written before ProbeSupport() existed. TaskProbeSupport must report it
+// as undeclared rather than inventing a status, which is what lets the docs
+// generator omit the section and the coverage test name the offender.
+type probelessTask struct{}
+
+func (t probelessTask) Doc() string              { return "" }
+func (t probelessTask) Examples() ([]Doc, error) { return nil, nil }
+func (t probelessTask) Plan() PlanResult         { return PlanResult{} }
+func (t probelessTask) Execute() TaskOutputState { return TaskOutputState{} }
+
+func TestTaskProbeSupportUndeclared(t *testing.T) {
+	support, ok := TaskProbeSupport(probelessTask{})
+	if ok {
+		t.Errorf("expected ok=false for a task without ProbeSupport(), got %+v", support)
+	}
+	if support != (ProbeSupport{}) {
+		t.Errorf("expected zero ProbeSupport for an undeclared task, got %+v", support)
+	}
+}
+
+func TestTaskProbeSupportSupported(t *testing.T) {
+	support, ok := TaskProbeSupport(&AppTask{})
+	if !ok {
+		t.Fatal("expected AppTask to declare ProbeSupport()")
+	}
+	if support.Status != ProbeSupported {
+		t.Errorf("expected AppTask to be %q, got %q", ProbeSupported, support.Status)
+	}
+	if support.Caveat != "" {
+		t.Errorf("expected no caveat on a fully probed task, got %q", support.Caveat)
+	}
+}
+
+func TestTaskProbeSupportUnsupportedCarriesCaveat(t *testing.T) {
+	support, ok := TaskProbeSupport(&GitAuthTask{})
+	if !ok {
+		t.Fatal("expected GitAuthTask to declare ProbeSupport()")
+	}
+	if support.Status != ProbeUnsupported {
+		t.Errorf("expected GitAuthTask to be %q, got %q", ProbeUnsupported, support.Status)
+	}
+	if !contains(support.Caveat, "no read command") {
+		t.Errorf("expected the caveat to explain the missing read command, got %q", support.Caveat)
+	}
+}
+
+func TestTaskProbeSupportPartialCarriesCaveat(t *testing.T) {
+	support, ok := TaskProbeSupport(&ServiceBackupTask{})
+	if !ok {
+		t.Fatal("expected ServiceBackupTask to declare ProbeSupport()")
+	}
+	if support.Status != ProbePartial {
+		t.Errorf("expected ServiceBackupTask to be %q, got %q", ProbePartial, support.Status)
+	}
+	if !contains(support.Caveat, "encryption passphrase") {
+		t.Errorf("expected the caveat to name the unprobed fields, got %q", support.Caveat)
+	}
+}

--- a/tasks/proxy_property_task.go
+++ b/tasks/proxy_property_task.go
@@ -42,6 +42,11 @@ func (t ProxyPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t ProxyPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the proxy property task
 func (t ProxyPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]ProxyPropertyTaskExample{

--- a/tasks/proxy_toggle_task.go
+++ b/tasks/proxy_toggle_task.go
@@ -65,6 +65,11 @@ func (t ProxyToggleTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t ProxyToggleTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the proxy toggle task
 func (t ProxyToggleTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]ProxyToggleTaskExample{

--- a/tasks/ps_property_task.go
+++ b/tasks/ps_property_task.go
@@ -42,6 +42,11 @@ func (t PsPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t PsPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the ps property task
 func (t PsPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]PsPropertyTaskExample{

--- a/tasks/ps_scale_task.go
+++ b/tasks/ps_scale_task.go
@@ -49,6 +49,11 @@ func (t PsScaleTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t PsScaleTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the ps scale task
 func (t PsScaleTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]PsScaleTaskExample{

--- a/tasks/registry_auth_task.go
+++ b/tasks/registry_auth_task.go
@@ -53,6 +53,11 @@ func (t RegistryAuthTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportUnsupported, Caveat: "registry login credentials are write-only and cannot be read back"}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t RegistryAuthTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeUnsupported, Caveat: "registry login state has no read command, so the task plans as drift on every run"}
+}
+
 // Examples returns the examples for the registry auth task
 func (t RegistryAuthTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]RegistryAuthTaskExample{

--- a/tasks/registry_property_task.go
+++ b/tasks/registry_property_task.go
@@ -42,6 +42,11 @@ func (t RegistryPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t RegistryPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the registry property task
 func (t RegistryPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]RegistryPropertyTaskExample{

--- a/tasks/resource_limit_task.go
+++ b/tasks/resource_limit_task.go
@@ -43,6 +43,11 @@ func (t ResourceLimitTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t ResourceLimitTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the resource limit task
 func (t ResourceLimitTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]ResourceLimitTaskExample{

--- a/tasks/resource_reserve_task.go
+++ b/tasks/resource_reserve_task.go
@@ -43,6 +43,11 @@ func (t ResourceReserveTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t ResourceReserveTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the resource reserve task
 func (t ResourceReserveTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]ResourceReserveTaskExample{

--- a/tasks/scheduler_docker_local_property_task.go
+++ b/tasks/scheduler_docker_local_property_task.go
@@ -39,6 +39,11 @@ func (t SchedulerDockerLocalPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t SchedulerDockerLocalPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the scheduler-docker-local property task
 func (t SchedulerDockerLocalPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]SchedulerDockerLocalPropertyTaskExample{

--- a/tasks/scheduler_k3s_annotations_task.go
+++ b/tasks/scheduler_k3s_annotations_task.go
@@ -52,6 +52,11 @@ func (t SchedulerK3sAnnotationsTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t SchedulerK3sAnnotationsTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the scheduler-k3s annotations task
 func (t SchedulerK3sAnnotationsTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]SchedulerK3sAnnotationsTaskExample{

--- a/tasks/scheduler_k3s_autoscaling_auth_task.go
+++ b/tasks/scheduler_k3s_autoscaling_auth_task.go
@@ -48,6 +48,11 @@ func (t SchedulerK3sAutoscalingAuthTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportPartial, Caveat: "trigger authentication metadata values are secrets, so they are written to the companion vars-file"}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t SchedulerK3sAutoscalingAuthTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the scheduler-k3s autoscaling-auth task
 func (t SchedulerK3sAutoscalingAuthTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]SchedulerK3sAutoscalingAuthTaskExample{

--- a/tasks/scheduler_k3s_chart_task.go
+++ b/tasks/scheduler_k3s_chart_task.go
@@ -56,6 +56,11 @@ func (t SchedulerK3sChartTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t SchedulerK3sChartTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the scheduler-k3s chart task
 func (t SchedulerK3sChartTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]SchedulerK3sChartTaskExample{

--- a/tasks/scheduler_k3s_labels_task.go
+++ b/tasks/scheduler_k3s_labels_task.go
@@ -50,6 +50,11 @@ func (t SchedulerK3sLabelsTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t SchedulerK3sLabelsTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the scheduler-k3s labels task
 func (t SchedulerK3sLabelsTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]SchedulerK3sLabelsTaskExample{

--- a/tasks/scheduler_k3s_profile_task.go
+++ b/tasks/scheduler_k3s_profile_task.go
@@ -67,6 +67,11 @@ func (t SchedulerK3sProfileTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t SchedulerK3sProfileTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the scheduler-k3s profile task
 func (t SchedulerK3sProfileTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]SchedulerK3sProfileTaskExample{

--- a/tasks/scheduler_k3s_property_task.go
+++ b/tasks/scheduler_k3s_property_task.go
@@ -47,6 +47,11 @@ func (t SchedulerK3sPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t SchedulerK3sPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the scheduler-k3s property task
 func (t SchedulerK3sPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]SchedulerK3sPropertyTaskExample{

--- a/tasks/scheduler_property_task.go
+++ b/tasks/scheduler_property_task.go
@@ -42,6 +42,11 @@ func (t SchedulerPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t SchedulerPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the scheduler property task
 func (t SchedulerPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]SchedulerPropertyTaskExample{

--- a/tasks/service_backup_task.go
+++ b/tasks/service_backup_task.go
@@ -79,6 +79,11 @@ func (t ServiceBackupTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportPartial, Caveat: "the backup schedule, bucket, and use_iam flag are exported; the AWS credentials and encryption passphrase are write-only and must be re-supplied before the recipe can back up"}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t ServiceBackupTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbePartial, Caveat: "the backup schedule and bucket are probed; the AWS credentials and the encryption passphrase have no read command and are re-applied on every run when supplied"}
+}
+
 // ExportGlobal reconstructs the backup schedule of every datastore service on
 // the server. Discovery is via listServices; the schedule, bucket, and use_iam
 // flag are parsed from `<service>:backup-schedule-cat <name>`. The AWS

--- a/tasks/service_create_task.go
+++ b/tasks/service_create_task.go
@@ -92,6 +92,11 @@ func (t ServiceCreateTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportPartial, Caveat: "the service and the image it is running are exported; the remaining create-time options (config_options, custom_env, memory, shm_size, the networks, and the passwords) have no read command and must be re-supplied"}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t ServiceCreateTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbePartial, Caveat: "the service's existence and image are probed; config_options, custom_env, memory, shm_size, the networks, and the passwords have no read command and are not drift-detected"}
+}
+
 // ExportGlobal reconstructs every datastore service instance on the server as a
 // dokku_service_create task. Discovery is via listServices (the `service-list`
 // plugin trigger). Like dokku_storage_mount, the service's data is migrated

--- a/tasks/service_expose_task.go
+++ b/tasks/service_expose_task.go
@@ -48,6 +48,11 @@ func (t ServiceExposeTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t ServiceExposeTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // ExportGlobal reconstructs the exposed-ports state of every datastore service
 // on the server. Discovery is via listServices; the exposed host ports are read
 // from `<service>:info <name> --exposed-ports`. Services with no exposed ports

--- a/tasks/service_link_task.go
+++ b/tasks/service_link_task.go
@@ -44,6 +44,11 @@ func (t ServiceLinkTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t ServiceLinkTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // ExportApp reconstructs an app's datastore service links: it enumerates
 // services (listServices) and emits a dokku_service_link for each service the
 // app appears in (serviceLinkedApps). The link, not dokku_config, is the source

--- a/tasks/service_property_task.go
+++ b/tasks/service_property_task.go
@@ -59,6 +59,11 @@ func (t ServicePropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportUnsupported, Caveat: "no datastore plugin exposes a machine-readable report of the properties set via `<service>:set`, so they cannot be read back (tracked upstream in dokku/dokku-datastore#98)"}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t ServicePropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeUnsupported, Caveat: "the service's existence is probed but the property value is not, so the task plans as drift on every run"}
+}
+
 // Requirements lists the non-core dokku plugins this task depends on.
 func (t ServicePropertyTask) Requirements() []string {
 	return []string{"a dokku datastore service plugin matching the service type (e.g. dokku-postgres, dokku-redis, dokku-mysql)"}

--- a/tasks/ssh_key_task.go
+++ b/tasks/ssh_key_task.go
@@ -48,6 +48,11 @@ func (t SshKeyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t SshKeyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeSupported}
+}
+
 // Examples returns the examples for the ssh key task
 func (t SshKeyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]SshKeyTaskExample{

--- a/tasks/storage_ensure_task.go
+++ b/tasks/storage_ensure_task.go
@@ -44,6 +44,11 @@ func (t StorageEnsureTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportUnsupported, Caveat: "deprecated; storage state is exported via dokku_storage_mount"}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t StorageEnsureTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbeUnsupported, Caveat: "`storage:ensure-directory` has no read command, so the task plans as drift on every run"}
+}
+
 // Deprecation marks dokku_storage_ensure as deprecated. dokku's
 // underlying storage:ensure-directory subcommand has been deprecated in
 // favor of storage:create, which docket exposes through

--- a/tasks/storage_entry_task.go
+++ b/tasks/storage_entry_task.go
@@ -88,6 +88,11 @@ func (t StorageEntryTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t StorageEntryTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbePartial, Caveat: "idempotency is keyed on the entry name; scheduler, size, and chown changes to an existing entry are not drift-detected (tracked in dokku/docket#439)"}
+}
+
 // Examples returns the examples for the storage entry task
 func (t StorageEntryTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]StorageEntryTaskExample{

--- a/tasks/storage_mount_task.go
+++ b/tasks/storage_mount_task.go
@@ -99,6 +99,11 @@ func (t StorageMountTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t StorageMountTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbePartial, Caveat: "the mount source, container path, and volume options are probed; phases, process_type, subpath, readonly, and volume_chown apply at mount time and are not drift-detected"}
+}
+
 // Examples returns the examples for the storage mount task
 func (t StorageMountTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]StorageMountTaskExample{

--- a/tasks/traefik_property_task.go
+++ b/tasks/traefik_property_task.go
@@ -42,6 +42,11 @@ func (t TraefikPropertyTask) ExportSupport() ExportSupport {
 	return ExportSupport{Status: ExportSupported}
 }
 
+// ProbeSupport reports whether Plan() can read this task's current state.
+func (t TraefikPropertyTask) ProbeSupport() ProbeSupport {
+	return ProbeSupport{Status: ProbePartial, Caveat: "the mapped properties are probed; the dynamic `dns-provider-*` family has no report key and plans as drift on every run"}
+}
+
 // Examples returns the examples for the traefik property task
 func (t TraefikPropertyTask) Examples() ([]Doc, error) {
 	return MarshalExamples([]TraefikPropertyTaskExample{

--- a/tests/bats/list_resume.bats
+++ b/tests/bats/list_resume.bats
@@ -166,6 +166,66 @@ EOF
   assert_output --partial '"deprecation":"'
 }
 
+@test "--list-tasks marks task types that never converge" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: git auth
+      dokku_git_auth:
+        host: github.com
+        username: deploy-bot
+        password: examplepassword
+    - name: create app
+      dokku_app: { app: docket-test-list-1 }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  assert_output --partial "git auth  (never converges)"
+  refute_output --partial "create app  (never converges)"
+}
+
+@test "--list-tasks marks task types with a partial probe" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: deploy from image
+      dokku_git_from_image:
+        app: docket-test-list-1
+        image: dokku/smoke-test-app:dockerfile
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks
+  assert_success
+  assert_output --partial "deploy from image  (partial probe)"
+}
+
+@test "--list-tasks --json sets probe on tasks that cannot read their state" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: git auth
+      dokku_git_auth:
+        host: github.com
+        username: deploy-bot
+        password: examplepassword
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks --json
+  assert_success
+  assert_output --partial '"probe":"unsupported"'
+  assert_output --partial '"probe_caveat":"'
+}
+
+@test "--list-tasks --json omits probe on fully probed tasks" {
+  write_tasks_file <<EOF
+---
+- tasks:
+    - name: create app
+      dokku_app: { app: docket-test-list-1 }
+EOF
+  run "$(docket_bin)" apply --tasks "$TASKS_FILE" --list-tasks --json
+  assert_success
+  refute_output --partial '"probe"'
+}
+
 @test "--list-tasks works on plan as well" {
   write_tasks_file <<EOF
 ---


### PR DESCRIPTION
Tasks that cannot read their current state report drift on every `plan`, and which ones those are was recorded nowhere the code could see - it was a convention that `Plan()` never returns `InSync: true` and puts "not probed" in its `Reason`. The prose list in `docs/command-reference.md` had already drifted, omitting `dokku_service_property`, and said nothing about the tasks that probe only part of what they manage. `ProbeSupport()` makes it a declared property of the task, mirroring `ExportSupport()`: the docs generator renders a Probe support section on every task page, the tasks index marks a task that never converges, and `--list-tasks` marks it per recipe in both text and JSON. A probe that fails at runtime stays a `PlanWarning` and is deliberately kept distinct from a declared inability to read.

Four task types read nothing at all and are declared unsupported: `dokku_git_auth`, `dokku_registry_auth`, `dokku_storage_ensure`, and `dokku_service_property`. Thirteen more read some of what they manage but not all of it and are declared partial, each with a caveat naming the gap. A static analysis over the tasks package holds those declarations to the code, so a task cannot claim it converges when no in-sync result is reachable from its `Plan()`, or claim it cannot when one is.

The per-branch form of that analysis - checking each `state:` branch separately rather than `Plan()` as a whole - is filed as #447.

Closes #426
