### PR TITLE
feat: probe letsencrypt dns-provider-* properties

### DIFF
--- a/docs/tasks/dokku_letsencrypt_property.md
+++ b/docs/tasks/dokku_letsencrypt_property.md
@@ -6,7 +6,7 @@ Manages the letsencrypt configuration for a given dokku application
 
 ## Requirements
 
-- dokku-letsencrypt plugin
+- dokku-letsencrypt plugin >= 0.25.0
 
 ## Export support
 
@@ -14,7 +14,7 @@ Supported.
 
 ## Probe support
 
-Partial - the mapped properties are probed; the dynamic `dns-provider-*` family has no report key and plans as drift on every run.
+Supported.
 
 ## Parameters
 

--- a/docs/writing-tasks.md
+++ b/docs/writing-tasks.md
@@ -210,10 +210,18 @@ func (t NginxPropertyTask) Plan() PlanResult {
 ```
 
 Keep the `PropertyKeys` map in sync with the plugin's `:report` output - that mapping is how `plan`
-and `apply` detect drift without mutating. A property whose report key only appears after it is set
-(a dynamic family such as letsencrypt's `dns-provider-*`) skips probing and is applied
-unconditionally; those are recognized by `isDynamicProperty` in `tasks/properties.go`. A task whose
-key map has such a family is `ProbePartial`, not `ProbeSupported`.
+and `apply` detect drift without mutating. Some plugins take a dynamic family of properties whose
+names cannot be enumerated in the map, such as the `dns-provider-<ENV_VAR>` credentials letsencrypt
+and traefik accept. `isDynamicProperty` in `tasks/properties.go` recognizes those so validation
+accepts a name the map has never heard of, and how they plan depends on the plugin:
+
+- The plugin reports the family (letsencrypt on 0.25.0+ emits a row per set property): synthesize
+  the scope keys in `dynamicPropertyKeys` and the property probes like any mapped one. Because the
+  row only exists once the property has a value, an absent row reads as unset. Note the minimum
+  plugin version in `Requirements()`, and mark the synthesized entry `Sensitive` when the value is a
+  credential so the probed value never reaches a drift reason unmasked.
+- The plugin does not report it: the property skips probing and is applied unconditionally, and the
+  task is `ProbePartial` with a caveat naming the family.
 
 ## Regenerating the task docs
 

--- a/tasks/export.go
+++ b/tasks/export.go
@@ -350,13 +350,18 @@ func (res *ExportResult) processBody(app string, body interface{}, opts ExportOp
 		return res.processMaintenanceCustomPage(app, b, opts)
 	case SchedulerK3sAutoscalingAuthTask:
 		return res.processSchedulerK3sAutoscalingAuth(app, b, opts)
+	case LetsencryptPropertyTask:
+		return res.processPropertyValue(app, b, b.Property, b.Value, propertyEntry("letsencrypt", b.Property, letsencryptPropertyKeys).Sensitive, opts, func(v string) interface{} {
+			b.Value = v
+			return b
+		})
 	case SchedulerK3sPropertyTask:
-		return res.processPropertyValue(app, b, b.Property, b.Value, schedulerK3sPropertyKeys[b.Property].Sensitive, opts, func(v string) interface{} {
+		return res.processPropertyValue(app, b, b.Property, b.Value, propertyEntry("scheduler-k3s", b.Property, schedulerK3sPropertyKeys).Sensitive, opts, func(v string) interface{} {
 			b.Value = v
 			return b
 		})
 	case TraefikPropertyTask:
-		return res.processPropertyValue(app, b, b.Property, b.Value, traefikPropertyKeys[b.Property].Sensitive, opts, func(v string) interface{} {
+		return res.processPropertyValue(app, b, b.Property, b.Value, propertyEntry("traefik", b.Property, traefikPropertyKeys).Sensitive, opts, func(v string) interface{} {
 			b.Value = v
 			return b
 		})
@@ -366,10 +371,12 @@ func (res *ExportResult) processBody(app string, body interface{}, opts ExportOp
 }
 
 // processPropertyValue lifts a sensitive property value (for example the
-// scheduler-k3s cluster token or a traefik basic-auth password) into a required
-// sensitive input in file mode, blanks it under inline+redact, and otherwise
-// keeps it inline (like a config value). A non-sensitive property value is
-// returned unchanged, so only secret-flagged properties are ever lifted (#327).
+// scheduler-k3s cluster token or a letsencrypt DNS provider credential) into a
+// required sensitive input in file mode, blanks it under inline+redact, and
+// otherwise keeps it inline (like a config value). A non-sensitive property
+// value is returned unchanged, so only secret-flagged properties are ever
+// lifted (#327), and the input is named after the property so a vars-file entry
+// says which property it fills (#451).
 func (res *ExportResult) processPropertyValue(app string, body interface{}, property, value string, sensitive bool, opts ExportOptions, rebuild func(string) interface{}) (interface{}, []map[string]interface{}) {
 	if !sensitive || value == "" {
 		return body, nil

--- a/tasks/export_test.go
+++ b/tasks/export_test.go
@@ -865,6 +865,103 @@ func TestExportGlobalPropertiesReadsGlobalScope(t *testing.T) {
 	}
 }
 
+// TestExportLetsencryptDynamicPropertiesFromAppReport covers the export half of
+// #449: dns-provider-* rows cannot be enumerated in the key map, so they are
+// lifted straight out of the report. The app scope also carries the global and
+// computed variants of a key, and only the bare row is the app's own value.
+func TestExportLetsencryptDynamicPropertiesFromAppReport(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet letsencrypt:report web --format json": `{"email":"admin@example.com","dns-provider":"namecheap","dns-provider-NAMECHEAP_API_USER":"deploy-bot","global-dns-provider-NAMECHEAP_API_KEY":"globalkey","computed-dns-provider-NAMECHEAP_API_USER":"deploy-bot"}`,
+	}))()
+
+	bodies, err := exportProperties("web", "letsencrypt:set", letsencryptPropertyKeys, func(app, property, value string) interface{} {
+		return LetsencryptPropertyTask{App: app, Property: property, Value: value}
+	})
+	if err != nil {
+		t.Fatalf("exportProperties: %v", err)
+	}
+	got := map[string]string{}
+	for _, b := range bodies {
+		p := b.(LetsencryptPropertyTask)
+		got[p.Property] = p.Value
+	}
+	if got["dns-provider-NAMECHEAP_API_USER"] != "deploy-bot" {
+		t.Errorf("dns-provider-NAMECHEAP_API_USER = %q, want deploy-bot", got["dns-provider-NAMECHEAP_API_USER"])
+	}
+	if got["email"] != "admin@example.com" || got["dns-provider"] != "namecheap" {
+		t.Errorf("mapped properties should still export, got %v", got)
+	}
+	for _, unwanted := range []string{"global-dns-provider-NAMECHEAP_API_KEY", "dns-provider-NAMECHEAP_API_KEY", "computed-dns-provider-NAMECHEAP_API_USER"} {
+		if _, ok := got[unwanted]; ok {
+			t.Errorf("%q is not the app's own value and must not export", unwanted)
+		}
+	}
+}
+
+func TestExportGlobalLetsencryptDynamicProperties(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet letsencrypt:report --global --format json": `{"global-email":"","global-dns-provider":"namecheap","global-dns-provider-NAMECHEAP_API_KEY":"globalkey"}`,
+	}))()
+
+	bodies, err := exportGlobalProperties("letsencrypt:set", letsencryptPropertyKeys, func(property, value string) interface{} {
+		return LetsencryptPropertyTask{Global: true, Property: property, Value: value}
+	})
+	if err != nil {
+		t.Fatalf("exportGlobalProperties: %v", err)
+	}
+	got := map[string]string{}
+	for _, b := range bodies {
+		p := b.(LetsencryptPropertyTask)
+		if !p.Global {
+			t.Errorf("expected Global:true for %q", p.Property)
+		}
+		got[p.Property] = p.Value
+	}
+	if got["dns-provider-NAMECHEAP_API_KEY"] != "globalkey" {
+		t.Errorf("dns-provider-NAMECHEAP_API_KEY = %q, want globalkey", got["dns-provider-NAMECHEAP_API_KEY"])
+	}
+	if _, ok := got["email"]; ok {
+		t.Error("an empty global property must be skipped")
+	}
+}
+
+// TestExportGlobalLetsencryptCredentialLiftedAsSensitiveInput proves the newly
+// exported credential never lands in the recipe in cleartext. Unlike the traefik
+// and scheduler-k3s property tasks, the letsencrypt one is lifted by
+// processSensitiveScalars (its Value field is tagged sensitive), so the input is
+// named after the field rather than the property - look the value up instead of
+// pinning the name.
+func TestExportGlobalLetsencryptCredentialLiftedAsSensitiveInput(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list": "",
+		"--quiet letsencrypt:report --global --format json": `{"global-dns-provider-NAMECHEAP_API_KEY":"s3cr3tkey"}`,
+	}))()
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	var lifted bool
+	for _, value := range res.Vars {
+		if value == "s3cr3tkey" {
+			lifted = true
+		}
+	}
+	if !lifted {
+		t.Errorf("expected the credential lifted into vars, got %v", res.Vars)
+	}
+	recipe, _ := res.MarshalRecipe("yaml")
+	out := string(recipe)
+	if strings.Contains(out, "s3cr3tkey") {
+		t.Errorf("recipe leaked the dns provider credential:\n%s", out)
+	}
+	for _, want := range []string{"dokku_letsencrypt_property", "dns-provider-NAMECHEAP_API_KEY", "sensitive: true"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("recipe missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestExportGlobalK3sTokenLiftedAsSensitiveInput(t *testing.T) {
 	// #327: the scheduler-k3s global token is core bootstrap state and must be
 	// exported - but as a secret, lifted into a sensitive input, never inline.

--- a/tasks/export_test.go
+++ b/tasks/export_test.go
@@ -926,39 +926,70 @@ func TestExportGlobalLetsencryptDynamicProperties(t *testing.T) {
 }
 
 // TestExportGlobalLetsencryptCredentialLiftedAsSensitiveInput proves the newly
-// exported credential never lands in the recipe in cleartext. Unlike the traefik
-// and scheduler-k3s property tasks, the letsencrypt one is lifted by
-// processSensitiveScalars (its Value field is tagged sensitive), so the input is
-// named after the field rather than the property - look the value up instead of
-// pinning the name.
+// exported credential never lands in the recipe in cleartext, and that the input
+// it is lifted into is named after the property rather than the `value` field
+// (#451). The benign properties alongside it are not secrets and stay inline, so
+// an exported recipe still describes the letsencrypt configuration and only asks
+// the operator for the credential.
 func TestExportGlobalLetsencryptCredentialLiftedAsSensitiveInput(t *testing.T) {
 	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
 		"--quiet apps:list": "",
-		"--quiet letsencrypt:report --global --format json": `{"global-dns-provider-NAMECHEAP_API_KEY":"s3cr3tkey"}`,
+		"--quiet letsencrypt:report --global --format json": `{"global-email":"admin@example.com","global-dns-provider":"namecheap","global-dns-provider-NAMECHEAP_API_KEY":"s3cr3tkey"}`,
 	}))()
 
 	res, err := ExportRecipe(ExportOptions{})
 	if err != nil {
 		t.Fatalf("ExportRecipe: %v", err)
 	}
-	var lifted bool
-	for _, value := range res.Vars {
-		if value == "s3cr3tkey" {
-			lifted = true
-		}
+	if got := res.Vars["global_dns_provider_NAMECHEAP_API_KEY"]; got != "s3cr3tkey" {
+		t.Errorf("vars[global_dns_provider_NAMECHEAP_API_KEY] = %q, want the credential lifted (vars: %v)", got, res.Vars)
 	}
-	if !lifted {
-		t.Errorf("expected the credential lifted into vars, got %v", res.Vars)
+	if len(res.Vars) != 1 {
+		t.Errorf("only the credential should be lifted, got %v", res.Vars)
 	}
 	recipe, _ := res.MarshalRecipe("yaml")
 	out := string(recipe)
 	if strings.Contains(out, "s3cr3tkey") {
 		t.Errorf("recipe leaked the dns provider credential:\n%s", out)
 	}
-	for _, want := range []string{"dokku_letsencrypt_property", "dns-provider-NAMECHEAP_API_KEY", "sensitive: true"} {
+	for _, want := range []string{
+		"dokku_letsencrypt_property",
+		"dns-provider-NAMECHEAP_API_KEY",
+		"{{ .global_dns_provider_NAMECHEAP_API_KEY }}",
+		"sensitive: true",
+		"admin@example.com", // a benign property stays inline
+		"namecheap",
+	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("recipe missing %q:\n%s", want, out)
 		}
+	}
+}
+
+// TestExportLetsencryptBenignPropertyNotLifted keeps the app scope honest: only
+// the credential family is a secret, so a plain property must not turn into a
+// required input the operator has to re-supply on every apply (#451).
+func TestExportLetsencryptBenignPropertyNotLifted(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet apps:list":                            "web",
+		"--quiet letsencrypt:report web --format json": `{"email":"admin@example.com","dns-provider-CLOUDFLARE_API_TOKEN":"tok3n"}`,
+	}))()
+
+	res, err := ExportRecipe(ExportOptions{})
+	if err != nil {
+		t.Fatalf("ExportRecipe: %v", err)
+	}
+	if got := res.Vars["web_dns_provider_CLOUDFLARE_API_TOKEN"]; got != "tok3n" {
+		t.Errorf("vars[web_dns_provider_CLOUDFLARE_API_TOKEN] = %q, want the credential lifted (vars: %v)", got, res.Vars)
+	}
+	for name, value := range res.Vars {
+		if value == "admin@example.com" {
+			t.Errorf("the email is not a secret and must not be lifted into input %q", name)
+		}
+	}
+	recipe, _ := res.MarshalRecipe("yaml")
+	if out := string(recipe); !strings.Contains(out, "admin@example.com") {
+		t.Errorf("expected the email inline in the recipe:\n%s", out)
 	}
 }
 

--- a/tasks/letsencrypt_property_task.go
+++ b/tasks/letsencrypt_property_task.go
@@ -45,13 +45,20 @@ func (t LetsencryptPropertyTask) ExportSupport() ExportSupport {
 }
 
 // ProbeSupport reports whether Plan() can read this task's current state.
+//
+// Supported without a caveat because dokku-letsencrypt 0.25.0+ reports the
+// dynamic `dns-provider-*` family alongside the mapped properties, so every
+// property this task manages is readable and converges (#449).
 func (t LetsencryptPropertyTask) ProbeSupport() ProbeSupport {
-	return ProbeSupport{Status: ProbePartial, Caveat: "the mapped properties are probed; the dynamic `dns-provider-*` family has no report key and plans as drift on every run"}
+	return ProbeSupport{Status: ProbeSupported}
 }
 
-// Requirements lists the non-core dokku plugins this task depends on.
+// Requirements lists the non-core dokku plugins this task depends on. The
+// version floor is the release that surfaced `dns-provider-*` properties in
+// `letsencrypt:report`; below it those properties are absent from the report
+// and a `state: absent` task would read an unset property as already gone.
 func (t LetsencryptPropertyTask) Requirements() []string {
-	return []string{"dokku-letsencrypt plugin"}
+	return []string{"dokku-letsencrypt plugin >= 0.25.0"}
 }
 
 // Examples returns the examples for the letsencrypt property task
@@ -99,8 +106,9 @@ func (t LetsencryptPropertyTask) Execute() TaskOutputState {
 
 // letsencryptPropertyKeys maps letsencrypt property names to the JSON keys
 // emitted by `dokku letsencrypt:report --format json` on
-// dokku-letsencrypt v0.20.4+. The `dns-provider-*` family is dynamic and
-// handled by isDynamicProperty without a map entry.
+// dokku-letsencrypt v0.20.4+. The `dns-provider-*` family takes an arbitrary
+// provider env var name, so it cannot be enumerated here; its keys are
+// synthesized per property by dynamicPropertyKeys, which v0.25.0+ reports.
 var letsencryptPropertyKeys = map[string]PropertyKeys{
 	"dns-provider":        {PerApp: "dns-provider", Global: "global-dns-provider"},
 	"email":               {PerApp: "email", Global: "global-email"},

--- a/tasks/letsencrypt_property_task.go
+++ b/tasks/letsencrypt_property_task.go
@@ -14,6 +14,9 @@ type LetsencryptPropertyTask struct {
 	// Value is the value to set for the letsencrypt property. Tagged sensitive
 	// because some letsencrypt properties carry DNS-API credentials; benign
 	// property values get masked too, which is preferable to leaking secrets.
+	// The tag drives output masking only - export decides what to lift into a
+	// vars file from the property's PropertyKeys entry, so a benign value stays
+	// readable in the exported recipe (#451).
 	Value string `required:"false" sensitive:"true" yaml:"value,omitempty" description:"Value to set for the letsencrypt property"`
 
 	// State is the desired state of the letsencrypt configuration

--- a/tasks/letsencrypt_property_task_integration_test.go
+++ b/tasks/letsencrypt_property_task_integration_test.go
@@ -20,6 +20,11 @@ func TestIntegrationLetsencryptPropertyAll(t *testing.T) {
 		global   bool
 	}{
 		{"dns-provider", "cloudflare", true, true},
+		// A dns-provider-<ENV> credential has no map entry - its keys are
+		// synthesized from the property name - so it exercises the dynamic
+		// probe path added in #449. dokku-letsencrypt 0.25.0+ reports it, so
+		// it converges like any mapped property.
+		{"dns-provider-CLOUDFLARE_API_TOKEN", "token123", true, true},
 		{"email", "admin@example.com", true, true},
 		{"graceperiod", "2592000", true, true},
 		{"lego-args", "--key=value", true, true},
@@ -48,19 +53,4 @@ func TestIntegrationLetsencryptPropertyAll(t *testing.T) {
 			})
 		}
 	}
-
-	// dns-provider-* keys are dynamic (per-credential env var names) and
-	// have no probe key, so the task always reports Changed=true. Exercise
-	// set/unset without the idempotency assertion to confirm the dispatch
-	// path through isDynamicProperty works.
-	t.Run("dns-provider-CLOUDFLARE_API_TOKEN/dynamic", func(t *testing.T) {
-		set := LetsencryptPropertyTask{App: appName, Property: "dns-provider-CLOUDFLARE_API_TOKEN", Value: "token123", State: StatePresent}
-		if r := set.Execute(); r.Error != nil {
-			t.Fatalf("set dynamic dns-provider key: %v", r.Error)
-		}
-		unset := LetsencryptPropertyTask{App: appName, Property: "dns-provider-CLOUDFLARE_API_TOKEN", State: StateAbsent}
-		if r := unset.Execute(); r.Error != nil {
-			t.Fatalf("unset dynamic dns-provider key: %v", r.Error)
-		}
-	})
 }

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -317,6 +317,19 @@ func dynamicPropertyKeys(plugin, property string) (PropertyKeys, bool) {
 	return PropertyKeys{PerApp: property, Global: "global-" + property, Sensitive: true}, true
 }
 
+// propertyEntry returns the PropertyKeys a plugin uses for one property,
+// falling back to the synthesized entry when the property belongs to a
+// probeable dynamic family the map cannot enumerate. Reading the map directly
+// instead would report a `dns-provider-<KEY>` credential as non-Sensitive and
+// export it in cleartext (#451).
+func propertyEntry(plugin, property string, keys map[string]PropertyKeys) PropertyKeys {
+	if entry, ok := keys[property]; ok {
+		return entry
+	}
+	entry, _ := dynamicPropertyKeys(plugin, property)
+	return entry
+}
+
 // withDynamicProperties returns keys plus a synthesized entry for every probeable
 // dynamic property in props. The map is copied only when there is something to
 // add, since the caller's map is a package-level singleton shared by every task

--- a/tasks/properties.go
+++ b/tasks/properties.go
@@ -84,6 +84,14 @@ func getProperty(subcommand, app string, global bool, property string, keys map[
 
 	value, ok := payload[lookup]
 	if !ok {
+		// A probeable dynamic property only gets a report row once it holds a
+		// value, so an absent row means the property is unset rather than that
+		// the key map is stale. The entry is compared against the synthesized
+		// one so a caller that passed a map without it - where lookup would be
+		// the empty string - still takes the error path (#449).
+		if dyn, dynamic := dynamicPropertyKeys(plugin, property); dynamic && entry == dyn {
+			return "", nil
+		}
 		keyList := make([]string, 0, len(payload))
 		for k := range payload {
 			keyList = append(keyList, k)
@@ -107,6 +115,10 @@ func getProperty(subcommand, app string, global bool, property string, keys map[
 // `computed-` key), so this naturally captures the non-default settings without
 // a defaults table. Read-only/computed keys are skipped because they are not in
 // keys.
+//
+// A probeable dynamic family cannot be enumerated in keys, so the properties the
+// payload happens to carry are synthesized into it first; without that a set
+// letsencrypt `dns-provider-<KEY>` credential is dropped from the export (#449).
 func exportProperties(app, subcommand string, keys map[string]PropertyKeys, factory func(app, property, value string) interface{}) ([]interface{}, error) {
 	plugin := pluginFromSubcommand(subcommand)
 	payload, err := readPropertyReport(plugin, app, false)
@@ -116,6 +128,7 @@ func exportProperties(app, subcommand string, keys map[string]PropertyKeys, fact
 	if payload == nil {
 		return nil, nil
 	}
+	keys = withDynamicProperties(plugin, keys, dynamicPropertiesFromReport(plugin, payload, false))
 
 	props := make([]string, 0, len(keys))
 	for prop := range keys {
@@ -144,7 +157,8 @@ func exportProperties(app, subcommand string, keys map[string]PropertyKeys, fact
 // Global key is present and non-empty, emits a task body (built by factory). A
 // property with no global form (an empty Global key) is skipped, so
 // globally-scoped state (for example scheduler-k3s bootstrap keys) is captured
-// instead of silently dropped (#327).
+// instead of silently dropped (#327). Probeable dynamic properties are
+// synthesized into keys the same way exportProperties does it.
 func exportGlobalProperties(subcommand string, keys map[string]PropertyKeys, factory func(property, value string) interface{}) ([]interface{}, error) {
 	plugin := pluginFromSubcommand(subcommand)
 	payload, err := readPropertyReport(plugin, "", true)
@@ -154,6 +168,7 @@ func exportGlobalProperties(subcommand string, keys map[string]PropertyKeys, fac
 	if payload == nil {
 		return nil, nil
 	}
+	keys = withDynamicProperties(plugin, keys, dynamicPropertiesFromReport(plugin, payload, true))
 
 	props := make([]string, 0, len(keys))
 	for prop := range keys {
@@ -234,7 +249,7 @@ func unknownPropertyWarning(plugin, property string, err error) (PlanWarning, bo
 	var unknown *errUnknownProperty
 	if errors.As(err, &unknown) {
 		// Skip the warning for known dynamic-property families (e.g.
-		// letsencrypt dns-provider-*) where missing-from-report is the
+		// traefik dns-provider-*) where missing-from-report is the
 		// normal pre-set state, not a typo.
 		if isDynamicProperty(plugin, property) {
 			return PlanWarning{}, false
@@ -266,7 +281,12 @@ func unknownPropertyWarning(plugin, property string, err error) (PlanWarning, bo
 //   - dokku-letsencrypt `dns-provider-*` (arbitrary env var names)
 //   - dokku traefik `dns-provider-*` (same shape, per-provider env vars)
 //
-// Dynamic property names are validated by `:set`, not the report schema.
+// Dynamic property names are validated by `:set`, not the report schema, so
+// this is what lets validateProperty accept a name that cannot be enumerated in
+// the key map. It says nothing about whether the property can be probed: a
+// family whose plugin reports its keys is probed through dynamicPropertyKeys,
+// and only the families that helper does not recognize skip the probe.
+//
 // scheduler-k3s `chart.*.*` used to live here but moved to the dedicated
 // dokku_scheduler_k3s_chart task; SchedulerK3sPropertyTask.Plan rejects
 // chart.* before reaching this helper.
@@ -276,6 +296,82 @@ func isDynamicProperty(plugin, property string) bool {
 		return strings.HasPrefix(property, "dns-provider-")
 	}
 	return false
+}
+
+// dynamicPropertyKeys returns the report keys for a dynamic property whose
+// plugin surfaces the family in its `:report` payload. dokku-letsencrypt
+// 0.25.0+ emits a `dns-provider-<KEY>` row for the app scope and a
+// `global-dns-provider-<KEY>` row for the global one per property that is set,
+// so the keys can be synthesized from the property name and probed like any
+// mapped property (#449). The values are DNS provider API credentials, hence
+// Sensitive: planProperty registers the probed value with the masker before it
+// can reach a `(was %q)` drift reason.
+//
+// traefik's `dns-provider-*` family has the same shape but is still absent from
+// `traefik:report` (dokku/dokku#8928, tracked for docket in #450), so it stays
+// on the unprobed path.
+func dynamicPropertyKeys(plugin, property string) (PropertyKeys, bool) {
+	if plugin != "letsencrypt" || !isDynamicProperty(plugin, property) {
+		return PropertyKeys{}, false
+	}
+	return PropertyKeys{PerApp: property, Global: "global-" + property, Sensitive: true}, true
+}
+
+// withDynamicProperties returns keys plus a synthesized entry for every probeable
+// dynamic property in props. The map is copied only when there is something to
+// add, since the caller's map is a package-level singleton shared by every task
+// of that plugin.
+func withDynamicProperties(plugin string, keys map[string]PropertyKeys, props []string) map[string]PropertyKeys {
+	var merged map[string]PropertyKeys
+	for _, property := range props {
+		entry, ok := dynamicPropertyKeys(plugin, property)
+		if !ok {
+			continue
+		}
+		if merged == nil {
+			merged = make(map[string]PropertyKeys, len(keys)+len(props))
+			for k, v := range keys {
+				merged[k] = v
+			}
+		}
+		merged[property] = entry
+	}
+	if merged == nil {
+		return keys
+	}
+	return merged
+}
+
+// dynamicPropertiesFromReport returns the probeable dynamic property names a
+// report payload carries for the given scope, sorted. In the app scope the
+// payload also carries the `global-` and `computed-` variants of a key; only the
+// bare row is the app's own value, so a key is kept only when the scope's
+// synthesized lookup round-trips back to it.
+func dynamicPropertiesFromReport(plugin string, payload map[string]string, global bool) []string {
+	var props []string
+	for key := range payload {
+		property := key
+		if global {
+			property = strings.TrimPrefix(key, "global-")
+			if property == key {
+				continue
+			}
+		}
+		entry, ok := dynamicPropertyKeys(plugin, property)
+		if !ok {
+			continue
+		}
+		lookup := entry.PerApp
+		if global {
+			lookup = entry.Global
+		}
+		if lookup != key {
+			continue
+		}
+		props = append(props, property)
+	}
+	sort.Strings(props)
+	return props
 }
 
 // planProperty is the shared Plan() implementation for property tasks. It
@@ -324,6 +420,13 @@ func planProperty(state State, app string, global bool, property, value, subcomm
 	if global {
 		target = "--global"
 	}
+
+	// A dynamic property has no static map entry. When its plugin reports the
+	// family, synthesize the entry so the probe path below runs against it; the
+	// families that stay unreported keep falling through to the unprobed path.
+	// This has to happen before the Sensitive read below, which is what
+	// registers a synthesized credential with the masker.
+	keys = withDynamicProperties(plugin, keys, []string{property})
 
 	// A property flagged Sensitive carries a secret value. Register the desired
 	// value now so the command echo is masked; empties are dropped. The
@@ -456,7 +559,7 @@ func validateProperty(plugin, property string, global bool, keys map[string]Prop
 }
 
 // runUnprobedSet returns a PlanResult that runs `:set` unconditionally for
-// dynamic properties that have no probe key (e.g. letsencrypt dns-provider-*).
+// dynamic properties that have no probe key (e.g. traefik dns-provider-*).
 func runUnprobedSet(subcommand, target, property, value string) PlanResult {
 	inputs := propertySetInputs(subcommand, target, property, value)
 	return PlanResult{

--- a/tasks/properties_test.go
+++ b/tasks/properties_test.go
@@ -254,14 +254,17 @@ func TestUnknownPropertyWarningIgnoresOtherErrors(t *testing.T) {
 	}
 }
 
+// TestUnknownPropertyWarningDynamicPropertySkipsWarning uses traefik because
+// letsencrypt's dns-provider-* family is probed now (#449) and its missing rows
+// never reach this branch; traefik is the family that still does.
 func TestUnknownPropertyWarningDynamicPropertySkipsWarning(t *testing.T) {
 	err := &errUnknownProperty{
-		plugin:    "letsencrypt",
-		property:  "dns-provider-NAMECHEAP_API_USER",
-		lookedFor: "dns-provider-NAMECHEAP_API_USER",
-		validKeys: []string{"email", "server"},
+		plugin:    "traefik",
+		property:  "dns-provider-CLOUDFLARE_API_TOKEN",
+		lookedFor: "dns-provider-CLOUDFLARE_API_TOKEN",
+		validKeys: []string{"global-dns-provider", "global-letsencrypt-email"},
 	}
-	if _, ok := unknownPropertyWarning("letsencrypt", "dns-provider-NAMECHEAP_API_USER", err); ok {
+	if _, ok := unknownPropertyWarning("traefik", "dns-provider-CLOUDFLARE_API_TOKEN", err); ok {
 		t.Error("dynamic property should not warn")
 	}
 }
@@ -338,6 +341,220 @@ func TestIsDynamicProperty(t *testing.T) {
 		got := isDynamicProperty(tc.plugin, tc.property)
 		if got != tc.want {
 			t.Errorf("isDynamicProperty(%q, %q) = %v; want %v", tc.plugin, tc.property, got, tc.want)
+		}
+	}
+}
+
+func TestDynamicPropertyKeys(t *testing.T) {
+	cases := []struct {
+		plugin   string
+		property string
+		want     PropertyKeys
+		wantOK   bool
+	}{
+		{"letsencrypt", "dns-provider-NAMECHEAP_API_USER", PropertyKeys{
+			PerApp:    "dns-provider-NAMECHEAP_API_USER",
+			Global:    "global-dns-provider-NAMECHEAP_API_USER",
+			Sensitive: true,
+		}, true},
+		// The mapped provider name is not dynamic, and neither is any other
+		// mapped property.
+		{"letsencrypt", "dns-provider", PropertyKeys{}, false},
+		{"letsencrypt", "email", PropertyKeys{}, false},
+		// traefik's family has the same shape but is still absent from
+		// traefik:report (#450), so it must stay unprobed.
+		{"traefik", "dns-provider-CLOUDFLARE_API_TOKEN", PropertyKeys{}, false},
+		{"nginx", "dns-provider-X", PropertyKeys{}, false},
+	}
+	for _, tc := range cases {
+		got, ok := dynamicPropertyKeys(tc.plugin, tc.property)
+		if ok != tc.wantOK {
+			t.Errorf("dynamicPropertyKeys(%q, %q) ok = %v; want %v", tc.plugin, tc.property, ok, tc.wantOK)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("dynamicPropertyKeys(%q, %q) = %+v; want %+v", tc.plugin, tc.property, got, tc.want)
+		}
+	}
+}
+
+// TestDynamicPropertiesFromReport pins the scope filtering the exporters rely
+// on: an app report also carries the global and computed variants of a key, and
+// only the bare row is the app's own value.
+func TestDynamicPropertiesFromReport(t *testing.T) {
+	appPayload := map[string]string{
+		"email":                                    "admin@example.com",
+		"dns-provider":                             "namecheap",
+		"dns-provider-NAMECHEAP_API_USER":          "deploy-bot",
+		"global-dns-provider-NAMECHEAP_API_KEY":    "globalkey",
+		"computed-dns-provider-NAMECHEAP_API_USER": "deploy-bot",
+		"computed-dns-provider-NAMECHEAP_API_KEY":  "globalkey",
+	}
+	got := dynamicPropertiesFromReport("letsencrypt", appPayload, false)
+	if !reflect.DeepEqual(got, []string{"dns-provider-NAMECHEAP_API_USER"}) {
+		t.Errorf("app scope = %v; want only the bare app row", got)
+	}
+
+	globalPayload := map[string]string{
+		"global-email":                           "",
+		"global-dns-provider":                    "namecheap",
+		"global-dns-provider-NAMECHEAP_API_USER": "deploy-bot",
+		"global-dns-provider-NAMECHEAP_API_KEY":  "globalkey",
+	}
+	got = dynamicPropertiesFromReport("letsencrypt", globalPayload, true)
+	want := []string{"dns-provider-NAMECHEAP_API_KEY", "dns-provider-NAMECHEAP_API_USER"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("global scope = %v; want %v", got, want)
+	}
+
+	// traefik is not probeable, so its report rows are never lifted.
+	if got := dynamicPropertiesFromReport("traefik", map[string]string{"global-dns-provider-CLOUDFLARE_API_TOKEN": "token"}, true); got != nil {
+		t.Errorf("traefik = %v; want nil", got)
+	}
+}
+
+// TestPlanPropertyDynamicLetsencryptInSync is the core of #449: a
+// dns-provider-* credential that already matches the recipe plans as in sync
+// instead of reporting drift on every run.
+func TestPlanPropertyDynamicLetsencryptInSync(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet letsencrypt:report myapp --format json": `{"email":"admin@example.com","dns-provider-CLOUDFLARE_API_TOKEN":"token123"}`,
+	}))()
+
+	res := planProperty(StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "token123", "letsencrypt:set", letsencryptPropertyKeys)
+	if res.Error != nil {
+		t.Fatalf("planProperty error: %v", res.Error)
+	}
+	if !res.InSync {
+		t.Errorf("expected in sync, got status %q reason %q", res.Status, res.Reason)
+	}
+	if res.Status != PlanStatusOK {
+		t.Errorf("status = %q; want %q", res.Status, PlanStatusOK)
+	}
+}
+
+func TestPlanPropertyDynamicLetsencryptGlobalInSync(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet letsencrypt:report --global --format json": `{"global-dns-provider-NAMECHEAP_API_USER":"deploy-bot"}`,
+	}))()
+
+	res := planProperty(StatePresent, "", true, "dns-provider-NAMECHEAP_API_USER", "deploy-bot", "letsencrypt:set", letsencryptPropertyKeys)
+	if res.Error != nil {
+		t.Fatalf("planProperty error: %v", res.Error)
+	}
+	if !res.InSync {
+		t.Errorf("expected in sync from the global row, got status %q reason %q", res.Status, res.Reason)
+	}
+}
+
+// TestPlanPropertyDynamicLetsencryptDriftMasksProbedValue guards the Sensitive
+// mark on the synthesized keys: the probed credential reaches the drift reason
+// and must be registered with the masker.
+func TestPlanPropertyDynamicLetsencryptDriftMasksProbedValue(t *testing.T) {
+	subprocess.SetGlobalSensitive(nil)
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet letsencrypt:report myapp --format json": `{"dns-provider-CLOUDFLARE_API_TOKEN":"oldtoken"}`,
+	}))()
+
+	res := planProperty(StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "newtoken", "letsencrypt:set", letsencryptPropertyKeys)
+	if res.Error != nil {
+		t.Fatalf("planProperty error: %v", res.Error)
+	}
+	if res.Status != PlanStatusModify {
+		t.Errorf("status = %q; want %q", res.Status, PlanStatusModify)
+	}
+	if !strings.Contains(res.Reason, "drift") {
+		t.Errorf("reason = %q; want a drift reason", res.Reason)
+	}
+	if masked := subprocess.MaskString(res.Reason); strings.Contains(masked, "oldtoken") {
+		t.Errorf("drift reason leaked the probed credential: %q -> %q", res.Reason, masked)
+	}
+	for _, cmd := range res.Commands {
+		if masked := subprocess.MaskString(cmd); strings.Contains(masked, "newtoken") {
+			t.Errorf("command leaked the desired credential: %q -> %q", cmd, masked)
+		}
+	}
+}
+
+// TestPlanPropertyDynamicLetsencryptMissingRowPlansCreate covers the pre-set
+// state: the plugin only emits a row once the property holds a value, so an
+// absent row is an unset property and not a probe failure worth warning about.
+func TestPlanPropertyDynamicLetsencryptMissingRowPlansCreate(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet letsencrypt:report myapp --format json": `{"email":"admin@example.com"}`,
+	}))()
+
+	res := planProperty(StatePresent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "token123", "letsencrypt:set", letsencryptPropertyKeys)
+	if res.Error != nil {
+		t.Fatalf("planProperty error: %v", res.Error)
+	}
+	if res.Status != PlanStatusCreate {
+		t.Errorf("status = %q; want %q (reason %q)", res.Status, PlanStatusCreate, res.Reason)
+	}
+	if !strings.Contains(res.Reason, "missing on myapp") {
+		t.Errorf("reason = %q; want a missing-on reason", res.Reason)
+	}
+	if len(res.Warnings) != 0 {
+		t.Errorf("an unset dynamic property must not warn, got %v", res.Warnings)
+	}
+}
+
+func TestPlanPropertyDynamicLetsencryptAbsentMissingRowIsInSync(t *testing.T) {
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet letsencrypt:report myapp --format json": `{"email":"admin@example.com"}`,
+	}))()
+
+	res := planProperty(StateAbsent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "", "letsencrypt:set", letsencryptPropertyKeys)
+	if res.Error != nil {
+		t.Fatalf("planProperty error: %v", res.Error)
+	}
+	if !res.InSync {
+		t.Errorf("an already-unset credential must plan as in sync, got status %q reason %q", res.Status, res.Reason)
+	}
+}
+
+func TestPlanPropertyDynamicLetsencryptAbsentPlansDestroy(t *testing.T) {
+	subprocess.SetGlobalSensitive(nil)
+	t.Cleanup(func() { subprocess.SetGlobalSensitive(nil) })
+
+	defer subprocess.SetExecRunner(fakeDokku(map[string]string{
+		"--quiet letsencrypt:report myapp --format json": `{"dns-provider-CLOUDFLARE_API_TOKEN":"livetoken"}`,
+	}))()
+
+	res := planProperty(StateAbsent, "myapp", false, "dns-provider-CLOUDFLARE_API_TOKEN", "", "letsencrypt:set", letsencryptPropertyKeys)
+	if res.Error != nil {
+		t.Fatalf("planProperty error: %v", res.Error)
+	}
+	if res.Status != PlanStatusDestroy {
+		t.Errorf("status = %q; want %q", res.Status, PlanStatusDestroy)
+	}
+	if masked := subprocess.MaskString(res.Reason); strings.Contains(masked, "livetoken") {
+		t.Errorf("unset reason leaked the probed credential: %q -> %q", res.Reason, masked)
+	}
+}
+
+// TestPlanPropertyDynamicTraefikStaysUnprobed keeps the traefik half of the
+// family on the unprobed path while dokku/dokku#8928 is open (#450): it must not
+// even attempt a report read.
+func TestPlanPropertyDynamicTraefikStaysUnprobed(t *testing.T) {
+	var ran []string
+	defer subprocess.SetExecRunner(func(_ context.Context, in subprocess.ExecCommandInput) (subprocess.ExecCommandResponse, error) {
+		ran = append(ran, strings.Join(in.Args, " "))
+		return subprocess.ExecCommandResponse{}, nil
+	})()
+
+	res := planProperty(StatePresent, "", true, "dns-provider-CLOUDFLARE_API_TOKEN", "token123", "traefik:set", traefikPropertyKeys)
+	if res.Error != nil {
+		t.Fatalf("planProperty error: %v", res.Error)
+	}
+	if !strings.Contains(res.Reason, "(no probe key)") {
+		t.Errorf("reason = %q; want the unprobed reason", res.Reason)
+	}
+	for _, cmd := range ran {
+		if strings.Contains(cmd, "traefik:report") {
+			t.Errorf("traefik dynamic properties must not be probed, ran %q", cmd)
 		}
 	}
 }


### PR DESCRIPTION
dokku-letsencrypt 0.25.0 surfaces every set `dns-provider-<KEY>` credential in `letsencrypt:report`, so those properties are now read back like the mapped ones instead of planning as drift on every run, and an exported recipe carries them instead of dropping them. The task requires dokku-letsencrypt 0.25.0 as a result, and declares full probe support. traefik's identically shaped family is still missing from its own report and stays unprobed behind #450.

Because the plugin only emits a row once a property holds a value, an absent row is read as an unset property rather than a probe failure, which is what lets a `state: absent` task converge. The probed credential is registered with the masker before it can reach a drift reason.

Exporting a letsencrypt property also stops lifting every value into a required sensitive input named after the task's `value` field, which produced recipes full of `web_value`, `web_value_2` and so on and demanded the email and grace period back as though they were secrets. The credentials are the only secrets in the family, so they are the only values lifted, and the input takes the property name.

Fixes #449. Fixes #451.
