### PR TITLE
test: check probe support per state branch

### DIFF
--- a/docs/writing-tasks.md
+++ b/docs/writing-tasks.md
@@ -98,10 +98,14 @@ A few conventions to follow:
   `ProbeUnsupported` (none do, so the task reports drift on every run and never converges). Name
   what cannot be read in the `Caveat`. The generator renders it in a Probe support section, the
   tasks index marks an unsupported task `(never converges)`, and `--list-tasks` marks it the same
-  way. `TestProbeSupportMatchesPlanWiring` cross-checks the declaration against the code: a task
-  that claims it converges must have an `InSync: true` result reachable from its `Plan()`, and one
-  that claims it cannot must not. Declare it for the task type, not for the run - a probe that
-  fails on a particular server is a `PlanWarning`, not a `ProbeUnsupported` task.
+  way. `TestProbeSupportMatchesPlanWiring` cross-checks the declaration against the code, and it
+  asks the question per `state:`, not per task: every branch of your `DispatchPlan` map must have
+  an `InSync: true` result reachable from it, and a task that claims it cannot converge must have
+  none. Adding a state you have no read command for therefore fails the build even when the task's
+  other states probe fine - there is no way to declare "converges for `present`, drifts forever for
+  `absent`". Branches reached through `planToggle`, `planProperty` and `planResource` count as your
+  task's own. Declare it for the task type, not for the run - a probe that fails on a particular
+  server is a `PlanWarning`, not a `ProbeUnsupported` task.
 - When a task has conditional or semantic input rules that a `required:"true"` tag cannot express -
   a list that must be non-empty only when `state: present`, mutually-exclusive fields, an enum, a
   per-item requirement on a slice field - put them in the optional `Validate() error` method (the

--- a/tasks/probe_coverage_test.go
+++ b/tasks/probe_coverage_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -8,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -44,17 +46,35 @@ func TestEveryTaskDeclaresProbeSupport(t *testing.T) {
 // named while being absent from every list (#426). The invariant is:
 //
 //   - ProbeUnsupported means Plan() can never report in sync.
-//   - ProbeSupported and ProbePartial mean it can.
+//   - ProbeSupported and ProbePartial mean every state it accepts can.
 //
 // "Can report in sync" is decided statically: a PlanResult composite literal
-// with `InSync: true` reachable from the task's Plan() through intra-package
-// calls. ProbePartial is not distinguishable from ProbeSupported this way -
-// both converge for some inputs - so the caveat text stays a human judgement,
-// but the always-drift case is machine-checked in both directions.
+// with `InSync: true` reachable through intra-package calls. ProbePartial is
+// not distinguishable from ProbeSupported this way - both converge - so the
+// caveat text stays a human judgement, but the always-drift case is
+// machine-checked in both directions.
+//
+// The converging direction is asked per `state:` branch, not per Plan() (#447).
+// Almost every task dispatches on state and the branches are independent, so a
+// whole-Plan() check would pass a task that probes `present` and not `absent` -
+// `state: absent` would report drift forever while the `present` branch kept
+// the method as a whole looking convergent. Branches reached through
+// planProperty, planToggle and planResource count as the calling task's own,
+// which is what covers the 34 tasks whose Plan() body has no DispatchPlan.
 func TestProbeSupportMatchesPlanWiring(t *testing.T) {
 	g := buildPlanGraph(t)
 
-	for name, task := range RegisteredTasks {
+	// A shared helper's branches are reached by dozens of tasks, so a broken
+	// one is reported once against the first task that reaches it rather than
+	// once per task.
+	type branchFailure struct {
+		branch planBranch
+		task   string
+	}
+	failures := map[planFuncKey]branchFailure{}
+
+	for _, name := range sortedTaskNames() {
+		task := RegisteredTasks[name]
 		support, ok := TaskProbeSupport(task)
 		if !ok {
 			continue // TestEveryTaskDeclaresProbeSupport reports this
@@ -70,22 +90,82 @@ func TestProbeSupportMatchesPlanWiring(t *testing.T) {
 			continue
 		}
 
+		// Without a dispatch map there is nothing to check per state, and the
+		// per-branch invariant would hold vacuously for the task. Every task
+		// routes through DispatchPlan today, directly or via planProperty /
+		// planToggle / planResource; hand-rolling the state switch instead
+		// would quietly opt out of the check.
+		branches := g.reachableBranches(key)
+		if len(branches) == 0 {
+			t.Errorf("task %q reaches no DispatchPlan branch from its Plan(), so the per-branch probe "+
+				"check cannot see its states - dispatch on state with DispatchPlan", name)
+			continue
+		}
+
 		capable := g.inSyncCapable(key)
 		switch support.Status {
 		case ProbeUnsupported:
-			if capable {
+			if !capable {
+				continue
+			}
+			var converging []string
+			for _, b := range branches {
+				if g.inSyncCapable(b.key) {
+					converging = append(converging, fmt.Sprintf("%s (%s:%d)",
+						b.state, filepath.Base(b.pos.Filename), b.pos.Line))
+				}
+			}
+			if len(converging) == 0 {
 				t.Errorf("task %q declares probe status %q but its Plan() can return an in-sync result, "+
 					"so it does converge - declare %q or %q instead",
 					name, support.Status, ProbeSupported, ProbePartial)
+				continue
 			}
+			t.Errorf("task %q declares probe status %q but its %s branch(es) can return an in-sync result, "+
+				"so it does converge - declare %q or %q instead",
+				name, support.Status, strings.Join(converging, ", "), ProbeSupported, ProbePartial)
 		case ProbeSupported, ProbePartial:
 			if !capable {
 				t.Errorf("task %q declares probe status %q but no `InSync: true` result is reachable from its Plan(), "+
 					"so it plans as drift on every run - declare %q instead",
 					name, support.Status, ProbeUnsupported)
+				continue
+			}
+			for _, b := range branches {
+				if g.inSyncCapable(b.key) {
+					continue
+				}
+				if _, seen := failures[b.key]; !seen {
+					failures[b.key] = branchFailure{branch: b, task: name}
+				}
 			}
 		}
 	}
+
+	keys := make([]planFuncKey, 0, len(failures))
+	for k := range failures {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	for _, k := range keys {
+		f := failures[k]
+		t.Errorf("%s:%d: the %q branch of %s has no reachable `InSync: true` result, so a task using "+
+			"`state: %s` plans as drift on every run - probe that state, or the task cannot claim it converges "+
+			"(reached from task %q)",
+			filepath.Base(f.branch.pos.Filename), f.branch.pos.Line, f.branch.state, f.branch.owner,
+			f.branch.state, f.task)
+	}
+}
+
+// sortedTaskNames returns the registered task names in a stable order, so the
+// task blamed for a shared helper's broken branch does not change run to run.
+func sortedTaskNames() []string {
+	names := make([]string, 0, len(RegisteredTasks))
+	for name := range RegisteredTasks {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // TestPlanResultInSyncImpliesStatusOK asserts that every `InSync: true`
@@ -117,27 +197,83 @@ func TestPlanResultInSyncImpliesStatusOK(t *testing.T) {
 	}
 }
 
-// planFuncKey identifies a function the static analysis can reach: a
-// package-level func ("planProperty") or a method ("GitAuthTask.Plan").
-// Methods must be keyed by receiver type - every task's Execute() is
-// `return ExecutePlan(t.Plan())`, so a bare "Plan" key would merge all 73
-// method bodies into one node and the invariant would hold vacuously.
+// planFuncKey identifies a node the static analysis can reach: a package-level
+// func ("planProperty"), a method ("GitAuthTask.Plan"), or one branch of a
+// DispatchPlan map ("GitAuthTask.Plan[present]"). Methods must be keyed by
+// receiver type - every task's Execute() is `return ExecutePlan(t.Plan())`, so
+// a bare "Plan" key would merge all 73 method bodies into one node and the
+// invariant would hold vacuously. Branch keys use a spelling no Go identifier
+// can collide with.
 type planFuncKey string
 
+// planBranch is one entry of a `map[State]func() PlanResult` passed to
+// DispatchPlan: the state a recipe would write in `state:`, the function the
+// map literal lives in, and the node key the closure's body was recorded under.
+type planBranch struct {
+	key   planFuncKey
+	owner planFuncKey
+	state string
+	pos   token.Position
+}
+
+// branchKey spells the node key for one dispatch branch.
+func branchKey(owner planFuncKey, state string) planFuncKey {
+	return planFuncKey(string(owner) + "[" + state + "]")
+}
+
 // planGraph is the intra-package call graph restricted to functions that
-// return a PlanResult. Restricting edges by return type is what excludes the
-// `apply:` closures: they return TaskOutputState and call runExecInputs /
-// applyPropertySet / applyToggle, none of which is a plan path.
+// return a PlanResult, plus one node per DispatchPlan branch. Restricting edges
+// by return type is what excludes the `apply:` closures: they return
+// TaskOutputState and call runExecInputs / applyPropertySet / applyToggle, none
+// of which is a plan path.
+//
+// Each branch closure is its own node rather than part of its enclosing
+// function, which is what lets the coverage test ask "can `state: absent`
+// converge" instead of only "can this task converge at all". A branch is also
+// recorded as a call edge of its enclosing function, so reachability for a
+// whole function still means "some branch of it converges".
 type planGraph struct {
 	inSync   map[planFuncKey]bool
 	calls    map[planFuncKey][]planFuncKey
 	planFunc map[string]bool
+	branches map[planFuncKey]planBranch
 	memo     map[planFuncKey]bool
 }
 
 func (g *planGraph) known(k planFuncKey) bool {
 	_, ok := g.calls[k]
 	return ok
+}
+
+// reachableBranches returns every dispatch branch reachable from k, in source
+// order. The walk crosses call edges, so a task delegating to planProperty,
+// planToggle or planResource reports that helper's branches as its own - which
+// is the only way the 34 tasks whose Plan() body has no DispatchPlan of its own
+// get per-branch coverage.
+func (g *planGraph) reachableBranches(k planFuncKey) []planBranch {
+	seen := map[planFuncKey]bool{}
+	var out []planBranch
+	var walk func(planFuncKey)
+	walk = func(node planFuncKey) {
+		if seen[node] {
+			return
+		}
+		seen[node] = true
+		if b, ok := g.branches[node]; ok {
+			out = append(out, b)
+		}
+		for _, callee := range g.calls[node] {
+			walk(callee)
+		}
+	}
+	walk(k)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].pos.Filename != out[j].pos.Filename {
+			return out[i].pos.Filename < out[j].pos.Filename
+		}
+		return out[i].pos.Offset < out[j].pos.Offset
+	})
+	return out
 }
 
 // inSyncCapable reports whether an `InSync: true` PlanResult is reachable from
@@ -187,9 +323,8 @@ func packageSourceFiles(t *testing.T) []string {
 	return out
 }
 
-// buildPlanGraph parses the tasks package and records, for every function
-// returning a PlanResult, whether its body builds an in-sync result and which
-// other plan-returning functions it calls.
+// buildPlanGraph parses the tasks package and builds the plan graph over it,
+// reporting every structural problem newPlanGraph found as a test failure.
 func buildPlanGraph(t *testing.T) *planGraph {
 	t.Helper()
 
@@ -204,12 +339,30 @@ func buildPlanGraph(t *testing.T) *planGraph {
 		parsed = append(parsed, f)
 	}
 
+	g, problems := newPlanGraph(fs, parsed)
+	for _, p := range problems {
+		t.Error(p)
+	}
+	return g
+}
+
+// newPlanGraph records, for every function carrying a PlanResult and every
+// DispatchPlan branch inside one, whether its body builds an in-sync result and
+// which other plan nodes it reaches. Structural problems - a shape the walk
+// cannot follow, which would silently weaken the invariant or blame an innocent
+// branch - are returned rather than reported, so the analysis can be exercised
+// against synthetic sources.
+func newPlanGraph(fs *token.FileSet, parsed []*ast.File) (*planGraph, []string) {
 	g := &planGraph{
 		inSync:   map[planFuncKey]bool{},
 		calls:    map[planFuncKey][]planFuncKey{},
 		planFunc: map[string]bool{},
+		branches: map[planFuncKey]planBranch{},
 		memo:     map[planFuncKey]bool{},
 	}
+	var problems []string
+
+	states := stateConstants(parsed)
 
 	// Pass 1: name every plan-returning function.
 	type decl struct {
@@ -230,8 +383,9 @@ func buildPlanGraph(t *testing.T) *planGraph {
 			}
 			recv := receiverTypeName(fn)
 			if recv == "" {
-				t.Errorf("%s: cannot resolve receiver type for method %s returning PlanResult",
-					filepath.Base(fs.Position(fn.Pos()).Filename), fn.Name.Name)
+				problems = append(problems, fmt.Sprintf(
+					"%s: cannot resolve receiver type for method %s returning PlanResult",
+					filepath.Base(fs.Position(fn.Pos()).Filename), fn.Name.Name))
 				continue
 			}
 			// The graph only follows bare identifiers, so a plan-returning
@@ -239,47 +393,279 @@ func buildPlanGraph(t *testing.T) *planGraph {
 			// make a task look unable to converge. Fail with a pointed message
 			// rather than letting an innocent task take the blame.
 			if fn.Name.Name != "Plan" {
-				t.Errorf("%s.%s returns PlanResult; only Plan() may be a plan-returning method, "+
-					"otherwise TestProbeSupportMatchesPlanWiring cannot follow the call. "+
-					"Make it a package-level func instead.", recv, fn.Name.Name)
+				problems = append(problems, fmt.Sprintf(
+					"%s.%s returns PlanResult; only Plan() may be a plan-returning method, "+
+						"otherwise TestProbeSupportMatchesPlanWiring cannot follow the call. "+
+						"Make it a package-level func instead.", recv, fn.Name.Name))
 				continue
 			}
 			decls = append(decls, decl{key: planFuncKey(recv + ".Plan"), body: fn.Body})
 		}
 	}
 
-	// Pass 2: record in-sync results and call edges. ast.Inspect descends into
-	// function literals, which is what covers the closures every task passes to
-	// DispatchPlan.
+	// Pass 2: record in-sync results, call edges, and dispatch branches. Each
+	// branch closure becomes its own node; the walk of the enclosing body skips
+	// the closure so its in-sync result is attributed to the branch alone.
 	for _, d := range decls {
-		if _, seen := g.calls[d.key]; !seen {
-			g.calls[d.key] = nil
-		}
-		ast.Inspect(d.body, func(n ast.Node) bool {
-			switch node := n.(type) {
-			case *ast.CompositeLit:
-				if isIdent(node.Type, "PlanResult") && litHasIdentField(node, "InSync", "true") {
-					g.inSync[d.key] = true
-				}
-			case *ast.CallExpr:
-				if id, ok := node.Fun.(*ast.Ident); ok && g.planFunc[id.Name] {
-					g.calls[d.key] = append(g.calls[d.key], planFuncKey(id.Name))
-				}
-			}
-			return true
-		})
+		problems = append(problems, g.walkBody(fs, states, d.key, d.body)...)
 	}
 
-	return g
+	return g, problems
 }
 
-// returnsPlanResult reports whether fn's result list is exactly one PlanResult.
+// walkBody records one node's in-sync results, call edges and dispatch
+// branches, recursing into each branch closure as a node of its own.
+func (g *planGraph) walkBody(fs *token.FileSet, states map[string]string, key planFuncKey, body ast.Node) []string {
+	if _, seen := g.calls[key]; !seen {
+		g.calls[key] = nil
+	}
+
+	var problems []string
+	branches, branchProblems := dispatchBranches(fs, states, key, body)
+	problems = append(problems, branchProblems...)
+
+	skip := map[ast.Node]bool{}
+	for _, b := range branches {
+		skip[b.lit] = true
+	}
+
+	ast.Inspect(body, func(n ast.Node) bool {
+		if n == nil || skip[n] {
+			return false
+		}
+		switch node := n.(type) {
+		case *ast.CompositeLit:
+			if isIdent(node.Type, "PlanResult") && litHasIdentField(node, "InSync", "true") {
+				g.inSync[key] = true
+			}
+		case *ast.CallExpr:
+			if id, ok := node.Fun.(*ast.Ident); ok && g.planFunc[id.Name] {
+				g.calls[key] = append(g.calls[key], planFuncKey(id.Name))
+			}
+		}
+		return true
+	})
+
+	for _, b := range branches {
+		g.branches[b.branch.key] = b.branch
+		g.calls[key] = append(g.calls[key], b.branch.key)
+		problems = append(problems, g.walkBody(fs, states, b.branch.key, b.lit.Body)...)
+	}
+	return problems
+}
+
+// dispatchBranchLit pairs a branch with the closure its body lives in.
+type dispatchBranchLit struct {
+	branch planBranch
+	lit    *ast.FuncLit
+}
+
+// dispatchBranches finds every DispatchPlan call in body and returns one entry
+// per state in its map. The map has to be readable statically: either inline in
+// the call or a local assigned a single map literal. Anything else is reported
+// rather than skipped - a branch the walk cannot see is a branch the coverage
+// test would never check.
+func dispatchBranches(fs *token.FileSet, states map[string]string, owner planFuncKey, body ast.Node) ([]dispatchBranchLit, []string) {
+	var out []dispatchBranchLit
+	var problems []string
+
+	ast.Inspect(body, func(n ast.Node) bool {
+		// Stop at closure boundaries: a branch's own body is walked as its own
+		// node, so descending here would register a nested dispatch twice,
+		// once under each owner.
+		if _, ok := n.(*ast.FuncLit); ok {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok || !isIdent(call.Fun, "DispatchPlan") || len(call.Args) != 2 {
+			return true
+		}
+		where := fs.Position(call.Pos())
+		lit, problem := resolveDispatchMap(fs, body, call.Args[1])
+		if problem != "" {
+			problems = append(problems, problem)
+			return true
+		}
+		for _, elt := range lit.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				problems = append(problems, fmt.Sprintf(
+					"%s:%d: DispatchPlan map entry in %s is not a `State: func() PlanResult` pair, "+
+						"so the per-branch probe check cannot name the state it covers",
+					filepath.Base(where.Filename), fs.Position(elt.Pos()).Line, owner))
+				continue
+			}
+			fn, ok := kv.Value.(*ast.FuncLit)
+			if !ok {
+				problems = append(problems, fmt.Sprintf(
+					"%s:%d: DispatchPlan map entry in %s is not a func literal; "+
+						"write the branch inline so the per-branch probe check can walk it",
+					filepath.Base(where.Filename), fs.Position(kv.Pos()).Line, owner))
+				continue
+			}
+			state, ok := stateName(states, kv.Key)
+			if !ok {
+				problems = append(problems, fmt.Sprintf(
+					"%s:%d: DispatchPlan map key in %s is not a State constant or string literal, "+
+						"so the per-branch probe check cannot name the state it covers",
+					filepath.Base(where.Filename), fs.Position(kv.Pos()).Line, owner))
+				continue
+			}
+			out = append(out, dispatchBranchLit{
+				branch: planBranch{
+					key:   branchKey(owner, state),
+					owner: owner,
+					state: state,
+					pos:   fs.Position(kv.Pos()),
+				},
+				lit: fn,
+			})
+		}
+		return true
+	})
+
+	return out, problems
+}
+
+// resolveDispatchMap returns the map literal DispatchPlan was handed. An inline
+// literal is the usual shape; a local holding exactly one map literal, never
+// reassigned and never index-assigned, resolves to that literal so naming the
+// map does not blind the check.
+func resolveDispatchMap(fs *token.FileSet, scope ast.Node, arg ast.Expr) (*ast.CompositeLit, string) {
+	where := filepath.Base(fs.Position(arg.Pos()).Filename)
+	line := fs.Position(arg.Pos()).Line
+
+	if lit, ok := arg.(*ast.CompositeLit); ok {
+		return lit, ""
+	}
+
+	id, ok := arg.(*ast.Ident)
+	if !ok {
+		return nil, fmt.Sprintf("%s:%d: DispatchPlan was passed an expression the per-branch probe "+
+			"check cannot resolve to a map literal; pass the map inline", where, line)
+	}
+
+	var found *ast.CompositeLit
+	assignments := 0
+	mutated := false
+	ast.Inspect(scope, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.AssignStmt:
+			for i, lhs := range node.Lhs {
+				if index, ok := lhs.(*ast.IndexExpr); ok && isIdent(index.X, id.Name) {
+					mutated = true
+					continue
+				}
+				if !isIdent(lhs, id.Name) {
+					continue
+				}
+				assignments++
+				if i < len(node.Rhs) {
+					if lit, ok := node.Rhs[i].(*ast.CompositeLit); ok {
+						found = lit
+					}
+				}
+			}
+		case *ast.ValueSpec:
+			for i, name := range node.Names {
+				if name.Name != id.Name {
+					continue
+				}
+				assignments++
+				if i < len(node.Values) {
+					if lit, ok := node.Values[i].(*ast.CompositeLit); ok {
+						found = lit
+					}
+				}
+			}
+		}
+		return true
+	})
+
+	switch {
+	case found == nil || assignments == 0:
+		return nil, fmt.Sprintf("%s:%d: DispatchPlan was passed %q, which the per-branch probe check "+
+			"cannot trace to a map literal in the same function; pass the map inline",
+			where, line, id.Name)
+	case assignments > 1 || mutated:
+		return nil, fmt.Sprintf("%s:%d: the DispatchPlan map %q is assembled after its literal, so the "+
+			"per-branch probe check cannot enumerate its states; build it in one map literal",
+			where, line, id.Name)
+	}
+	return found, ""
+}
+
+// stateConstants maps each `State` constant to its value, so a branch keyed
+// StateAbsent is reported as `absent` - what a recipe actually writes.
+func stateConstants(parsed []*ast.File) map[string]string {
+	out := map[string]string{}
+	for _, f := range parsed {
+		for _, d := range f.Decls {
+			gen, ok := d.(*ast.GenDecl)
+			if !ok || gen.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok || !isIdent(vs.Type, "State") {
+					continue
+				}
+				for i, name := range vs.Names {
+					if i >= len(vs.Values) {
+						continue
+					}
+					if lit, ok := vs.Values[i].(*ast.BasicLit); ok && lit.Kind == token.STRING {
+						if value, err := strconv.Unquote(lit.Value); err == nil {
+							out[name.Name] = value
+						}
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+// stateName renders a dispatch map key as the state a recipe would write,
+// falling back to the identifier for a key that is not a known constant. A key
+// that is neither an identifier nor a string reports false: it cannot be named
+// in a failure message, so the caller raises it as a structural problem.
+func stateName(states map[string]string, key ast.Expr) (string, bool) {
+	switch k := key.(type) {
+	case *ast.Ident:
+		if value, ok := states[k.Name]; ok {
+			return value, true
+		}
+		return k.Name, true
+	case *ast.BasicLit:
+		if k.Kind == token.STRING {
+			if value, err := strconv.Unquote(k.Value); err == nil {
+				return value, true
+			}
+		}
+	}
+	return "", false
+}
+
+// returnsPlanResult reports whether any of fn's results is a PlanResult. A
+// pointer or a multi-value return counts: readHttpAuthUserState hands one back
+// as its third result, and a plan edge the graph does not follow would fail the
+// per-branch check on an innocent branch.
 func returnsPlanResult(fn *ast.FuncDecl) bool {
 	res := fn.Type.Results
-	if res == nil || len(res.List) != 1 || len(res.List[0].Names) > 1 {
+	if res == nil {
 		return false
 	}
-	return isIdent(res.List[0].Type, "PlanResult")
+	for _, field := range res.List {
+		expr := field.Type
+		if star, ok := expr.(*ast.StarExpr); ok {
+			expr = star.X
+		}
+		if isIdent(expr, "PlanResult") {
+			return true
+		}
+	}
+	return false
 }
 
 // receiverTypeName returns fn's receiver type name, dereferencing a pointer
@@ -316,4 +702,301 @@ func litHasIdentField(lit *ast.CompositeLit, field, want string) bool {
 		}
 	}
 	return false
+}
+
+// planGraphFixturePrologue gives every fixture the State constants the walk
+// resolves branch keys against, so a branch keyed StatePresent is reported as
+// `present` - what a recipe writes.
+const planGraphFixturePrologue = `package tasks
+
+const (
+	StatePresent State = "present"
+	StateAbsent  State = "absent"
+)
+`
+
+// planGraphFixture builds the graph over a synthetic one-file package. The
+// analysis is purely syntactic, so a fixture only needs the declarations the
+// walk reads - it never has to compile.
+func planGraphFixture(t *testing.T, body string) (*planGraph, []string) {
+	t.Helper()
+	fs := token.NewFileSet()
+	f, err := parser.ParseFile(fs, "fixture.go", planGraphFixturePrologue+body, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	return newPlanGraph(fs, []*ast.File{f})
+}
+
+// branchStates lists the states of every branch reachable from key, and the
+// subset that cannot reach an in-sync result, both in source order.
+func branchStates(g *planGraph, key planFuncKey) (all, nonConverging []string) {
+	for _, b := range g.reachableBranches(key) {
+		all = append(all, b.state)
+		if !g.inSyncCapable(b.key) {
+			nonConverging = append(nonConverging, b.state)
+		}
+	}
+	return all, nonConverging
+}
+
+// TestPlanGraphBranchConvergence exercises the per-branch analysis that
+// TestProbeSupportMatchesPlanWiring relies on. Every branch in the real package
+// converges, so running against the package proves only that the check does not
+// misfire - these fixtures are what prove it fires at all, and that it fires on
+// the right state.
+func TestPlanGraphBranchConvergence(t *testing.T) {
+	const inSync = "PlanResult{InSync: true, Status: PlanStatusOK}"
+	const drift = "PlanResult{InSync: false, Status: PlanStatusModify}"
+
+	tests := []struct {
+		name          string
+		src           string
+		key           planFuncKey
+		all           []string
+		nonConverging []string
+	}{
+		{
+			name: "every branch converges",
+			src: `
+func (t FooTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return ` + inSync + ` },
+		StateAbsent:  func() PlanResult { return ` + inSync + ` },
+	})
+}`,
+			key: "FooTask.Plan",
+			all: []string{"present", "absent"},
+		},
+		{
+			name: "one branch never converges",
+			src: `
+func (t FooTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return ` + inSync + ` },
+		StateAbsent:  func() PlanResult { return ` + drift + ` },
+	})
+}`,
+			key:           "FooTask.Plan",
+			all:           []string{"present", "absent"},
+			nonConverging: []string{"absent"},
+		},
+		{
+			name: "no branch converges",
+			src: `
+func (t FooTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return ` + drift + ` },
+		StateAbsent:  func() PlanResult { return ` + drift + ` },
+	})
+}`,
+			key:           "FooTask.Plan",
+			all:           []string{"present", "absent"},
+			nonConverging: []string{"present", "absent"},
+		},
+		{
+			// The planProperty / planToggle / planResource shape: 34 tasks own
+			// no dispatch map of their own and inherit the helper's branches.
+			name: "branches inherited from a shared helper",
+			src: `
+func (t FooTask) Plan() PlanResult {
+	return planShared(t.State)
+}
+
+func planShared(state State) PlanResult {
+	return DispatchPlan(state, map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return ` + inSync + ` },
+		StateAbsent:  func() PlanResult { return ` + drift + ` },
+	})
+}`,
+			key:           "FooTask.Plan",
+			all:           []string{"present", "absent"},
+			nonConverging: []string{"absent"},
+		},
+		{
+			// A branch that delegates converges through the call edge.
+			name: "branch converges through a called plan func",
+			src: `
+func (t FooTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return planFooPresent(t) },
+	})
+}
+
+func planFooPresent(t FooTask) PlanResult {
+	return ` + inSync + `
+}`,
+			key: "FooTask.Plan",
+			all: []string{"present"},
+		},
+		{
+			// readHttpAuthUserState hands a PlanResult back as its third
+			// result; a graph keyed on a lone PlanResult return would miss the
+			// edge and blame the branch.
+			name: "branch converges through a multi-result pointer helper",
+			src: `
+func (t FooTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: func() PlanResult {
+			_, res := readFooState(t)
+			if res != nil {
+				return *res
+			}
+			return ` + drift + `
+		},
+	})
+}
+
+func readFooState(t FooTask) (bool, *PlanResult) {
+	return true, &` + inSync + `
+}`,
+			key: "FooTask.Plan",
+			all: []string{"present"},
+		},
+		{
+			name: "dispatch map held in a local",
+			src: `
+func (t FooTask) Plan() PlanResult {
+	handlers := map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return ` + inSync + ` },
+		StateAbsent:  func() PlanResult { return ` + drift + ` },
+	}
+	return DispatchPlan(t.State, handlers)
+}`,
+			key:           "FooTask.Plan",
+			all:           []string{"present", "absent"},
+			nonConverging: []string{"absent"},
+		},
+		{
+			name: "dispatch map declared with var",
+			src: `
+func (t FooTask) Plan() PlanResult {
+	var handlers = map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return ` + inSync + ` },
+		StateAbsent:  func() PlanResult { return ` + drift + ` },
+	}
+	return DispatchPlan(t.State, handlers)
+}`,
+			key:           "FooTask.Plan",
+			all:           []string{"present", "absent"},
+			nonConverging: []string{"absent"},
+		},
+		{
+			// An unmapped key still names something a reader can act on.
+			name: "keys that are not State constants fall back to their spelling",
+			src: `
+func (t FooTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		"deployed":   func() PlanResult { return ` + inSync + ` },
+		StateUnknown: func() PlanResult { return ` + drift + ` },
+	})
+}`,
+			key:           "FooTask.Plan",
+			all:           []string{"deployed", "StateUnknown"},
+			nonConverging: []string{"StateUnknown"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g, problems := planGraphFixture(t, tc.src)
+			if len(problems) > 0 {
+				t.Fatalf("unexpected structural problems: %v", problems)
+			}
+			all, nonConverging := branchStates(g, tc.key)
+			if !reflect.DeepEqual(all, tc.all) {
+				t.Errorf("reachable branches: got %v, want %v", all, tc.all)
+			}
+			if !reflect.DeepEqual(nonConverging, tc.nonConverging) {
+				t.Errorf("non-converging branches: got %v, want %v", nonConverging, tc.nonConverging)
+			}
+		})
+	}
+}
+
+// TestPlanGraphReportsUnwalkableShapes asserts the walk fails loudly on a shape
+// it cannot follow. Silently skipping one would leave the branch unchecked
+// while the suite stayed green, which is the failure mode the per-branch
+// invariant exists to close.
+func TestPlanGraphReportsUnwalkableShapes(t *testing.T) {
+	const inSync = "PlanResult{InSync: true, Status: PlanStatusOK}"
+
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "map assembled after its literal",
+			src: `
+func (t FooTask) Plan() PlanResult {
+	handlers := map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return ` + inSync + ` },
+	}
+	handlers[StateAbsent] = func() PlanResult { return ` + inSync + ` }
+	return DispatchPlan(t.State, handlers)
+}`,
+			want: "assembled after its literal",
+		},
+		{
+			name: "map reassigned",
+			src: `
+func (t FooTask) Plan() PlanResult {
+	handlers := map[State]func() PlanResult{}
+	handlers = map[State]func() PlanResult{
+		StatePresent: func() PlanResult { return ` + inSync + ` },
+	}
+	return DispatchPlan(t.State, handlers)
+}`,
+			want: "assembled after its literal",
+		},
+		{
+			name: "map comes from outside the function",
+			src: `
+func planShared(state State, handlers map[State]func() PlanResult) PlanResult {
+	return DispatchPlan(state, handlers)
+}`,
+			want: "cannot trace to a map literal",
+		},
+		{
+			name: "branch is not a func literal",
+			src: `
+func (t FooTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		StatePresent: presentBranch,
+	})
+}`,
+			want: "not a func literal",
+		},
+		{
+			name: "branch key is computed",
+			src: `
+func (t FooTask) Plan() PlanResult {
+	return DispatchPlan(t.State, map[State]func() PlanResult{
+		State("present"): func() PlanResult { return ` + inSync + ` },
+	})
+}`,
+			want: "not a State constant or string literal",
+		},
+		{
+			name: "plan-returning method other than Plan",
+			src: `
+func (t FooTask) planPresent() PlanResult {
+	return ` + inSync + `
+}`,
+			want: "only Plan() may be a plan-returning method",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, problems := planGraphFixture(t, tc.src)
+			for _, p := range problems {
+				if strings.Contains(p, tc.want) {
+					return
+				}
+			}
+			t.Errorf("expected a problem containing %q, got %v", tc.want, problems)
+		})
+	}
 }

--- a/tasks/probe_support.go
+++ b/tasks/probe_support.go
@@ -50,7 +50,10 @@ type ProbeSupport struct {
 // Nothing in the plan or apply path reads this: drift is decided entirely by
 // each Plan() implementation. What keeps the declaration honest is
 // TestProbeSupportMatchesPlanWiring, which fails when a task claims it can
-// converge but its Plan() has no reachable in-sync result (or vice versa).
+// converge but one of its DispatchPlan branches has no reachable in-sync result
+// (or when it claims it cannot and some branch does). Asking per branch rather
+// than per Plan() is what stops a task that probes `present` and not `absent`
+// from passing on the strength of its `present` branch alone.
 type ProbeDocer interface {
 	ProbeSupport() ProbeSupport
 }


### PR DESCRIPTION
`TestProbeSupportMatchesPlanWiring` asked its question once per `Plan()`, so it could only separate a task that converges for some input from one that never converges at all. Almost every task dispatches on state and the branches are independent, so a task that probed `present` and not `absent` would have passed on the strength of its `present` branch while `state: absent` reported drift forever. The analysis now walks each `map[State]func() PlanResult` entry as its own node and requires every branch a converging task reaches to have its own reachable in-sync result, naming the state and its source position when one does not. Branches reached through `planProperty`, `planToggle` and `planResource` count as the calling task's own, which is what covers the tasks whose `Plan()` body has no dispatch map of its own, and a broken branch of a shared helper is reported once rather than once per task that reaches it.

All 85 branches already satisfy this: the seven that cannot converge are exactly the branches of the four tasks declared `unsupported`, so no declaration and no task changes. There is deliberately no way to declare that one state converges and another does not - a task with an unprobeable state fails the build rather than getting an opt-out.

Because every branch in the package converges, running the check against the package proves only that it does not misfire. Synthetic-source fixtures are what prove it fires at all and blames the right state, and they cover the shapes the walk refuses to guess at: a dispatch map assembled after its literal, a map it cannot trace to a literal, an entry that is not a func literal, and a key that is not a state.

Closes #447
